### PR TITLE
Fix to expire match cache

### DIFF
--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -144,7 +144,7 @@ module Fluent
         # this is not thread-safe but inconsistency doesn't
         # cause serious problems while locking causes.
         if @match_cache_keys.size >= MATCH_CACHE_SIZE
-          @match_cache_keys.delete @match_cache_keys.shift
+          @match_cache.delete @match_cache_keys.shift
         end
         @match_cache[tag] = target
         @match_cache_keys << tag


### PR DESCRIPTION
The element of `@match_cache_keys` is deleted but the one of `@match_cache` is not.
When many (over 1024) kinds of tags are used, match cache continues to expand.
