### PR TITLE
Add --gemfile option to manage fluentd gems

### DIFF
--- a/lib/fluent/command/bundler_injection.rb
+++ b/lib/fluent/command/bundler_injection.rb
@@ -1,0 +1,31 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+system("bundle install")
+unless $?.success?
+  exit $?.exitstatus
+end
+
+cmdline = [
+  'bundle',
+  'exec',
+  RbConfig.ruby,
+  File.expand_path(File.join(File.dirname(__FILE__), 'fluentd.rb')),
+] + ARGV
+
+exec *cmdline
+exit! 127
+


### PR DESCRIPTION
At Fluentd start phase, install fluentd related gems separated from existence gem environment using bundler.

I need the feedback.
Please try this feature in your environment!
