### PR TITLE
enable log event for <match flunetd.*>

### DIFF
--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -145,7 +145,7 @@ class EngineClass
     begin
       start
 
-      if match?($log.tag)
+      if match?("#{$log.tag}.dummy")
         $log.enable_event
       end
 


### PR DESCRIPTION
Log event is not emitted when you have <match fluent.*> because $log.tag, 'fluent', does not match that pattern alone.

Discard this patch if this is intended behavior.
