### PR TITLE
Serialize plugin shutdown order. Shutdown Input first for safety

### DIFF
--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -264,6 +264,7 @@ module Fluent
     end
 
     def shutdown
+      # Shutdown Input plugin first to prevent emitting to terminated Output plugin
       @started_sources.map { |s|
         Thread.new do
           begin
@@ -276,6 +277,8 @@ module Fluent
       }.each { |t|
         t.join
       }
+      # Output plugin as filter emits records at shutdown so emit problem still exist.
+      # This problem will be resolved after actual filter mechanizm.
       @started_matches.map { |m|
         Thread.new do
           begin


### PR DESCRIPTION
This is a testbed for `shutdown` improvement.
Current `Engine#shutdown` calles plugin's `shutdown` in parallel.
The merit is fast shutdown and it works on almost cases, but it has one problem that output plugin may be closed before input plugin shutdown.

To resolve the problem calls input shutdown before output shutdown.
The demerit is taking more time to shutdown Fluentd if input and output have long time shutdown. 

In addition, I consider adding timeout to each plugin shutdown.
For keeping compatibility, default is no timeout but add `--shutdown-timeout SECONDS` like option to Fluentd.

What do you think?
