### PR TITLE
Fix fluent-debug raises undefined method 'usage'

### DIFF
--- a/lib/fluent/command/debug.rb
+++ b/lib/fluent/command/debug.rb
@@ -36,6 +36,14 @@ op.on('-u', '--unix PATH', "use unix socket instead of tcp") {|b|
   unix = b
 }
 
+(class<<self;self;end).module_eval do
+  define_method(:usage) do |msg|
+    puts op.to_s
+    puts "error: #{msg}" if msg
+    exit 1
+  end
+end
+
 begin
   op.parse!(ARGV)
 


### PR DESCRIPTION
`fluent-debug` can't handle invalid option correctory.

```
$ ./bin/fluent-debug -p
/Users/uu59/works/td/fluentd/lib/fluent/command/debug.rb:47:in `rescue in <top (required)>': undefined method `usage' for main:Object (NoMethodError)
        from /Users/uu59/works/td/fluentd/lib/fluent/command/debug.rb:40:in `<top (required)>'
        from /Users/uu59/.rbenv/versions/2.1.0/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /Users/uu59/.rbenv/versions/2.1.0/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from ./bin/fluent-debug:6:in `<main>'
```

↓ fixed

```
$ ./bin/fluent-debug -p
Usage: fluent-debug [options]
    -h, --host HOST                  fluent host (default: 127.0.0.1)
    -p, --port PORT                  debug_agent tcp port (default: 24230)
    -u, --unix PATH                  use unix socket instead of tcp
error: missing argument: -p
```
