### PR TITLE
Add --suppress-repeated-stacktrace option

### DIFF
--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -36,6 +36,7 @@ opts = {
   :chuser => nil,
   :chgroup => nil,
   :suppress_interval => 0,
+  :suppress_repeated_stacktrace => false,
 }
 
 op.on('-s', "--setup [DIR=#{File.dirname(Fluent::DEFAULT_CONFIG_PATH)}]", "install sample configuration file to the directory") {|s|
@@ -84,6 +85,10 @@ op.on('-i', '--inline-config CONFIG_STRING', "inline config which is appended to
 
 op.on('--emit-error-log-interval SECONDS', "suppress interval seconds of emit error logs") {|s|
   opts[:suppress_interval] = s.to_i
+}
+
+op.on('--suppress-repeated-stacktrace', "suppress repeated stacktrace", TrueClass) {|b|
+  opts[:suppress_repeated_stacktrace] = b
 }
 
 op.on('-v', '--verbose', "increase verbose level (-v: debug, -vv: trace)", TrueClass) {|b|

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -18,11 +18,12 @@
 module Fluent
   class Supervisor
     class LoggerInitializer
-      def initialize(path, level, chuser, chgroup)
+      def initialize(path, level, chuser, chgroup, opts)
         @path = path
         @level = level
         @chuser = chuser
         @chgroup = chgroup
+        @opts = opts
       end
 
       def init
@@ -37,7 +38,7 @@ module Fluent
           @io = STDOUT
         end
 
-        $log = Fluent::Log.new(@io, @level)
+        $log = Fluent::Log.new(@io, @level, @opts)
 
         $log.enable_color(false) if @path
         $log.enable_debug if @level <= Fluent::Log::LEVEL_DEBUG
@@ -69,7 +70,8 @@ module Fluent
       @dry_run = opt[:dry_run]
       @suppress_config_dump = opt[:suppress_config_dump]
 
-      @log = LoggerInitializer.new(@log_path, @log_level, @chuser, @chgroup)
+      log_opts = {:suppress_repeated_stacktrace => opt[:suppress_repeated_stacktrace]}
+      @log = LoggerInitializer.new(@log_path, @log_level, @chuser, @chgroup, log_opts)
       @finished = false
       @main_pid = nil
     end


### PR DESCRIPTION
Relatead to https://github.com/fluent/fluentd/issues/221 issue.

Remaining discussion is dump message.
Current logs:

```
2013-12-04 15:05:53 +0900 [warn]: fluent/engine.rb:154:rescue in emit_stream: emit transaction failed  error_class=RuntimeError error=#<RuntimeError: syslog>
  2013-12-04 15:05:53 +0900 [warn]: fluent/engine.rb:140:emit_stream: /Users/repeatedly/devel/fluent/fluentd/lib/fluent/plugin/out_stdout.rb:43:in `emit'
  2013-12-04 15:05:53 +0900 [warn]: fluent/engine.rb:140:emit_stream: /Users/repeatedly/devel/fluent/fluentd/lib/fluent/match.rb:36:in `emit'
  2013-12-04 15:05:53 +0900 [warn]: fluent/engine.rb:140:emit_stream: /Users/repeatedly/devel/fluent/fluentd/lib/fluent/engine.rb:151:in `emit_stream'
  2013-12-04 15:05:53 +0900 [warn]: fluent/engine.rb:140:emit_stream: /Users/repeatedly/devel/fluent/fluentd/lib/fluent/engine.rb:131:in `emit'
  2013-12-04 15:05:53 +0900 [warn]: fluent/engine.rb:140:emit_stream: /Users/repeatedly/devel/fluent/fluentd/lib/fluent/plugin/in_object_space.rb:111:in `on_timer'
  2013-12-04 15:05:53 +0900 [warn]: fluent/engine.rb:140:emit_stream: /Users/repeatedly/devel/fluent/fluentd/lib/fluent/plugin/in_object_space.rb:37:in `call'
  2013-12-04 15:05:53 +0900 [warn]: fluent/engine.rb:140:emit_stream: /Users/repeatedly/devel/fluent/fluentd/lib/fluent/plugin/in_object_space.rb:37:in `on_timer'
  2013-12-04 15:05:53 +0900 [warn]: fluent/engine.rb:140:emit_stream: /Users/repeatedly/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/cool.io-1.1.1/lib/cool.io/loop.rb:96:in `run_once'
  2013-12-04 15:05:53 +0900 [warn]: fluent/engine.rb:140:emit_stream: /Users/repeatedly/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/cool.io-1.1.1/lib/cool.io/loop.rb:96:in `run'
  2013-12-04 15:05:53 +0900 [warn]: fluent/engine.rb:140:emit_stream: /Users/repeatedly/devel/fluent/fluentd/lib/fluent/plugin/in_object_space.rb:63:in `run'
2013-12-04 15:05:53 +0900 [error]: plugin/in_object_space.rb:113:rescue in on_timer: object space failed to emit error="foo.bar" error_class="RuntimeError" tag="foo" record="{...}"
2013-12-04 15:05:55 +0900 [warn]: fluent/engine.rb:154:rescue in emit_stream: emit transaction failed  error_class=RuntimeError error=#<RuntimeError: syslog>
  2013-12-04 15:05:55 +0900 [warn]: plugin/in_object_space.rb:111:on_timer: suppressed same stacktrace
```
