### PR TITLE
Port fluent-plugin-grep as out_grep

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,13 +5,20 @@ require 'fileutils'
 require 'rake/testtask'
 require 'rake/clean'
 
-task :test => [:base_test]
+task :test => [:base_test, :spec]
 
 Rake::TestTask.new(:base_test) do |t|
   t.libs << "test"
   t.test_files = (Dir["test/*.rb"] + Dir["test/plugin/*.rb"] - ["helper.rb"]).sort
   t.verbose = true
   #t.warning = true
+end
+
+require 'rspec/core'
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec) do |spec|
+  spec.pattern = FileList['spec/**/*_spec.rb']
 end
 
 task :parallel_test do

--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -28,4 +28,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency(%q<parallel_tests>, [">= 0.15.3"])
   gem.add_development_dependency(%q<rr>, [">= 1.0.0"])
   gem.add_development_dependency(%q<timecop>, [">= 0.3.0"])
+  gem.add_development_dependency "rspec", ">= 2.13.0"
+  gem.add_development_dependency "coveralls", ">= 0.7.0"
 end

--- a/lib/fluent/plugin/out_grep.rb
+++ b/lib/fluent/plugin/out_grep.rb
@@ -1,0 +1,105 @@
+module Fluent
+  class GrepOutput < Output
+    Plugin.register_output('grep', self)
+
+    REGEXP_MAX_NUM = 20
+
+    config_param :tag, :string, :default => nil
+    config_param :add_tag_prefix, :string, :default => nil
+    config_param :remove_tag_prefix, :string, :default => nil
+    config_param :replace_invalid_sequence, :bool, :default => false
+    (1..REGEXP_MAX_NUM).each {|i| config_param :"regexp#{i}",  :string, :default => nil }
+    (1..REGEXP_MAX_NUM).each {|i| config_param :"exclude#{i}", :string, :default => nil }
+
+    # for test
+    attr_reader :regexps
+    attr_reader :excludes
+
+    def configure(conf)
+      super
+
+      @regexps = {}
+      (1..REGEXP_MAX_NUM).each do |i|
+        next unless conf["regexp#{i}"]
+        key, regexp = conf["regexp#{i}"].split(/ /, 2)
+        raise Fluent::ConfigError, "regexp#{i} does not contain 2 parameters" unless regexp
+        raise Fluent::ConfigError, "regexp#{i} contains a duplicated key, #{key}" if @regexps[key]
+        @regexps[key] = Regexp.compile(regexp)
+      end
+
+      @excludes = {}
+      (1..REGEXP_MAX_NUM).each do |i|
+        next unless conf["exclude#{i}"]
+        key, exclude = conf["exclude#{i}"].split(/ /, 2)
+        raise Fluent::ConfigError, "exclude#{i} does not contain 2 parameters" unless exclude
+        raise Fluent::ConfigError, "exclude#{i} contains a duplicated key, #{key}" if @excludes[key]
+        @excludes[key] = Regexp.compile(exclude)
+      end
+
+      if @tag.nil? && @add_tag_prefix.nil? && @remove_tag_prefix.nil?
+        @add_tag_prefix = 'greped' # not ConfigError to support lower version compatibility
+      end
+
+      @tag_prefix = "#{@add_tag_prefix}." if @add_tag_prefix
+      @tag_prefix_match = "#{@remove_tag_prefix}." if @remove_tag_prefix
+      @tag_proc = case
+                  when @tag
+                    Proc.new { |tag| @tag }
+                  when @tag_prefix && @tag_prefix_match
+                    Proc.new { |tag| "#{@tag_prefix}#{lstrip(tag, @tag_prefix_match)}" }
+                  when @tag_prefix_match
+                    Proc.new { |tag| lstrip(tag, @tag_prefix_match) }
+                  when @tag_prefix
+                    Proc.new { |tag| "#{@tag_prefix}#{tag}" }
+                  else
+                    Proc.new { |tag| tag }
+                  end
+    end
+
+    def emit(tag, es, chain)
+      emit_tag = @tag_proc.call(tag)
+
+      es.each do |time, record|
+        catch(:break_loop) do
+          @regexps.each do |key, regexp|
+            throw :break_loop unless match(regexp, record[key].to_s)
+          end
+          @excludes.each do |key, exclude|
+            throw :break_loop if match(exclude, record[key].to_s)
+          end
+          Fluent::Engine.emit(emit_tag, time, record)
+        end
+      end
+
+      chain.next
+    rescue => e
+      $log.warn e.message
+      $log.warn e.backtrace.join(', ')
+    end
+
+    private
+
+    def lstrip(string, substring)
+      string.index(substring) == 0 ? string[substring.size..-1] : string
+    end
+
+    def match(regexp, string)
+      begin
+        return regexp.match(string)
+      rescue ArgumentError => e
+        raise e unless e.message.index("invalid byte sequence in") == 0
+        string = replace_invalid_byte(string)
+        retry
+      end
+      true
+    end
+
+    REPLACE_OPTIONS = {invalid: :replace, undef: :replace, replace: '?'}
+
+    def replace_invalid_byte(string)
+      original_encoding = string.encoding
+      temporal_encoding = (original_encoding == Encoding::UTF_8 ? Encoding::UTF_16BE : Encoding::UTF_8)
+      string.encode(temporal_encoding, original_encoding, REPLACE_OPTIONS).encode(original_encoding)
+    end
+  end
+end

