### PR TITLE
Added ASIS parser for reducing regexp overhead.

### DIFF
--- a/lib/fluent/parser.rb
+++ b/lib/fluent/parser.rb
@@ -147,6 +147,14 @@ class TextParser
     end
   end
 
+  class AsisParser
+    def call(text)
+      record = {}
+      record['message'] = text
+      return Engine.now, record
+    end
+  end
+
   class ApacheParser
     include Configurable
 
@@ -205,6 +213,7 @@ class TextParser
     'json' => Proc.new { JSONParser.new },
     'tsv' => Proc.new { TSVParser.new },
     'csv' => Proc.new { CSVParser.new },
+    'asis' => Proc.new { AsisParser.new },
     'nginx' => Proc.new { RegexpParser.new(/^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$/,  {'time_format'=>"%d/%b/%Y:%H:%M:%S %z"}) },
   }
 


### PR DESCRIPTION
This parser behave like the fluent-agent-lite.

fluent-agent-lite よりもデータのロスや重複に気を使っている in_tail を使いたいが regex のオーバーヘッドは確かに気になるので regexp 無しで行をまるごと取り込む Parser を追加してみました。
