### PR TITLE
Fix to stuck at shutdown

### DIFF
--- a/lib/fluent/plugin/in_forward.rb
+++ b/lib/fluent/plugin/in_forward.rb
@@ -57,9 +57,13 @@ module Fluent
       @loop.stop
       @usock.close
       listen_address = (@bind == '0.0.0.0' ? '127.0.0.1' : @bind)
-      # This line is for connecting listen socket to stop the event loop.
-      # We should use more better approach, e.g. using pipe, fixing cool.io with timeout, etc.
-      TCPSocket.open(listen_address, @port) {|sock| } # FIXME @thread.join blocks without this line
+      begin
+        # This line is for connecting listen socket to stop the event loop.
+        # We should use more better approach, e.g. using pipe, fixing cool.io with timeout, etc.
+        SocketUtil.open_tcp_socket(listen_address, @port) {|sock| }  # FIXME @thread.join blocks without this line
+      rescue Timeout::Error => e
+        $log.warn "opening tcp socket is timeout on #{listen_address}:#{@port}"
+      end
       @thread.join
       @lsock.close
     end

--- a/lib/fluent/plugin/socket_util.rb
+++ b/lib/fluent/plugin/socket_util.rb
@@ -10,5 +10,57 @@ module Fluent
       end
     end
     module_function :create_udp_socket
+
+    # Create TCP Socket
+    #
+    # Example:
+    #
+    #     begin
+    #       SocketUtil.create_tcp_socket(host, port, connect_timeout: 0.5)
+    #     rescue Timeout::Error
+    #       log.debug "Timeout!"
+    #     end
+    #
+    # @param [String] host
+    # @param [Integer] port
+    # @param [Hash] opts
+    # @return [Socket]
+    #
+    # cf. https://bugs.ruby-lang.org/issues/5101
+    def create_tcp_socket(host, port, opts={})
+      connect_timeout = opts[:connect_timeout] || 5.0
+      addr = Socket.pack_sockaddr_in(port, host)
+      s = Socket.new(:AF_INET, :SOCK_STREAM, 0)
+      begin
+        s.connect_nonblock(addr)
+      rescue Errno::EINPROGRESS
+        IO.select(nil, [s], nil, connect_timeout) or raise Timeout::Error
+      end
+      s
+    end
+    module_function :create_tcp_socket
+
+    # Open TCP Socket
+    #
+    # Example:
+    #
+    #     begin
+    #       SocketUtil.open_tcp_socket(host, port, connect_timeout: 0.5) {|sock| }
+    #     rescue Timeout::Error
+    #       log.debug "Timeout!"
+    #     end
+    #
+    # @param [String] host
+    # @param [Integer] port
+    # @param [Hash] opts
+    def open_tcp_socket(host, port, opts={}, &block)
+      s = create_tcp_socket(host, port, opts)
+      begin
+        yield s
+      ensure
+        s.close
+      end
+    end
+    module_function :open_tcp_socket
   end
 end

--- a/test/plugin/socket_util.rb
+++ b/test/plugin/socket_util.rb
@@ -1,0 +1,80 @@
+require 'fluent/test'
+require 'helper'
+require 'fluent/plugin/socket_util'
+
+class SocketUtilTest < Test::Unit::TestCase
+  def setup
+    Fluent::Test.setup
+  end
+
+  HOST = '127.0.0.1'
+  PORT = unused_port
+  CONFIG = %[
+    port #{PORT}
+    bind #{HOST}
+  ]
+  TIME = Time.parse("2011-01-02 13:14:15 UTC").to_i
+
+  def create_driver(conf=CONFIG)
+    Fluent::Test::InputTestDriver.new(Fluent::ForwardInput).configure(conf)
+  end
+
+  def create_and_send(data, opts = {})
+    io = Fluent::SocketUtil.create_tcp_socket(HOST, PORT, opts)
+    begin
+      io.write data
+    ensure
+      io.close
+    end
+  end
+
+  def open_and_send(data, opts = {})
+    Fluent::SocketUtil.open_tcp_socket(HOST, PORT, opts) {|io| io.write data }
+  end
+
+  def test_create_tcp_socket
+    d = create_driver
+
+    d.expect_emit "tag1", TIME, {"a"=>1}
+    d.expect_emit "tag2", TIME, {"a"=>2}
+
+    d.run do
+      d.expected_emits.each {|tag,time,record|
+        create_and_send [tag, time, record].to_msgpack
+      }
+      sleep 0.5
+    end
+  end
+
+  def test_open_tcp_socket
+    d = create_driver
+
+    d.expect_emit "tag1", TIME, {"a"=>1}
+    d.expect_emit "tag2", TIME, {"a"=>2}
+
+    d.run do
+      d.expected_emits.each {|tag,time,record|
+        open_and_send [tag, time, record].to_msgpack
+      }
+      sleep 0.5
+    end
+  end
+
+  def test_tcp_socket_timeout
+    d = create_driver
+
+    samples = []
+    samples << ["tag1", TIME, {"a"=>1}]
+    samples << ["tag2", TIME, {"a"=>2}]
+
+    stub(IO).select { nil } # IO.select returns nil if timeout
+
+    d.run do
+      samples.each {|tag,time,record|
+        assert_raise(Timeout::Error) {
+          create_and_send [tag, time, record].to_msgpack, connect_timeout: 0.5
+        }
+      }
+    end
+  end
+end


### PR DESCRIPTION
I met troubles that fluentd does not terminate sometimes. 
Using [sigdump](https://github.com/frsyuki/sigdump), I found that fluentd was stuck at `TCPSocket.new` on shutdown. Please see https://gist.github.com/sonots/e05d8fbcd7ab39e4a5f8 for details. 

So, I implemented `SocketUtil.create_tcp_socket` and `SocketUtil.open_tcp_socket` having `connect_timeout` option as https://bugs.ruby-lang.org/issues/5101 says. 

PS. Please wait to merge. I will test for a week on my production environment. 
