### PR TITLE
tcp heartbeat

### DIFF
--- a/lib/fluent/plugin/in_forward.rb
+++ b/lib/fluent/plugin/in_forward.rb
@@ -28,6 +28,16 @@ class ForwardInput < Input
 
   config_param :port, :integer, :default => DEFAULT_LISTEN_PORT
   config_param :bind, :string, :default => '0.0.0.0'
+  config_param :heartbeat_type, :default => :udp do |val|
+    case val.downcase
+    when 'tcp'
+      :tcp
+    when 'udp'
+      :udp
+    else
+      raise ConfigError, "forward output heartbeat type is 'tcp' or 'udp'"
+    end
+  end
 
   def configure(conf)
     super
@@ -102,6 +112,11 @@ class ForwardInput < Input
   #   3: object record
   # }
   def on_message(msg)
+    if msg == nil
+      # for future TCP heartbeat
+      return
+    end
+
     # TODO format error
     tag = msg[0].to_s
     entries = msg[1]


### PR DESCRIPTION
https://github.com/fluent/fluentd/pull/74

Modified version of TCP heartbeat created by @tagomoris.
This doesn't send actual data and assumes connection success as the existence of the node to not break backward compatibility.

This also includes change for the future changes. in_forward ignores nil data so that in_forward can send actual data in the future without breaking compatibility.
