### PR TITLE
fix to increment @rr just before @weight_array access

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -128,8 +128,8 @@ class ForwardOutput < ObjectBufferedOutput
 
     wlen = @weight_array.length
     wlen.times do
-      node = @weight_array[@rr]
       @rr = (@rr + 1) % wlen
+      node = @weight_array[@rr]
 
       if node.available?
         begin


### PR DESCRIPTION
ForwardOutput node selection has bug of OutOfIndex with @rr and @weight_array after resize of @weight_array.

Just after recovery of detached nodes, @weight_array is shortened, but @rr is not initialized and may be greater than @weight_array.length. This makes OutOfIndex (node is nil).

This pullreq fixes this problem.

(@rr starts from 1 not 0, but this is very little problem....)
