### PR TITLE
fix bug that TimeSlicedOutputTestDriver ignores expect_format

### DIFF
--- a/lib/fluent/test/output_test.rb
+++ b/lib/fluent/test/output_test.rb
@@ -112,12 +112,18 @@ class TimeSlicedOutputTestDriver < InputTestDriver
   def run(&block)
     result = []
     super {
+      buffer = ''
       @entries.keys.each {|key|
         es = ArrayEventStream.new(@entries[key])
         @instance.emit(@tag, es, NullOutputChain.instance)
+        buffer << @instance.format_stream(@tag, es)
       }
 
       block.call if block
+
+      if @expected_buffer
+        assert_equal(@expected_buffer, buffer)
+      end
 
       chunks = @instance.instance_eval {
         @buffer.instance_eval {


### PR DESCRIPTION
I made original TimeSlicedOutputTestDriver to ignore expect_format. That is bug.
