### PR TITLE
Add hook point to override how to check flush-or-not-yet

### DIFF
--- a/lib/fluent/buffer.rb
+++ b/lib/fluent/buffer.rb
@@ -158,13 +158,17 @@ module Fluent
       end
     end
 
+    def storable?(chunk, data)
+      top.size + data.bytesize <= @buffer_chunk_limit
+    end
+
     def emit(key, data, chain)
       key = key.to_s
 
       synchronize do
         top = (@map[key] ||= new_chunk(key))  # TODO generate unique chunk id
 
-        if top.size + data.bytesize <= @buffer_chunk_limit
+        if storable?(top, data)
           chain.next
           top << data
           return false


### PR DESCRIPTION
3rd party buffer plugins needs hook point how to check whether chunk should be flushed or not.
Chunks are flushed for many reasons, like
- how many data stored in it
- how many data stored in one second
- ... and many other types of buffers may exists
