### PR TITLE
Fix the method to check rotated file in NewTailInput

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -352,13 +352,15 @@ module Fluent
             inode = stat.ino
 
             last_inode = @pe.read_inode
-            if inode == last_inode
+            last_pos = @pe.read_pos
+            if inode == last_inode && last_pos != PositionFile::UNWATCHED_POSITION
               # rotated file has the same inode number with the last file.
+              # However, it is a new file if it has unwatched position.
               # assuming following situation:
               #   a) file was once renamed and backed, or
               #   b) symlink or hardlink to the same file is recreated
               # in either case, seek to the saved position
-              pos = @pe.read_pos
+              pos = last_pos
             elsif last_inode != 0
               # this is FilePositionEntry and fluentd once started.
               # read data from the head of the rotated file.


### PR DESCRIPTION
When I use in_tail plugin to watch multi files like in_tail_ex, following errors happen on log rotation.
```
2014-06-19 21:34:53 +0900 [error]: plugin/in_tail.rb:573:rescue in on_notify: bignum too big to convert into `long'
  2014-06-19 21:34:53 +0900 [error]: plugin/in_tail.rb:324:attach: /home/sabo/work/fluentd/fluentd/lib/fluent/plugin/in_tail.rb:376:in `seek'
  2014-06-19 21:34:53 +0900 [error]: plugin/in_tail.rb:324:attach: /home/sabo/work/fluentd/fluentd/lib/fluent/plugin/in_tail.rb:376:in `on_rotate'
```

The position of PositionFile is updated to 0xffffffffffffffff after log rotation to show it is a unwatched file. If next generated file to be watched has same inode to the old rotated file, the value is used as current position of the new file. This patch fixes the problem by checking the position file has valid position.

**complete process to reproduce  the bug**

```
<source>
  type tail
  format none
  tag test
  path ./log/*.log
  pos_file ./pos
  refresh_interval 5s
</source>
```

```
# logging
$ echo 'foo' >> log/foo.log
# wating a second
# show position file
$ cat pos
./log/foo.log	0000000000000004	002002cb

# remove watching file
$ rm log/foo.log
# wating refresh inteval
# show position file
$ cat pos 
./log/foo.log	ffffffffffffffff	002002cb

# re-logging (case ERROR on in_tail)
$ echo 'bar' >> log/foo.log
```

This problem also happens when rotated file is compressed immediately. (ex: using `logrotate`)