### PR TITLE
update msgpack dependency (v0.4.4 -> v0.5.4)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ begin
     gemspec.homepage = "http://fluentd.org/"
     gemspec.has_rdoc = false
     gemspec.require_paths = ["lib"]
-    gemspec.add_dependency "msgpack", "~> 0.4.4", "~> 0.5.4"
+    gemspec.add_dependency "msgpack", ">= 0.4.4", "!= 0.5.0", "!= 0.5.1", "!= 0.5.2", "!= 0.5.3"
     gemspec.add_dependency "json", ">= 1.4.3"
     gemspec.add_dependency "yajl-ruby", "~> 1.0"
     gemspec.add_dependency "cool.io", "~> 1.1.0"


### PR DESCRIPTION
Fluentd with msgpack 0.5.4 works with dramatically less memory than with msgpack 0.4.7.

Memory resource graphs for my personal benchmarks below:
- Fluentd 0.10.32 + ruby 2.0.0-p0 + msgpack 0.4.7

http://cdn-ak.f.st-hatena.com/images/fotolife/t/tagomoris/20130315/20130315173133.png
- Fluentd 0.10.32 + ruby 2.0.0-p0 + msgpack 0.5.4 (09:00 - 12:00)

http://cdn-ak.f.st-hatena.com/images/fotolife/t/tagomoris/20130316/20130316125232.png
