### PR TITLE
Could you add hostname option to in_tail.rb ?

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -98,7 +98,7 @@ class TailInput < Input
     lines.each {|line|
       begin
         line.chomp!  # remove \n
-        time,  record = parse_line(line)
+        time, record = parse_line(line)
 
         if time && record
           if @hostname


### PR DESCRIPTION
Configuration : 
<source>
  type tail
  format /^(?<remote>[^ ]_) (?<host>[^ ]_) (?<user>[^ ]_) [(?<time>[^]]_)] "(?<method>\S+)(?: +(?<path>[^ ]_) +\S_)?" (?<code>[^ ]_) (?<size>[^ ]_)(?: "(?<referer>[^\"]_)" "(?<agent>[^\"]_)" "(?<forward>[^\"]_)" (?<response_time>[^ ]_))?$/
  path /usr/local/nginx/logs/access.log
  pos_file /var/log/td-agent/access.log.pos
  time_format %d/%b/%Y:%H:%M:%S %z
  tag hostname.in.tail
  hostname_command hostname
</source>

Result :

2012-11-27T00:00:43+09:00       hostname.in.tail  {"hostname":"myhost","remote":"172.28.32.249","host":"-","user":"-","method":"GET","path":"/monitor","code":"200","size":"15","referer":"-","agent":"-","forward":"-","response_time":"0.003"}
