### PR TITLE
Print remote address and port to trace who sends invalid logs.

### DIFF
--- a/lib/fluent/plugin/in_forward.rb
+++ b/lib/fluent/plugin/in_forward.rb
@@ -151,7 +151,10 @@ module Fluent
         end
         @on_message = on_message
         @log = log
-        @log.trace { "accepted fluent socket object_id=#{self.object_id}" }
+        @log.trace {
+          remote_port, remote_addr = *Socket.unpack_sockaddr_in(@_io.getpeername) rescue nil
+          "accepted fluent socket from '#{remote_addr}:#{remote_port}': object_id=#{self.object_id}"
+        }
       end
 
       def on_connect

--- a/lib/fluent/plugin/in_stream.rb
+++ b/lib/fluent/plugin/in_stream.rb
@@ -112,7 +112,10 @@ module Fluent
         end
         @on_message = on_message
         @log = log
-        @log.trace { "accepted fluent socket object_id=#{self.object_id}" }
+        @log.trace {
+          remote_port, remote_addr = *Socket.unpack_sockaddr_in(@_io.getpeername) rescue nil
+          "accepted fluent socket from '#{remote_addr}:#{remote_port}': object_id=#{self.object_id}"
+        }
       end
 
       def on_connect


### PR DESCRIPTION
Sometimes user got invalid logs via client or other node.
Remote address and port help the debug in this situation.
