### PR TITLE
Added headers to record (in_http).

### DIFF
--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -33,6 +33,7 @@ module Fluent
     config_param :body_size_limit, :size, :default => 32*1024*1024  # TODO default
     config_param :keepalive_timeout, :time, :default => 10   # TODO default
     config_param :backlog, :integer, :default => nil
+    config_param :add_http_headers, :bool, :default => false
 
     def configure(conf)
       super
@@ -122,11 +123,13 @@ module Fluent
           return ["200 OK", {'Content-type'=>'text/plain'}, ""]
         end
         
-        params.each_pair { |k,v|
-          if k.start_with?("HTTP_")
-            record[k] = v
-          end
-        }
+        if @add_http_headers
+          params.each_pair { |k,v|
+            if k.start_with?("HTTP_")
+              record[k] = v
+            end
+          }
+        end
 
         time = params['time']
         time = time.to_i


### PR DESCRIPTION
We should be able to use headers. This is especially important when a proxy passes IP in a custom header. Might be useful for other headers as well.
