### PR TITLE
add file writable check in #configure

### DIFF
--- a/lib/fluent/plugin/file_util.rb
+++ b/lib/fluent/plugin/file_util.rb
@@ -1,0 +1,30 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+module Fluent
+  module FileUtil
+    # Check file is writable if file exists
+    # Check directory is writable if file does not exist
+    #
+    # @param [String] path File path
+    # @return [Boolean] file is writable or not
+    def writable?(path)
+      path = File.exist?(path) ? path : File.dirname(path)
+      File.writable?(path)
+    end
+    module_function :writable?
+  end
+end

--- a/lib/fluent/plugin/in_debug_agent.rb
+++ b/lib/fluent/plugin/in_debug_agent.rb
@@ -20,6 +20,7 @@ module Fluent
 
     def initialize
       require 'drb/drb'
+      require 'fluent/plugin/file_util'
       super
     end
 
@@ -31,6 +32,11 @@ module Fluent
 
     def configure(conf)
       super
+      if @unix_path
+        unless ::Fluent::FileUtil.writable?(@unix_path)
+          raise ConfigError, "in_debug_agent: `#{@unix_path}` is not writable"
+        end
+      end
     end
 
     def start

--- a/test/plugin/test_file_util.rb
+++ b/test/plugin/test_file_util.rb
@@ -1,0 +1,39 @@
+require_relative '../helper'
+require 'fluent/plugin/file_util'
+require 'fileutils'
+
+class FileUtilTest < Test::Unit::TestCase
+  def setup
+    FileUtils.rm_rf(TEST_DIR)
+    FileUtils.mkdir_p(TEST_DIR)
+  end
+
+  TEST_DIR = File.expand_path(File.dirname(__FILE__) + "/../tmp/file_util")
+
+  sub_test_case 'writable?' do
+    test 'file exists and writable' do
+      FileUtils.touch("#{TEST_DIR}/test_file")
+      assert_true Fluent::FileUtil.writable?("#{TEST_DIR}/test_file")
+    end
+
+    test 'file exists and not writable' do
+      FileUtils.touch("#{TEST_DIR}/test_file")
+      File.chmod(0444, "#{TEST_DIR}/test_file")
+      assert_false Fluent::FileUtil.writable?("#{TEST_DIR}/test_file")
+    end
+
+    test 'file does not exist and directory is writable' do
+      assert_true Fluent::FileUtil.writable?("#{TEST_DIR}/test_file")
+    end
+
+    test 'file does not exist and directory is not writable' do
+      File.chmod(0444, TEST_DIR)
+      assert_false Fluent::FileUtil.writable?("#{TEST_DIR}/test_file")
+    end
+
+    test 'directory does not exist' do
+      FileUtils.rm_rf(TEST_DIR)
+      assert_false Fluent::FileUtil.writable?("#{TEST_DIR}/test_file")
+    end
+  end
+end

--- a/test/plugin/test_in_debug_agent.rb
+++ b/test/plugin/test_in_debug_agent.rb
@@ -1,0 +1,26 @@
+require_relative '../helper'
+require 'fileutils'
+
+class DebugAgentInputTest < Test::Unit::TestCase
+  def setup
+    Fluent::Test.setup
+    FileUtils.rm_rf(TMP_DIR)
+    FileUtils.mkdir_p(TMP_DIR)
+  end
+
+  TMP_DIR = File.expand_path(File.dirname(__FILE__) + "/../tmp/in_debug_agent")
+
+  def create_driver(conf = '')
+    Fluent::Test::InputTestDriver.new(Fluent::DebugAgentInput).configure(conf)
+  end
+
+  def test_unix_path_writable
+    assert_nothing_raised do
+      create_driver %[unix_path #{TMP_DIR}/test_path]
+    end
+
+    assert_raise(Fluent::ConfigError) do
+      create_driver %[unix_path #{TMP_DIR}/does_not_exist/test_path]
+    end
+  end
+end

--- a/test/plugin/test_out_file.rb
+++ b/test/plugin/test_out_file.rb
@@ -40,6 +40,16 @@ class FileOutputTest < Test::Unit::TestCase
     assert_equal :gz, d.instance.compress
   end
 
+  def test_path_writable
+    assert_nothing_raised do
+      create_driver %[path #{TMP_DIR}/test_path]
+    end
+
+    assert_raise(Fluent::ConfigError) do
+      create_driver %[path #{TMP_DIR}/does_not_exist/test_path]
+    end
+  end
+
   def test_default_localtime
     d = create_driver(%[path #{TMP_DIR}/out_file_test])
     time = Time.parse("2011-01-02 13:14:15 UTC").to_i


### PR DESCRIPTION
`--config-test` is very useful, but it does not check file permission. This proposition is to make a rule to check file permissions in #configure method of each plugin because I thought it is impossible to check file permissions for each configuration parameter of each plugin from Fluentd side (Fluentd can not know what each plugin wants to do)

This pull request is just the first example of the proposition.

@repeatedly What do you think? Yes, each plugin author should support file permission check in #configure method of each plugin when we decide as this is an official way. 

PS. @repeatedly Could you tell me if you have a right place to put the file permission check utility function?
