### PR TITLE
add relabel plugin to `add-filter-and-label` branch

### DIFF
--- a/lib/fluent/plugin/out_relabel.rb
+++ b/lib/fluent/plugin/out_relabel.rb
@@ -1,0 +1,10 @@
+module Fluent
+  class RelabelOutput < Output
+    Plugin.register_output('relabel', self)
+
+    def emit(tag, es, chain)
+      router.emit_stream(tag, es)
+      chain.next
+    end
+  end
+end


### PR DESCRIPTION
This is a config example:

```
<source>
  type dummydata_producer
  tag  dummy.data
  rate 1        # messages per second
  dummydata0   {"type":"sample","code":50,"format":"json string allowed"}
  dummydata1   {"message":"other format needed?"}
  dummydata2   {"comment":"N of dummydataN is number and not limited"}
  @label @raw
</source>

<match flowcounter>
  type stdout
</match>

<label @raw>
  <match **>
    type copy
    <store>
      type flowcounter
      count_keys *
      unit second
      aggregate all
      tag flowcounter
    </store>
    <store>
      type relabel
      @label @main
    </store>
  </match>
</label>

<label @main>
  <match **>
    type stdout
  </match>
</label>
```
