### PR TITLE
Use an Integer instead of an Array for error count.

### DIFF
--- a/lib/fluent/plugin/in_monitor_agent.rb
+++ b/lib/fluent/plugin/in_monitor_agent.rb
@@ -217,7 +217,7 @@ module Fluent
       'output_plugin' => 'is_a?(::Fluent::Output)',
       'buffer_queue_length' => '@buffer.queue_size',
       'buffer_total_queued_size' => '@buffer.total_queued_chunk_size',
-      'retry_count' => '@error_history.size',
+      'retry_count' => '@num_errors',
       'config' => 'config',
     }
 

--- a/test/test_output.rb
+++ b/test/test_output.rb
@@ -42,13 +42,18 @@ module FluentOutputTest
     def test_calc_retry_wait
       # default
       d = create_driver
-      d.instance.retry_limit.times { d.instance.instance_variable_get(:@error_history) << Engine.now }
+      d.instance.retry_limit.times {
+        # "d.instance.instance_variable_get(:@num_errors) += 1" causes SyntaxError
+        d.instance.instance_eval { @num_errors += 1 }
+      }
       wait = d.instance.retry_wait * (2 ** (d.instance.retry_limit - 1))
       assert( d.instance.calc_retry_wait > wait - wait / 8.0 )
 
       # max_retry_wait
       d = create_driver(CONFIG + %[max_retry_wait 4])
-      d.instance.retry_limit.times { d.instance.instance_variable_get(:@error_history) << Engine.now }
+      d.instance.retry_limit.times {
+        d.instance.instance_eval { @num_errors += 1 }
+      }
       assert_equal 4, d.instance.calc_retry_wait
     end
 


### PR DESCRIPTION
Using array for error count consumes lots of memory when
retry_limit is large. We don't use an item in @error_history,
so we can use simply number count instead of array based approach.

@frsyuki Could you check this PR?
