### PR TITLE
(v11) fix -g GEMFILE option

### DIFF
--- a/lib/fluentd/bundler_injection.rb
+++ b/lib/fluentd/bundler_injection.rb
@@ -30,8 +30,13 @@ module Fluentd
 
       require 'bundler'
 
-      Bundler.ui = Bundler::UI::Shell.new(UIShell.new)
-      #Bundler.ui.debug!
+      if Bundler::VERSION < "1.3.0"
+        Bundler.ui = Bundler::UI::Shell.new(UIShell.new)
+        #Bundler.ui.debug!
+      else
+        require 'bundler/vendored_thor' unless defined?(Thor)
+        Bundler.ui = Bundler::UI::Shell.new
+      end
       Bundler.rubygems.ui = Bundler::UI::RGProxy.new(Bundler.ui)
 
       if install_path = opts[:install_path]

--- a/lib/fluentd/worker_launcher.rb
+++ b/lib/fluentd/worker_launcher.rb
@@ -172,7 +172,7 @@ module Fluentd
         $LOAD_PATH.clear
         @load_path.each {|path| $LOAD_PATH << path }
 
-        @loaded_features.each {|feature|
+        @loaded_features.sort.each {|feature|
           require feature
         }
 


### PR DESCRIPTION
 bin/fluentd -g MyGemfile

```
/home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/bundler-1.3.5/lib/bundler/ui.rb:36:in `initialize': undefined method `[]' for #<Fluentd::BundlerInjection::UIShell:0x002b5264302190> (NoMethodError)
    from /home/seo.naotoshi/gitrepos/fluentd_v11/lib/fluentd/bundler_injection.rb:33:in `new'
    from /home/seo.naotoshi/gitrepos/fluentd_v11/lib/fluentd/bundler_injection.rb:33:in `install'
    from /home/seo.naotoshi/gitrepos/fluentd_v11/lib/fluentd/command/fluentd.rb:162:in `<top (required)>'
    from /home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in `require'
    from /home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in `require'
    from bin/fluentd:5:in `<main>'
```

where https://github.com/bundler/bundler/blob/v1.3.5/lib/bundler/ui.rb#L36. The modification of `lib/fluentd/bundler_injection.rb` is to fix the above error.  This error was caused because Bundler changed its internal method interface on v1.3.0. 
- v1.2.5 https://github.com/bundler/bundler/blob/v1.2.5/lib/bundler/ui.rb#L28
- v1.3.0 https://github.com/bundler/bundler/blob/v1.3.0/lib/bundler/ui.rb#L34
- at https://github.com/bundler/bundler/commit/d5e8d58999b450ec289b1231610674c2dac70e21#lib/bundler/ui.rb

Next, I met with another error. 
bin/fluentd -g MyGemfile

```
/home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/bundler-1.3.5/lib/bundler/vendor/thor/actions/create_file.rb:33:in `<module:Actions>': uninitialized constant Thor::Actions::EmptyDirectory (NameError)
        from /home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/bundler-1.3.5/lib/bundler/vendor/thor/actions/create_file.rb:4:in `<class:Thor>'
        from /home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/bundler-1.3.5/lib/bundler/vendor/thor/actions/create_file.rb:3:in `<top (required)>'
        from /home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/bundler-1.3.5/lib/bundler/vendor/thor/actions.rb:4:in `require'
        from /home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/bundler-1.3.5/lib/bundler/vendor/thor/actions.rb:4:in `<top (required)>'
        from /home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/bundler-1.3.5/lib/bundler/vendor/thor/actions/empty_directory.rb:2:in `<class:Thor>'
        from /home/seo.naotoshi/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/bundler-1.3.5/lib/bundler/vendor/thor/actions/empty_directory.rb:1:in `<top (required)>'
        from /home/seo.naotoshi/gitrepos/fluentd_v11/lib/fluentd/worker_launcher.rb:177:in `require'
        from /home/seo.naotoshi/gitrepos/fluentd_v11/lib/fluentd/worker_launcher.rb:177:in `block in restore!'
        from /home/seo.naotoshi/gitrepos/fluentd_v11/lib/fluentd/worker_launcher.rb:176:in `each'
        from /home/seo.naotoshi/gitrepos/fluentd_v11/lib/fluentd/worker_launcher.rb:176:in `restore!'
        from /home/seo.naotoshi/gitrepos/fluentd_v11/lib/fluentd/worker_launcher.rb:188:in `restore'
        from /home/seo.naotoshi/gitrepos/fluentd_v11/lib/fluentd/worker_launcher.rb:73:in `main'
        from /home/seo.naotoshi/gitrepos/fluentd_v11/lib/fluentd/command/fluentd-worker.rb:19:in `<main>'
```

Seeing values of @loaded_features at `lib/fluentd/worker_launcher.rb`, it seems that this error was caused by order of `require`. By adding `sort`, this problem was fixed. 

FINAL THOUGHT: 

However, I feel that `-g GEMFILE` functionality is very _fragile_ because it can easily be broken by the change of Bundler's internal interface like this. I also think as `require`ing in alphabetical order does not always assure that the order is correct. 

It would be better to re-consider to adopt this feature. Dropping the position of this feature as an experimental feature would be required until we find a great solution. 
