### PR TITLE
in_forward: use AsyncWatcher to break event loop instead of blocking timeout

### DIFF
--- a/test/plugin/test_in_forward.rb
+++ b/test/plugin/test_in_forward.rb
@@ -21,11 +21,8 @@ class ForwardInputTest < Test::Unit::TestCase
     assert_equal PORT, d.instance.port
     assert_equal '127.0.0.1', d.instance.bind
     assert_equal 0, d.instance.linger_timeout
-    assert_equal 0.5, d.instance.blocking_timeout
     assert !d.instance.backlog
   end
-
-  # TODO: Will add Loop::run arity check with stub/mock library
 
   def connect
     TCPSocket.new('127.0.0.1', PORT)


### PR DESCRIPTION
refs #297

Blocking timeout approach causes needless loop break each 0.5
seconds. It is not effective.

AsyncWatcher approach doesn't cause any needless loop break. It just
causes a loop break on shutdown.

https://github.com/fluent/fluentd/pull/297#issuecomment-40694681 says
loop break approach doesn't increase CPU LOAD. So this is just a
trivial problem...

NOTE: We can use the AsyncWatcher approach in in_stream and
in_syslog. If we apply the AsyncWatcher approach to them, we can
improve "rake base_test" speed. It takes 683s without the AsyncWatcher
approach on Travis CI. It takes 80s with the AsyncWatcher approach on
my environment.
