### PR TITLE
Assert emits after InputTestDriver#run finished

### DIFF
--- a/test/plugin/test_in_forward.rb
+++ b/test/plugin/test_in_forward.rb
@@ -37,15 +37,19 @@ class ForwardInputTest < Test::Unit::TestCase
     time = Time.parse("2011-01-02 13:14:15 UTC").to_i
     Fluent::Engine.now = time
 
-    d.expect_emit "tag1", time, {"a"=>1}
-    d.expect_emit "tag2", time, {"a"=>2}
+    tests = [
+      ["tag1", time, {"a"=>1}],
+      ["tag2", time, {"a"=>2}]
+    ]
+    d.expected_emits_length = tests.length
 
     d.run do
-      d.expected_emits.each {|tag,time,record|
+      tests.each {|tag,time,record|
         send_data [tag, 0, record].to_msgpack
       }
-      sleep 0.5
     end
+
+    compare_test_result(tests, d.emits)
   end
 
   def test_message
@@ -53,15 +57,19 @@ class ForwardInputTest < Test::Unit::TestCase
 
     time = Time.parse("2011-01-02 13:14:15 UTC").to_i
 
-    d.expect_emit "tag1", time, {"a"=>1}
-    d.expect_emit "tag2", time, {"a"=>2}
+    tests = [
+      ["tag1", time, {"a"=>1}],
+      ["tag2", time, {"a"=>2}]
+    ]
+    d.expected_emits_length = tests.length
 
     d.run do
-      d.expected_emits.each {|tag,time,record|
+      tests.each {|tag,time,record|
         send_data [tag, time, record].to_msgpack
       }
-      sleep 0.5
     end
+
+    compare_test_result(tests, d.emits)
   end
 
   def test_forward
@@ -69,17 +77,21 @@ class ForwardInputTest < Test::Unit::TestCase
 
     time = Time.parse("2011-01-02 13:14:15 UTC").to_i
 
-    d.expect_emit "tag1", time, {"a"=>1}
-    d.expect_emit "tag1", time, {"a"=>2}
+    tests = [
+      ["tag1", time, {"a"=>1}],
+      ["tag1", time, {"a"=>2}]
+    ]
+    d.expected_emits_length = tests.length
 
     d.run do
       entries = []
-      d.expected_emits.each {|tag,time,record|
+      tests.each {|tag,time,record|
         entries << [time, record]
       }
       send_data ["tag1", entries].to_msgpack
-      sleep 0.5
     end
+
+    compare_test_result(tests, d.emits)
   end
 
   def test_packed_forward
@@ -87,17 +99,21 @@ class ForwardInputTest < Test::Unit::TestCase
 
     time = Time.parse("2011-01-02 13:14:15 UTC").to_i
 
-    d.expect_emit "tag1", time, {"a"=>1}
-    d.expect_emit "tag1", time, {"a"=>2}
+    tests = [
+      ["tag1", time, {"a"=>1}],
+      ["tag1", time, {"a"=>2}]
+    ]
+    d.expected_emits_length = tests.length
 
     d.run do
       entries = ''
-      d.expected_emits.each {|tag,time,record|
+      tests.each {|tag,time,record|
         [time, record].to_msgpack(entries)
       }
       send_data ["tag1", entries].to_msgpack
-      sleep 0.5
     end
+
+    compare_test_result(tests, d.emits)
   end
 
   def test_message_json
@@ -105,15 +121,19 @@ class ForwardInputTest < Test::Unit::TestCase
 
     time = Time.parse("2011-01-02 13:14:15 UTC").to_i
 
-    d.expect_emit "tag1", time, {"a"=>1}
-    d.expect_emit "tag2", time, {"a"=>2}
+    tests = [
+      ["tag1", time, {"a"=>1}],
+      ["tag2", time, {"a"=>2}]
+    ]
+    d.expected_emits_length = tests.length
 
     d.run do
-      d.expected_emits.each {|tag,time,record|
+      tests.each {|tag,time,record|
         send_data [tag, time, record].to_json
       }
-      sleep 0.5
     end
+
+    compare_test_result(tests, d.emits)
   end
 
   def test_send_large_chunk_warning
@@ -209,6 +229,13 @@ class ForwardInputTest < Test::Unit::TestCase
       io.write data
     ensure
       io.close
+    end
+  end
+
+  def compare_test_result(tests, emits)
+    assert_equal(tests.length, emits.length)
+    emits.each_index do |i|
+      assert_equal(tests[i], emits[i])
     end
   end
 

--- a/test/plugin/test_in_http.rb
+++ b/test/plugin/test_in_http.rb
@@ -34,15 +34,20 @@ class HttpInputTest < Test::Unit::TestCase
     time = Time.parse("2011-01-02 13:14:15 UTC").to_i
     Fluent::Engine.now = time
 
-    d.expect_emit "tag1", time, {"a"=>1}
-    d.expect_emit "tag2", time, {"a"=>2}
+    tests = [
+      ["tag1", time, {"a"=>1}],
+      ["tag2", time, {"a"=>2}]
+    ]
+    d.expected_emits_length = tests.length
 
     d.run do
-      d.expected_emits.each {|tag,time,record|
+      tests.each {|tag,time,record|
         res = post("/#{tag}", {"json"=>record.to_json})
         assert_equal "200", res.code
       }
     end
+
+    compare_test_result(tests, d.emits)
   end
 
   def test_json
@@ -50,15 +55,20 @@ class HttpInputTest < Test::Unit::TestCase
 
     time = Time.parse("2011-01-02 13:14:15 UTC").to_i
 
-    d.expect_emit "tag1", time, {"a"=>1}
-    d.expect_emit "tag2", time, {"a"=>2}
+    tests = [
+      ["tag1", time, {"a"=>1}],
+      ["tag2", time, {"a"=>2}]
+    ]
+    d.expected_emits_length = tests.length
 
     d.run do
-      d.expected_emits.each {|tag,time,record|
+      tests.each {|tag,time,record|
         res = post("/#{tag}", {"json"=>record.to_json, "time"=>time.to_s})
         assert_equal "200", res.code
       }
     end
+
+    compare_test_result(tests, d.emits)
 
     d.emit_streams.each { |tag, es|
       assert !include_http_header?(es.first[1])
@@ -73,15 +83,15 @@ class HttpInputTest < Test::Unit::TestCase
     events = [{"a"=>1},{"a"=>2}]
     tag = "tag1"
 
-    events.each { |ev|
-      d.expect_emit tag, time, ev
-    }
+    tests = events.map { |ev| [tag, time, ev] }
+    d.expected_emits_length = tests.length
 
     d.run do
       res = post("/#{tag}", {"json"=>events.to_json, "time"=>time.to_s})
       assert_equal "200", res.code
     end
 
+    compare_test_result(tests, d.emits)
   end
 
   def test_json_with_add_http_headers
@@ -109,15 +119,20 @@ class HttpInputTest < Test::Unit::TestCase
 
     time = Time.parse("2011-01-02 13:14:15 UTC").to_i
 
-    d.expect_emit "tag1", time, {"a"=>1}
-    d.expect_emit "tag2", time, {"a"=>2}
+    tests = [
+      ["tag1", time, {"a"=>1}],
+      ["tag2", time, {"a"=>2}]
+    ]
+    d.expected_emits_length = tests.length
 
     d.run do
-      d.expected_emits.each {|tag,time,record|
+      tests.each {|tag,time,record|
         res = post("/#{tag}?time=#{time.to_s}", record.to_json, {"content-type"=>"application/json; charset=utf-8"})
         assert_equal "200", res.code
       }
     end
+
+    compare_test_result(tests, d.emits)
   end
 
   def test_msgpack
@@ -125,15 +140,20 @@ class HttpInputTest < Test::Unit::TestCase
 
     time = Time.parse("2011-01-02 13:14:15 UTC").to_i
 
-    d.expect_emit "tag1", time, {"a"=>1}
-    d.expect_emit "tag2", time, {"a"=>2}
+    tests = [
+      ["tag1", time, {"a"=>1}],
+      ["tag2", time, {"a"=>2}]
+    ]
+    d.expected_emits_length = tests.length
 
     d.run do
-      d.expected_emits.each {|tag,time,record|
+      tests.each {|tag,time,record|
         res = post("/#{tag}", {"msgpack"=>record.to_msgpack, "time"=>time.to_s})
         assert_equal "200", res.code
       }
     end
+
+    compare_test_result(tests, d.emits)
   end
 
   def test_multi_msgpack
@@ -144,15 +164,15 @@ class HttpInputTest < Test::Unit::TestCase
     events = [{"a"=>1},{"a"=>2}]
     tag = "tag1"
 
-    events.each { |ev|
-      d.expect_emit tag, time, ev
-    }
+    tests = events.map { |ev| [tag, time, ev] }
+    d.expected_emits_length = tests.length
 
     d.run do
       res = post("/#{tag}", {"msgpack"=>events.to_msgpack, "time"=>time.to_s})
       assert_equal "200", res.code
     end
 
+    compare_test_result(tests, d.emits)
   end
 
   def test_with_regexp
@@ -163,11 +183,13 @@ class HttpInputTest < Test::Unit::TestCase
 
     time = Time.parse("2011-01-02 13:14:15 UTC").to_i
 
-    d.expect_emit "tag1", time, {"field_1" => 1, "field_2" => 'str'}
-    d.expect_emit "tag2", time, {"field_1" => 2, "field_2" => 'str'}
+    tests = [
+      ["tag1", time, {"field_1" => 1, "field_2" => 'str'}],
+      ["tag2", time, {"field_1" => 2, "field_2" => 'str'}]
+    ]
 
     d.run do
-      d.expected_emits.each { |tag, time, record|
+      tests.each { |tag, time, record|
         body = record.map { |k, v|
           v.to_s
         }.join(':')
@@ -175,6 +197,8 @@ class HttpInputTest < Test::Unit::TestCase
         assert_equal "200", res.code
       }
     end
+
+    compare_test_result(tests, d.emits)
   end
 
   def test_with_csv
@@ -187,16 +211,21 @@ class HttpInputTest < Test::Unit::TestCase
 
     time = Time.parse("2011-01-02 13:14:15 UTC").to_i
 
-    d.expect_emit "tag1", time, {"foo" => "1", "bar" => 'st"r'}
-    d.expect_emit "tag2", time, {"foo" => "2", "bar" => 'str'}
+    tests = [
+      ["tag1", time, {"foo" => "1", "bar" => 'st"r'}],
+      ["tag2", time, {"foo" => "2", "bar" => 'str'}]
+    ]
+    d.expected_emits_length = tests.length
 
     d.run do
-      d.expected_emits.each { |tag, time, record|
+      tests.each { |tag, time, record|
         body = record.map { |k, v| v }.to_csv
         res = post("/#{tag}?time=#{time.to_s}", body)
         assert_equal "200", res.code
       }
     end
+
+    compare_test_result(tests, d.emits)
   end
 
   def post(path, params, header = {})
@@ -212,5 +241,12 @@ class HttpInputTest < Test::Unit::TestCase
 
   def include_http_header?(record)
     record.keys.find { |header| header.start_with?('HTTP_') }
+  end
+
+  def compare_test_result(tests, emits)
+    assert_equal(tests.length, emits.length)
+    emits.each_index do |i|
+      assert_equal(tests[i], emits[i])
+    end
   end
 end

--- a/test/plugin/test_in_stream.rb
+++ b/test/plugin/test_in_stream.rb
@@ -12,15 +12,19 @@ module StreamInputTest
     time = Time.parse("2011-01-02 13:14:15 UTC").to_i
     Fluent::Engine.now = time
 
-    d.expect_emit "tag1", time, {"a"=>1}
-    d.expect_emit "tag2", time, {"a"=>2}
+    tests = [
+      ["tag1", time, {"a"=>1}],
+      ["tag2", time, {"a"=>2}]
+    ]
+    d.expected_emits_length = tests.length
 
     d.run do
-      d.expected_emits.each {|tag,time,record|
+      tests.each {|tag,time,record|
         send_data [tag, 0, record].to_msgpack
       }
-      sleep 0.5
     end
+
+    compare_test_result(tests, d.emits)
   end
 
   def test_message
@@ -28,15 +32,19 @@ module StreamInputTest
 
     time = Time.parse("2011-01-02 13:14:15 UTC").to_i
 
-    d.expect_emit "tag1", time, {"a"=>1}
-    d.expect_emit "tag2", time, {"a"=>2}
+    tests = [
+      ["tag1", time, {"a"=>1}],
+      ["tag2", time, {"a"=>2}]
+    ]
+    d.expected_emits_length = tests.length
 
     d.run do
-      d.expected_emits.each {|tag,time,record|
+      tests.each {|tag,time,record|
         send_data [tag, time, record].to_msgpack
       }
-      sleep 0.5
     end
+
+    compare_test_result(tests, d.emits)
   end
 
   def test_forward
@@ -44,17 +52,21 @@ module StreamInputTest
 
     time = Time.parse("2011-01-02 13:14:15 UTC").to_i
 
-    d.expect_emit "tag1", time, {"a"=>1}
-    d.expect_emit "tag1", time, {"a"=>2}
+    tests = [
+      ["tag1", time, {"a"=>1}],
+      ["tag1", time, {"a"=>2}]
+    ]
+    d.expected_emits_length = tests.length
 
     d.run do
       entries = []
-      d.expected_emits.each {|tag,time,record|
+      tests.each {|tag,time,record|
         entries << [time, record]
       }
       send_data ["tag1", entries].to_msgpack
-      sleep 0.5
     end
+
+    compare_test_result(tests, d.emits)
   end
 
   def test_packed_forward
@@ -62,17 +74,21 @@ module StreamInputTest
 
     time = Time.parse("2011-01-02 13:14:15 UTC").to_i
 
-    d.expect_emit "tag1", time, {"a"=>1}
-    d.expect_emit "tag1", time, {"a"=>2}
+    tests = [
+      ["tag1", time, {"a"=>1}],
+      ["tag1", time, {"a"=>2}]
+    ]
+    d.expected_emits_length = tests.length
 
     d.run do
       entries = ''
-      d.expected_emits.each {|tag,time,record|
+      tests.each {|tag,time,record|
         [time, record].to_msgpack(entries)
       }
       send_data ["tag1", entries].to_msgpack
-      sleep 0.5
     end
+
+    compare_test_result(tests, d.emits)
   end
 
   def test_message_json
@@ -80,15 +96,19 @@ module StreamInputTest
 
     time = Time.parse("2011-01-02 13:14:15 UTC").to_i
 
-    d.expect_emit "tag1", time, {"a"=>1}
-    d.expect_emit "tag2", time, {"a"=>2}
+    tests = [
+      ["tag1", time, {"a"=>1}],
+      ["tag2", time, {"a"=>2}]
+    ]
+    d.expected_emits_length = tests.length
 
     d.run do
-      d.expected_emits.each {|tag,time,record|
+      tests.each {|tag,time,record|
         send_data [tag, time, record].to_json
       }
-      sleep 0.5
     end
+
+    compare_test_result(tests, d.emits)
   end
 
   def create_driver(klass, conf)
@@ -101,6 +121,13 @@ module StreamInputTest
       io.write data
     ensure
       io.close
+    end
+  end
+
+  def compare_test_result(tests, emits)
+    assert_equal(tests.length, emits.length)
+    emits.each_index do |i|
+      assert_equal(tests[i], emits[i])
     end
   end
 end


### PR DESCRIPTION
I think it is problematic to specify expected emits by `InputTestDriver#expect_emit` before `#run` and assert them during `#run`.
- First, it needs to call `sleep` explicitly in the argument block of `#run` so that input loop will emit test data. But depending on the amount of sleeping time it cannot be ensured that all the test data has been emited before assertion.
- Second, assertions are hidden into `#run` from test codes and assertions occur during `#run`. So when some test fails during `#run`, where the fail occurs is not clear.

I rewirte `InputTestDriver#run` so that test codes specify only expected emits length before `#run` and assert emits after `#run`.
#397 and this pull request are same in that it is intended that `InputTestDriver#run` sleeps only enough amount of time. But how to specify the length of expected emits and where assersions are occured are different. I think this is better because test codes will be clearer, so if you merge this, please ignore #397.
