### PR TITLE
add current_time option to out_stdout

### DIFF
--- a/lib/fluent/plugin/out_stdout.rb
+++ b/lib/fluent/plugin/out_stdout.rb
@@ -18,30 +18,19 @@ module Fluent
   class StdoutOutput < Output
     Plugin.register_output('stdout', self)
 
-    OUTPUT_PROCS = {
-      :json => Proc.new {|record| Yajl.dump(record) },
-      :hash => Proc.new {|record| record.to_s },
-    }
-
-    config_param :output_type, :default => :json do |val|
-      case val.downcase
-      when 'json'
-        :json
-      when 'hash'
-        :hash
-      else
-        raise ConfigError, "stdout output output_type should be 'json' or 'hash'"
-      end
-    end
+    attr_reader :formatter # for test
+    config_param :format, :string, :default => 'out_stdout'
 
     def configure(conf)
       super
-      @output_proc = OUTPUT_PROCS[@output_type]
+
+      @formatter = Plugin.new_formatter(@format)
+      @formatter.configure(conf)
     end
 
     def emit(tag, es, chain)
       es.each {|time,record|
-        $log.write "#{Time.at(time).localtime} #{tag}: #{@output_proc.call(record)}\n"
+        $log.write @formatter.format(tag, time, record)
       }
       $log.flush
 

--- a/test/plugin/test_out_stdout.rb
+++ b/test/plugin/test_out_stdout.rb
@@ -1,9 +1,15 @@
 require_relative '../helper'
 require 'fluent/test'
+require 'timecop'
 
 class StdoutOutputTest < Test::Unit::TestCase
   def setup
     Fluent::Test.setup
+    Timecop.freeze
+  end
+
+  def teardown
+    Timecop.return
   end
 
   CONFIG = %[
@@ -15,22 +21,25 @@ class StdoutOutputTest < Test::Unit::TestCase
 
   def test_configure
     d = create_driver
-    assert_equal :json, d.instance.output_type
+    assert_equal 'json', d.instance.formatter.output_type
   end
 
   def test_configure_output_type
     d = create_driver(CONFIG + "\noutput_type json")
-    assert_equal :json, d.instance.output_type
+    assert_equal 'json', d.instance.formatter.output_type
 
     d = create_driver(CONFIG + "\noutput_type hash")
-    assert_equal :hash, d.instance.output_type
+    assert_equal 'hash', d.instance.formatter.output_type
+
+    d = create_driver(CONFIG + "\noutput_type ltsv")
+    assert_equal 'ltsv', d.instance.formatter.output_type
 
     assert_raise(Fluent::ConfigError) do
       d = create_driver(CONFIG + "\noutput_type foo")
     end
   end
 
-  def test_emit_json
+  def test_output_type_json
     d = create_driver(CONFIG + "\noutput_type json")
     time = Time.now
     out = capture_log { d.emit({'test' => 'test'}, time) }
@@ -40,7 +49,7 @@ class StdoutOutputTest < Test::Unit::TestCase
     assert_raise(Yajl::EncodeError) { d.emit({'test' => Float::NAN}, time) }
   end
 
-  def test_emit_hash
+  def test_output_type_hash
     d = create_driver(CONFIG + "\noutput_type hash")
     time = Time.now
     out = capture_log { d.emit({'test' => 'test'}, time) }
@@ -49,6 +58,23 @@ class StdoutOutputTest < Test::Unit::TestCase
     # NOTE: Float::NAN is not jsonable, but hash string can output it.
     out = capture_log { d.emit({'test' => Float::NAN}, time) }
     assert_equal "#{time.localtime} test: {\"test\"=>NaN}\n", out
+  end
+
+  # Use include_time_key to output the message's time
+  def test_include_time_key
+    d = create_driver(CONFIG + "\noutput_type json\ninclude_time_key true\nutc")
+    time = Time.now
+    message_time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    out = capture_log { d.emit({'test' => 'test'}, message_time) }
+    assert_equal "#{time.localtime} test: {\"test\":\"test\",\"time\":\"2011-01-02T13:14:15Z\"}\n", out
+  end
+
+  # out_stdout formatter itself can also be replaced
+  def test_format_json
+    d = create_driver(CONFIG + "\nformat json")
+    time = Time.now
+    out = capture_log { d.emit({'test' => 'test'}, time) }
+    assert_equal "{\"test\":\"test\"}\n", out
   end
 
   private


### PR DESCRIPTION
Current `out_stdout` outputs messages as

```
2010-05-04 12:02:01 +0900 test: {"test":"test"}
```

where the time expresses the time parameter of messages, i.e., the time when the message is created or, the time written in application logs. 

`current_time` option enables to output the current time of *logging* which looks like

```
2014-04-24 18:49:23 +0900 2010-05-04 12:02:01 +0900 test: {"test":"test"}
```

so that we can tell the latency between receiving (logging) and sending (creating) of messages. 

PS. I am still wondering the log format and the option name. 