### PR TITLE
Use <server> option instead of obsoleted host option

### DIFF
--- a/fluent.conf
+++ b/fluent.conf
@@ -56,9 +56,13 @@
 # match tag=system.** and forward to another fluent server
 <match system.**>
   type forward
-  host 192.168.0.11
+  <server>
+    host 192.168.0.11
+  </server>
   <secondary>
-    host 192.168.0.12
+    <server>
+      host 192.168.0.12
+    </server>
   </secondary>
 </match>
 
@@ -67,11 +71,13 @@
 #  type copy
 #  <store>
 #    type forward
-#    host 192.168.0.13
 #    buffer_type file
 #    buffer_path /var/log/fluent/myapp-forward
 #    retry_limit 50
 #    flush_interval 10s
+#    <server>
+#      host 192.168.0.13
+#    </server>
 #  </store>
 #  <store>
 #    type file


### PR DESCRIPTION
I often use `--setup` option to create initial configuration file. The file created by the setup option uses obsoleted `host` option in out_forward, so the following warnins occur when Fluentd starts with the configuration. If there is no reason to keep it, please fix it.

```
2014-03-22 16:38:27 +0900 [warn]: 'host' option in forward output is obsoleted. Use '<server> host xxx </server>' instead.
```
