### PR TITLE
Has changed the "remove \n" method (rstrip! -> chomp!).

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -90,7 +90,7 @@ class TailInput < Input
     es = MultiEventStream.new
     lines.each {|line|
       begin
-        line.rstrip!  # remove \n
+        line.chomp!  # remove \n
         time, record = parse_line(line)
         if time && record
           es.add(time, record)

--- a/test/plugin/in_tail.rb
+++ b/test/plugin/in_tail.rb
@@ -75,5 +75,33 @@ class TailInputTest < Test::Unit::TestCase
     assert_equal(true, emits.length > 0)
     assert_equal({"message"=>"test3test4"}, emits[0][2])
   end
-end
 
+  def test_whitespace
+    File.open("#{TMP_DIR}/tail.txt", "w") {|f| }
+
+    d = create_driver
+
+    d.run do
+      sleep 1
+
+      File.open("#{TMP_DIR}/tail.txt", "a") {|f|
+        f.puts "    "		# 4 spaces
+        f.puts "    4 spaces"
+        f.puts "4 spaces    "
+        f.puts "	"	# tab
+        f.puts "	tab"
+        f.puts "tab	"
+      }
+      sleep 1
+    end
+
+    emits = d.emits
+    assert_equal(true, emits.length > 0)
+    assert_equal({"message"=>"    "}, emits[0][2])
+    assert_equal({"message"=>"    4 spaces"}, emits[1][2])
+    assert_equal({"message"=>"4 spaces    "}, emits[2][2])
+    assert_equal({"message"=>"	"}, emits[3][2])
+    assert_equal({"message"=>"	tab"}, emits[4][2])
+    assert_equal({"message"=>"tab	"}, emits[5][2])
+  end
+end


### PR DESCRIPTION
Please merge, thanks.
- Changes:
  - I changed `String#rstrip!` to `String#chomp!` for `recieve_lines` method of in_tail plugin.
- Reason:
  - `String#rsrip!` deletes all whitespace(tab,space,line break).That means it deletes end of null columns for TSV(Tab Separated Values).
