### PR TITLE
Update travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.0
-  - 2.1.1
+  - 2.1
   - ruby-head
   - rbx
 


### PR DESCRIPTION
Travis does not support ruby 2.1.0 anymore. We have to write as `2.1` or `2.1.*`. 
See http://blog.travis-ci.com/2014-04-28-upcoming-build-environment-updates/

See the test is failing https://travis-ci.org/fluent/fluentd/jobs/24082638
