### PR TITLE
fixed a variable name in TestDriver#configure

### DIFF
--- a/lib/fluent/test/base.rb
+++ b/lib/fluent/test/base.rb
@@ -39,7 +39,7 @@ class TestDriver
 
   def configure(str)
     if str.is_a?(Config)
-      @config = @str
+      @config = str
     else
       @config = Config.parse(str, "(test)")
     end


### PR DESCRIPTION
This is just a minor bug. Please see the diff.
