### PR TITLE
Calculation phi in out_forward.rb seems wrong.

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -486,7 +486,7 @@ class ForwardOutput < ObjectBufferedOutput
       mean = (mean_usec.to_f / 1e6) - @heartbeat_interval + 1
 
       # Calculate phi of the phi accrual failure detector
-      t = now - @last
+      t = now - @last - @heartbeat_interval + 1
       phi = PHI_FACTOR * t / mean
 
       return phi


### PR DESCRIPTION
The method 'phi(now) of 'FailureDetector class seems to calculate the variable 't wrong way.

When @heartbeat_interval is not the default value (1 sec), 't value contains (@heartbeat_interval - 1) sec. But 'mean doesn't. So @heartbeat_interval is set higher, 'phi(now) returns a higher value.

I'm sorry but I don't know the phi accuracy calculation logic precisely. But there seems no documentation or reference of the phi_threshold directive and this logic may confuse some people like me.

Thank you in advance.
