### PR TITLE
fixed TextParser to register template correctly

### DIFF
--- a/lib/fluent/parser.rb
+++ b/lib/fluent/parser.rb
@@ -24,7 +24,7 @@ class TextParser
     'syslog' => [/^(?<time>[^ ]* [^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?[^\:]*\: *(?<message>.*)$/, "%b %d %H:%M:%S"],
   }
 
-  def self.register_template(name, regexp)
+  def self.register_template(name, regexp, time_format)
     TEMPLATES[name] = [regexp, time_format]
   end
 


### PR DESCRIPTION
'undefined local variable or method' occur when TextParser.register_template is called.

> 2011-09-30 06:01:04 +0900: command/fluentd.rb:235:rescue in <top (required)>: unexpected error error="undefined local variable or method `time_format' for Fluent::TextParser:Class"

This patch solves the problem by adding the argument to TextParser.register_template
