### PR TITLE
MemoryBufferChunk#msgpack_each uses undefined variable.

### DIFF
--- a/lib/fluent/plugin/buf_memory.rb
+++ b/lib/fluent/plugin/buf_memory.rb
@@ -53,7 +53,7 @@ class MemoryBufferChunk < BufferChunk
 
   # optimize
   def msgpack_each(&block)
-    u = MessagePack::Unpacker.new(io)
+    u = MessagePack::Unpacker.new
     u.feed_each(@data, &block)
   end
 end


### PR DESCRIPTION
This is a bug and blocks fluent-plugin-mongo updating to 0.10.0.
