### PR TITLE
parser.rb: Make ':' optional after pid

### DIFF
--- a/lib/fluent/parser.rb
+++ b/lib/fluent/parser.rb
@@ -471,9 +471,9 @@ module Fluent
       include Configurable
 
       # From existence TextParser pattern
-      REGEXP = /^(?<time>[^ ]*\s*[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?[^\:]*\: *(?<message>.*)$/
+      REGEXP = /^(?<time>[^ ]*\s*[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$/
       # From in_syslog default pattern
-      REGEXP_WITH_PRI = /^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?[^\:]*\: *(?<message>.*)$/
+      REGEXP_WITH_PRI = /^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$/
 
       config_param :time_format, :string, :default => "%b %d %H:%M:%S"
       config_param :with_priority, :bool, :default => false

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -197,6 +197,21 @@ module ParserTest
       assert_equal(TextParser::SyslogParser::REGEXP_WITH_PRI, @parser.patterns['format'])
       assert_equal("%b %d %H:%M:%S", @parser.patterns['time_format'])
     end
+
+    def test_call_without_colon
+      @parser.configure({})
+      @parser.call('Feb 28 12:00:00 192.168.0.1 fluentd[11111] [error] Syslog test') { |time, record|
+        assert_equal(str2time('Feb 28 12:00:00', '%b %d %H:%M:%S'), time)
+        assert_equal({
+          'host'    => '192.168.0.1',
+          'ident'   => 'fluentd',
+          'pid'     => '11111',
+          'message' => '[error] Syslog test'
+        }, record)
+      }
+      assert_equal(TextParser::SyslogParser::REGEXP, @parser.patterns['format'])
+      assert_equal("%b %d %H:%M:%S", @parser.patterns['time_format'])
+    end
   end
 
   class JsonParserTest < ::Test::Unit::TestCase


### PR DESCRIPTION
In some cases, there is no ':' after the pid, the following log would fail to parse

```
<77>Jul 11 15:14:01 my.example.com run-parts(/etc/cron.daily)[8231] finished logrotate
```

resulting in

```
"_source": {
    "data": "<77>Jul 11 15:14:01 my.example.com run-parts(/etc/cron.daily)[8231] finished logrotate",
    "message": "invalid syslog message data=\"<77>Jul 11 15:14:01 my.example.com run-parts(/etc/cron.daily)[8231] finished logrotate\"",
    "@timestamp": "2014-07-11T19:14:01+00:00"
  },
```

This PR aims to make those ':' after the pid optional
