### PR TITLE
add pitches in plugin_spec_helper (v11)

### DIFF
--- a/lib/fluentd/plugin_spec_helper.rb
+++ b/lib/fluentd/plugin_spec_helper.rb
@@ -39,6 +39,10 @@ module Fluentd
         @instance.emit(tag, time, record)
       end
 
+      def pitches(tag, es)
+        @instance.emits(tag, es)
+      end
+
       class BatchPitcher
         def initialize(parent, tag, time)
           @parent = parent
@@ -47,6 +51,10 @@ module Fluentd
         end
         def pitch(record)
           @parent.pitch(@tag, @time, record)
+        end
+
+        def pitches(es)
+          @parent.pitches(@tag, es)
         end
       end
 


### PR DESCRIPTION
I wanted to have a test helper method `#pitches` which calls pugin's `#emits(tag, es)` to test plugins such as fluent-plugin-grepcounter. This is maybe useful for fluent-plugin-datacounter, too. 
