### PR TITLE
Tests on Travis CI against rbx instead rbx-19mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
-  - rbx-19mode
+  - rbx
 
 branches:
   only:
@@ -14,4 +14,4 @@ script: bundle exec rake
 
 matrix:
   allow_failures:
-    - rvm: rbx-19mode
+    - rvm: rbx


### PR DESCRIPTION
There is no support for rbx-19mode on Travis CI:
http://docs.travis-ci.com/user/languages/ruby/#Rubinius
