### PR TITLE
Small typo in lib/engine.rb

### DIFF
--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -108,7 +108,7 @@ class EngineClass
     end
     target.emit(tag, es)
   rescue
-    $log.warn "emit transaction faild ", :error=>$!.to_s
+    $log.warn "emit transaction failed ", :error=>$!.to_s
     $log.warn_backtrace
     raise
   end


### PR DESCRIPTION
Not a big deal at all, but I believe that this error message has a typo.

http://www.wordnik.com/words/faild

“With enough eyeballs, all bugs are shallow.”
— Linus Torvalds

Regards.
