### PR TITLE
(v11) fix uninitialized constant Fluentd::Config::DSL

### DIFF
--- a/lib/fluentd/server.rb
+++ b/lib/fluentd/server.rb
@@ -23,6 +23,7 @@ module Fluentd
   require_relative 'socket_manager'
   require_relative 'version'
   require_relative 'config/parser'
+  require_relative 'config/dsl'
   require_relative 'config/compat_parser'
   require_relative 'logger'
 


### PR DESCRIPTION
bin/fluentd -c fluentd-conf.rb

```
Unexpected error uninitialized constant Fluentd::Config::DSL
  /home/seo.naotoshi/gitrepos/fluentd_v11/lib/fluentd/server.rb:116:in `read_config'
  /home/seo.naotoshi/gitrepos/fluentd_v11/lib/fluentd/server.rb:76:in `reload_config'
  /home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/serverengine-1.5.3/lib/serverengine/supervisor.rb:61:in `initialize'
  /home/seo.naotoshi/gitrepos/fluentd_v11/lib/fluentd/server.rb:68:in `initialize'
  /home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/serverengine-1.5.3/lib/serverengine/supervisor.rb:83:in `block (2 levels) in create_server_proc'
  /home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/serverengine-1.5.3/lib/serverengine/supervisor.rb:83:in `instance_eval'
  /home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/serverengine-1.5.3/lib/serverengine/supervisor.rb:83:in `block in create_server_proc'
  /home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/serverengine-1.5.3/lib/serverengine/daemon.rb:160:in `call'
  /home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/serverengine-1.5.3/lib/serverengine/daemon.rb:160:in `create_server'
  /home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/serverengine-1.5.3/lib/serverengine/daemon.rb:99:in `main'
  /home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/serverengine-1.5.3/lib/serverengine/daemon.rb:90:in `run'
  /home/seo.naotoshi/gitrepos/fluentd_v11/lib/fluentd/server.rb:64:in `run'
  /home/seo.naotoshi/gitrepos/fluentd_v11/lib/fluentd/command/fluentd.rb:166:in `<top (required)>'
  /home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in `require'
  /home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in `require' bin/fluentd:5:in `<main>'
```
