### PR TITLE
add option to suppress error logs with specified interval

### DIFF
--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -35,6 +35,7 @@ opts = {
   :setup_path => nil,
   :chuser => nil,
   :chgroup => nil,
+  :suppress_interval => 0,
 }
 
 op.on('-s', "--setup [DIR=#{File.dirname(Fluent::DEFAULT_CONFIG_PATH)}]", "install sample configuration file to the directory") {|s|
@@ -77,6 +78,9 @@ op.on('-i', '--inline-config CONFIG_STRING', "inline config which is appended to
   opts[:inline_config] = s
 }
 
+op.on('--emit-error-log-interval SECONDS', "suppress interval seconds of emit error logs") {|s|
+  opts[:suppress_interval] = s.to_i
+}
 
 op.on('-v', '--verbose', "increase verbose level (-v: debug, -vv: trace)", TrueClass) {|b|
   if b

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -67,6 +67,7 @@ class Supervisor
     @libs = opt[:libs]
     @plugin_dirs = opt[:plugin_dirs]
     @inline_config = opt[:inline_config]
+    @suppress_interval = opt[:suppress_interval]
 
     @log = LoggerInitializer.new(@log_path, @log_level, @chuser, @chgroup)
     @finished = false
@@ -281,6 +282,9 @@ class Supervisor
   def init_engine
     require 'fluent/load'
     Fluent::Engine.init
+    if @suppress_interval
+      Fluent::Engine.suppress_interval(@suppress_interval)
+    end
 
     @libs.each {|lib|
       require lib


### PR DESCRIPTION
When fluentd is in trouble (ex: buffer chunk full) that every emit for all messages will fails, Fluent::Engine.emit writes error log and stacktrace for every emit event.

This brings error log storm for fluentd's log. Traffic of 10 message per seconds brings 15 lines of warn log and stacktrace lines in `Fluent::Engine#emit`.
And out_exec_filter calls every time for each one messages. This brings more fluentd error log storm, and its including message content itself.

In troubles, investigations are very hard by this fluentd's log storm. We need options to suppress these logs seriously.

(For farther versions, we may need configuration sections like `<logger>` or other such that.)
