### PR TITLE
Implement 'disable_retry_limit' output option.

### DIFF
--- a/test/test_output.rb
+++ b/test/test_output.rb
@@ -27,6 +27,7 @@ module FluentOutputTest
       d = create_driver
       assert_equal 'memory', d.instance.buffer_type
       assert_equal 60, d.instance.flush_interval
+      assert_equal false, d.instance.disable_retry_limit
       assert_equal 17, d.instance.retry_limit
       assert_equal 1.0, d.instance.retry_wait
       assert_equal nil, d.instance.max_retry_wait
@@ -37,6 +38,10 @@ module FluentOutputTest
       # max_retry_wait
       d = create_driver(CONFIG + %[max_retry_wait 4])
       assert_equal 4, d.instance.max_retry_wait
+
+      # disable_retry_limit
+      d = create_driver(CONFIG + %[disable_retry_limit true])
+      assert_equal true, d.instance.disable_retry_limit
     end
 
     def test_calc_retry_wait


### PR DESCRIPTION
Setting 'disable_retry_limit' causes 'retry_limit' to be ignored
in favor of retrying forever.  This implicitly disables any
secondary output configuration as well.
