### PR TITLE
Add file permission parameter to each file creation. fixes #138

### DIFF
--- a/lib/fluent/env.rb
+++ b/lib/fluent/env.rb
@@ -3,4 +3,5 @@ DEFAULT_CONFIG_PATH = ENV['FLUENT_CONF'] || '/etc/fluent/fluent.conf'
 DEFAULT_PLUGIN_DIR = ENV['FLUENT_PLUGIN'] || '/etc/fluent/plugin'
 DEFAULT_SOCKET_PATH = ENV['FLUENT_SOCKET'] || '/var/run/fluent/fluent.sock'
 DEFAULT_LISTEN_PORT = 24224
+DEFAULT_FILE_PERMISSION = 0644
 end

--- a/lib/fluent/plugin/buf_file.rb
+++ b/lib/fluent/plugin/buf_file.rb
@@ -23,7 +23,7 @@ class FileBufferChunk < BufferChunk
     super(key)
     @path = path
     @unique_id = unique_id
-    @file = File.open(@path, mode)
+    @file = File.open(@path, mode, DEFAULT_FILE_PERMISSION)
     @file.sync = true
     @size = @file.stat.size
   end

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -42,7 +42,7 @@ class TailInput < Input
     end
 
     if @pos_file
-      @pf_file = File.open(@pos_file, File::RDWR|File::CREAT)
+      @pf_file = File.open(@pos_file, File::RDWR|File::CREAT, DEFAULT_FILE_PERMISSION)
       @pf_file.sync = true
       @pf = PositionFile.parse(@pf_file)
     else

--- a/lib/fluent/plugin/out_file.rb
+++ b/lib/fluent/plugin/out_file.rb
@@ -89,7 +89,7 @@ class FileOutput < TimeSlicedOutput
 
     case @compress
     when nil
-      File.open(path, "a") {|f|
+      File.open(path, "a", DEFAULT_FILE_PERMISSION) {|f|
         chunk.write_to(f)
       }
     when :gz


### PR DESCRIPTION
Non daemonized fluentd, create a file as 0644 permission.
But daemonized fluentd, create a file as 0666 or other permission.
It is caused by File.umask(0) at daemonize process,
so we should specify file permission for better permission management.
