### PR TITLE
LabeledTSVParser cannot handle time_key and time_format

### DIFF
--- a/lib/fluent/parser.rb
+++ b/lib/fluent/parser.rb
@@ -141,7 +141,7 @@ class TextParser
     config_param :label_delimiter, :string, :default =>  ":"
 
     def configure(conf)
-      conf['keys'] = ''
+      conf['keys'] = conf['time_key'] || ''
       super(conf)
     end
 

--- a/test/parser.rb
+++ b/test/parser.rb
@@ -166,5 +166,20 @@ module ParserTest
         'req'  => 'GET /list HTTP/1.1',
       }, record)
     end
+
+    def test_call_with_customized_time_format
+      parser = TextParser::LabeledTSVParser.new
+      parser.configure(
+        'time_key'    => 'time',
+        'time_format' => '[%d/%b/%Y:%H:%M:%S %z]',
+      )
+      time, record = parser.call("time:[28/Feb/2013:12:00:00 +0900]\thost:192.168.0.1\treq:GET /list HTTP/1.1")
+
+      assert_equal({
+        'time' => '[28/Feb/2013:12:00:00 +0900]',
+        'host' => '192.168.0.1',
+        'req'  => 'GET /list HTTP/1.1',
+      }, record)
+    end
   end
 end


### PR DESCRIPTION
LabeledTSVParser cannot handle `time_key` and `time_format` expectedly.
Without this fix, ValuesParser#configure will throw following ConfigError.

```
2013-02-14 21:03:45 +0900 [error]: config error file="fluent.conf" error="time_key (\"time\") is not included in keys ([])"
```

I used following fluent.conf for my tests.

```
<source>
  type tail
  path /var/log/nginx/ltsv.log
  pos_file tmp/ltsv.log.pos
  tag nginx.ltsv
  format ltsv
  time_key time
  time_format %d/%b/%Y:%H:%M:%S %z
</source>
```
