### PR TITLE
add use-v0-config (v0.10 branch)

### DIFF
--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -84,6 +84,10 @@ op.on('--use-v1-config', "Use v1 configuration format", TrueClass) {|b|
   opts[:use_v1_config] = b
 }
 
+op.on('--use-v0-config', "Use v0 configuration format (default)", TrueClass) {|b|
+  opts[:use_v1_config] = !b
+}
+
 op.on('-v', '--verbose', "increase verbose level (-v: debug, -vv: trace)", TrueClass) {|b|
   if b
     opts[:log_level] = [opts[:log_level] - 1, Fluent::Log::LEVEL_TRACE].max


### PR DESCRIPTION
Add same option with https://github.com/fluent/fluentd/pull/431. 

This options makes easy to migrate from v0.10 to v1 for users by setting `--use-v0-config` before versioning up (I mean that, this is useful when they do not have time to rewrite config, but want to version up). 
