### PR TITLE
Use expect syntax instead of should syntax

### DIFF
--- a/spec/config/config_parser_spec.rb
+++ b/spec/config/config_parser_spec.rb
@@ -28,21 +28,21 @@ describe Fluent::Config::V1Parser do
 
   describe 'attribute parsing' do
     it "parses attributes" do
-      %[
+      expect(%[
         k1 v1
         k2 v2
-      ].should be_parsed_as("k1"=>"v1", "k2"=>"v2")
+      ]).to be_parsed_as("k1"=>"v1", "k2"=>"v2")
     end
 
     it "allows attribute without value" do
-      %[
+      expect(%[
         k1
         k2 v2
-      ].should be_parsed_as("k1"=>"", "k2"=>"v2")
+      ]).to be_parsed_as("k1"=>"", "k2"=>"v2")
     end
 
     it "parses attribute key always string" do
-      "1 1".should be_parsed_as("1" => "1")
+      expect("1 1").to be_parsed_as("1" => "1")
     end
 
     [
@@ -51,41 +51,41 @@ describe Fluent::Config::V1Parser do
       "()*{}.[]",
     ].each do |v|
       it "parses a value with symbol #{v.inspect}" do
-        "k #{v}".should be_parsed_as("k" => v)
+        expect("k #{v}").to be_parsed_as("k" => v)
       end
     end
 
     it "ignores spacing around value" do
-      "  k1     a    ".should be_parsed_as("k1" => "a")
+      expect("  k1     a    ").to be_parsed_as("k1" => "a")
     end
 
     it "allows spaces in value" do
-      "k1 a  b  c".should be_parsed_as("k1" => "a  b  c")
+      expect("k1 a  b  c").to be_parsed_as("k1" => "a  b  c")
     end
 
     it "ignores comments after value" do
-      "  k1 a#comment".should be_parsed_as("k1" => "a")
+      expect("  k1 a#comment").to be_parsed_as("k1" => "a")
     end
 
     it "allows # in value if quoted" do
-      '  k1 "a#comment"'.should be_parsed_as("k1" => "a#comment")
+      expect('  k1 "a#comment"').to be_parsed_as("k1" => "a#comment")
     end
 
     it "rejects characters after quoted string" do
-      '  k1 "a" 1'.should be_parse_error
+      expect('  k1 "a" 1').to be_parse_error
     end
   end
 
   describe 'element parsing' do
     it do
-      "".should be_parsed_as(root)
+      expect("").to be_parsed_as(root)
     end
 
     it "accepts empty element" do
