### PR TITLE
add options remove_prefix/add_prefix and its tests

### DIFF
--- a/test/plugin/out_exec_filter.rb
+++ b/test/plugin/out_exec_filter.rb
@@ -16,8 +16,8 @@ class ExecFilterOutputTest < Test::Unit::TestCase
     localtime
   ]
 
-  def create_driver(conf = CONFIG)
-    Fluent::Test::OutputTestDriver.new(Fluent::ExecFilterOutput).configure(conf)
+  def create_driver(conf = CONFIG, tag = 'test')
+    Fluent::Test::OutputTestDriver.new(Fluent::ExecFilterOutput, tag).configure(conf)
   end
 
   def test_configure
@@ -29,6 +29,22 @@ class ExecFilterOutputTest < Test::Unit::TestCase
     assert_equal "time", d.instance.time_key
     assert_equal "%Y-%m-%d %H:%M:%S", d.instance.time_format
     assert_equal true, d.instance.localtime
+
+    d = create_driver %[
+      command sed -l -e s/foo/bar/
+      in_keys time,k1
+      out_keys time,k2
+      tag xxx
+      time_key time
+    ]
+    assert_equal "sed -l -e s/foo/bar/", d.instance.command
+
+    d = create_driver(CONFIG + %[
+      remove_prefix before
+      add_prefix after
+    ])
+    assert_equal "before", d.instance.remove_prefix
+    assert_equal "after" , d.instance.add_prefix
   end
 
   def test_emit_1
@@ -69,6 +85,74 @@ class ExecFilterOutputTest < Test::Unit::TestCase
     assert_equal 2, emits.length
     assert_equal ["xxx", time, {"k2"=>"1"}], emits[0]
     assert_equal ["xxx", time, {"k2"=>"2"}], emits[1]
+  end
+
+  def test_emit_3
+    d = create_driver %[
+      command grep --line-buffered -v poo
+      in_keys time,val1
+      out_keys time,val2
+      tag xxx
+      time_key time
+    ]
+
+    time = Time.parse("2011-01-02 13:14:15").to_i
+
+    d.run do
+      d.emit({"val1"=>"sed-ed value foo"}, time)
+      d.emit({"val1"=>"sed-ed value poo"}, time)
+      sleep 0.5
+    end
+
+    emits = d.emits
+    assert_equal 1, emits.length
+    assert_equal ["xxx", time, {"val2"=>"sed-ed value foo"}], emits[0]
+
+    d = create_driver %[
+      command sed -l -e s/foo/bar/
+      in_keys time,val1
+      out_keys time,val2
+      tag xxx
+      time_key time
+    ]
+
+    time = Time.parse("2011-01-02 13:14:15").to_i
+
+    d.run do
+      d.emit({"val1"=>"sed-ed value foo"}, time)
+      d.emit({"val1"=>"sed-ed value poo"}, time)
+      sleep 0.5
+    end
+
+    emits = d.emits
+    assert_equal 2, emits.length
+    assert_equal ["xxx", time, {"val2"=>"sed-ed value bar"}], emits[0]
+    assert_equal ["xxx", time, {"val2"=>"sed-ed value poo"}], emits[1]
+  end
+
+  def test_emit_4
+    d = create_driver(%[
+      command sed -l -e s/foo/bar/
+      in_keys tag,time,val1
+      remove_prefix input
+      out_keys tag,time,val2
+      add_prefix output
+      tag_key tag
+      time_key time
+    ], 'input.test')
+
+    time = Time.parse("2011-01-02 13:14:15").to_i
+
+    d.run do
+      d.emit({"val1"=>"sed-ed value foo"}, time)
+      d.emit({"val1"=>"sed-ed value poo"}, time)
+      sleep 0.5
+    end
+
+    emits = d.emits
+    assert_equal 2, emits.length
+    assert_equal ["output.test", time, {"val2"=>"sed-ed value bar"}], emits[0]
+    assert_equal ["output.test", time, {"val2"=>"sed-ed value poo"}], emits[1]
   end
 end
 


### PR DESCRIPTION
'add_prefix' option is useful to route events flexibly, and to simplify configurations.
To build pipeline-like <match> flow (like below), 'remove_prefix' is also needed.

```
<source>
  type any_input_plugin
  add_prefix original
</source>
<match original.**>
  type exec_filter
  command foo_command_1
  remove_prefix original
  add_prefix converted_once
</match>
<match converted_once.**>
  type exec_filter
  command foo_command_2
  remove_prefix converted_once
  add_prefix fully_converted
</match>
<match fully_converted.**>
  type any_output_plugin
  remove_prefix fully_converted
</match>
```
