### PR TITLE
Allow empty value parameter in v1 config

### DIFF
--- a/lib/fluent/config/basic_parser.rb
+++ b/lib/fluent/config/basic_parser.rb
@@ -65,6 +65,10 @@ module Fluent
         @ss.eos?
       end
 
+      def prev_match
+        @ss[0]
+      end
+
       def line_end
         skip(LINE_END)
       end

--- a/lib/fluent/config/types.rb
+++ b/lib/fluent/config/types.rb
@@ -38,6 +38,8 @@ module Fluent
         true
       when 'false', 'no'
         false
+      when ''
+        true
       else
         nil
       end

--- a/lib/fluent/config/v1_parser.rb
+++ b/lib/fluent/config/v1_parser.rb
@@ -102,11 +102,15 @@ module Fluent
           else
             k = scan_string(SPACING)
             spacing
-            v = parse_literal
-            unless line_end
-              parse_error! "expected end of line"
+            if prev_match.include?("\n") # support 'tag_mapped' like "without value" configuration
+              attrs[k] = ""
+            else
+              v = parse_literal
+              unless line_end
+                parse_error! "expected end of line"
+              end
+              attrs[k] = v
             end
-            attrs[k] = v
           end
         end
 

--- a/spec/config/config_parser_spec.rb
+++ b/spec/config/config_parser_spec.rb
@@ -34,6 +34,13 @@ describe Fluent::Config::V1Parser do
       ].should be_parsed_as("k1"=>"v1", "k2"=>"v2")
     end
 
+    it "allows attribute without value" do
+      %[
+        k1
+        k2 v2
+      ].should be_parsed_as("k1"=>"", "k2"=>"v2")
+    end
+
     it "parses attribute key always string" do
       "1 1".should be_parsed_as("1" => "1")
     end


### PR DESCRIPTION
In old configuration, we can specify parameters with empty string:

``` aconf
<match mongo.**>
  type mongo
  tag_mapped
  # others
</match>
```

but v1 can't. This format is popular so v1 should support this.
