### PR TITLE
randomize max_retry_wait

### DIFF
--- a/lib/fluent/output.rb
+++ b/lib/fluent/output.rb
@@ -388,14 +388,14 @@ module Fluent
 
     def calc_retry_wait
       # TODO retry pattern
-      wait = if @error_history.size <= @retry_limit
-               @retry_wait * (2 ** (@error_history.size-1))
-             else
-               # secondary retry
-               @retry_wait * (2 ** (@error_history.size-2-@retry_limit))
-             end
+      exponent_wait = if @error_history.size <= @retry_limit
+                        @retry_wait * (2 ** (@error_history.size-1))
+                      else
+                        # secondary retry
+                        @retry_wait * (2 ** (@error_history.size-2-@retry_limit))
+                      end
+      wait = @max_retry_wait ? [exponent_wait, @max_retry_wait].min : exponent_wait
       retry_wait = wait + (rand * (wait / 4.0) - (wait / 8.0))
-      @max_retry_wait ? [retry_wait, @max_retry_wait].min : retry_wait
     end
 
     def write_abort

--- a/test/output.rb
+++ b/test/output.rb
@@ -49,7 +49,8 @@ module FluentOutputTest
       # max_retry_wait
       d = create_driver(CONFIG + %[max_retry_wait 4])
       d.instance.retry_limit.times { d.instance.instance_variable_get(:@error_history) << Engine.now }
-      assert_equal 4, d.instance.calc_retry_wait
+      wait = 4
+      assert( d.instance.calc_retry_wait > wait - wait / 8.0 )
     end
 
     def create_mock_driver(conf=CONFIG)


### PR DESCRIPTION
Although I added an option `max_retry_wait` with the pull request https://github.com/fluent/fluentd/pull/219 before, `max_retry_wait` should be randomized because, otherwise, retry would burst at the same time. 
