### PR TITLE
Improve apache_error format

### DIFF
--- a/lib/fluent/parser.rb
+++ b/lib/fluent/parser.rb
@@ -622,7 +622,7 @@ module Fluent
     TEMPLATE_REGISTRY = Registry.new(:config_type, 'fluent/plugin/parser_')
     {
       'apache' => Proc.new { RegexpParser.new(/^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$/, {'time_format'=>"%d/%b/%Y:%H:%M:%S %z"}) },
-      'apache_error' => Proc.new { RegexpParser.new(/^\[[^ ]* (?<time>[^\]]*)\] \[(?<level>[^\]]*)\](?: \[pid (?<pid>[^\]]*)\])? \[client (?<client>[^\]]*)\] (?<message>.*)$/) },
+      'apache_error' => Proc.new { RegexpParser.new(/^\[[^ ]* (?<time>[^\]]*)\] \[(?<level>[^\]]*)\](?: \[pid (?<pid>[^\]]*)\])?( \[client (?<client>[^\]]*)\])? (?<message>.*)$/) },
       'apache2' => Proc.new { ApacheParser.new },
       'syslog' => Proc.new { SyslogParser.new },
       'json' => Proc.new { JSONParser.new },

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -155,6 +155,16 @@ module ParserTest
         assert_equal(@expected.merge('pid' => '1000'), record)
       }
     end
+
+    def test_call_without_client
+      @parser.call('[Wed Oct 11 14:32:52 2000] [notice] Apache/2.2.15 (Unix) DAV/2 configured -- resuming normal operations') { |time, record|
+        assert_equal(str2time('Wed Oct 11 14:32:52 2000'), time)
+        assert_equal({
+          'level' => 'notice',
+          'message' => 'Apache/2.2.15 (Unix) DAV/2 configured -- resuming normal operations'
+        }, record)
+      }
+    end
   end
 
   class Apache2ParserTest < ::Test::Unit::TestCase


### PR DESCRIPTION
Hi @repeatedly

This PR supports apache error log format without host key.
c.f. https://gist.github.com/y-ken/a542b466c5998d03d148

These pattern are supported by this PR.

```
2014-08-19 17:44:22 +0900 [warn]: pattern not match: "[Tue Aug 05 15:48:43 2014] [notice] Apache/2.2.15 (Unix) DAV/2 configured -- resuming normal operations"
2014-08-19 17:44:22 +0900 [warn]: pattern not match: "[Thr Mar 29 17:52:01 2007] [notice] child pid 20001 exit signal Segmentation fault (11)"
```

related issue: #396
