### PR TITLE
Add `encoding` option to `fluentd` command

### DIFF
--- a/lib/fluent/config.rb
+++ b/lib/fluent/config.rb
@@ -167,6 +167,7 @@ module Config
 
     def parse!(allow_include, elem_name=nil, attrs={}, elems=[])
       while line = @iterator.next
+        line.force_encoding('UTF-8')
         @i += 1
         line.lstrip!
         line.gsub!(/\s*(?:\#.*)?$/,'')


### PR DESCRIPTION
I have an issue td-agent fails to parse the config file that includes multi-bytes characters. Which doesn't occurs when td-agent is started with `/etc/init.d/td-agent`, but does when started with `service` command.

It seems to be due to the difference of environment variables between `/etc/init.d/td-agent` and `service` command. The latter doesn't inherit environment variables from the terminal from which the command is executed.

You can see the details in [this blog post](http://heartbeats.jp/hbblog/2013/06/service-start-stop.html).

I'll propose we set default encoding of the config file and provide an option to change the encoding via `fluentd` command. The default value (UTF-8) can be considered safe in almost all of the cases, I guess.
