### PR TITLE
fix warn log message to have same string for same kind of warnings

### DIFF
--- a/lib/fluent/output.rb
+++ b/lib/fluent/output.rb
@@ -324,7 +324,7 @@ class BufferedOutput < Output
       end
 
       if error_count < @retry_limit
-        $log.warn "temporarily failed to flush the buffer, next retry will be at #{Time.at(@next_retry_time)}.", :error=>e.to_s, :instance=>object_id
+        $log.warn "temporarily failed to flush the buffer.", :next_retry=>Time.at(@next_retry_time), :error=>e.to_s, :instance=>object_id
         $log.warn_backtrace e.backtrace
 
       elsif @secondary
@@ -334,7 +334,7 @@ class BufferedOutput < Output
           $log.warn_backtrace e.backtrace
           retry  # retry immediately
         elsif error_count <= @retry_limit + @secondary_limit
-          $log.warn "failed to flush the buffer, next retry will be with secondary output at #{Time.at(@next_retry_time)}.", :error=>e.to_s, :instance=>object_id
+          $log.warn "failed to flush the buffer, next retry will be with secondary output.", :next_retry=>Time.at(@next_retry_time), :error=>e.to_s, :instance=>object_id
           $log.warn_backtrace e.backtrace
         else
           $log.warn "failed to flush the buffer.", :error=>e.to_s, :instance=>object_id


### PR DESCRIPTION
To suppress warn/error logs, we need same string for same errors.
Next retry time at the end of warn string prevent same warn/error check.
