### PR TITLE
(v11) porting `format none` from v10 to v11

### DIFF
--- a/lib/fluentd/plugin/util/text_parser.rb
+++ b/lib/fluentd/plugin/util/text_parser.rb
@@ -168,6 +168,18 @@ module Fluentd
           end
         end
 
+        class NoneParser
+          include Configurable
+
+          config_param :message_key, :string, :default => 'message'
+
+          def call(text)
+            record = {}
+            record[@message_key] = text
+            return Time.now.to_i, record
+          end
+        end
+
         class ApacheParser
           include Configurable
 
@@ -255,6 +267,7 @@ module Fluentd
           'ltsv' => Proc.new { LabeledTSVParser.new },
           'csv' => Proc.new { CSVParser.new },
           'nginx' => Proc.new { NginxParser.new },
+          'none' => Proc.new { NoneParser.new },
         }
 
         def self.register_template(name, regexp_or_proc, time_format=nil)

--- a/spec/plugin/util/text_parser_spec.rb
+++ b/spec/plugin/util/text_parser_spec.rb
@@ -130,6 +130,27 @@ describe Fluentd::Plugin::Util::TextParser do
     end
   end
 
+  context Fluentd::Plugin::Util::TextParser::NoneParser do
+    before :each do
+      @parser = Fluentd::Plugin::Util::TextParser::TEMPLATE_FACTORIES['none'].call
+      @parser.init_configurable
+      @parser.configure({})
+    end
+
+    it "can parse a message" do
+      time, record = @parser.call('log message!')
+
+      expect(record).to eq({'message' => 'log message!'})
+    end
+
+    it "can parse a message with `message_key` option" do
+      @parser.configure('message_key' => 'foobar')
+      time, record = @parser.call('log message!')
+
+      expect(record).to eq({'foobar' => 'log message!'})
+    end
+  end
+
   context Fluentd::Plugin::Util::TextParser::NginxParser do
     str_time = '28/Feb/2013:12:00:00 +0900'
     expected_time = Time.strptime(str_time, '%d/%b/%Y:%H:%M:%S %z').to_i


### PR DESCRIPTION
Porting https://github.com/fluent/fluentd/pull/182
