### PR TITLE
Set UTF-8 encoding to '@include' result string

### DIFF
--- a/lib/fluent/config/v1_parser.rb
+++ b/lib/fluent/config/v1_parser.rb
@@ -142,16 +142,16 @@ module Fluent
             basepath = File.dirname(path)
             fname = File.basename(path)
             data = File.read(path)
+            data.force_encoding('UTF-8')
             ss = StringScanner.new(data)
             V1Parser.new(ss, basepath, fname, @eval_context).parse_element(true, nil, attrs, elems)
           }
-
         else
+          require 'open-uri'
           basepath = '/'
           fname = path
-          require 'open-uri'
-          data = nil
-          open(uri) { |f| data = f.read }
+          data = open(uri) { |f| f.read }
+          data.force_encoding('UTF-8')
           ss = StringScanner.new(data)
           V1Parser.new(ss, basepath, fname, @eval_context).parse_element(true, nil, attrs, elems)
         end


### PR DESCRIPTION
Fluentd assumes configuration file encoding is UTF-8.
`@include` is parsed after set `Encoding.default_xxternal = 'ASCII-8BIT'` so
`@include` result becomes ASCII-8BIT encoding. It causes encoding mismatch.
