### PR TITLE
cannot call Kernel methods in BasicObject instance

### DIFF
--- a/lib/fluent/config_dsl.rb
+++ b/lib/fluent/config_dsl.rb
@@ -33,7 +33,7 @@ module Fluent
         end
 
         def method_missing(name, *args, &block)
-          raise ArgumentError, "Configuration DSL Syntax Error: only one argument allowed" if args.size > 1
+          ::Kernel.raise ::ArgumentError, "Configuration DSL Syntax Error: only one argument allowed" if args.size > 1
           value = args.first
           if block
             element = DSLElement.new(name.to_s, value)
@@ -57,7 +57,7 @@ module Fluent
         private
 
         def __element(name, arg, block)
-          raise ArgumentError, "#{name} block must be specified" if block.nil?
+          ::Kernel.raise ::ArgumentError, "#{name} block must be specified" if block.nil?
           element = DSLElement.new(name.to_s, arg)
           element.instance_exec(&block)
           @elements.push(element.__to_config_element)
@@ -65,7 +65,7 @@ module Fluent
         end
 
         def __need_arg(name, args)
-          raise ArgumentError, "#{name} block requires arguments for match pattern" if args.nil? || args.size != 1
+          ::Kernel.raise ::ArgumentError, "#{name} block requires arguments for match pattern" if args.nil? || args.size != 1
           true
         end
       end

--- a/test/configdsl.rb
+++ b/test/configdsl.rb
@@ -40,6 +40,20 @@ match('test.**') {
 v = [0, 1, 2]
 ]
 
+  TEST_DSL_CONFIG3 = %q[
+match
+]
+
+  TEST_DSL_CONFIG4 = %q[
+match('aa', 'bb'){
+  type :null
+}
+]
+
+  TEST_DSL_CONFIG5 = %q[
+match('aa')
+]
+
   def test_parse
     root = Fluent::Config::DSL::DSLParser.parse(TEST_DSL_CONFIG1)
 
@@ -73,5 +87,19 @@ v = [0, 1, 2]
 
     assert_equal 0, root.keys.size
     assert_equal 0, root.elements.size
+  end
+
+  def test_config_error
+    assert_raise(ArgumentError) {
+      Fluent::Config::DSL::DSLParser.parse(TEST_DSL_CONFIG3)
+    }
+
+    assert_raise(ArgumentError) {
+      Fluent::Config::DSL::DSLParser.parse(TEST_DSL_CONFIG4)
+    }
+
+    assert_raise(ArgumentError) {
+      Fluent::Config::DSL::DSLParser.parse(TEST_DSL_CONFIG5)
+    }
   end
 end


### PR DESCRIPTION
All kernel methods such as `raise` and child classes such as `ArgumentError` cannot used in BasicObject instance.
Those methods are currently handled in `method_missing`, so the methods itself are recognzied as elements.

I'm not sure this is an appropriate way to fix these issue.
Any commends are welcomed.
