### PR TITLE
Select writer threads by round-robin

### DIFF
--- a/lib/fluent/output.rb
+++ b/lib/fluent/output.rb
@@ -223,6 +223,8 @@ module Fluent
       @buffer.start
       @secondary.start if @secondary
       @writers.each {|writer| writer.start }
+      @writer_current_position = 0
+      @writers_size = @writers.size
     end
 
     def shutdown
@@ -240,8 +242,9 @@ module Fluent
     end
 
     def submit_flush
-      # TODO roundrobin?
-      @writers.first.submit_flush
+      # Without locks: it is rough but enough to select "next" writer selection
+      @writer_current_position = (@writer_current_position + 1) % @writers_size
+      @writers[@writer_current_position].submit_flush
     end
 
     def format_stream(tag, es)

--- a/test/output.rb
+++ b/test/output.rb
@@ -51,5 +51,66 @@ module FluentOutputTest
       d.instance.retry_limit.times { d.instance.instance_variable_get(:@error_history) << Engine.now }
       assert_equal 4, d.instance.calc_retry_wait
     end
+
+    def create_mock_driver(conf=CONFIG)
+      Fluent::Test::BufferedOutputTestDriver.new(Fluent::BufferedOutput) do
+        attr_accessor :submit_flush_threads
+
+        def start_mock
+          @started = false
+          start
+          # ensure OutputThread to start successfully
+          submit_flush
+          sleep 0.5
+          while !@started
+            submit_flush
+            sleep 0.5
+          end
+        end
+
+        def try_flush
+          @started = true
+          @submit_flush_threads ||= {}
+          @submit_flush_threads[Thread.current] ||= 0
+          @submit_flush_threads[Thread.current] += 1
+        end
+
+        def write(chunk)
+          chunk.read
+        end
+      end.configure(conf)
+    end
+
+    def test_submit_flush_target
+      # default
+      d = create_mock_driver
+      d.instance.start_mock
+      assert_equal 0, d.instance.instance_variable_get('@writer_current_position')
+      d.instance.submit_flush
+      assert_equal 0, d.instance.instance_variable_get('@writer_current_position')
+      d.instance.submit_flush
+      assert_equal 0, d.instance.instance_variable_get('@writer_current_position')
+      d.instance.submit_flush
+      assert_equal 0, d.instance.instance_variable_get('@writer_current_position')
+      d.instance.submit_flush
+      assert_equal 0, d.instance.instance_variable_get('@writer_current_position')
+      d.instance.shutdown
+      assert_equal 1, d.instance.submit_flush_threads.size
+
+      # num_threads 4
+      d = create_mock_driver(CONFIG + %[num_threads 4])
+      d.instance.start
+      assert_equal 0, d.instance.instance_variable_get('@writer_current_position')
+      d.instance.submit_flush
+      assert_equal 1, d.instance.instance_variable_get('@writer_current_position')
+      d.instance.submit_flush
+      assert_equal 2, d.instance.instance_variable_get('@writer_current_position')
+      d.instance.submit_flush
+      assert_equal 3, d.instance.instance_variable_get('@writer_current_position')
+      d.instance.submit_flush
+      assert_equal 0, d.instance.instance_variable_get('@writer_current_position')
+      d.instance.shutdown
+      assert (d.instance.submit_flush_threads.size > 1), "fails if only one thread works to submit flush"
+    end
   end
 end


### PR DESCRIPTION
At submit_buffer, fixed writer selection makes throughput bottleneck.
Fix to select a writer by rough round-robin,
- to reduce bottlenecks
- not to reduce performance without locks

What is important is to select a different writer from previous submits, not to select "strictly next" writer.
That is why this patch doesn't include locks.
