### PR TITLE
Add format option to in_http. fixes #302

### DIFF
--- a/test/plugin/test_in_http.rb
+++ b/test/plugin/test_in_http.rb
@@ -95,10 +95,7 @@ class HttpInputTest < Test::Unit::TestCase
 
     d.run do
       d.expected_emits.each {|tag,time,record|
-        http = Net::HTTP.new("127.0.0.1", PORT)
-        req = Net::HTTP::Post.new("/#{tag}?time=#{time.to_s}", {"content-type"=>"application/json; charset=utf-8"})
-        req.body = record.to_json
-        res = http.request(req)
+        res = post("/#{tag}?time=#{time.to_s}", record.to_json, {"content-type"=>"application/json; charset=utf-8"})
         assert_equal "200", res.code
       }
     end
@@ -120,10 +117,58 @@ class HttpInputTest < Test::Unit::TestCase
     end
   end
 
-  def post(path, params)
+  def test_with_regexp
+    d = create_driver(CONFIG + %[
+      format /^(?<field_1>\\d+):(?<field_2>\\w+)$/
+      types field_1:integer
+    ])
+
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+
+    d.expect_emit "tag1", time, {"field_1" => 1, "field_2" => 'str'}
+    d.expect_emit "tag2", time, {"field_1" => 2, "field_2" => 'str'}
+
+    d.run do
+      d.expected_emits.each { |tag, time, record|
+        body = record.map { |k, v|
+          v.to_s
+        }.join(':')
+        res = post("/#{tag}?time=#{time.to_s}", body)
+        assert_equal "200", res.code
+      }
+    end
+  end
+
+  def test_with_csv
+    require 'csv'
+
+    d = create_driver(CONFIG + %[
+      format csv
+      keys foo,bar
+    ])
+
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+
+    d.expect_emit "tag1", time, {"foo" => "1", "bar" => 'st"r'}
+    d.expect_emit "tag2", time, {"foo" => "2", "bar" => 'str'}
+
+    d.run do
+      d.expected_emits.each { |tag, time, record|
+        body = record.map { |k, v| v }.to_csv
+        res = post("/#{tag}?time=#{time.to_s}", body)
+        assert_equal "200", res.code
+      }
+    end
+  end
+
+  def post(path, params, header = {})
     http = Net::HTTP.new("127.0.0.1", PORT)
-    req = Net::HTTP::Post.new(path, {})
-    req.set_form_data(params)
+    req = Net::HTTP::Post.new(path, header)
+    if params.is_a?(String)
+      req.body = params
+    else
+      req.set_form_data(params)
+    end
     http.request(req)
   end
 


### PR DESCRIPTION
I implemented first version of `format` support in `in_http`.

This implementation doesn't support `field_name` option and assumes body is entire content like header provided json behaviour.

https://github.com/fluent/fluentd/blob/cd3e4461695543d16c18c0d7f873d0522506ee1e/lib/fluent/plugin/in_http.rb#L259

@kiyoto What do you think? Do we need `field_name` option?
Existence `default` behaviour can accept json / msgpack without explicit format so need `json` or `msgpack` identifier in HTTP body.
But with `format` option, we already specified body format in configuration so `field_name` seems redundant.
