### PR TITLE
fix "lib/fluentd/actors/timer_actor.rb:27:in `after': undefined local variable or method `interval_sec'"

### DIFF
--- a/lib/fluentd/actors/timer_actor.rb
+++ b/lib/fluentd/actors/timer_actor.rb
@@ -24,7 +24,7 @@ module Fluentd
       end
 
       def after(sec, &callback)
-        @loop.attach CallbackTimerWatcher.new(interval_sec, false, &callback)
+        @loop.attach CallbackTimerWatcher.new(sec, false, &callback)
       end
 
       class CallbackTimerWatcher < Coolio::TimerWatcher

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -1,0 +1,10 @@
+require 'fluentd/actor'
+
+describe Fluentd::Actor do
+  describe Fluentd::Actors::TimerActor
+  it '#after' do
+    actor = described_class.new
+
+    expect(actor.after(0){}).to_not be_nil
+  end
+end


### PR DESCRIPTION
- rename interval_sec to sec
