### PR TITLE
Modify .travis.yml to test v11 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,6 @@ rvm:
 branches:
   only:
     - master
+    - v11
 
-script: bundle exec rake test
+script: bundle exec rake


### PR DESCRIPTION
Now "v11" branch is very active but not yet on CI workflow.
in this PR I modified .travis.yml to build "v11" branch by Travis CI (as with "master" branch).
