### PR TITLE
Can register conditions in which the loop continues/exits

### DIFF
--- a/lib/fluent/test/input_test.rb
+++ b/lib/fluent/test/input_test.rb
@@ -75,17 +75,17 @@ module Fluent
         all
       end
 
-      def register_run_post_condition(proc)
-        if proc.respond_to?(:call)
+      def register_run_post_condition(&block)
+        if block
           @run_post_conditions ||= []
-          @run_post_conditions << proc
+          @run_post_conditions << block
         end
       end
 
-      def register_run_breaking_condition(proc)
-        if proc.respond_to?(:call)
+      def register_run_breaking_condition(&block)
+        if block
           @run_breaking_conditions ||= []
-          @run_breaking_conditions << proc
+          @run_breaking_conditions << block
         end
       end
 
@@ -118,11 +118,17 @@ module Fluent
             # Events of expected length will be emitted at the end.
             max_length = @expected_emits_length
             max_length ||= @expects.length if @expects
-            register_run_post_condition(lambda { i == max_length }) if max_length
+            if max_length
+              register_run_post_condition do
+                i == max_length
+              end
+            end
 
             # Set runnning timeout to avoid infinite loop caused by some errors.
             started_at = Time.now
-            register_run_breaking_condition(lambda { Time.now >= started_at + @run_timeout })
+            register_run_breaking_condition do
+              Time.now >= started_at + @run_timeout
+            end
 
             until run_should_stop?
               if j >= @emit_streams.length


### PR DESCRIPTION
Add two types of loop conditions that can be registered as lambda expressions:
- Post conditions: conditions that will have to be all satisfied at the end of the loop if the loop ends normally.
- Breaking conditions: conditions that is used to exit the loop.

The loop in InputTestDriver#run stops if all of the post conditions are satisfied or any of the breaking conditions is satisfied.
To avoid infinite loops caused by some errors or incorrect post conditions, breaking conditions are prior to post conditions and InputTestDriver set timeout as a breaking condition.

This can be used to set loop conditions more flexibly than #397, in which only the length of expected emits can be set as a post condition.
To be honest, I am writing codes about #408 and it is not sufficient to set only the length of expected emits as a post condition to write test codes.

The names of these conditions sounds a bit strange to me, but I cannot think of better ones. How do you think of these names?
