### PR TITLE
Use Engine.now when time_key is missing in ValuesParser#call

### DIFF
--- a/lib/fluent/parser.rb
+++ b/lib/fluent/parser.rb
@@ -236,7 +236,11 @@ module Fluent
 
         if @time_key
           value = record.delete(@time_key)
-          time = @mutex.synchronize { @time_parser.parse(value) }
+          time = if value.nil?
+                   Engine.now
+                 else
+                   @mutex.synchronize { @time_parser.parse(value) }
+                 end
         else
           time = Engine.now
         end


### PR DESCRIPTION
Currently, "Value must be String" error happens.
