### PR TITLE
Add add_newline option to SingleValueFormatter

### DIFF
--- a/lib/fluent/formatter.rb
+++ b/lib/fluent/formatter.rb
@@ -126,9 +126,12 @@ module Fluent
       include Configurable
 
       config_param :message_key, :string, :default => 'message'
+      config_param :add_newline, :bool, :default => true
 
       def format(tag, time, record)
-        record[@message_key]
+        text = record[@message_key].to_s
+        text << "\n" if @add_newline
+        text
       end
     end
 

--- a/test/plugin/test_out_file.rb
+++ b/test/plugin/test_out_file.rb
@@ -89,6 +89,30 @@ class FileOutputTest < Test::Unit::TestCase
     check_gzipped_result(path, %[#{Yajl.dump({"a" => 1, 'time' => time})}\n] + %[#{Yajl.dump({"a" => 2, 'time' => time})}\n])
   end
 
+  def test_write_with_format_ltsv
+    d = create_driver [CONFIG, 'format ltsv', 'include_time_key true'].join("\n")
+
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    d.emit({"a"=>1}, time)
+    d.emit({"a"=>2}, time)
+
+    # FileOutput#write returns path
+    path = d.run
+    check_gzipped_result(path, %[a:1\ttime:2011-01-02T13:14:15Z\n] + %[a:2\ttime:2011-01-02T13:14:15Z\n])
+  end
+
+  def test_write_with_format_single_value
+    d = create_driver [CONFIG, 'format single_value', 'message_key a'].join("\n")
+
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    d.emit({"a"=>1}, time)
+    d.emit({"a"=>2}, time)
+
+    # FileOutput#write returns path
+    path = d.run
+    check_gzipped_result(path, %[1\n] + %[2\n])
+  end
+
   def test_write_path_increment
     d = create_driver
 

--- a/test/test_formatter.rb
+++ b/test/test_formatter.rb
@@ -177,7 +177,14 @@ module FormatterTest
     def test_format
       formatter = TextFormatter::TEMPLATE_REGISTRY.lookup('single_value').call
       formatted = formatter.format('tag', Engine.now, {'message' => 'awesome'})
-      assert_equal('awesome', formatted)
+      assert_equal("awesome\n", formatted)
+    end
+
+    def test_format_without_newline
+      formatter = TextFormatter::TEMPLATE_REGISTRY.lookup('single_value').call
+      formatter.configure('add_newline' => 'false')
+      formatted = formatter.format('tag', Engine.now, {'message' => 'awesome'})
+      assert_equal("awesome", formatted)
     end
 
     def test_format_with_message_key
@@ -185,7 +192,7 @@ module FormatterTest
       formatter.configure('message_key' => 'foobar')
       formatted = formatter.format('tag', Engine.now, {'foobar' => 'foo'})
 
-      assert_equal('foo', formatted)
+      assert_equal("foo\n", formatted)
     end
   end
 


### PR DESCRIPTION
Sometimes message_key doesn't contain LF so add_newline option is needed to separate each line.
