### PR TITLE
Add apache_error format to parse Apache error logs

### DIFF
--- a/lib/fluent/parser.rb
+++ b/lib/fluent/parser.rb
@@ -624,6 +624,7 @@ module Fluent
     TEMPLATE_REGISTRY = Registry.new(:config_type, 'fluent/plugin/parser_')
     {
       'apache' => Proc.new { RegexpParser.new(/^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$/, {'time_format'=>"%d/%b/%Y:%H:%M:%S %z"}) },
+      'apache_error' => Proc.new { RegexpParser.new(/^\[[^ ]* (?<time>[^\]]*)\] \[(?<level>[^\]]*)\](?: \[pid (?<pid>[^\]]*)\])? \[client (?<client>[^\]]*)\] (?<message>.*)$/) },
       'apache2' => Proc.new { ApacheParser.new },
       'syslog' => Proc.new { SyslogParser.new },
       'json' => Proc.new { JSONParser.new },

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -130,6 +130,33 @@ module ParserTest
     end
   end
 
+  class ApacheErrorParserTest < ::Test::Unit::TestCase
+    include ParserTest
+
+    def setup
+      @parser = TextParser::TEMPLATE_REGISTRY.lookup('apache_error').call
+      @expected = {
+        'level' => 'error',
+        'client' => '127.0.0.1',
+        'message' => 'client denied by server configuration'
+      }
+    end
+
+    def test_call
+      @parser.call('[Wed Oct 11 14:32:52 2000] [error] [client 127.0.0.1] client denied by server configuration') { |time, record|
+        assert_equal(str2time('Wed Oct 11 14:32:52 2000'), time)
+        assert_equal(@expected, record)
+      }
+    end
+
+    def test_call_with_pid
+      @parser.call('[Wed Oct 11 14:32:52 2000] [error] [pid 1000] [client 127.0.0.1] client denied by server configuration') { |time, record|
+        assert_equal(str2time('Wed Oct 11 14:32:52 2000'), time)
+        assert_equal(@expected.merge('pid' => '1000'), record)
+      }
+    end
+  end
+
   class Apache2ParserTest < ::Test::Unit::TestCase
     include ParserTest
 


### PR DESCRIPTION
There are some users who tail Apache error logs with Fluentd.
So adding `apache_error` is useful for existence and new users.
