### PR TITLE
Porting out_stdout (v11)

### DIFF
--- a/lib/fluentd/plugin/out_stdout.rb
+++ b/lib/fluentd/plugin/out_stdout.rb
@@ -44,7 +44,7 @@ module Fluentd
       end
 
       def emit(tag, time, record)
-        STDOUT.write "#{Time.at(time).localtime} #{tag}: #{@output_proc.call(record)}\n"
+        $stdout.write "#{Time.at(time).localtime} #{tag}: #{@output_proc.call(record)}\n"
       end
     end
 

--- a/spec/plugin/out_stdout_spec.rb
+++ b/spec/plugin/out_stdout_spec.rb
@@ -1,0 +1,63 @@
+require 'fluentd/plugin_spec_helper'
+require 'fluentd/plugin/out_stdout'
+
+include Fluentd::PluginSpecHelper
+
+describe Fluentd::Plugin::StdoutOutput do
+  let(:default_config) {
+    %[]
+  }
+
+  def create_driver(conf = default_config)
+    generate_driver(Fluentd::Plugin::StdoutOutput, conf)
+  end
+
+  it 'test configure' do
+    d = create_driver
+    expect(d.instance.output_type).to eql(:json)
+  end
+
+  it 'test configure output type' do
+    d = create_driver(default_config + "\noutput_type json")
+    expect(d.instance.output_type).to eql(:json)
+
+    d = create_driver(default_config + "\noutput_type hash")
+    expect(d.instance.output_type).to eql(:hash)
+
+    expect { create_driver(default_config + "\noutput_type foo") }.to raise_error(Fluentd::ConfigError)
+  end
+
+  it 'test emit json' do
+    d = create_driver(default_config + "\noutput_type json")
+    time = Time.now
+    out = capture_stdout { d.pitch('test', time.to_i, {'test' => 'test'}) }
+    expect(out).to eql("#{time.localtime} test: {\"test\":\"test\"}\n")
+
+    # NOTE: Float::NAN is not jsonable
+    expect { d.pitch('test', time.to_i, {'test' => Float::NAN}) }.to raise_error(Yajl::EncodeError)
+  end
+
+  it 'test emit hash' do
+    d = create_driver(default_config + "\noutput_type hash")
+    time = Time.now
+    out = capture_stdout { d.pitch('test', time.to_i, {'test' => 'test'}) }
+    expect(out).to eql("#{time.localtime} test: {\"test\"=>\"test\"}\n")
+
+    # NOTE: Float::NAN is not jsonable, but hash string can output it.
+    out = capture_stdout { d.pitch('test', time.to_i, {'test' => Float::NAN}) }
+    expect(out).to eql("#{time.localtime} test: {\"test\"=>NaN}\n")
+  end
+
+  private
+
+  # Capture the stdout of the block given
+  def capture_stdout(&block)
+    out = StringIO.new
+    $stdout = out
+    yield
+    return out.string
+  ensure
+    $stdout = STDOUT
+  end
+end
+


### PR DESCRIPTION
Ported out_stdout's `output_type` option which I pull requested at https://github.com/fluent/fluentd/pull/153 to v11. 
I ported spec also. 
