### PR TITLE
(v11) Fix Unexpected error undefined method `path=` for Fluentd::Logger

### DIFF
--- a/lib/fluentd/logger.rb
+++ b/lib/fluentd/logger.rb
@@ -36,6 +36,10 @@ module Fluentd
       @level = LEVEL_DEBUG
     end
 
+    def path=(path)
+      @dl.path = path
+    end
+
     attr_accessor :tag
     attr_accessor :time_format
 


### PR DESCRIPTION
bin/fluentd -o log.txt

```
Unexpected error undefined method `path=' for #<Fluentd::Logger:0x002aeb54010e40>
  /home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/serverengine-1.5.3/lib/serverengine/config_loader.rb:54:in `reload_config'
  /home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/serverengine-1.5.3/lib/serverengine/multi_worker_server.rb:80:in `reload_config'
  /home/seo.naotoshi/gitrepos/fluentd_v11/lib/fluentd/server.rb:73:in `reload_config'
  /home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/serverengine-1.5.3/lib/serverengine/supervisor.rb:61:in `initialize'
  /home/seo.naotoshi/gitrepos/fluentd_v11/lib/fluentd/server.rb:68:in `initialize'
  /home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/serverengine-1.5.3/lib/serverengine/supervisor.rb:83:in `block (2 levels) in create_server_proc'
  /home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/serverengine-1.5.3/lib/serverengine/supervisor.rb:83:in `instance_eval'
  /home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/serverengine-1.5.3/lib/serverengine/supervisor.rb:83:in `block in create_server_proc'
  /home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/serverengine-1.5.3/lib/serverengine/daemon.rb:160:in `call'
  /home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/serverengine-1.5.3/lib/serverengine/daemon.rb:160:in `create_server'
  /home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/serverengine-1.5.3/lib/serverengine/daemon.rb:99:in `main'
  /home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/serverengine-1.5.3/lib/serverengine/daemon.rb:90:in `run'
  /home/seo.naotoshi/gitrepos/fluentd_v11/lib/fluentd/server.rb:64:in `run'
  /home/seo.naotoshi/gitrepos/fluentd_v11/lib/fluentd/command/fluentd.rb:166:in `<top (required)>'
  /home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in `require'
  /home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in `require'
```

serverengine requires `path=` method for a logger. ServerEngine::DaemonLogger has it.
