### PR TITLE
make chunk key configurable from plugins

### DIFF
--- a/lib/fluent/output.rb
+++ b/lib/fluent/output.rb
@@ -234,8 +234,9 @@ module Fluent
       @buffer.shutdown
     end
 
-    def emit(tag, es, chain, key="")
+    def emit(tag, es, chain)
       @emit_count += 1
+      key = chunk_key(tag)
       data = format_stream(tag, es)
       if @buffer.emit(key, data, chain)
         submit_flush
@@ -254,6 +255,10 @@ module Fluent
         out << format(tag, time, record)
       }
       out
+    end
+
+    def chunk_key(tag)
+      ''
     end
 
     #def format(tag, time, record)


### PR DESCRIPTION
A key name of chunk can be specified in 4th argument of `BufferedOutput#emit` in BufferedOutput class, but no one use this argument and no hook point for setting the value. It is good to be able to configure it from plugins like `format`.

If this feature is available, plugins can determine how to handle chunks depending on the chunk key. For instance, destination server is determined by the tag. I know the example can be achieved by using fluent-plugin-forest. Though I think it is easy to provide a plugin with built-in features like fluent-plugin-hash-forward.

Actually I want to set the key name from _log data_, but it is inefficient to call `chunk_key` for each message just like `format`.  For that purpose, I think Mixin approach is better and allow `format` to also return a key name of chunk. How do you think about it?
