### PR TITLE
Adds buffer_ignore_exceeded_chunk option to Buffer

### DIFF
--- a/lib/fluent/buffer.rb
+++ b/lib/fluent/buffer.rb
@@ -182,7 +182,8 @@ module Fluent
         elsif @queue.size >= @buffer_queue_limit
           ex = BufferQueueLimitError.new("queue size exceeds limit")
           if @buffer_ignore_exceeded_chunk
-            $log.error ex.message, :error => ex
+            $log.error ex.message, :error_class => ex.class.to_s, :error => ex.message
+            return false
           else
             raise ex
           end

--- a/test/test_buffer.rb
+++ b/test/test_buffer.rb
@@ -8,6 +8,8 @@ module FluentBufferTest
   include Fluent
 
   class SimpleBufferedOutput < BasicBuffer
+    attr_reader :queue
+
     def resume
       # queue, map
       return [], {}
@@ -38,12 +40,16 @@ module FluentBufferTest
 
     def test_doesnt_raise_exception_if_chunk_limit_exceeded_and_ignored
       @out.configure %[
-        buffer_chunk_limit 3
+        buffer_chunk_limit 4
         buffer_queue_limit 0
         buffer_ignore_exceeded_chunk true
       ]
 
-      @out.run { @out.instance.emit('sample.key', "data", Fluent::NullOutputChain.instance) }
+      @out.run do
+        @out.instance.emit('sample.key', "data", Fluent::NullOutputChain.instance)
+        @out.instance.emit('sample.key', "data", Fluent::NullOutputChain.instance)
+        assert_equal [], @out.instance.queue
+      end
     end
   end
 end


### PR DESCRIPTION
Controls whether exceeded chunk should raise an exception (and break the chain) or log and ignore
the exception. As discussed in #296
