### PR TITLE
add flush_at_shutdown option to buf_memory

### DIFF
--- a/lib/fluent/plugin/buf_memory.rb
+++ b/lib/fluent/plugin/buf_memory.rb
@@ -71,6 +71,7 @@ module Fluent
       super
     end
 
+    config_param :flush_at_shutdown, :bool, :default => true
     # Overwrite default BasicBuffer#buffer_queue_limit
     # to limit total memory usage upto 512MB.
     config_set_default :buffer_queue_limit, 64
@@ -80,11 +81,13 @@ module Fluent
     end
 
     def before_shutdown(out)
-      synchronize do
-        @map.each_key {|key|
-          push(key)
-        }
-        while pop(out)
+      if @flush_at_shutdown
+        synchronize do
+          @map.each_key {|key|
+            push(key)
+          }
+          while pop(out)
+          end
         end
       end
     end


### PR DESCRIPTION
This is just same thing with one which buf_file has https://github.com/fluent/fluentd/blob/master/lib/fluent/plugin/buf_file.rb#L180

I want this option because I do not need to flush all buffers at shutdown on my system, want to just discard them. 

Unlike buf_file, flush_at_shutdown is true as default for lower version compatibility. 
