### PR TITLE
Add suppress_parse_error_log option to ignore parsing error in in_tail

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -31,6 +31,7 @@ module Fluent
     config_param :pos_file, :string, :default => nil
     config_param :read_from_head, :bool, :default => false
     config_param :refresh_interval, :time, :default => 60
+    config_param :suppress_parse_error_log, :bool, :default => false
 
     attr_reader :paths
 
@@ -237,7 +238,7 @@ module Fluent
         @parser.parse(line) { |time, record|
           if time && record
             es.add(time, record)
-          else
+          elsif !@suppress_parse_error_log
             log.warn "pattern not match: #{line.inspect}"
           end
         }
@@ -708,6 +709,7 @@ module Fluent
     config_param :tag, :string
     config_param :rotate_wait, :time, :default => 5
     config_param :pos_file, :string, :default => nil
+    config_param :suppress_parse_error_log, :bool, :default => false
 
     attr_reader :paths
 
@@ -776,7 +778,7 @@ module Fluent
           time, record = parse_line(line)
           if time && record
             es.add(time, record)
-          else
+          elsif !@suppress_parse_error_log
             log.warn "pattern not match: #{line.inspect}"
           end
         rescue

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -199,6 +199,41 @@ class TailInputTest < Test::Unit::TestCase
     assert_equal({"message" => "tab	"}, emits[5][2])
   end
 
+  def test_suppress_parse_error
+    File.open("#{TMP_DIR}/tail.txt", "w") {|f|
+      f.puts "test1"
+    }
+
+    config1 = %[
+      format /^foo (?<message>.*)$/
+    ]
+    config2 = config1 + '  suppress_parse_error_log'
+    d1 = create_driver(config1)
+    d2 = create_driver(config2)
+
+    [d1, d2].each do |d|
+      d.run do
+        sleep 1
+
+        File.open("#{TMP_DIR}/tail.txt", "a") {|f|
+          f.puts "foo foo"
+          f.puts "bar bar"
+        }
+        sleep 1
+      end
+    end
+
+    emits = d1.emits
+    assert_equal(true, emits.length > 0)
+    assert_equal({"message" => "foo"}, emits[0][2])
+    assert_equal(true, d1.instance.log.logs.any?{|x| x.match(/pattern not match/)})
+
+    emits = d2.emits
+    assert_equal(true, emits.length > 0)
+    assert_equal({"message" => "foo"}, emits[0][2])
+    assert_equal(false, d2.instance.log.logs.any?{|x| x.match(/pattern not match/)})
+  end
+
   # multiline mode test
 
   def test_multiline


### PR DESCRIPTION
Add `suppress_parse_error_log` option to in_tail plugin. This is a same feature to fluent-plugin-parser.