### PR TITLE
Fix SYSLOG_ALL_REGEXP

### DIFF
--- a/lib/fluent/plugin/in_syslog.rb
+++ b/lib/fluent/plugin/in_syslog.rb
@@ -22,7 +22,7 @@ class SyslogInput < Input
   Plugin.register_input('syslog', self)
 
   SYSLOG_REGEXP = /^\<([0-9]+)\>(.*)/
-  SYSLOG_ALL_REGEXP = /^\<(?<pri>[0-9]+)\>(?<time>[^ ]* [^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?[^\:]*\: *(?<message>.*)$/
+  SYSLOG_ALL_REGEXP = /^\<(?<pri>[0-9]+)\>(?<time>[^ ]*\s+[^ ]*\s+[^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?[^\:]*\: *(?<message>.*)$/
   TIME_FORMAT = "%b %d %H:%M:%S"
 
   FACILITY_MAP = {


### PR DESCRIPTION
When day of the month is one-digit SYSLOG_ALL_REGEXP doesn't match time properly

``` ruby
message = "<30>Sep  4 09:23:02 fluent dhclient: DHCPACK of 192.168.20.8 from 192.168.20.1" # from fluent debug

# fluent.warn: {"message":"\"<30>Sep  4 09:23:02 fluent dhclient: DHCPACK of 192.168.20.8 from 192.168.20.1\"","error":"invalid strptime format - `%b %d %H:%M:%S'"}

SYSLOG_ALL_REGEXP = /^\<(?<pri>[0-9]+)\>(?<time>[^ ]*\ [^ ]*\ [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?[^\:]*\: *(?<message>.*)$/
m = SYSLOG_ALL_REGEXP.match(message)
m[:time]   # output Sep 4
m[:host]   # output 09:23:02
```

Care for two spaces between Sep and 4

When day of the month is two-digit SYSLOG_ALL_REGEXP matches time properly

SYSLOG_ALL_REGEXP assumes that there will be a single space

With this minor fix time matches properly
