### PR TITLE
add undef_method to fluent-debug

### DIFF
--- a/lib/fluent/command/debug.rb
+++ b/lib/fluent/command/debug.rb
@@ -59,6 +59,13 @@ require 'fluent/load'
 $log = Fluent::Log.new(STDERR, Fluent::Log::LEVEL_TRACE)
 Fluent::Engine.init
 
+DRb::DRbObject.class_eval do
+  undef_method :methods
+  undef_method :instance_eval
+  undef_method :instance_variables
+  undef_method :instance_variable_get
+end
+
 remote_engine = DRb::DRbObject.new_with_uri(uri)
 
 Fluent.module_eval do


### PR DESCRIPTION
This patch enables us to check the instance variable without running `undef_method instance_variable_get`.

before

``` ruby
irb(main):001:0> out = Engine.match('hoge').output
=> #<Fluent::ForwardOutput:0xb4b2a7a0>
irb(main):002:0> class << out
irb(main):003:1>  undef_method :instance_variables
irb(main):004:1>  undef_method :instance_variable_get
irb(main):005:1> end
=> #<Class:#<DRb::DRbObject:0x934458c>>
irb(main):006:0> out.instance_variables
=> [:@log_level, :@buffer_type, :@flush_interval, :@try_flush_interval, :@retry_limit, :@retry_wait, :@max_retry_wait, :@num_threads, :@queued_chunk_flush_interval, :@send_timeout, :@heartbeat_type, :@heartbeat_interval, :@recover_wait, :@hard_timeout, :@expire_dns_cache, :@phi_threshold, :@port, :@host, :@log, :@next_flush_time, :@last_retry_time, :@next_retry_time, :@error_history, :@secondary_limit, :@emit_count, :@nodes, :@id, :@config, :@buffer, :@writers, :@writer_current_position, :@writers_size, :@rand_seed, :@weight_array, :@rr, :@loop, :@usock, :@hb, :@timer, :@thread]
irb(main):007:0> buffer = out.instance_variable_get(:@buffer)
=> #<Fluent::FileBuffer:0xb4b29094>
irb(main):008:0> buffer.instance_variables
=> [:@uri, :@ref]

```

↓
after

``` ruby
irb(main):001:0> out = Engine.match('hoge').output
=> #<Fluent::ForwardOutput:0xb4b2a7a0>
irb(main):002:0> out.instance_variables
=> [:@log_level, :@buffer_type, :@flush_interval, :@try_flush_interval, :@retry_limit, :@retry_wait, :@max_retry_wait, :@num_threads, :@queued_chunk_flush_interval, :@send_timeout, :@heartbeat_type, :@heartbeat_interval, :@recover_wait, :@hard_timeout, :@expire_dns_cache, :@phi_threshold, :@port, :@host, :@log, :@next_flush_time, :@last_retry_time, :@next_retry_time, :@error_history, :@secondary_limit, :@emit_count, :@nodes, :@id, :@config, :@buffer, :@writers, :@writer_current_position, :@writers_size, :@rand_seed, :@weight_array, :@rr, :@loop, :@usock, :@hb, :@timer, :@thread]
irb(main):003:0> buffer = out.instance_variable_get(:@buffer)
=> #<Fluent::FileBuffer:0xb4b29094>
irb(main):004:0> buffer.instance_variables
=> [:@buffer_chunk_limit, :@buffer_queue_limit, :@mon_owner, :@mon_count, :@mon_mutex, :@parallel_pop, :@config, :@buffer_path, :@buffer_path_prefix, :@buffer_path_suffix, :@flush_at_shutdown, :@queue, :@map]
irb(main):005:0> exit
```
