### PR TITLE
(v11) Fix in tail so that it works without time_format

### DIFF
--- a/lib/fluentd/plugin/util/text_parser.rb
+++ b/lib/fluentd/plugin/util/text_parser.rb
@@ -81,6 +81,8 @@ module Fluentd
               else
                 time = value.to_i
               end
+            else
+              time = Time.now.to_i
             end
 
             return time, record
@@ -114,13 +116,14 @@ module Fluentd
           def values_map(values)
             record = Hash[keys.zip(values)]
 
-            if @time_key
-              value = record.delete(@time_key)
+            if @time_key and (value = record.delete(@time_key))
               if @time_format
                 time = Time.strptime(value, @time_format).to_i
               else
                 time = Time.parse(value).to_i
               end
+            else
+              time = Time.now.to_i
             end
 
             return time, record

--- a/spec/plugin/util/text_parser_spec.rb
+++ b/spec/plugin/util/text_parser_spec.rb
@@ -3,6 +3,35 @@ require 'fluentd/plugin/util/text_parser'
 require 'time'
 
 describe Fluentd::Plugin::Util::TextParser do
+  context Fluentd::Plugin::Util::TextParser::RegexpParser do
+    str_time = '28/Feb/2013:12:00:00 +0900'
+    expected_time = Time.strptime(str_time, '%d/%b/%Y:%H:%M:%S %z').to_i
+
+    before :each do
+      @parser = Fluentd::Plugin::Util::TextParser::RegexpParser.new(/^\[(?<time>[^\]]*)\] (?<message>.*)$/)
+      @parser.init_configurable
+      @parser.configure({})
+    end
+
+    it 'can parse log' do
+      @parser.configure({'time_format' => "%d/%b/%Y:%H:%M:%S %z"})
+      time, record = @parser.call("[#{str_time}] foobar")
+
+      expect(time).to eq expected_time
+      expect(record).to eq({'message' => 'foobar'})
+    end
+
+    it 'can parse log without time' do
+      @parser = Fluentd::Plugin::Util::TextParser::RegexpParser.new(/^(?<message>.*)$/)
+      @parser.init_configurable
+      @parser.configure({})
+      time, record = @parser.call('foobar')
+
+      expect(time).not_to be_nil
+      expect(record).to eq({'message' => 'foobar'})
+    end
+  end
+
   context Fluentd::Plugin::Util::TextParser::ApacheParser do
     str_time = '28/Feb/2013:12:00:00 +0900'
     expected_time = Time.strptime(str_time, '%d/%b/%Y:%H:%M:%S %z').to_i
@@ -61,9 +90,19 @@ describe Fluentd::Plugin::Util::TextParser do
       @parser.configure({})
     end
 
-    it "can parses json" do
+    it "can parse json" do
       time, record = @parser.call('{"time":1362020400,"host":"192.168.0.1","size":777,"method":"PUT"}')
       expect(time).to eq expected_time
+      expect(record).to eq({
+                            'host'   => '192.168.0.1',
+                            'size'   => 777,
+                            'method' => 'PUT',
+                          })
+    end
+
+    it "can parse json without time" do
+      time, record = @parser.call('{"host":"192.168.0.1","size":777,"method":"PUT"}')
+      expect(time).not_to be_nil
       expect(record).to eq({
                             'host'   => '192.168.0.1',
                             'size'   => 777,
@@ -87,9 +126,18 @@ describe Fluentd::Plugin::Util::TextParser do
       expect(@parser.label_delimiter).to eq ":"
     end
 
-    it "can parses ltsv" do
+    it "can parse ltsv" do
       time, record = @parser.call("time:#{str_time}\thost:192.168.0.1\treq_id:111")
       expect(time).to eq expected_time
+      expect(record).to eq({
+                            'host'   => '192.168.0.1',
+                            'req_id' => '111',
+                          })
+    end
+
+    it "can parse ltsv without time" do
+      time, record = @parser.call("host:192.168.0.1\treq_id:111")
+      expect(time).not_to be_nil
       expect(record).to eq({
                             'host'   => '192.168.0.1',
                             'req_id' => '111',


### PR DESCRIPTION
The below configuration does not work in v11 although it works in v10.

```
<source>
  type tail
  path /var/log/syslog
  pos_file /tmp/_var_log_syslog.pos
  format /^(?<message>.*)$/
  tag raw.syslog
</source>
<match raw.syslog>
  type stdout
</match>
```

 It is because in_tail requires `time` not to be nil at https://github.com/fluent/fluentd/blob/v11/lib/fluentd/plugin/in_tail.rb#L89, but v11's RegexpParser returns nil when `time` field does not exist. This patch fixes it as of v10's code at https://github.com/fluent/fluentd/blob/master/lib/fluent/parser.rb#L58

Along the way, I've noticed that the same thing happens for JSONParser and LabeledTSVParser. Adding tests without modification of main codes, following failures occurred. This patch fixes these errors.  

```
1) Fluentd::Plugin::Util::TextParser Fluentd::Plugin::Util::TextParser::RegexpParser can parse log without time
 Failure/Error: expect(time).not_to be_nil
   expected: not nil
        got: nil
 # ./spec/plugin/util/text_parser_spec.rb:30:in `block (3 levels) in <top (required)>'

2) Fluentd::Plugin::Util::TextParser Fluentd::Plugin::Util::TextParser::JSONParser can parse json without time
 Failure/Error: expect(time).not_to be_nil
   expected: not nil
        got: nil
 # ./spec/plugin/util/text_parser_spec.rb:105:in `block (3 levels) in <top (required)>'

3) Fluentd::Plugin::Util::TextParser Fluentd::Plugin::Util::TextParser::LabeledTSVParser can parses ltsv without time
 Failure/Error: time, record = @parser.call("host:192.168.0.1\treq_id:111")
 TypeError:
   no implicit conversion of nil into String
 # ./lib/fluentd/plugin/util/text_parser.rb:120:in `values_map'
 # ./lib/fluentd/plugin/util/text_parser.rb:156:in `call'
 # ./spec/plugin/util/text_parser_spec.rb:139:in `block (3 levels) in <top (required)>'
```
