### PR TITLE
Fix copy plugin event leak

### DIFF
--- a/lib/fluent/event.rb
+++ b/lib/fluent/event.rb
@@ -112,9 +112,8 @@ end
 
 
 class MessagePackEventStream < EventStream
-  def initialize(data, cached_unpacker=nil)
+  def initialize(data)
     @data = data
-    @unpacker = cached_unpacker || MessagePack::Unpacker.new
   end
 
   def repeatable?
@@ -122,9 +121,9 @@ class MessagePackEventStream < EventStream
   end
 
   def each(&block)
-    @unpacker.reset
     # TODO format check
-    @unpacker.feed_each(@data, &block)
+    unpacker = MessagePack::Unpacker.new
+    unpacker.feed_each(@data, &block)
     nil
   end
 

--- a/lib/fluent/plugin/in_forward.rb
+++ b/lib/fluent/plugin/in_forward.rb
@@ -46,7 +46,6 @@ class ForwardInput < Input
     @loop.attach(@hbr)
 
     @thread = Thread.new(&method(:run))
-    @cached_unpacker = MessagePack::Unpacker.new
   end
 
   def shutdown
@@ -114,7 +113,7 @@ class ForwardInput < Input
 
     if entries.class == String
       # PackedForward
-      es = MessagePackEventStream.new(entries, @cached_unpacker)
+      es = MessagePackEventStream.new(entries)
       Engine.emit_stream(tag, es)
 
     elsif entries.class == Array

--- a/lib/fluent/plugin/in_stream.rb
+++ b/lib/fluent/plugin/in_stream.rb
@@ -31,7 +31,6 @@ class StreamInput < Input
     @lsock = listen
     @loop.attach(@lsock)
     @thread = Thread.new(&method(:run))
-    @cached_unpacker = MessagePack::Unpacker.new
   end
 
   def shutdown
@@ -79,7 +78,7 @@ class StreamInput < Input
 
     if entries.class == String
       # PackedForward
-      es = MessagePackEventStream.new(entries, @cached_unpacker)
+      es = MessagePackEventStream.new(entries)
       Engine.emit_stream(tag, es)
 
     elsif entries.class == Array

--- a/lib/fluent/process.rb
+++ b/lib/fluent/process.rb
@@ -180,7 +180,6 @@ class DetachProcessManager
 
   def read_event_stream(r, &block)
     u = MessagePack::Unpacker.new(r)
-    cached_unpacker = MessagePack::Unpacker.new
     begin
       #buf = ''
       #map = {}
@@ -195,14 +194,14 @@ class DetachProcessManager
       #  }
       #  unless map.empty?
       #    map.each_pair {|tag,ms|
-      #      es = MessagePackEventStream.new(ms, cached_unpacker)
+      #      es = MessagePackEventStream.new(ms)
       #      block.call(tag, es)
       #    }
       #    map.clear
       #  end
       #end
       u.each {|tag,ms|
-        es = MessagePackEventStream.new(ms, cached_unpacker)
+        es = MessagePackEventStream.new(ms)
         block.call(tag, es)
       }
     rescue EOFError

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -3,6 +3,11 @@ require 'fileutils'
 require 'fluent/log'
 require 'rr'
 
+unless defined?(Test::Unit::AssertionFailedError)
+  class Test::Unit::AssertionFailedError < StandardError
+  end
+end
+
 class Test::Unit::TestCase
   include RR::Adapters::TestUnit
 end


### PR DESCRIPTION
This fixes a serious bug that makes the copy plugin leak events when used with time sliced output plugins. And possibly other cases of event leak.

Sharing a a single instance of MesspaPack::Unpacker between input plugins and
MessagePackEventStream instances is unsafe. A test case has been added
to prove how easy it is leak events with the copy plugin and multiple
output plugins.

/cc: @kzk
