### PR TITLE
#actor in filter plugin (v11)

### DIFF
--- a/lib/fluentd/plugin/filter.rb
+++ b/lib/fluentd/plugin/filter.rb
@@ -24,6 +24,9 @@ module Fluentd
     class Filter < Output
       # provides #collector
       include EventEmitter
+
+      # provides #actor
+      include Actor::AgentMixin
     end
 
   end


### PR DESCRIPTION
I want to use `actor.every(interval) { ... }` in filter plugins such as fluent-plugin-grepcounter. 
