### PR TITLE
implement simple weighted round robin

### DIFF
--- a/test/plugin/out_roundrobin.rb
+++ b/test/plugin/out_roundrobin.rb
@@ -19,6 +19,20 @@ class RoundRobinOutputTest < Test::Unit::TestCase
       name c2
     </store>
   ]
+  CONFIG2 = %[
+<store weight:3>
+  type test
+  name c0
+</store>
+<store weight:3>
+  type test
+  name c1
+</store>
+<store>
+  type test
+  name c2
+</store>
+]
 
   def create_driver(conf = CONFIG)
     Fluent::Test::OutputTestDriver.new(Fluent::RoundRobinOutput).configure(conf)
@@ -35,6 +49,29 @@ class RoundRobinOutputTest < Test::Unit::TestCase
     assert_equal "c0", outputs[0].name
     assert_equal "c1", outputs[1].name
     assert_equal "c2", outputs[2].name
+
+    weights = d.instance.weights
+    assert_equal 3, weights.size
+    assert_equal 1, weights[0]
+    assert_equal 1, weights[1]
+    assert_equal 1, weights[2]
+
+    d = create_driver(CONFIG2)
+
+    outputs = d.instance.outputs
+    assert_equal 3, outputs.size
+    assert_equal Fluent::TestOutput, outputs[0].class
+    assert_equal Fluent::TestOutput, outputs[1].class
+    assert_equal Fluent::TestOutput, outputs[2].class
+    assert_equal "c0", outputs[0].name
+    assert_equal "c1", outputs[1].name
+    assert_equal "c2", outputs[2].name
+
+    weights = d.instance.weights
+    assert_equal 3, weights.size
+    assert_equal 3, weights[0]
+    assert_equal 3, weights[1]
+    assert_equal 1, weights[2]
   end
 
   def test_emit
@@ -60,6 +97,38 @@ class RoundRobinOutputTest < Test::Unit::TestCase
     assert_equal [
         [time, {"a"=>3}],
       ], os[2].events
+  end
+
+  def test_emit_weighted
+    d = create_driver(CONFIG2)
+
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    (1..12).each do |i|
+      d.emit({"a"=>i}, time)
+    end
+
+    os = d.instance.outputs
+
+    assert_equal [
+      [time, {"a"=>1}],
+      [time, {"a"=>4}],
+      [time, {"a"=>6}],
+      [time, {"a"=>8}],
+      [time, {"a"=>11}],
+    ], os[0].events
+
+    assert_equal [
+      [time, {"a"=>2}],
+      [time, {"a"=>5}],
+      [time, {"a"=>7}],
+      [time, {"a"=>9}],
+      [time, {"a"=>12}],
+    ], os[1].events
+
+    assert_equal [
+      [time, {"a"=>3}],
+      [time, {"a"=>10}],
+    ], os[2].events
   end
 end
 


### PR DESCRIPTION
Patches that we can specify 'weight' for each stores like this:

```
<match foo.**>
  type roundrobin
  <store weight:3> # A
    type bar
    # ...
  </store>
  <store weight:2> # B
    type bar
    # ...
  </store>
  <store weight:1> # C
    type bar
    # ...
  </store>
</match>
```

out_roundrobin with this patch does very simple weighted round-robin, like below:

```
A(1), B(1), C(1), A(2), B(2), A(3), A(1), B(1), C(1), A(2), B(2), A(3), ...
```
