### PR TITLE
fixed for fluent-cat cannot recognize --port option

### DIFF
--- a/lib/fluent/command/cat.rb
+++ b/lib/fluent/command/cat.rb
@@ -32,7 +32,7 @@ config_path = Fluent::DEFAULT_CONFIG_PATH
 format = 'json'
 
 op.on('-p', '--port PORT', "fluent tcp port (default: #{port})", Integer) {|i|
-  port = s
+  port = i
 }
 
 op.on('-h', '--host HOST', "fluent host (default: #{host})") {|s|


### PR DESCRIPTION
fluent-catが--portオプションを受け付けてくれないので調べてみたら単純なtypoだったので修正してみました。
よろしくお願いします。
