### PR TITLE
syslogの正規表現 : syslog regexp seems wrong

### DIFF
--- a/lib/fluent/parser.rb
+++ b/lib/fluent/parser.rb
@@ -223,7 +223,7 @@ module Fluent
     TEMPLATE_FACTORIES = {
       'apache' => Proc.new { RegexpParser.new(/^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$/, {'time_format'=>"%d/%b/%Y:%H:%M:%S %z"}) },
       'apache2' => Proc.new { ApacheParser.new },
-      'syslog' => Proc.new { RegexpParser.new(/^(?<time>[^ ]*\s*[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?[^\:]*\: *(?<message>.*)$/, {'time_format'=>"%b %d %H:%M:%S"}) },
+      'syslog' => Proc.new { RegexpParser.new(/^(?<time>[^ ]*\s+[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?[^\:]*\: *(?<message>.*)$/, {'time_format'=>"%b %d %H:%M:%S"}) },
       'json' => Proc.new { JSONParser.new },
       'tsv' => Proc.new { TSVParser.new },
       'ltsv' => Proc.new { LabeledTSVParser.new },


### PR DESCRIPTION
こんにちは！

CentOS の /var/log/messges を食わせてみたのですが、このようにしないと

```
2013-09-08 06:58:57 +0900 [error]: forward error: invalid strptime format - `%b %d %H:%M:%S'
```

のように出てしまって、うまく動きませんでした。。。

必要なfixか分かりませんが、御報告まで。。。

あ、あとWebサイトとコードが一致していないようです！
http://docs.fluentd.org/ja/articles/in_tail

失礼いたします。
