### PR TITLE
Option to supply inline config on commandline. This bring some dynamic-ness to config

### DIFF
--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -73,6 +73,11 @@ op.on('-o', '--log PATH', "log file path") {|s|
   opts[:log_path] = s
 }
 
+op.on('-i', '--inline-config CONFIG_STRING', "inline config which is appended to the config file on-fly") {|s|
+  opts[:inline_config] = s
+}
+
+
 op.on('-v', '--verbose', "increment verbose level (-v: debug, -vv: trace)", TrueClass) {|b|
   if b
     case opts[:log_level]

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -59,6 +59,7 @@ class Supervisor
     @chuser = opt[:chuser]
     @libs = opt[:libs]
     @plugin_dirs = opt[:plugin_dirs]
+    @inline_config = opt[:inline_config]
 
     @log = LoggerInitializer.new(@log_path, @log_level)
     @finished = false
@@ -224,6 +225,7 @@ class Supervisor
     @config_fname = File.basename(@config_path)
     @config_basedir = File.dirname(@config_path)
     @config_data = File.read(@config_path)
+    @config_data << "\n" << @inline_config.gsub("\\n","\n") unless @inline_config.nil?
   end
 
   def run_configure


### PR DESCRIPTION
This is very useful if you want to hook fluentd directly on heroku dyno (or any Foreman managed system) 

Imagine running something like this 
<code>
ruby bin/fluentd -c etc/fluent.conf -i "<source>\n  type http\n  port $PORT\n </source>"
</code>

This immensely helps when port numbers are not known before hand.
