### PR TITLE
add use-v0-config option

### DIFF
--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -78,8 +78,12 @@ op.on('--without-source', "invoke a fluentd without input plugins", TrueClass) {
   opts[:without_source] = b
 }
 
-op.on('--use-v1-config', "Use v1 configuration format", TrueClass) {|b|
+op.on('--use-v1-config', "Use v1 configuration format (default)", TrueClass) {|b|
   opts[:use_v1_config] = b
+}
+
+op.on('--use-v0-config', "Use v0 configuration format", TrueClass) {|b|
+  opts[:use_v1_config] = !b
 }
 
 op.on('-v', '--verbose', "increase verbose level (-v: debug, -vv: trace)", TrueClass) {|b|


### PR DESCRIPTION
The default of v1 (master) branch is use-v1-config = true, but there is no way to use v0 config because this options is missing. 
