### PR TITLE
Pass Kernel.binding to enable embbeded code configuration

### DIFF
--- a/lib/fluentd/server.rb
+++ b/lib/fluentd/server.rb
@@ -174,7 +174,7 @@ module Fluentd
 
       begin
         # try to use v11 mode first
-        conf = Config::Parser.read(path)
+        conf = Config::Parser.read(path, Kernel.binding)
 
         # use backward compatible mode if <worker> element doesn't exist
         unless conf.elements.find {|e| e.name == 'worker' }


### PR DESCRIPTION
Currently, we hit following error when use embbeded code configuration.

``` sh
Unexpected error embedded code is not allowed in this file at dummy.conf line 14,22
 13:     type stdout
 14:     foo "#{ENV['PATH']}"

     ------------
```

Using Kernel.binding but I'm not sure the best context.
