### PR TITLE
Add args from 2nd to fluent.** internal messages

### DIFF
--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -265,6 +265,10 @@ module Fluent
         end
       }
 
+      map.each_pair {|k,v|
+        message << " #{k}=#{v.inspect}"
+      }
+
       unless @threads_exclude_events.include?(Thread.current)
         record = map.dup
         record.keys.each {|key|
@@ -273,10 +277,6 @@ module Fluent
         record['message'] = message.dup
         Engine.push_log_event("#{@tag}.#{level}", time.to_i, record)
       end
-
-      map.each_pair {|k,v|
-        message << " #{k}=#{v.inspect}"
-      }
 
       return time, message
     end


### PR DESCRIPTION
Currently, when fluentd calls logger like ([out_forwrd.rb#L397](https://github.com/fluent/fluentd/blob/master/lib/fluent/plugin/out_forward.rb#L397))

```
@log.warn "detached forwarding server '#{@name}'", :host=>@host, :port=>@port, :hard_timeout=>true
```

although the logger outputs to the log file like,

```
2014-03-12 12:38:59 +0900 [warn]: detached forwarding server 'host1:22000' host="host1" port=22000 hard_timeout=true
```

fluent.warn message becomes as followings:

``` json
{"message":"detached forwarding server 'host1:22000'"}
```

It is losing information, and it made me confuse. I prefer to have the same information with the log. 

This patch fixes the issue. 

I checked all log method calling, and it looked the volume to be added is not huge. 
