### PR TITLE
Add sigdump

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency(%q<yajl-ruby>, ["~> 1.0"])
   gem.add_runtime_dependency(%q<cool.io>, ["~> 1.1.1"])
   gem.add_runtime_dependency(%q<http_parser.rb>, ["~> 0.5.1"])
+  gem.add_runtime_dependency(%q<sigdump>, ["~> 0.2.2"])
 
   gem.add_development_dependency(%q<rake>, [">= 0.9.2"])
   gem.add_development_dependency(%q<parallel_tests>, [">= 0.15.3"])

--- a/lib/fluent/load.rb
+++ b/lib/fluent/load.rb
@@ -9,6 +9,7 @@ require 'json'
 require 'yajl'
 require 'uri'
 require 'msgpack'
+require 'sigdump/setup'
 # I hate global variable but we suffer pain now for the sake of future.
 # We will switch to MessagePack 0.5 and deprecate 0.4.
 $use_msgpack_5 = defined?(MessagePack::Packer) ? true : false


### PR DESCRIPTION
[sigdump](https://github.com/frsyuki/sigdump) created by @frsyuki is very useful gem. Why don't you require `sigdump` as default? 

This patch enables users to dump the internal status of ruby (fluentd) by just sending CONT signal to fluentd process pid like

```
$ kill -CONT <pid>
```

The dump is stored into `/tmp/sigdump-<pid>.log` file. 

Sigdump was very useful to debug why fluentd process stucked. See this as an example https://gist.github.com/sonots/e05d8fbcd7ab39e4a5f8. 
