### PR TITLE
add single quoted string literal

### DIFF
--- a/lib/fluent/config/literal_parser.rb
+++ b/lib/fluent/config/literal_parser.rb
@@ -65,13 +65,15 @@ module Fluent
 
       def scan_string(string_boundary_charset = LINE_END)
         if skip(/\"/)
-          return scan_quoted_string
+          return scan_double_quoted_string
+        elsif skip(/\'/)
+          return scan_single_quoted_string
         else
           return scan_nonquoted_string(string_boundary_charset)
         end
       end
 
-      def scan_quoted_string
+      def scan_double_quoted_string
         string = []
         while true
           if skip(/\"/)
@@ -84,7 +86,24 @@ module Fluent
           elsif s = scan(/./)
             string << s
           else
-            parse_error! "unexpected end of file in a quoted string"
+            parse_error! "unexpected end of file in a double quoted string"
+          end
+        end
+      end
+
+      def scan_single_quoted_string
+        string = []
+        while true
+          if skip(/\'/)
+            return string.join
+          elsif s = scan(/\\'/)
+            string << "'"
+          elsif s = scan(/\\\\/)
+            string << "\\"
+          elsif s = scan(/./)
+            string << s
+          else
+            parse_error! "unexpected end of file in a signle quoted string"
           end
         end
       end

--- a/spec/config/literal_parser_spec.rb
+++ b/spec/config/literal_parser_spec.rb
@@ -2,6 +2,7 @@ require "config/helper"
 require "fluent/config/error"
 require "fluent/config/literal_parser"
 require "fluent/config/v1_parser"
+require 'json'
 
 describe Fluent::Config::LiteralParser do
   include_context 'config_helper'
@@ -75,7 +76,7 @@ describe Fluent::Config::LiteralParser do
     it { expect('-InfinityX').to be_parsed_as("-InfinityX") }
   end
 
-  describe 'quoted string' do
+  describe 'double quoted string' do
     it { expect('""').to be_parsed_as("") }
     it { expect('"text"').to be_parsed_as("text") }
     it { expect('"\\""').to be_parsed_as("\"") }
@@ -98,6 +99,35 @@ describe Fluent::Config::LiteralParser do
     it { expect('"$"').to be_parsed_as('$') }
     it { expect('"$t"').to be_parsed_as('$t') }
     it { expect('"$}"').to be_parsed_as('$}') }
+    it { expect('"\\\\"').to be_parsed_as("\\") }
+    it { expect('"\\["').to be_parsed_as("[") }
+  end
+
+  describe 'single quoted string' do
+    it { expect("''").to be_parsed_as("") }
+    it { expect("'text'").to be_parsed_as("text") }
+    it { expect("'\\''").to be_parsed_as('\'') }
+    it { expect("'\\t'").to be_parsed_as('\t') }
+    it { expect("'\\n'").to be_parsed_as('\n') }
+    it { expect("'\\r\\n'").to be_parsed_as('\r\n') }
+    it { expect("'\\f\\b'").to be_parsed_as('\f\b') }
+    it { expect("'\\.t'").to be_parsed_as('\.t') }
+    it { expect("'\\$t'").to be_parsed_as('\$t') }
+    it { expect("'\\#t'").to be_parsed_as('\#t') }
+    it { expect("'\\z'").to be_parsed_as('\z') }
+    it { expect("'\\0'").to be_parsed_as('\0') }
+    it { expect("'\\1'").to be_parsed_as('\1') }
+    it { expect("'t").to be_parse_error }  # non-terminated quoted character
+    it { expect("t'").to be_parsed_as("t'") }
+    it { expect("'.'").to be_parsed_as('.') }
+    it { expect("'*'").to be_parsed_as('*') }
+    it { expect("'@'").to be_parsed_as('@') }
+    it { expect(%q['#{test}']).to be_parsed_as('#{test}') }
+    it { expect("'$'").to be_parsed_as('$') }
+    it { expect("'$t'").to be_parsed_as('$t') }
+    it { expect("'$}'").to be_parsed_as('$}') }
+    it { expect("'\\\\'").to be_parsed_as('\\') }
+    it { expect("'\\['").to be_parsed_as('\[') }
   end
 
   describe 'nonquoted string parsing' do


### PR DESCRIPTION
Added single quoted string literal which behaves like ruby's single quoted string.
This idea was introduced at https://github.com/fluent/fluentd/issues/435#issuecomment-56919111

Please note that this is effective only for :string datatype, not effective inside array or hash yet. 
