### PR TITLE
Make source_path of DSL a path, not a filename

### DIFF
--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -63,7 +63,7 @@ module Fluent
 
     def parse_config(io, fname, basepath=Dir.pwd)
       conf = if fname =~ /\.rb$/
-               Config::DSL::Parser.parse(io, fname)
+               Config::DSL::Parser.parse(io, File.join(basepath, fname))
              else
                Config.parse(io, fname, basepath)
              end


### PR DESCRIPTION
The path given to `instance_eval` can be a path, not just a file name.
This enables the config DSL file to use `__FILE__` variable.
