### PR TITLE
Reject '@' prefix in parameter name with V1 configuration

### DIFF
--- a/lib/fluent/config/v1_parser.rb
+++ b/lib/fluent/config/v1_parser.rb
@@ -103,6 +103,10 @@ module Fluent
               if k == '@include'
                 parse_include(attrs, elems)
               else
+                if k.start_with?('@')
+                  parse_error! "'@' is reserved prefix. Don't use '@' in parameter name"
+                end
+
                 v = parse_literal
                 unless line_end
                   parse_error! "expected end of line"

--- a/spec/config/config_parser_spec.rb
+++ b/spec/config/config_parser_spec.rb
@@ -80,6 +80,10 @@ describe Fluent::Config::V1Parser do
     it "rejects characters after quoted string" do
       expect('  k1 "a" 1').to be_parse_error
     end
+
+    it "rejects @ prefix in parameter name" do
+      expect('  @k v').to be_parse_error
+    end
   end
 
   describe 'element parsing' do


### PR DESCRIPTION
'@' is reserved prefix in V1 configuration.
So the parser should reject '@' in parameter name.
