### PR TITLE
fix to mark node alive when send_data(over TCP) succeeded

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -223,6 +223,11 @@ class ForwardOutput < ObjectBufferedOutput
 
       # writeRawBody(packed_es)
       es.write_to(sock)
+
+      # success of send_data (over tcp) is valid heartbeat signal
+      if node.heartbeat
+        rebuild_weight_array
+      end
     ensure
       sock.close
     end


### PR DESCRIPTION
This fix to mark node of out_forward when TCP data transportation succeeded,
for udp unavailable (or unstable udp transportation) environment.