--- a/spec/plugin/out_grep_spec.rb
+++ b/spec/plugin/out_grep_spec.rb
@@ -1,0 +1,203 @@
+# encoding: UTF-8
+require_relative '../spec_helper'
+
+describe Fluent::GrepOutput do
+  before { Fluent::Test.setup }
+  CONFIG = ""
+  let(:tag) { 'syslog.host1' }
+  let(:driver) { Fluent::Test::OutputTestDriver.new(Fluent::GrepOutput, tag).configure(config) }
+
+  describe 'test configure' do
+    describe 'bad configuration' do
+      context 'regexp contains a duplicated key' do
+        let(:config) { CONFIG + %[
+          regexp1 message foo
+          regexp2 message foo
+        ]}
+        it { expect { driver }.to raise_error(Fluent::ConfigError) }
+      end
+      context 'exclude contains a duplicated key' do
+        let(:config) { %[
+          exclude1 message foo
+          exclude2 message foo
+        ]}
+        it { expect { driver }.to raise_error(Fluent::ConfigError) }
+      end
+    end
+
+    describe 'good configuration' do
+      subject { driver.instance }
+
+      context "check default" do
+        let(:config) { CONFIG }
+        its(:tag) { should be_nil }
+        its(:add_tag_prefix) { should == 'greped' }
+        its(:replace_invalid_sequence) { should be_false }
+      end
+
+      context "regexpN can contain a space" do
+        let(:config) { CONFIG + %[regexp1 message  foo] }
+        it { subject.regexps['message'].should == Regexp.compile(/ foo/) }
+      end
+
+      context "excludeN can contain a space" do
+        let(:config) { CONFIG + %[exclude1 message  foo] }
+        it { subject.excludes['message'].should == Regexp.compile(/ foo/) }
+      end
+    end
+  end
+
+  describe 'test emit' do
+    let(:time) { Time.now.to_i }
+    let(:messages) do
+      [
+        "2013/01/13T07:02:11.124202 INFO GET /ping",
+        "2013/01/13T07:02:13.232645 WARN POST /auth",
+        "2013/01/13T07:02:21.542145 WARN GET /favicon.ico",
+        "2013/01/13T07:02:43.632145 WARN POST /login",
+      ]
+    end
+    let(:emit) do
+      driver.run { messages.each {|message| driver.emit({'foo'=>'bar', 'message' => message}, time) } }
+    end
+
+    context 'default' do
+      let(:config) { CONFIG }
+      before do
+        Fluent::Engine.stub(:now).and_return(time)
+        Fluent::Engine.should_receive(:emit).with("greped.#{tag}", time, {'foo'=>'bar', 'message'=>"2013/01/13T07:02:11.124202 INFO GET /ping"})
+        Fluent::Engine.should_receive(:emit).with("greped.#{tag}", time, {'foo'=>'bar', 'message'=>"2013/01/13T07:02:13.232645 WARN POST /auth"})
+        Fluent::Engine.should_receive(:emit).with("greped.#{tag}", time, {'foo'=>'bar', 'message'=>"2013/01/13T07:02:21.542145 WARN GET /favicon.ico"})
+        Fluent::Engine.should_receive(:emit).with("greped.#{tag}", time, {'foo'=>'bar', 'message'=>"2013/01/13T07:02:43.632145 WARN POST /login"})
+      end
+      it { emit }
+    end
+
+    context 'regexpN' do
+      let(:config) do
+        CONFIG + %[
+          regexp1 message WARN
+        ]
+      end
+      before do
+        Fluent::Engine.stub(:now).and_return(time)
+        Fluent::Engine.should_receive(:emit).with("greped.#{tag}", time, {'foo'=>'bar', 'message'=>"2013/01/13T07:02:13.232645 WARN POST /auth"})
+        Fluent::Engine.should_receive(:emit).with("greped.#{tag}", time, {'foo'=>'bar', 'message'=>"2013/01/13T07:02:21.542145 WARN GET /favicon.ico"})
+        Fluent::Engine.should_receive(:emit).with("greped.#{tag}", time, {'foo'=>'bar', 'message'=>"2013/01/13T07:02:43.632145 WARN POST /login"})
+      end
+      it { emit }
+    end
+
+    context 'excludeN' do
+      let(:config) do
+        CONFIG + %[
+          exclude1 message favicon
+        ]
+      end
+      before do
+        Fluent::Engine.stub(:now).and_return(time)
+        Fluent::Engine.should_receive(:emit).with("greped.#{tag}", time, {'foo'=>'bar', 'message'=>"2013/01/13T07:02:11.124202 INFO GET /ping"})
+        Fluent::Engine.should_receive(:emit).with("greped.#{tag}", time, {'foo'=>'bar', 'message'=>"2013/01/13T07:02:13.232645 WARN POST /auth"})
+        Fluent::Engine.should_receive(:emit).with("greped.#{tag}", time, {'foo'=>'bar', 'message'=>"2013/01/13T07:02:43.632145 WARN POST /login"})
+      end
+      it { emit }
+    end
+
+    context 'tag' do
+      let(:config) do
+        CONFIG + %[
+          regexp1 message ping
+          tag foo
+        ]
+      end
+      before do
+        Fluent::Engine.stub(:now).and_return(time)
+        Fluent::Engine.should_receive(:emit).with("foo", time, {'foo'=>'bar', 'message'=>"2013/01/13T07:02:11.124202 INFO GET /ping"})
+      end
+      it { emit }
+    end
+
+    context 'add_tag_prefix' do
+      let(:config) do
+        CONFIG + %[
+          regexp1 message ping
+          add_tag_prefix foo
+        ]
+      end
+      before do
+        Fluent::Engine.stub(:now).and_return(time)
+        Fluent::Engine.should_receive(:emit).with("foo.#{tag}", time, {'foo'=>'bar', 'message'=>"2013/01/13T07:02:11.124202 INFO GET /ping"})
+      end
+      it { emit }
+    end
+
+    context 'remove_tag_prefix' do
+      let(:config) do
+        CONFIG + %[
+          regexp1 message ping
+          remove_tag_prefix syslog
+        ]
+      end
+      before do
+        Fluent::Engine.stub(:now).and_return(time)
+        Fluent::Engine.should_receive(:emit).with("host1", time, {'foo'=>'bar', 'message'=>"2013/01/13T07:02:11.124202 INFO GET /ping"})
+      end
+      it { emit }
+    end
+
+    context 'replace_invalid_sequence' do
+      let(:config) do
+        CONFIG + %[
+          regexp1 message WARN
+          replace_invalid_sequence true
+        ]
+      end
+      let(:messages) do
+        [
+          "\xff".force_encoding('UTF-8'),
+        ]
+      end
+      before do
+        Fluent::Engine.stub(:now).and_return(time)
+      end
+      it { expect { emit }.not_to raise_error }
+    end
+  end
+
+  describe 'grep non-string jsonable values' do
+    let(:config) { CONFIG + %[regexp 0] }
+    let(:message) { 0 }
+    let(:time) { Time.now.to_i }
+    let(:emit) { driver.run { driver.emit({'foo'=>'bar', 'message' => message}, time) } }
+    before do
+      Fluent::Engine.stub(:now).and_return(time)
+      Fluent::Engine.should_receive(:emit).with("greped.#{tag}", time, {'foo'=>'bar', 'message'=>message})
+    end
+
+    context "array" do
+      let(:message) { ["0"] }
+      it { emit }
+    end
+
+    context "hash" do
+      let(:message) { ["0"=>"0"] }
+      it { emit }
+    end
+
+    context "integer" do
+      let(:message) { 0 }
+      it { emit }
+    end
+
+    context "float" do
+      let(:message) { 0.1 }
+      it { emit }
+    end
+
+    context "boolean" do
+      let(:config) { CONFIG + %[regexp true] }
+      let(:message) { true }
+      it { emit }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,16 @@
+# encoding: UTF-8
+require 'rubygems'
+require 'bundler'
+
+Bundler.setup(:default, :test)
+Bundler.require(:default, :test)
+
+require 'coveralls'
+Coveralls.wear!
+
+require 'fluent/test'
+require 'rspec'
+
+$TESTING=true
+$:.unshift File.join(File.dirname(__FILE__), '..', 'lib')
+require 'fluent/plugin/out_grep'


### PR DESCRIPTION
First step of https://github.com/fluent/fluentd/issues/250

I removed obsolete features and applying fluentd core format to codes.
Additionally, I created spec directory for newest plugins.
We have a plan to replace test framework with RSpec, so I think this is not a problem.

@sonots Could you check the code?
