### PR TITLE
How about implements Fluent::TextParser::TypeConverter as mix-in function?

### DIFF
--- a/lib/fluent/mixin.rb
+++ b/lib/fluent/mixin.rb
@@ -215,4 +215,43 @@ module Fluent
       end
     end
   end
+
+  module TypeConverterMixin
+    require 'fluent/parser'
+    include Configurable
+    include RecordFilterMixin
+    include Fluent::TextParser::TypeConverter
+
+    attr_accessor :types, :types_delimiter, :types_label_delimiter
+
+    def configure(conf)
+      super
+
+      if types = conf['types']
+        @types = types
+      end
+
+      if types_delimiter = conf['types_delimiter']
+        @types_delimiter = types_delimiter
+      end
+
+      if types_label_delimiter = conf['types_label_delimiter']
+        @types_label_delimiter = types_label_delimiter
+      end
+    end
+
+    def filter_record(tag, time, record)
+      super
+      if @types
+        convert_field_type!(record)
+      end
+    end
+
+    def convert_field_type!(record)
+      record.each { |key, value|
+        record[key] = convert_type(key, value)
+      }
+      self
+    end
+  end
 end

--- a/test/mixin.rb
+++ b/test/mixin.rb
@@ -276,4 +276,58 @@ module MixinTest
       d.run
     end
   end
+
+  class TypeConverterMixinText < Test::Unit::TestCase
+    include Utils
+
+    def test_type_converter_default
+      format_check({
+        'a' => '1'
+      })
+
+      d = create_driver(Fluent::TypeConverterMixin, %[
+      ])
+      d.emit({'a' => '1'})
+      d.run
+    end
+
+    def test_all_type_converter
+      format_check({
+        'k_str'   => 'foo',
+        'k_int'   => 500,
+        'k_float' => 0.5,
+        'k_bool'  => true,
+        'k_time'  => 1390274984,
+        'k_array' => ["foo", "1", "2.0", "true"]
+      })
+
+      d = create_driver(Fluent::TypeConverterMixin, %[
+        types  k_str:string,k_int:integer,k_float:float,k_bool:bool,k_time:time,k_array:array
+      ])
+
+      d.emit({
+        'k_str'   => 'foo',
+        'k_int'   => '500',
+        'k_float' => '0.5',
+        'k_bool'  => 'true',
+        'k_time'  => '2014-01-21 12:29:44 +0900',
+        'k_array' => 'foo,1,2.0,true'
+      })
+      d.run
+    end
+
+    def test_with_handle_tag_name_mixin
+      format_check({
+        'a' => 1
+      }, 'test')
+
+      d = create_driver([Fluent::HandleTagNameMixin, Fluent::TypeConverterMixin], %[
+        remove_tag_prefix tag_prefix.
+        types  a:integer
+      ], 'tag_prefix.test')
+
+      d.emit({'a' => '1'})
+      d.run
+    end
+  end
 end


### PR DESCRIPTION
It is very useful for type converting with in_tail plugin or using fluent-plugin-typecast. But for now, other plugin couldn't use this module as mix-in plugin.
I have created [fluent-mixin-type-converter](https://github.com/y-ken/fluent-mixin-type-converter) to act calling [Fluent::TextParser::TypeConverter](https://github.com/fluent/fluentd/blob/master/lib/fluent/parser.rb#L54) as mix-in plugin.

However, It is better to provide this function as build-in mix-in.
Would you please give me opinion about this issue?

Thank you.
