### PR TITLE
Closer should detach own timer to prevent object leak

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -462,6 +462,8 @@ module Fluent
         rescue => e
           @log.error e.to_s
           @log.error_backtrace(e.backtrace)
+        ensure
+          detach
         end
       end
 


### PR DESCRIPTION
All of watchers must detach from Loop on JRuby.
If watchers didn't detach, JRuby process won't be stop.
