### PR TITLE
add "ruby" keyword 

### DIFF
--- a/lib/fluentd/config/dsl.rb
+++ b/lib/fluentd/config/dsl.rb
@@ -83,6 +83,24 @@ module Fluentd
             @proxy.add_element(name, args.first, block)
           end
         end
+
+        def self.const_missing(name)
+          return ::Kernel.const_get(name) if ::Kernel.const_defined?(name)
+
+          if name.to_s =~ /^Fluentd::Config::DSL::Element::(.*)$/
+            name = "#{$1}".to_sym
+            return ::Kernel.const_get(name) if ::Kernel.const_defined?(name)
+          end
+          ::Kernel.eval("#{name}")
+        end
+
+        def ruby(&block)
+          if block
+            @proxy.instance_exec(&block)
+          else
+            ::Kernel
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This pull-request is for #195
- to pass Kernel functions

``` ruby
file_path_list = ruby.open("/path/to/log_file.list"){|f| f.readlines}.map(&:chomp)
file_path_list.each do |path_string|
  source {
    type "tail"
    path path_string
    ...
  }
end
```
- to provide blocks with normal ruby syntax/features

``` ruby
file_path_list = ruby {
  require 'net/http'
  res = Net::HTTP.start("ourserver.local", 80) {|http|
    http.get('/server_list.txt')
  }
  res.split(/\r?\n/)
}
file_path_list.each do |path_string|
  ...
end
```
