### PR TITLE
Add dummy log device and fix to use it

### DIFF
--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -357,7 +357,9 @@ module Fluent
       super
 
       if @log_level
-        @log = PluginLogger.new($log)
+        unless @log.is_a?(PluginLogger)
+          @log = PluginLogger.new($log)
+        end
         @log.level = @log_level
       end
     end

--- a/lib/fluent/test.rb
+++ b/lib/fluent/test.rb
@@ -4,5 +4,3 @@ require 'fluent/test/base'
 require 'fluent/test/input_test'
 require 'fluent/test/output_test'
 
-$log ||= Fluent::Log.new
-

--- a/lib/fluent/test/base.rb
+++ b/lib/fluent/test/base.rb
@@ -32,6 +32,8 @@ module Fluent
         else
           @instance = klass
         end
+        @instance.log = TestLogger.new
+
         @config = Config.new
       end
 
@@ -56,6 +58,45 @@ module Fluent
         ensure
           @instance.shutdown
         end
+      end
+    end
+
+    class DummyLogDevice
+      attr_reader :logs
+
+      def initialize
+        @logs = []
+      end
+
+      def tty?
+        false
+      end
+
+      def puts(*args)
+        args.each{ |arg| write(arg + "\n") }
+      end
+
+      def write(message)
+        @logs.push message
+      end
+
+      def flush
+        true
+      end
+
+      def close
+        true
+      end
+    end
+
+    class TestLogger < Fluent::PluginLogger
+      def initialize
+        @logdev = DummyLogDevice.new
+        super(Fluent::Log.new(@logdev))
+      end
+
+      def logs
+        @logdev.logs
       end
     end
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,6 +1,7 @@
 require 'test/unit'
 require 'fileutils'
 require 'fluent/log'
+require 'fluent/test'
 require 'rr'
 
 unless defined?(Test::Unit::AssertionFailedError)
@@ -26,4 +27,4 @@ def ipv6_enabled?
   end
 end
 
-$log = Fluent::Log.new(STDOUT, Fluent::Log::LEVEL_WARN)
+$log = Fluent::Log.new(Fluent::Test::DummyLogDevice.new, Fluent::Log::LEVEL_WARN)


### PR DESCRIPTION
- remove setting global logger in lib/fluent/test.rb
  - developer cannot understand when this assignment happen
  - global logger assignment exists in test/helper
- dummy logger should contain messages that logger writes
  - to assert logger's output from core/plugin tests
- test dummy logger is set in default in create_driver
  - to test logger message in configure
