### PR TITLE
fluentd requires ruby 1.9 syntax.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,6 +22,7 @@ begin
     gemspec.files = Dir["bin/**/*", "lib/**/*", "test/**/*.rb"] +
       %w[fluent.conf VERSION AUTHORS Rakefile COPYING fluentd.gemspec]
     gemspec.executables = ['fluentd', 'fluent-cat', 'fluent-gem']
+    gemspec.required_ruby_version = '~> 1.9.2'
   end
   Jeweler::GemcutterTasks.new
 rescue LoadError


### PR DESCRIPTION
1.9環境が必要と知らずに1.8環境でgem install。実行して悲しい思いをしたので、rubyのバージョン要求をgemspecに追加してみました。
gemspecの再生成は御手元のjewelerで行ったほうがよろしいかと思い、コミットしていません。(手元でやったらファイル列挙の出力などが微妙に違ってパッチが不必要に膨らんだので)
