### PR TITLE
PROPOSE: support time argument in #pitch at plugin_spec_helper (v11)

### DIFF
--- a/lib/fluentd/plugin_spec_helper.rb
+++ b/lib/fluentd/plugin_spec_helper.rb
@@ -40,17 +40,17 @@ module Fluentd
       end
 
       class BatchPitcher
-        def initialize(parent, tag, time)
+        def initialize(parent, tag, time=Time.now.to_i)
           @parent = parent
           @tag = tag
           @time = time
         end
-        def pitch(record)
-          @parent.pitch(@tag, @time, record)
+        def pitch(record, time=nil)
+          @parent.pitch(@tag, time ? time : @time, record)
         end
       end
 
-      def with(tag, time)
+      def with(tag, time=Time.now.to_i)
         raise ArgumentError unless block_given?
         yield BatchPitcher.new(self, tag, time)
       end


### PR DESCRIPTION
@tagomoris

In addition to

1)

```
  time = Time.now.to_i
  d.with('xxx', time) do |d|
    d.pitch({"f1"=>"data1", "f2"=>"data2"})
  end
```

I propose to support ways to write test as

2)

```
  time = Time.now.to_i
  d.with('xxx') do |d|
    d.pitch({"f1"=>"data1", "f2"=>"data2"}, time)
  end
```

and

3)

```
  d.with('xxx') do |d|
    d.pitch({"f1"=>"data1", "f2"=>"data2"})
  end
```

The 2nd way is good for v10 compatibility since v10's TestDriver#emit supports 2 arguments as

```
 def emit(record, time=Time.now)
```

Futhermore, someone may want to write test with different `time`s. We should support it. 

The 3rd way is the simplest way to write test. We often do not care of time in some test cases.
In the 3rd way, the time property is initialized with Time.now.to_i internally. 
