### PR TITLE
Small fix to syslog parser for rsyslog on CentOS and likely others

### DIFF
--- a/lib/fluent/parser.rb
+++ b/lib/fluent/parser.rb
@@ -21,7 +21,7 @@ module Fluent
 class TextParser
   TEMPLATES = {
     'apache' => [/^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$/, "%d/%b/%Y:%H:%M:%S %z"],
-    'syslog' => [/^(?<time>[^ ]* [^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?[^\:]*\: *(?<message>.*)$/, "%b %d %H:%M:%S"],
+    'syslog' => [/^(?<time>[^ ]*\s*[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?[^\:]*\: *(?<message>.*)$/, "%b %d %H:%M:%S"],
   }
 
   def self.register_template(name, regexp, time_format=nil)


### PR DESCRIPTION
Some syslog daemons (rsyslog on CentOS for example) seem to format the
day in the date string without a leading 0 in the case of days 0-9. The
parser would not parse them before even with the data format set to %b
%-d %H:%M:%S. By allowing for 1 or more spaces between the month and
day this issue is resolved.
