### PR TITLE
config_param log_level (v11)

### DIFF
--- a/lib/fluentd/plugin.rb
+++ b/lib/fluentd/plugin.rb
@@ -51,7 +51,6 @@ module Fluentd
   # loads base classes of plugins
   require_relative 'event_collection'
   require_relative 'config_error'
-  require_relative 'plugin/agent'
   require_relative 'plugin/output'
   require_relative 'plugin/input'
   require_relative 'plugin/filter'

--- a/lib/fluentd/plugin/input.rb
+++ b/lib/fluentd/plugin/input.rb
@@ -18,9 +18,10 @@
 module Fluentd
   module Plugin
 
-    require_relative 'agent'
+    require_relative '../agent'
     require_relative '../event_emitter'
     require_relative '../actor'
+    require_relative 'mixin_logger'
 
     class Input < Agent
       # provides #collector
@@ -28,6 +29,9 @@ module Fluentd
 
       # provides #actor
       include Actor::AgentMixin
+
+      # provides config_param :log_level
+      include LoggerMixin
     end
 
   end

--- a/lib/fluentd/plugin/mixin_logger.rb
+++ b/lib/fluentd/plugin/mixin_logger.rb
@@ -18,14 +18,10 @@
 module Fluentd
   module Plugin
 
-    require_relative '../agent'
-
-    class Agent < Fluentd::Agent
-      def initialize
-        super
+    module LoggerMixin
+      def self.included(klass)
+        klass.config_param :log_level, :string, :default => nil
       end
-
-      config_param :log_level, :string, :default => nil
 
       def configure(conf)
         super
@@ -35,11 +31,12 @@ module Fluentd
           begin
             @log.level = conf['log_level'] # reuse error handling of Fluentd::Logger
           rescue ArgumentError => e
-            raise ConfigError, "log_level should be 'fatal', 'error', 'warn', 'info', or 'debug'"
+            raise ConfigError, "log_level should be 'fatal', 'error', 'warn', 'info', 'debug', or 'trace'"
           end
         end
       end
     end
+
   end
 end
 

--- a/lib/fluentd/plugin/output.rb
+++ b/lib/fluentd/plugin/output.rb
@@ -18,10 +18,11 @@
 module Fluentd
   module Plugin
 
-    require_relative 'agent'
+    require_relative '../agent'
     require_relative '../collector'
     require_relative '../actor'
     require_relative '../worker_global_methods'
+    require_relative 'mixin_logger'
 
     class Output < Agent
       # provides #emit, #emits
@@ -29,6 +30,9 @@ module Fluentd
 
       # provides #actor
       include Actor::AgentMixin
+
+      # provides config_param :log_level
+      include LoggerMixin
 
       ###TODO: These definition of #emit and #emits conflict with collector.rb
       def emit(tag, time, record)

--- a/lib/fluentd/plugin_spec_helper.rb
+++ b/lib/fluentd/plugin_spec_helper.rb
@@ -17,7 +17,7 @@ module Fluentd
 
       def initialize(plugin_klass, conf)
         plugin = plugin_klass.new
-        unless plugin.is_a?(Fluentd::Plugin::Agent)
+        unless plugin.is_a?(Fluentd::Plugin::Input) || plugin.is_a?(Fluentd::Plugin::Filter) || plugin.is_a?(Fluentd::Plugin::Output)
           raise ArgumentError, "unknown class as plugin #{plugin.class}"
         end
 

--- a/spec/plugin/mixin_logger_spec.rb
+++ b/spec/plugin/mixin_logger_spec.rb
@@ -1,18 +1,18 @@
 require 'fluentd/plugin_spec_helper'
-require 'fluentd/plugin/agent'
+require 'fluentd/plugin/mixin_logger'
 
 include Fluentd::PluginSpecHelper
 
-describe Fluentd::Plugin::Agent do
+describe Fluentd::Plugin::LoggerMixin do
   let(:default_config) {
     %[]
   }
 
   def create_driver(conf = default_config)
-    generate_driver(Fluentd::Plugin::Agent, conf)
+    generate_driver(Fluentd::Plugin::Input, conf)
   end
 
-  it 'test default config' do
+  it 'test default configuration' do
     d = create_driver
     expect(d.instance.logger.level).to eql(Fluentd::Logger::LEVEL_DEBUG)
   end
@@ -46,4 +46,14 @@ describe Fluentd::Plugin::Agent do
 
     expect { create_driver(default_config + "\nlog_level foo") }.to raise_error(Fluentd::ConfigError)
   end
+
+  it 'test mixin' do
+    d = generate_driver(Fluentd::Plugin::Input, "log_level fatal")
+    expect(d.instance.logger.level).to eql(Fluentd::Logger::LEVEL_FATAL)
+    d = generate_driver(Fluentd::Plugin::Output, "log_level fatal")
+    expect(d.instance.logger.level).to eql(Fluentd::Logger::LEVEL_FATAL)
+    d = generate_driver(Fluentd::Plugin::Filter, "log_level fatal")
+    expect(d.instance.logger.level).to eql(Fluentd::Logger::LEVEL_FATAL)
+  end
+
 end


### PR DESCRIPTION
What I want to do with this patch is to configure log_level in each plugin. To do it, I newly created a plugin option, `log_level` which is broadly available by _all_ plugins. I created a top-level class of all plugins named `Fluentd::Plugin::Agent` to introduce the broad option. 

HOW TO USE: An example of `fluentd.rb` is as followings:

```
worker {
  match('raw.syslog') {
    type :stdout
    log_level "error"
  }
}
```

Inside of the plugin code, plugin creators should write as

```
logger.info "foobar"
```
