### PR TITLE
Fix TextParser to add estimate_current_event

### DIFF
--- a/lib/fluent/parser.rb
+++ b/lib/fluent/parser.rb
@@ -257,8 +257,6 @@ module Fluent
       config_param :time_key, :string, :default => nil
       config_param :time_format, :string, :default => nil
 
-      # SET false BEFORE CONFIGURE, to return nil when time not parsed
-      # 'configure()' may raise errors for unexpected configurations
       attr_accessor :estimate_current_event
 
       def initialize
@@ -651,9 +649,14 @@ module Fluent
 
     def initialize
       @parser = nil
+      @estimate_current_event = nil
     end
 
     attr_reader :parser
+
+    # SET false BEFORE CONFIGURE, to return nil when time not parsed
+    # 'configure()' may raise errors for unexpected configurations
+    attr_accessor :estimate_current_event
 
     def configure(conf, required=true)
       format = conf['format']
@@ -686,6 +689,10 @@ module Fluent
           raise ConfigError, "Unknown format template '#{format}'"
         end
         @parser = factory.call
+      end
+
+      if ! @estimate_current_event.nil? && @parser.respond_to?(:'estimate_current_event=')
+        @parser.estimate_current_event = @estimate_current_event
       end
 
       if @parser.respond_to?(:configure)

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -683,5 +683,23 @@ EOS
         i += 1
       }
     end
+
+    def test_setting_estimate_current_event_value
+      p1 = TextParser.new
+      assert_nil p1.estimate_current_event
+      assert_nil p1.parser
+
+      p1.configure('format' => 'none')
+      assert_equal true, p1.parser.estimate_current_event
+
+      p2 = TextParser.new
+      assert_nil p2.estimate_current_event
+      assert_nil p2.parser
+
+      p2.estimate_current_event = false
+
+      p2.configure('format' => 'none')
+      assert_equal false, p2.parser.estimate_current_event
+    end
   end
 end


### PR DESCRIPTION
- to set estimate_current_event on child parser instance, between initialize and configure
  - external code cannot set it before @parser.confgure()
