### PR TITLE
bug in TextParser.register_template typing

### DIFF
--- a/lib/fluent/parser.rb
+++ b/lib/fluent/parser.rb
@@ -98,10 +98,10 @@ class TextParser
 
   def self.register_template(name, regexp_or_proc, time_format=nil)
     if regexp_or_proc.is_a?(Regexp)
-      pr = regexp_or_proc
-    else
       regexp = regexp_or_proc
       pr = RegexpParser.new(regexp, {'time_format'=>time_format})
+    else
+      pr = regexp_or_proc
     end
 
     TEMPLATES[name] = pr


### PR DESCRIPTION
The "if" statement is reversed: it checks for a Regexp type but handles the case of a Regexp type in the "else" block.  If you pass a Regexp in it treats it as a class instance which results in
`error="undefined method `call' for #<Regexp:0x007f3c0f8b1df0>"`
