### PR TITLE
Invoke new thread to avoid 'mutex can't lock' issue

### DIFF
--- a/lib/fluent/process.rb
+++ b/lib/fluent/process.rb
@@ -378,9 +378,12 @@ module Fluent
       def stop
         return if @finished
         @finished = true
-        @mutex.synchronize do
-          @cond.broadcast
-        end
+        # Creating new thread due to mutex can't lock in main thread during trap context
+        Thread.new {
+          @mutex.synchronize do
+            @cond.broadcast
+          end
+        }.run
       end
 
       def finished?


### PR DESCRIPTION
In DetachMultiProcessMixin.
Same as https://github.com/fluent/fluentd/pull/191

@frsyuki Could you check this?
