### PR TITLE
v1_parser: Add missing require 'uri'

### DIFF
--- a/lib/fluent/config/v1_parser.rb
+++ b/lib/fluent/config/v1_parser.rb
@@ -17,6 +17,7 @@ module Fluent
   module Config
 
     require 'strscan'
+    require 'uri'
     require 'fluent/config/error'
     require 'fluent/config/literal_parser'
     require 'fluent/config/element'


### PR DESCRIPTION
URI was not initialized causing the following error on run

```
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.51/lib/fluent/config/v1_parser.rb:127:in `eval_include': uninitialized constant Fluent::Config::V1Parser::URI (NameError)
        from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.51/lib/fluent/config/v1_parser.rb:121:in `parse_include'
        from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.51/lib/fluent/config/v1_parser.rb:95:in `parse_element'
        from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.51/lib/fluent/config/v1_parser.rb:40:in `parse!'
        from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.51/lib/fluent/config/v1_parser.rb:30:in `parse'
        from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.51/lib/fluent/config.rb:30:in `parse'
        from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.51/lib/fluent/supervisor.rb:364:in `apply_system_config'
        from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.51/lib/fluent/supervisor.rb:110:in `initialize'
        from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.51/lib/fluent/command/fluentd.rb:160:in `new'
        from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.51/lib/fluent/command/fluentd.rb:160:in `<top (required)>'
        from /opt/td-agent/embedded/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /opt/td-agent/embedded/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.51/bin/fluentd:6:in `<top (required)>'
        from /opt/td-agent/embedded/bin/fluentd:23:in `load'
        from /opt/td-agent/embedded/bin/fluentd:23:in `<top (required)>'
        from /usr/sbin/td-agent:7:in `load'
        from /usr/sbin/td-agent:7:in `<main>'
```
