### PR TITLE
Add attr_reader :wait to RotationRequest.

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -271,7 +271,7 @@ class TailInput < Input
         @wait = wait
       end
 
-      attr_reader :io
+      attr_reader :io, :wait
 
       def tick
         @wait -= 1


### PR DESCRIPTION
RotationRequest should have :wait attr_reader.
Because the following line exists in in_tail.rb:232.

  wait -= @rotate_queue.first.wait unless @rotate_queue.empty?