-      %[
+      expect(%[
         <test>
         </test>
-      ].should be_parsed_as(
+      ]).to be_parsed_as(
         root(
           e("test")
         )
@@ -93,17 +93,17 @@ describe Fluent::Config::V1Parser do
     end
 
     it "accepts argument and attributes" do
-      %[
+      expect(%[
         <test var>
           key val
         </test>
-      ].should be_parsed_as(root(
+      ]).to be_parsed_as(root(
           e("test", 'var', {'key'=>"val"})
         ))
     end
 
     it "accepts nested elements" do
-      %[
+      expect(%[
         <test var>
           key 1
           <nested1>
@@ -111,7 +111,7 @@ describe Fluent::Config::V1Parser do
           <nested2>
           </nested2>
         </test>
-      ].should be_parsed_as(root(
+      ]).to be_parsed_as(root(
           e("test", 'var', {'key'=>'val'}, [
             e('nested1'),
             e('nested2')
@@ -128,52 +128,52 @@ describe Fluent::Config::V1Parser do
       "()*{}.[]",
     ].each do |arg|
       it "parses element argument #{arg.inspect}" do
-        %[
+        expect(%[
           <test #{arg}>
           </test>
-        ].should be_parsed_as(root(
+        ]).to be_parsed_as(root(
             e("test", arg)
           ))
       end
     end
 
     it "parses empty element argument to nil" do
-      %[
+      expect(%[
         <test >
         </test>
-      ].should be_parsed_as(root(
+      ]).to be_parsed_as(root(
           e("test", nil)
         ))
     end
 
     it "ignores spacing around element argument" do
-      %[
+      expect(%[
         <test    a    >
         </test>
-      ].should be_parsed_as(root(
+      ]).to be_parsed_as(root(
           e("test", "a")
         ))
     end
 
     it "considers comments in element argument" do
-      %[
+      expect(%[
         <test #a>
         </test>
-      ].should be_parse_error
+      ]).to be_parse_error
     end
 
     it "requires line_end after begin tag" do
-      %[
+      expect(%[
         <test></test>
-      ].should be_parse_error
+      ]).to be_parse_error
     end
 
     it "requires line_end after end tag" do
-      %[
+      expect(%[
         <test>
         </test><test>
         </test>
-      ].should be_parse_error
+      ]).to be_parse_error
     end
   end
 

--- a/spec/config/literal_parser_spec.rb
+++ b/spec/config/literal_parser_spec.rb
@@ -22,169 +22,169 @@ describe Fluent::Config::LiteralParser do
   end
 
   describe 'boolean parsing' do
-    it { 'true'.should be_parsed_as("true") }
-    it { 'false'.should be_parsed_as("false") }
-    it { 'trueX'.should be_parsed_as("trueX") }
-    it { 'falseX'.should be_parsed_as("falseX") }
+    it { expect('true').to be_parsed_as("true") }
+    it { expect('false').to be_parsed_as("false") }
+    it { expect('trueX').to be_parsed_as("trueX") }
+    it { expect('falseX').to be_parsed_as("falseX") }
   end
 
   describe 'integer parsing' do
-    it { '0'.should be_parsed_as("0") }
-    it { '1'.should be_parsed_as("1") }
-    it { '10'.should be_parsed_as("10") }
-    it { '-1'.should be_parsed_as("-1") }
-    it { '-10'.should be_parsed_as("-10") }
-    it { '0 '.should be_parsed_as("0") }
-    it { ' -1 '.should be_parsed_as("-1") }
+    it { expect('0').to be_parsed_as("0") }
+    it { expect('1').to be_parsed_as("1") }
+    it { expect('10').to be_parsed_as("10") }
+    it { expect('-1').to be_parsed_as("-1") }
+    it { expect('-10').to be_parsed_as("-10") }
+    it { expect('0 ').to be_parsed_as("0") }
+    it { expect(' -1 ').to be_parsed_as("-1") }
     # string
-    it { '01'.should be_parsed_as("01") }
-    it { '00'.should be_parsed_as("00") }
-    it { '-01'.should be_parsed_as("-01") }
-    it { '-00'.should be_parsed_as("-00") }
-    it { '0x61'.should be_parsed_as("0x61") }
-    it { '0s'.should be_parsed_as("0s") }
+    it { expect('01').to be_parsed_as("01") }
+    it { expect('00').to be_parsed_as("00") }
+    it { expect('-01').to be_parsed_as("-01") }
+    it { expect('-00').to be_parsed_as("-00") }
+    it { expect('0x61').to be_parsed_as("0x61") }
+    it { expect('0s').to be_parsed_as("0s") }
   end
 
   describe 'float parsing' do
-    it { '1.1'.should be_parsed_as("1.1") }
-    it { '0.1'.should be_parsed_as("0.1") }
-    it { '0.0'.should be_parsed_as("0.0") }
-    it { '-1.1'.should be_parsed_as("-1.1") }
-    it { '-0.1'.should be_parsed_as("-0.1") }
-    it { '1.10'.should be_parsed_as("1.10") }
+    it { expect('1.1').to be_parsed_as("1.1") }
+    it { expect('0.1').to be_parsed_as("0.1") }
+    it { expect('0.0').to be_parsed_as("0.0") }
+    it { expect('-1.1').to be_parsed_as("-1.1") }
+    it { expect('-0.1').to be_parsed_as("-0.1") }
+    it { expect('1.10').to be_parsed_as("1.10") }
     # string
-    it { '12e8'.should be_parsed_as("12e8") }
-    it { '12.1e7'.should be_parsed_as("12.1e7") }
-    it { '-12e8'.should be_parsed_as("-12e8") }
-    it { '-12.1e7'.should be_parsed_as("-12.1e7") }
-    it { '.0'.should be_parsed_as(".0") }
-    it { '.1'.should be_parsed_as(".1") }
-    it { '0.'.should be_parsed_as("0.") }
-    it { '1.'.should be_parsed_as("1.") }
-    it { '.0a'.should be_parsed_as(".0a") }
-    it { '1.a'.should be_parsed_as("1.a") }
-    it { '0@'.should be_parsed_as("0@") }
+    it { expect('12e8').to be_parsed_as("12e8") }
+    it { expect('12.1e7').to be_parsed_as("12.1e7") }
+    it { expect('-12e8').to be_parsed_as("-12e8") }
+    it { expect('-12.1e7').to be_parsed_as("-12.1e7") }
+    it { expect('.0').to be_parsed_as(".0") }
+    it { expect('.1').to be_parsed_as(".1") }
+    it { expect('0.').to be_parsed_as("0.") }
+    it { expect('1.').to be_parsed_as("1.") }
+    it { expect('.0a').to be_parsed_as(".0a") }
+    it { expect('1.a').to be_parsed_as("1.a") }
+    it { expect('0@').to be_parsed_as("0@") }
   end
 
   describe 'float keywords parsing' do
-    it { 'NaN'.should be_parsed_as("NaN") }
-    it { 'Infinity'.should be_parsed_as("Infinity") }
-    it { '-Infinity'.should be_parsed_as("-Infinity") }
-    it { 'NaNX'.should be_parsed_as("NaNX") }
-    it { 'InfinityX'.should be_parsed_as("InfinityX") }
-    it { '-InfinityX'.should be_parsed_as("-InfinityX") }
+    it { expect('NaN').to be_parsed_as("NaN") }
+    it { expect('Infinity').to be_parsed_as("Infinity") }
+    it { expect('-Infinity').to be_parsed_as("-Infinity") }
+    it { expect('NaNX').to be_parsed_as("NaNX") }
+    it { expect('InfinityX').to be_parsed_as("InfinityX") }
+    it { expect('-InfinityX').to be_parsed_as("-InfinityX") }
   end
 
   describe 'quoted string' do
-    it { '""'.should be_parsed_as("") }
-    it { '"text"'.should be_parsed_as("text") }
-    it { '"\\""'.should be_parsed_as("\"") }
-    it { '"\\t"'.should be_parsed_as("\t") }
-    it { '"\\n"'.should be_parsed_as("\n") }
-    it { '"\\r\\n"'.should be_parsed_as("\r\n") }
-    it { '"\\f\\b"'.should be_parsed_as("\f\b") }
-    it { '"\\.t"'.should be_parsed_as(".t") }
-    it { '"\\$t"'.should be_parsed_as("$t") }
-    it { '"\\#t"'.should be_parsed_as("#t") }
-    it { '"\\z"'.should be_parse_error }  # unknown escaped character
-    it { '"\\0"'.should be_parse_error }  # unknown escaped character
-    it { '"\\1"'.should be_parse_error }  # unknown escaped character
-    it { '"t'.should be_parse_error }  # non-terminated quoted character
-    it { 't"'.should be_parsed_as('t"') }
-    it { '"."'.should be_parsed_as('.') }
-    it { '"*"'.should be_parsed_as('*') }
-    it { '"@"'.should be_parsed_as('@') }
-    it { '"\\#{test}"'.should be_parsed_as("\#{test}") }
-    it { '"$"'.should be_parsed_as('$') }
-    it { '"$t"'.should be_parsed_as('$t') }
-    it { '"$}"'.should be_parsed_as('$}') }
+    it { expect('""').to be_parsed_as("") }
+    it { expect('"text"').to be_parsed_as("text") }
+    it { expect('"\\""').to be_parsed_as("\"") }
+    it { expect('"\\t"').to be_parsed_as("\t") }
+    it { expect('"\\n"').to be_parsed_as("\n") }
+    it { expect('"\\r\\n"').to be_parsed_as("\r\n") }
+    it { expect('"\\f\\b"').to be_parsed_as("\f\b") }
+    it { expect('"\\.t"').to be_parsed_as(".t") }
+    it { expect('"\\$t"').to be_parsed_as("$t") }
+    it { expect('"\\#t"').to be_parsed_as("#t") }
+    it { expect('"\\z"').to be_parse_error }  # unknown escaped character
+    it { expect('"\\0"').to be_parse_error }  # unknown escaped character
+    it { expect('"\\1"').to be_parse_error }  # unknown escaped character
+    it { expect('"t').to be_parse_error }  # non-terminated quoted character
+    it { expect('t"').to be_parsed_as('t"') }
+    it { expect('"."').to be_parsed_as('.') }
+    it { expect('"*"').to be_parsed_as('*') }
+    it { expect('"@"').to be_parsed_as('@') }
+    it { expect('"\\#{test}"').to be_parsed_as("\#{test}") }
+    it { expect('"$"').to be_parsed_as('$') }
+    it { expect('"$t"').to be_parsed_as('$t') }
+    it { expect('"$}"').to be_parsed_as('$}') }
   end
 
   describe 'nonquoted string parsing' do
     # empty
-    it { ''.should be_parsed_as(nil) }
+    it { expect('').to be_parsed_as(nil) }
 
-    it { 't'.should be_parsed_as('t') }
-    it { 'T'.should be_parsed_as('T') }
-    it { '_'.should be_parsed_as('_') }
-    it { 'T1'.should be_parsed_as('T1') }
-    it { '_2'.should be_parsed_as('_2') }
-    it { 't0'.should be_parsed_as('t0') }
-    it { 't@'.should be_parsed_as('t@') }
-    it { 't-'.should be_parsed_as('t-') }
-    it { 't.'.should be_parsed_as('t.') }
-    it { 't+'.should be_parsed_as('t+') }
-    it { 't/'.should be_parsed_as('t/') }
-    it { 't='.should be_parsed_as('t=') }
-    it { 't,'.should be_parsed_as('t,') }
-    it { '0t'.should be_parsed_as("0t") }
-    it { '@1t'.should be_parsed_as('@1t') }
-    it { '-1t'.should be_parsed_as('-1t') }
-    it { '.1t'.should be_parsed_as('.1t') }
-    it { ',1t'.should be_parsed_as(',1t') }
-    it { '.t'.should be_parsed_as('.t') }
-    it { '*t'.should be_parsed_as('*t') }
-    it { '@t'.should be_parsed_as('@t') }
-    it { '$t'.should be_parsed_as('$t') }
-    it { '{t'.should be_parse_error }  # '{' begins map
-    it { 't{'.should be_parsed_as('t{') }
-    it { '}t'.should be_parsed_as('}t') }
-    it { '[t'.should be_parse_error }  # '[' begins array
-    it { 't['.should be_parsed_as('t[') }
-    it { ']t'.should be_parsed_as(']t') }
-    it { '$t'.should be_parsed_as('$t') }
-    it { 't:'.should be_parsed_as('t:') }
-    it { 't;'.should be_parsed_as('t;') }
-    it { 't?'.should be_parsed_as('t?') }
-    it { 't^'.should be_parsed_as('t^') }
-    it { 't`'.should be_parsed_as('t`') }
-    it { 't~'.should be_parsed_as('t~') }
-    it { 't|'.should be_parsed_as('t|') }
-    it { 't>'.should be_parsed_as('t>') }
-    it { 't<'.should be_parsed_as('t<') }
-    it { 't('.should be_parsed_as('t(') }
-    it { 't['.should be_parsed_as('t[') }
+    it { expect('t').to be_parsed_as('t') }
+    it { expect('T').to be_parsed_as('T') }
+    it { expect('_').to be_parsed_as('_') }
+    it { expect('T1').to be_parsed_as('T1') }
+    it { expect('_2').to be_parsed_as('_2') }
+    it { expect('t0').to be_parsed_as('t0') }
+    it { expect('t@').to be_parsed_as('t@') }
+    it { expect('t-').to be_parsed_as('t-') }
+    it { expect('t.').to be_parsed_as('t.') }
+    it { expect('t+').to be_parsed_as('t+') }
+    it { expect('t/').to be_parsed_as('t/') }
+    it { expect('t=').to be_parsed_as('t=') }
+    it { expect('t,').to be_parsed_as('t,') }
+    it { expect('0t').to be_parsed_as("0t") }
+    it { expect('@1t').to be_parsed_as('@1t') }
+    it { expect('-1t').to be_parsed_as('-1t') }
+    it { expect('.1t').to be_parsed_as('.1t') }
+    it { expect(',1t').to be_parsed_as(',1t') }
+    it { expect('.t').to be_parsed_as('.t') }
+    it { expect('*t').to be_parsed_as('*t') }
+    it { expect('@t').to be_parsed_as('@t') }
+    it { expect('$t').to be_parsed_as('$t') }
+    it { expect('{t').to be_parse_error }  # '{' begins map
+    it { expect('t{').to be_parsed_as('t{') }
+    it { expect('}t').to be_parsed_as('}t') }
+    it { expect('[t').to be_parse_error }  # '[' begins array
+    it { expect('t[').to be_parsed_as('t[') }
+    it { expect(']t').to be_parsed_as(']t') }
+    it { expect('$t').to be_parsed_as('$t') }
+    it { expect('t:').to be_parsed_as('t:') }
+    it { expect('t;').to be_parsed_as('t;') }
+    it { expect('t?').to be_parsed_as('t?') }
+    it { expect('t^').to be_parsed_as('t^') }
+    it { expect('t`').to be_parsed_as('t`') }
+    it { expect('t~').to be_parsed_as('t~') }
+    it { expect('t|').to be_parsed_as('t|') }
+    it { expect('t>').to be_parsed_as('t>') }
+    it { expect('t<').to be_parsed_as('t<') }
+    it { expect('t(').to be_parsed_as('t(') }
+    it { expect('t[').to be_parsed_as('t[') }
   end
 
   describe 'embedded ruby code parsing' do
-    it { '"#{v1}"'.should be_parsed_as("#{v1}") }
-    it { '"#{v2}"'.should be_parsed_as("#{v2}") }
-    it { '"#{v3}"'.should be_parsed_as("#{v3}") }
-    it { '"#{1+1}"'.should be_parsed_as("2") }
-    it { '"#{}"'.should be_parsed_as("") }
-    it { '"t#{v1}"'.should be_parsed_as("t#{v1}") }
-    it { '"t#{v1}t"'.should be_parsed_as("t#{v1}t") }
-    it { '"#{"}"}"'.should be_parsed_as("}") }
-    it { '"#{#}"'.should be_parse_error }  # error in embedded ruby code
-    it { "\"\#{\n=begin\n}\"".should be_parse_error }  # error in embedded ruby code
+    it { expect('"#{v1}"').to be_parsed_as("#{v1}") }
+    it { expect('"#{v2}"').to be_parsed_as("#{v2}") }
+    it { expect('"#{v3}"').to be_parsed_as("#{v3}") }
+    it { expect('"#{1+1}"').to be_parsed_as("2") }
+    it { expect('"#{}"').to be_parsed_as("") }
+    it { expect('"t#{v1}"').to be_parsed_as("t#{v1}") }
+    it { expect('"t#{v1}t"').to be_parsed_as("t#{v1}t") }
+    it { expect('"#{"}"}"').to be_parsed_as("}") }
+    it { expect('"#{#}"').to be_parse_error }  # error in embedded ruby code
+    it { expect("\"\#{\n=begin\n}\"").to be_parse_error }  # error in embedded ruby code
   end
 
   describe 'array parsing' do
-    it { '[]'.should be_parsed_as_json([]) }
-    it { '[1]'.should be_parsed_as_json([1]) }
-    it { '[1,2]'.should be_parsed_as_json([1,2]) }
-    it { '[1, 2]'.should be_parsed_as_json([1,2]) }
-    it { '[ 1 , 2 ]'.should be_parsed_as_json([1,2]) }
-    it { '[1,2,]'.should be_parse_error } # TODO: Need trailing commas support?
-    it { "[\n1\n,\n2\n]".should be_parsed_as_json([1,2]) }
-    it { '["a"]'.should be_parsed_as_json(["a"]) }
-    it { '["a","b"]'.should be_parsed_as_json(["a","b"]) }
-    it { '[ "a" , "b" ]'.should be_parsed_as_json(["a","b"]) }
-    it { "[\n\"a\"\n,\n\"b\"\n]".should be_parsed_as_json(["a","b"]) }
-    it { '["ab","cd"]'.should be_parsed_as_json(["ab","cd"]) }
+    it { expect('[]').to be_parsed_as_json([]) }
+    it { expect('[1]').to be_parsed_as_json([1]) }
+    it { expect('[1,2]').to be_parsed_as_json([1,2]) }
+    it { expect('[1, 2]').to be_parsed_as_json([1,2]) }
+    it { expect('[ 1 , 2 ]').to be_parsed_as_json([1,2]) }
+    it { expect('[1,2,]').to be_parse_error } # TODO: Need trailing commas support?
+    it { expect("[\n1\n,\n2\n]").to be_parsed_as_json([1,2]) }
+    it { expect('["a"]').to be_parsed_as_json(["a"]) }
+    it { expect('["a","b"]').to be_parsed_as_json(["a","b"]) }
+    it { expect('[ "a" , "b" ]').to be_parsed_as_json(["a","b"]) }
+    it { expect("[\n\"a\"\n,\n\"b\"\n]").to be_parsed_as_json(["a","b"]) }
+    it { expect('["ab","cd"]').to be_parsed_as_json(["ab","cd"]) }
   end
 
   describe 'map parsing' do
-    it { '{}'.should be_parsed_as_json({}) }
-    it { '{"a":1}'.should be_parsed_as_json({"a"=>1}) }
-    it { '{"a":1,"b":2}'.should be_parsed_as_json({"a"=>1,"b"=>2}) }
-    it { '{ "a" : 1 , "b" : 2 }'.should be_parsed_as_json({"a"=>1,"b"=>2}) }
-    it { '{"a":1,"b":2,}'.should be_parse_error } # TODO: Need trailing commas support?
-    it { "{\n\"a\"\n:\n1\n,\n\"b\"\n:\n2\n}".should be_parsed_as_json({"a"=>1,"b"=>2}) }
-    it { '{"a":"b"}'.should be_parsed_as_json({"a"=>"b"}) }
-    it { '{"a":"b","c":"d"}'.should be_parsed_as_json({"a"=>"b","c"=>"d"}) }
-    it { '{ "a" : "b" , "c" : "d" }'.should be_parsed_as_json({"a"=>"b","c"=>"d"}) }
-    it { "{\n\"a\"\n:\n\"b\"\n,\n\"c\"\n:\n\"d\"\n}".should be_parsed_as_json({"a"=>"b","c"=>"d"}) }
+    it { expect('{}').to be_parsed_as_json({}) }
+    it { expect('{"a":1}').to be_parsed_as_json({"a"=>1}) }
+    it { expect('{"a":1,"b":2}').to be_parsed_as_json({"a"=>1,"b"=>2}) }
+    it { expect('{ "a" : 1 , "b" : 2 }').to be_parsed_as_json({"a"=>1,"b"=>2}) }
+    it { expect('{"a":1,"b":2,}').to be_parse_error } # TODO: Need trailing commas support?
+    it { expect("{\n\"a\"\n:\n1\n,\n\"b\"\n:\n2\n}").to be_parsed_as_json({"a"=>1,"b"=>2}) }
+    it { expect('{"a":"b"}').to be_parsed_as_json({"a"=>"b"}) }
+    it { expect('{"a":"b","c":"d"}').to be_parsed_as_json({"a"=>"b","c"=>"d"}) }
+    it { expect('{ "a" : "b" , "c" : "d" }').to be_parsed_as_json({"a"=>"b","c"=>"d"}) }
+    it { expect("{\n\"a\"\n:\n\"b\"\n,\n\"c\"\n:\n\"d\"\n}").to be_parsed_as_json({"a"=>"b","c"=>"d"}) }
   end
 end
 


### PR DESCRIPTION
`should` syntax is deprecated in RSpec 3. Use expect syntax in order to suppress warnings.
