### PR TITLE
Added compression and encryption feature to forward plugin.

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -38,6 +38,10 @@ class ForwardOutput < ObjectBufferedOutput
   # backward compatibility
   config_param :port, :integer, :default => DEFAULT_LISTEN_PORT
   config_param :host, :string, :default => nil
+  # encrypt
+  config_param :password, :string, :default => nil
+  # compress
+  config_param :compression_level, :integer, :default => 0
 
   def configure(conf)
     super
@@ -53,6 +57,10 @@ class ForwardOutput < ObjectBufferedOutput
     end
 
     recover_sample_size = @recover_wait / @heartbeat_interval
+
+    @compression_level = [9, @compression_level].min
+    @compression_level = nil if @compression_level <= 0
+    $log.info "compression level is #{@compression_level}" if @compression_level
 
     conf.elements.each {|e|
       next if e.name != "server"
@@ -148,6 +156,22 @@ class ForwardOutput < ObjectBufferedOutput
     end
   end
 
+  protected
+  def encrypt(data, password, salt = '')
+    cipher = OpenSSL::Cipher::BF.new
+    key_iv = OpenSSL::PKCS5.pbkdf2_hmac_sha1(password, salt, 2000, cipher.key_len + cipher.iv_len)
+    key = key_iv[0, cipher.key_len]
+    iv = key_iv[cipher.key_len, cipher.iv_len]
+    cipher.key = key
+    cipher.iv = iv
+    cipher.encrypt
+    
+    encrypted_data = ''
+    encrypted_data << cipher.update(data)
+    encrypted_data << cipher.final
+    encrypted_data 
+  end
+
   private
   def rebuild_weight_array
     standby_nodes, regular_nodes = @nodes.values.partition {|n|
@@ -191,8 +215,8 @@ class ForwardOutput < ObjectBufferedOutput
     @weight_array = weight_array
   end
 
-  # MessagePack FixArray length = 2
-  FORWARD_HEADER = [0x92].pack('C')
+  # MessagePack FixArray length = 3
+  FORWARD_HEADER = [0x93].pack('C')
 
   def send_data(node, tag, es)
     sock = connect(node)
@@ -203,6 +227,39 @@ class ForwardOutput < ObjectBufferedOutput
       opt = [@send_timeout.to_i, 0].pack('L!L!')  # struct timeval
       sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDTIMEO, opt)
 
+      # attribute
+      attribute = {}
+      attribute_detail = {}
+      attribute_detail['compressed'] = !@compression_level.nil?
+      attribute['encrypted'] = !@password.nil?
+      attribute['detail'] = attribute_detail
+
+      entries = es.read
+
+      if attribute_detail['compressed']
+        # entries
+        before_size = entries.bytesize
+        entries = Zlib::Deflate.deflate(entries, @compression_level)
+        after_size = entries.bytesize
+        percent = sprintf("%.2f", after_size.to_f / before_size.to_f * 100)
+        $log.trace("entries deflated: #{before_size} bytes to #{after_size} bytes (#{percent} %)")
+      end
+      if attribute['encrypted']
+        # salt
+        attribute['salt'] = OpenSSL::Random.random_bytes(8)
+        # tag
+        decrypted_tag = tag.dump
+        tag = encrypt(tag, @password, attribute['salt'])
+        encrypted_tag = tag.dump
+        $log.trace("tag encrypted(dump): [#{decrypted_tag}] -> [#{encrypted_tag}]")
+        # entries
+        entries = encrypt(entries, @password, attribute['salt'])
+        # attribute detail
+        attribute_detail = encrypt(attribute_detail.to_msgpack, @password, attribute['salt'])
+      end
+      $log.trace("msg attribute:#{attribute}")
+      attribute['detail'] = attribute_detail
+
       # beginArray(2)
       sock.write FORWARD_HEADER
 
@@ -210,7 +267,7 @@ class ForwardOutput < ObjectBufferedOutput
       sock.write tag.to_msgpack  # tag
 
       # beginRaw(size)
-      sz = es.size
+      sz = entries.bytesize
       #if sz < 32
       #  # FixRaw
       #  sock.write [0xa0 | sz].pack('C')
@@ -223,7 +280,10 @@ class ForwardOutput < ObjectBufferedOutput
       #end
 
       # writeRawBody(packed_es)
-      es.write_to(sock)
+      sock.write entries
+
+      # write attribute
+      sock.write attribute.to_msgpack
     ensure
       sock.close
     end

--- a/test/plugin/in_forward.rb
+++ b/test/plugin/in_forward.rb
@@ -93,6 +93,31 @@ class ForwardInputTest < Test::Unit::TestCase
     end
   end
 
+  def test_packed_compressed_forward
+    d = create_driver
+
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+
+    d.expect_emit "tag1", time, {"a"=>1}
+    d.expect_emit "tag1", time, {"a"=>2}
+
+    d.run do
+      entries = ''
+      d.expected_emits.each {|tag,time,record|
+        [time, record].to_msgpack(entries)
+      }
+      data = [
+        "tag1",
+        Zlib::Deflate.deflate(entries),
+	{
+          "detail" => { "compressed" => true, },
+	},
+      ]
+      send_data data.to_msgpack
+      sleep 0.5
+    end
+  end
+
   def test_message_json
     d = create_driver
 
@@ -107,6 +132,84 @@ class ForwardInputTest < Test::Unit::TestCase
       }
       sleep 0.5
     end
