### PR TITLE
Remove logging functionality from TextParsers

### DIFF
--- a/lib/fluent/parser.rb
+++ b/lib/fluent/parser.rb
@@ -145,7 +145,6 @@ module Fluent
       def call(text)
         m = @regexp.match(text)
         unless m
-          $log.warn "pattern not match: #{text.inspect}"
           return nil, nil
         end
 
@@ -203,7 +202,6 @@ module Fluent
 
         return time, record
       rescue Yajl::ParseError
-        $log.warn "pattern not match: #{text.inspect}: #{$!}"
         return nil, nil
       end
     end
@@ -327,7 +325,6 @@ module Fluent
       def call(text)
         m = REGEXP.match(text)
         unless m
-          $log.warn "pattern not match: #{text.inspect}"
           return nil, nil
         end
 

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -94,6 +94,8 @@ module Fluent
           time, record = parse_line(line)
           if time && record
             es.add(time, record)
+          else
+            $log.warn "pattern not match: #{line.inspect}"
           end
         rescue
           $log.warn line.dump, :error=>$!.to_s


### PR DESCRIPTION
Parsers in Fluent::TextParser are utility library.
Current implementaion depends on `$log` and it causes hard to use by other script.

I think $log should be removed from each Parsers.

Pros:
- code becomes simply
- other script can use without explicit $log instantiation.

Cons:
- breaking compatibility with -v option because logging position is changed
