### PR TITLE
Add Code Climate badge to README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,6 +1,6 @@
 = Fluentd
 
-{<img src="https://travis-ci.org/fluent/fluentd.png" />}[https://travis-ci.org/fluent/fluentd]
+{<img src="https://travis-ci.org/fluent/fluentd.png" />}[https://travis-ci.org/fluent/fluentd] {<img src="https://codeclimate.com/github/fluent/fluentd.png " />}[https://codeclimate.com/github/fluent/fluentd]
 
 Fluentd is an event collector system. It is a generalized version of syslogd, which handles JSON objects for its log messages.
 


### PR DESCRIPTION
Hello,

It looks like someone (maybe you) added fluentd to Code Climate a few months back, and I thought you might want to know.

I work at Code Climate -- we do automated code reviews for Ruby and JavaScript using static analysis -- and we're completely free for open source. You can view your metrics here: https://codeclimate.com/github/fluent/fluentd

In case you want this information to be available to contributors, this PR just adds a dynamic badge to the README (similar to Travis) that displays the code quality GPA

If you have any questions, let me know.

I hope you find Code Climate useful.

Cheers,
Mike
