### PR TITLE
PROPOSE: add format raw

### DIFF
--- a/lib/fluent/parser.rb
+++ b/lib/fluent/parser.rb
@@ -169,7 +169,7 @@ module Fluent
       end
     end
 
-    class RawParser
+    class NoneParser
       include Configurable
 
       config_param :message_key, :string, :default => 'message'
@@ -241,7 +241,7 @@ module Fluent
       'ltsv' => Proc.new { LabeledTSVParser.new },
       'csv' => Proc.new { CSVParser.new },
       'nginx' => Proc.new { RegexpParser.new(/^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$/,  {'time_format'=>"%d/%b/%Y:%H:%M:%S %z"}) },
-      'raw' => Proc.new { RawParser.new },
+      'none' => Proc.new { NoneParser.new },
     }
 
     def self.register_template(name, regexp_or_proc, time_format=nil)

--- a/test/parser.rb
+++ b/test/parser.rb
@@ -191,11 +191,11 @@ module ParserTest
     end
   end
 
-  class RawParserTest < ::Test::Unit::TestCase
+  class NoneParserTest < ::Test::Unit::TestCase
     include ParserTest
 
     def test_config_params
-      parser = TextParser::RawParser.new
+      parser = TextParser::NoneParser.new
       assert_equal "message", parser.message_key
 
       parser.configure('message_key' => 'foobar')
@@ -203,14 +203,14 @@ module ParserTest
     end
 
     def test_call
-      parser = TextParser::TEMPLATE_FACTORIES['raw'].call
+      parser = TextParser::TEMPLATE_FACTORIES['none'].call
       time, record = parser.call('log message!')
 
       assert_equal({'message' => 'log message!'}, record)
     end
 
     def test_call_with_message_key
-      parser = TextParser::RawParser.new
+      parser = TextParser::NoneParser.new
       parser.configure('message_key' => 'foobar')
       time, record = parser.call('log message!')
 


### PR DESCRIPTION
I propose to add `format raw`. 

Currently, even if users do not require to parse log lines, we have to write configuration like

```
<source>
    type tail
    format /^(?<message>.*)$/
    ....
</source>
```

This requires to parse log lines by a regular expression, and its overhead is not trivial. 

```
       user     system      total        real
asis:    0.080000   0.000000   0.080000 (  0.081076)
regexp:  7.590000   0.000000   7.590000 (  7.592521)
```

cf. http://blog.1q77.com/2013/01/fluent-agent-lite-%E3%81%A8-in_tail/

This plugin enables to write configuration like

```
<source>
    type tail
    format raw
    message_key message
    ....
</source>
```

(where `message_key` is set to `message` as default) and does not require to parse log lines by a regular expression. 

There is a plugin [fluent-plugin-tail-asis](https://github.com/yteraoka/fluent-plugin-tail-asis) which does the same thing with this patch, and downloaded 2354 times as in 2013.09.02 http://fluentd.org/plugin/. It tells us that some users are already using this feature, and I propose to have this feature in the fluentd itself. 
