### PR TITLE
Listen DRb on localhost only

### DIFF
--- a/fluent.conf
+++ b/fluent.conf
@@ -38,6 +38,7 @@
 # Listen DRb for debug
 <source>
   type debug_agent
+  bind 127.0.0.1
   port 24230
 </source>
 


### PR DESCRIPTION
DRb is unsafe by default.
Default `fluentd.conf` should be listen on localhost only like default td-agent.conf.

see security section of DRb document: http://docs.ruby-lang.org/en/2.1.0/DRb.html#module-DRb-label-Security (English)
and my blog post (eval from remote): http://blog.n-z.jp/blog/2014-06-13-fluentd-drb.html (Japanese)
