### PR TITLE
Fix invalid file seek in the file containing CRLF

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -54,7 +54,7 @@ module Fluent
 
     def start
       if @pos_file
-        @pf_file = File.open(@pos_file, File::RDWR|File::CREAT, DEFAULT_FILE_PERMISSION)
+        @pf_file = File.open(@pos_file, File::RDWR|File::CREAT|File::BINARY, DEFAULT_FILE_PERMISSION)
         @pf_file.sync = true
         @pf = PositionFile.parse(@pf_file)
       end


### PR DESCRIPTION
In the file containing CRLF, below code gets unexpected results.

``` ruby
file.each_line {|line|
  p "pos=#{file.seek}, bytesize=#{line.bytesize}"
  # => pos=69, bytesize=68
  # => expected results = pos=68, bytesize=68
}
```

In the file containing only LF, upper code gets expected results.
So I removed the code for computing `seek` from `file.pos` and `line.bytesize`.
