### PR TITLE
Add in current logfile symlink in FileBuffer

### DIFF
--- a/lib/fluent/plugin/buf_file.rb
+++ b/lib/fluent/plugin/buf_file.rb
@@ -84,7 +84,8 @@ module Fluent
     end
 
     config_param :buffer_path, :string
-    config_param :buffer_symlink_path, :string, :default => nil
+
+    attr_accessor :symlink_path
 
     def configure(conf)
       super
@@ -121,7 +122,7 @@ module Fluent
       encoded_key = encode_key(key)
       path, tsuffix = make_path(encoded_key, "b")
       unique_id = tsuffix_to_unique_id(tsuffix)
-      FileBufferChunk.new(key, path, unique_id, "a+", @buffer_symlink_path)
+      FileBufferChunk.new(key, path, unique_id, "a+", @symlink_path)
     end
 
     def resume

--- a/lib/fluent/plugin/out_file.rb
+++ b/lib/fluent/plugin/out_file.rb
@@ -65,6 +65,8 @@ module Fluent
       super
 
       @timef = TimeFormatter.new(@time_format, @localtime)
+
+      @buffer.symlink_path = @symlink_path if @symlink_path
     end
 
     def format(tag, time, record)
@@ -97,19 +99,12 @@ module Fluent
           chunk.write_to(f)
         }
       end
-      create_symlink(path, suffix) if @symlink_path
 
       return path  # for test
     end
 
     def secondary_init(primary)
       # don't warn even if primary.class is not FileOutput
-    end
-
-    private
-
-    def create_symlink(path, suffix)
-      FileUtils.ln_sf(path, "#{@symlink_path}#{suffix}")
     end
   end
 end


### PR DESCRIPTION
A feature like this was discussed on the previous issue https://github.com/fluent/fluentd/issues/83. The current symlink feature is something different from what I want.

**out_file** plugin uses **buf_file** plugin as buffer (in default), so new records are written to buffer at first. After a while the buffer is flushed out as logfile  by **out_file**
A matter is "what is a current logfile?"

The current symlink points a file created by **out_file**. But I think the symlink should point to a file created by **buf_file**. The feature to symlink a current buffer file can be used for not only **out_file** but also other BufferedOutput plugins.