+  end
+
+  CONFIG_ENCRYPTED = %[
+    port 13998
+    bind 127.0.0.1
+    password pass
+  ]
+  def test_packed_encrypted_forward
+    d = create_driver CONFIG_ENCRYPTED 
+
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+
+    d.expect_emit "tag1", time, {"a"=>1}
+    d.expect_emit "tag1", time, {"a"=>2}
+
+    salt = OpenSSL::Random.random_bytes(8)
+
+    d.run do
+      entries = ''
+      d.expected_emits.each {|tag,time,record|
+        [time, record].to_msgpack(entries)
+      }
+      data = [
+        encrypt("tag1", "pass", salt),
+        encrypt(entries, "pass", salt),
+	{
+	  "encrypted" => true,
+	  "salt" => salt,
+          "detail" => encrypt({}.to_msgpack, "pass", salt),
+	}
+      ]
+      send_data data.to_msgpack
+      sleep 0.5
+    end
+  end
+
+  def test_packed_encrypted_compressed_forward
+    d = create_driver CONFIG_ENCRYPTED 
+
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+
+    d.expect_emit "tag1", time, {"a"=>1}
+    d.expect_emit "tag1", time, {"a"=>2}
+
+    salt = OpenSSL::Random.random_bytes(8)
+
+    d.run do
+      entries = ''
+      d.expected_emits.each {|tag,time,record|
+        [time, record].to_msgpack(entries)
+      }
+      data = [
+        encrypt("tag1", "pass", salt),
+        encrypt(Zlib::Deflate.deflate(entries), "pass", salt),
+        {
+          "encrypted" => true,
+          "salt" => salt,
+          "detail" => encrypt({ "compressed" => true, }.to_msgpack, "pass", salt),
+        },
+      ]
+      send_data data.to_msgpack
+      sleep 0.5
+    end
+  end
+
+  def encrypt(data, password, salt = '')
+    cipher = OpenSSL::Cipher::BF.new
+    key_iv = OpenSSL::PKCS5.pbkdf2_hmac_sha1(password, salt, 2000, cipher.key_len + cipher.iv_len)
+    key = key_iv[0, cipher.key_len]
+    iv = key_iv[cipher.key_len, cipher.iv_len]
+    cipher.key = key
+    cipher.iv = iv
+    cipher.encrypt
+
+    encrypted_data = ''
+    encrypted_data << cipher.update(data)
+    encrypted_data << cipher.final
+    encrypted_data 
   end
 
   def send_data(data)

--- a/test/plugin/out_forward.rb
+++ b/test/plugin/out_forward.rb
@@ -7,6 +7,8 @@ class ForwardOutputTest < Test::Unit::TestCase
 
   CONFIG = %[
     send_timeout 51
+    password pass
+    compression_level 9
     <server>
       name test
       host 127.0.0.1
@@ -26,6 +28,8 @@ class ForwardOutputTest < Test::Unit::TestCase
     d = create_driver
     nodes = d.instance.nodes
     assert_equal 51, d.instance.send_timeout
+    assert_equal "pass", d.instance.password
+    assert_equal 9, d.instance.compression_level
     assert_equal 1, nodes.length
     node = nodes.values.first
     assert_equal "test", node.name


### PR DESCRIPTION
This patch provides compression and encryption feature to in_forward, out_forward plugin.
I also added `password` and `compression_level` for out_forward but only `password` added for in_forward.

out_forward's example goes bellow:

```
<match tags.**>
  type forward
  password pass
  compression_level 9
  <server>
    host localhost
    weight 10
  </server>
</match>
```

in_forward's example goes bellow:

```
<source>
  type forward
  password pass
</source>
```
##### description(in Japanese)

I'm Sorry I'm not good at writing English.
- 共通事項
  - forward時のmessageタイプがPackedForwardである場合, 後述の通り設定に応じてmessageが暗号化, 圧縮されます.
  - 暗号化と圧縮は個別にenable/disableすることができます.
  - 本patch適用後のin_forward, out_forwardは, 暗号化と圧縮をdisableにしている限り, 過去のバージョンとの互換性を保ちます.
  - 暗号化と圧縮についての属性情報を伝達する必要があるため, in_forwardとout_forwardは以下を行います.
    - out_forwardではPackedForward messageの第3要素にHashを格納して送信します.
    - in_forwardでは受信したmessageがPackedForwardであり, かつ第3要素が付加されている場合, 第3要素を属性情報として解釈します.
- 暗号化について
  - out_forward設定ファイルの`password`項目にパスワードを設定するとmessageが暗号化されます.
  - in_forward設定ファイルの`password`項目には, out_forward設定ファイルと同一のパスワードを設定する必要があります.
  - 暗号化にはOpenSSLを使用します.
  - 暗号化アルゴリズムは現時点ではBlowfishに限定しています, これはアルゴリズムを選択する必要性を見いださなかったためです.
  - 毎回異なるsaltが自動生成され, out_forwardからin_forwardへ平文で送信されます.
- 圧縮について
  - out_forward設定ファイルの`compression_level`項目に1以上の数値を設定するとmessageのraw entriesが圧縮されます.
  - 圧縮にはzlibを使用します.
  - `compression_level`の設定数値は9が一番圧縮率が高く, 9を超える数値を設定した場合, 9に補正されます.
  - `compression_level`に0を設定した場合, 圧縮されません.
