### PR TITLE
fix to suppress exception for flushing without any valid data

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -131,6 +131,8 @@ class ForwardOutput < ObjectBufferedOutput
   def write_objects(tag, es)
     error = nil
 
+    return if es.size < 1
+
     wlen = @weight_array.length
     wlen.times do
       @rr = (@rr + 1) % wlen


### PR DESCRIPTION
Fluentd configured with 'flush_interval' logs errors like below, with short downtime of forwarded node.

```
temporarily failed to flush the buffer, next retry will be at 2013-04-30 15:56:14 +0900.: no nodes are available
```

This log should be suppressed when buffer chunk is blank. So I wrote this patch.
