### PR TITLE
Change debug log level to warn in in_syslog

### DIFF
--- a/lib/fluent/plugin/in_syslog.rb
+++ b/lib/fluent/plugin/in_syslog.rb
@@ -139,8 +139,8 @@ module Fluent
 
         emit(pri, time, record)
       }
-    rescue
-      log.error data.dump, :error=>$!.to_s
+    rescue => e
+      log.error data.dump, :error => e.to_s
       log.error_backtrace
     end
 
@@ -171,8 +171,8 @@ module Fluent
       time ||= Engine.now
 
       emit(pri, time, record)
-    rescue
-      log.error data.dump, :error=>$!.to_s
+    rescue => e
+      log.error data.dump, :error => e.to_s
       log.error_backtrace
     end
 


### PR DESCRIPTION
Pattern mismatch log should be warn for early detection.
We can disable this message by `log_level error` in production.

https://groups.google.com/d/msg/fluentd/ZRreaaRFR2U/ineHN8FOGI0J
