### PR TITLE
Fixed a bug that RecordFilterMixin does not work with stream

### DIFF
--- a/lib/fluent/mixin.rb
+++ b/lib/fluent/mixin.rb
@@ -93,7 +93,7 @@ module RecordFilterMixin
   def format_stream(tag, es)
     out = ''
     es.each {|time,record|
-      tag_temp = String.new(tag)
+      tag_temp = tag.dup
       filter_record(tag_temp, time, record)
       out << format(tag_temp, time, record)
     }

--- a/test/mixin.rb
+++ b/test/mixin.rb
@@ -51,7 +51,7 @@ module MixinTest
         def write(chunk); end
       }
 
-      Fluent::Test::BufferedOutputTestDriver.new(klass,tag) {
+      Fluent::Test::BufferedOutputTestDriver.new(klass, tag) {
       }.configure("type #{register_output_name}" + conf)
     end
   end
@@ -207,7 +207,7 @@ module MixinTest
       d = create_driver(Fluent::HandleTagNameMixin, %[
         remove_tag_prefix te
         include_tag_key true
-      ],"tetest")
+      ], "tetest")
 
       d.emit({'a' => 1})
       d.emit({'a' => 2})
@@ -225,7 +225,7 @@ module MixinTest
       d = create_driver(Fluent::HandleTagNameMixin, %[
         remove_tag_suffix st
         include_tag_key true
-      ],"testst")
+      ], "testst")
 
       d.emit({'a' => 1})
       d.emit({'a' => 2})


### PR DESCRIPTION
"format_stream" passes tag variable to "filter_record" without deep copying.
It works fine when there is only 1 record in stream.
But If the stream have n records, filter_record filters tag n times.
