### PR TITLE
fix not to set time in TextParser for data without time

### DIFF
--- a/lib/fluent/plugin/in_syslog.rb
+++ b/lib/fluent/plugin/in_syslog.rb
@@ -127,7 +127,6 @@ class SyslogInput < Input
     text = m[2]
 
     time, record = @parser.parse(text)
-    time ||= Fluent::Engine.now
     unless time && record
       return
     end

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -92,7 +92,6 @@ class TailInput < Input
       begin
         line.rstrip!  # remove \n
         time, record = parse_line(line)
-        time ||= Fluent::Engine.now
         if time && record
           es.add(time, record)
         end


### PR DESCRIPTION
Fluent::TextParser sets current timestamp into message, but it is not parser's business.
Each input (or filter) plugin should decide what timestamp to sed into message.
