### PR TITLE
fix to protect log from record modification

### DIFF
--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -255,7 +255,9 @@ class Log
     if @self_event
       c = caller
       if c.count(c.shift) <= 0
-        Engine.emit("#{@tag}.#{level}", time.to_i, record.dup)
+        r = record.dup
+        r['message'] = message.dup
+        Engine.emit("#{@tag}.#{level}", time.to_i, r)
       end
     end
 


### PR DESCRIPTION
By emitting log record itself, we can break log record data by <match fluent.**> configurations.
To preserve log record itself in stdout, fix to do `log.dup`.
