### PR TITLE
use gem specification instead of gempathsearcher

### DIFF
--- a/lib/fluent/plugin.rb
+++ b/lib/fluent/plugin.rb
@@ -121,7 +121,20 @@ class PluginClass
     end
 
     # search gems
-    if defined?(::Gem) && ::Gem.respond_to?(:searcher)
+    if defined?(::Gem::Specification) && ::Gem::Specification.respond_to?(:find_all)
+      specs = Gem::Specification.find_all {|spec| spec.contains_requirable_file? path}
+      specs = specs.sort_by {|spec| spec.version }
+
+      # prefer newer version
+      unless specs.empty?
+        spec = specs.last
+        spec.require_paths.each do |lib|
+          file = "#{spec.full_gem_path}/#{lib}/#{path}"
+          require file
+        end
+      end
+    # backward compatibility
+    elsif defined?(::Gem) && ::Gem.respond_to?(:searcher)
       #files = Gem.find_files(path).sort
       specs = Gem.searcher.find_all(path)
       specs = specs.sort_by {|spec| spec.version }


### PR DESCRIPTION
rubygem1.8環境ではGem.searcherメソッドはdeprecatedと警告が出るので、
rubygem1.8から使えるGem::Specification.find_allメソッドを使って警告を抑止しました。
互換性のため元の部分も残していますので1.8未満のrubygemでも使えるはずです。
