### PR TITLE
use gem specification instead of gempathsearcher

### DIFF
--- a/lib/fluent/plugin.rb
+++ b/lib/fluent/plugin.rb
@@ -123,16 +123,14 @@ class PluginClass
     # search gems
     if defined?(::Gem) && ::Gem.respond_to?(:searcher)
       #files = Gem.find_files(path).sort
-      specs = Gem.searcher.find_all(path)
+      specs = Gem::Specification.find_all {|spec| spec.contains_requirable_file? path}
       specs = specs.sort_by {|spec| spec.version }
 
       # prefer newer version
-      specs.reverse_each {|spec|
-        files = Gem.searcher.matching_files(spec, path)
-        unless files.empty?
-          require files.first
-          return
-        end
+      unless specs.empty?
+        require specs.last
+        return
+      end
       }
     end
   end


### PR DESCRIPTION
remove annoying "deprecated" error like

NOTE: Gem.searcher is deprecated, use Specification. It will be removed on or after 2011-11-01.
Gem.searcher called from /Users/hiro/.rvm/gems/ruby-1.9.2-p290@global/gems/fluentd-0.10.7/lib/fluent/plugin.rb:126.
NOTE: Gem::GemPathSearcher#initialize is deprecated with no replacement. It will be removed on or after 2011-10-01.
Gem::GemPathSearcher#initialize called from /Users/hiro/.rvm/rubies/ruby-1.9.2-p290/lib/ruby/site_ruby/1.9.1/rubygems.rb:952.
NOTE: Gem::GemPathSearcher#find_all is deprecated with no replacement. It will be removed on or after 2011-10-01.
Gem::GemPathSearcher#find_all called from /Users/hiro/.rvm/gems/ruby-1.9.2-p290@global/gems/fluentd-0.10.7/lib/fluent/plugin.rb:126.
NOTE: Gem.searcher is deprecated, use Specification. It will be removed on or after 2011-11-01.
Gem.searcher called from /Users/hiro/.rvm/gems/ruby-1.9.2-p290@global/gems/fluentd-0.10.7/lib/fluent/plugin.rb:131.
