### PR TITLE
Fix bundler_injection for environment that has a embedded ruby

### DIFF
--- a/lib/fluent/command/bundler_injection.rb
+++ b/lib/fluent/command/bundler_injection.rb
@@ -14,18 +14,20 @@
 #    limitations under the License.
 #
 
-system("bundle install")
+bundle_bin = Gem::Specification.find_by_name('bundler').bin_file('bundle')
+ruby_bin = RbConfig.ruby
+system("#{ruby_bin} #{bundle_bin} install")
 unless $?.success?
   exit $?.exitstatus
 end
 
 cmdline = [
-  'bundle',
+  ruby_bin,
+  bundle_bin,
   'exec',
-  RbConfig.ruby,
+  ruby_bin,
   File.expand_path(File.join(File.dirname(__FILE__), 'fluentd.rb')),
 ] + ARGV
 
 exec *cmdline
 exit! 127
-

--- a/lib/fluent/command/bundler_injection.rb
+++ b/lib/fluent/command/bundler_injection.rb
@@ -14,20 +14,30 @@
 #    limitations under the License.
 #
 
-bundle_bin = Gem::Specification.find_by_name('bundler').bin_file('bundle')
-ruby_bin = RbConfig.ruby
-system("#{ruby_bin} #{bundle_bin} install")
-unless $?.success?
-  exit $?.exitstatus
+if ENV['BUNDLE_BIN_PATH']
+  puts 'error: You seem to use `bundle exec` already.'
+  exit 1
+else
+  begin
+    bundle_bin = Gem::Specification.find_by_name('bundler').bin_file('bundle')
+  rescue Gem::LoadError => e
+    puts "error: #{e}"
+    exit 1
+  end
+  ruby_bin = RbConfig.ruby
+  system("#{ruby_bin} #{bundle_bin} install")
+  unless $?.success?
+    exit $?.exitstatus
+  end
+
+  cmdline = [
+    ruby_bin,
+    bundle_bin,
+    'exec',
+    ruby_bin,
+    File.expand_path(File.join(File.dirname(__FILE__), 'fluentd.rb')),
+  ] + ARGV
+
+  exec *cmdline
+  exit! 127
 end
-
-cmdline = [
-  ruby_bin,
-  bundle_bin,
-  'exec',
-  ruby_bin,
-  File.expand_path(File.join(File.dirname(__FILE__), 'fluentd.rb')),
-] + ARGV
-
-exec *cmdline
-exit! 127


### PR DESCRIPTION
Hello.

In environment with embedded ruby, such as td-agent, the `--gemfile` option may be unavailable.
It will be caused by `bundler_injection.rb` trying to exec system's `bundle` command.
This PR is going to make it find `bundle` from current ruby's gems.

If this looks good to merge, there are two questions.

1. I couldn't find tests about `bundle_inject.rb`. Should I add it?
2. When it cannot find `bundle` command,  Should I make it will put some error message?

Thank you.