### PR TITLE
Add secondary groups to the process when changing process uid

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -267,6 +267,13 @@ class Supervisor
           exit 1
         end
       end
+
+      user_groups = `id -G #{@chuser}`.split.map(&:to_i)
+      if $?.to_i != 0
+        exit 1
+      end
+
+      Process.groups = Process.groups | user_groups
       Process::UID.change_privilege(chuid)
     end
   end


### PR DESCRIPTION
I ran into this limitation in my environment using the td-agent distribution when trying to tail a file for input. I have a log file which is owned by an app specific user/group and has permissions of 660. I don't want to run fluentd (td-agent) as root nor as my app specific user.

I assumed that adding the td-agent user to my app specific group would inherit the secondary group membership and therefore be able to access my log file; but that's currently not the case.

Attached is a patch which will update the process with any secondary groups when changing the uid of the process.
