### PR TITLE
Print warn message when flush_at_shutdown is true in buf_memory. refs #286

### DIFF
--- a/lib/fluent/plugin/buf_memory.rb
+++ b/lib/fluent/plugin/buf_memory.rb
@@ -78,6 +78,11 @@ module Fluent
 
     def configure(conf)
       super
+
+      unless @flush_at_shutdown
+        $log.warn "When flush_at_shutdown is false, buf_memory discards buffered chunks at shutdown."
+        $log.warn "Please confirm 'flush_at_shutdown false' configuration is correct or not."
+      end
     end
 
     def before_shutdown(out)


### PR DESCRIPTION
If the user changes `buf_file` to `buf_memory` with `flush_at_shutdown false`,
the user may discard buffered chunks unexpectedly.
I think printing warn message is better.

@sonots @tagomoris Please check.
