### PR TITLE
Suppress dumping of whole configuratinos by default

### DIFF
--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -98,8 +98,8 @@ op.on('-q', '--quiet', "decrease verbose level (-q: warn, -qq: error)", TrueClas
   end
 }
 
-op.on('--dump-config-as-info', "dump config at the log level of INFO", TrueClass) {|b|
-  opts[:dump_config_as_info] = b
+op.on('--suppress-config-dump', "suppress config dumping when fluentd starts", TrueClass) {|b|
+  opts[:suppress_config_dump] = b
 }
 
 (class<<self;self;end).module_eval do

--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -32,7 +32,7 @@ module Fluent
       @suppress_emit_error_log_interval = 0
       @next_emit_error_log_time = nil
 
-      @dump_config_as_info = false
+      @suppress_config_dump = false
     end
 
     MATCH_CACHE_SIZE = 1024
@@ -56,8 +56,8 @@ module Fluent
       @next_emit_error_log_time = Time.now.to_i
     end
 
-    def dump_config_as_info=(flag)
-      @dump_config_as_info = flag
+    def suppress_config_dump=(flag)
+      @suppress_config_dump = flag
     end
 
     def read_config(path)
@@ -80,8 +80,9 @@ module Fluent
     end
 
     def configure(conf)
-      logging_method = @dump_config_as_info ? :info : :debug
-      $log.send(logging_method, "using configuration file: #{conf.to_s.rstrip}")
+      unless @suppress_config_dump
+        $log.info "using configuration file: #{conf.to_s.rstrip}"
+      end
 
       conf.elements.select {|e|
         e.name == 'source'

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -67,7 +67,7 @@ module Fluent
       @inline_config = opt[:inline_config]
       @suppress_interval = opt[:suppress_interval]
       @dry_run = opt[:dry_run]
-      @dump_config_as_info = opt[:dump_config_as_info]
+      @suppress_config_dump = opt[:suppress_config_dump]
 
       @log = LoggerInitializer.new(@log_path, @log_level, @chuser, @chgroup)
       @finished = false
@@ -321,7 +321,7 @@ module Fluent
         Fluent::Engine.suppress_interval(@suppress_interval)
       end
 
-      Fluent::Engine.dump_config_as_info = @dump_config_as_info
+      Fluent::Engine.suppress_config_dump = @suppress_config_dump
 
       @libs.each {|lib|
         require lib


### PR DESCRIPTION
Fluentd dumps whole configuration content into log by default (`info` log level). It can be dangerous when a plugin includes secret data.

There's actually such a plugin, for example, fluent-plugin-secure-forward. With the plugin, fluentd dumps configuration like below:

```
...

<match secure_forward.**>
  type secure_forward
  shared_key xxxxxxxxxxxxxxxx
  self_hostname app.example.com
  <server>
    host log.example.com
    username foo
    password xxxxxxxxxxxxxxxx
  </server>
</match>

...
```

We had better not to expose secret data in such a place where people don't think their secret data can be.
