### PR TITLE
fix testlogger

### DIFF
--- a/lib/fluentd/plugin_spec_helper.rb
+++ b/lib/fluentd/plugin_spec_helper.rb
@@ -126,7 +126,7 @@ module Fluentd
       def initialize(dev, config={})
         super
         @logdev = DummyLogDevice.new
-        self.level = 'debug'
+        self.level = ::Logger::DEBUG
       end
 
       def logs


### PR DESCRIPTION
@tagomoris

I got an error as bolows when I tested my plugin (fluent-plugin-grep). 

```
"/Users/seo.naotoshi/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/logger.rb:370:in `<'",
"/Users/seo.naotoshi/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/logger.rb:370:in `add'",
"/Users/seo.naotoshi/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/logger.rb:456:in `error'",
```
