### PR TITLE
Get coverage to work

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -33,10 +33,10 @@ RSpec::Core::RakeTask.new(:spec) do |t|
   t.verbose = true
 end
 
-desc 'Run rspec with simplecov'
+desc 'Run test and rspec with simplecov'
 task :coverage do |t|
   ENV['SIMPLE_COV'] = '1'
-  Rake::Task["spec"].invoke
+  Rake::Task["test"].invoke
 end
 
 task :default => [:test, :build]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,4 @@
-
-require 'fluent/load'
-require 'fileutils'
-
-src_root = File.expand_path('..', File.dirname(__FILE__))
-$LOAD_PATH << File.join(src_root, "lib")
-$LOAD_PATH << src_root
-
+# simplecov must be loaded any of target code
 if ENV['SIMPLE_COV']
   require 'simplecov'
   if defined?(SimpleCov::SourceFile)
@@ -22,12 +15,20 @@ if ENV['SIMPLE_COV']
       m
     end
   end
-  SimpleCov.start do
-    add_filter 'spec/'
-    add_filter 'pkg/'
-    add_filter 'vendor/'
+  unless SimpleCov.running
+    SimpleCov.start do
+      add_filter '/spec/'
+      add_filter '/gems/'
+    end
   end
 end
+
+require 'fluent/load'
+require 'fileutils'
+
+src_root = File.expand_path('..', File.dirname(__FILE__))
+$LOAD_PATH << File.join(src_root, "lib")
+$LOAD_PATH << src_root
 
 if ENV['GC_STRESS']
   STDERR.puts "enable GC.stress"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,3 +1,14 @@
+# simplecov must be loaded before any of target code
+if ENV['SIMPLE_COV']
+  require 'simplecov'
+  unless SimpleCov.running
+    SimpleCov.start do
+      add_filter '/test/'
+      add_filter '/gems/'
+    end
+  end
+end
+
 require 'test/unit'
 require 'fileutils'
 require 'fluent/log'

--- a/test/plugin/test_in_exec.rb
+++ b/test/plugin/test_in_exec.rb
@@ -1,3 +1,4 @@
+require 'helper'
 require 'fluent/test'
 require 'net/http'
 

--- a/test/plugin/test_in_forward.rb
+++ b/test/plugin/test_in_forward.rb
@@ -1,5 +1,5 @@
-require 'fluent/test'
 require 'helper'
+require 'fluent/test'
 
 class ForwardInputTest < Test::Unit::TestCase
   def setup

--- a/test/plugin/test_in_gc_stat.rb
+++ b/test/plugin/test_in_gc_stat.rb
@@ -1,3 +1,4 @@
+require 'helper'
 require 'fluent/test'
 
 class GCStatInputTest < Test::Unit::TestCase

--- a/test/plugin/test_in_http.rb
+++ b/test/plugin/test_in_http.rb
@@ -1,5 +1,5 @@
-require 'fluent/test'
 require 'helper'
+require 'fluent/test'
 require 'net/http'
 
 class HttpInputTest < Test::Unit::TestCase

--- a/test/plugin/test_in_object_space.rb
+++ b/test/plugin/test_in_object_space.rb
@@ -1,3 +1,4 @@
+require 'helper'
 require 'fluent/test'
 
 class ObjectSpaceInputTest < Test::Unit::TestCase

--- a/test/plugin/test_in_status.rb
+++ b/test/plugin/test_in_status.rb
@@ -1,3 +1,4 @@
+require 'helper'
 require 'fluent/test'
 
 class StatusInputTest < Test::Unit::TestCase

--- a/test/plugin/test_in_stream.rb
+++ b/test/plugin/test_in_stream.rb
@@ -1,5 +1,5 @@
-require 'fluent/test'
 require 'helper'
+require 'fluent/test'
 
 module StreamInputTest
   def setup

--- a/test/plugin/test_in_syslog.rb
+++ b/test/plugin/test_in_syslog.rb
@@ -1,5 +1,5 @@
-require 'fluent/test'
 require 'helper'
+require 'fluent/test'
 
 class SyslogInputTest < Test::Unit::TestCase
   def setup

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -1,3 +1,4 @@
+require 'helper'
 require 'fluent/test'
 require 'net/http'
 require 'flexmock'

--- a/test/plugin/test_in_tcp.rb
+++ b/test/plugin/test_in_tcp.rb
@@ -1,5 +1,5 @@
-require 'fluent/test'
 require 'helper'
+require 'fluent/test'
 
 class TcpInputTest < Test::Unit::TestCase
   def setup

--- a/test/plugin/test_in_udp.rb
+++ b/test/plugin/test_in_udp.rb
@@ -1,5 +1,5 @@
-require 'fluent/test'
 require 'helper'
+require 'fluent/test'
 
 class UdpInputTest < Test::Unit::TestCase
   def setup

--- a/test/plugin/test_out_copy.rb
+++ b/test/plugin/test_out_copy.rb
@@ -1,3 +1,4 @@
+require 'helper'
 require 'fluent/test'
 
 class CopyOutputTest < Test::Unit::TestCase

--- a/test/plugin/test_out_exec.rb
+++ b/test/plugin/test_out_exec.rb
@@ -1,3 +1,4 @@
+require 'helper'
 require 'fluent/test'
 require 'fileutils'
 

--- a/test/plugin/test_out_exec_filter.rb
+++ b/test/plugin/test_out_exec_filter.rb
@@ -1,3 +1,4 @@
+require 'helper'
 require 'fluent/test'
 require 'fileutils'
 

--- a/test/plugin/test_out_file.rb
+++ b/test/plugin/test_out_file.rb
@@ -1,3 +1,4 @@
+require 'helper'
 require 'fluent/test'
 require 'fileutils'
 require 'time'

--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -1,5 +1,5 @@
-require 'fluent/test'
 require 'helper'
+require 'fluent/test'
 
 class ForwardOutputTest < Test::Unit::TestCase
   def setup

--- a/test/plugin/test_out_roundrobin.rb
+++ b/test/plugin/test_out_roundrobin.rb
@@ -1,3 +1,4 @@
+require 'helper'
 require 'fluent/test'
 
 class RoundRobinOutputTest < Test::Unit::TestCase

--- a/test/plugin/test_out_stdout.rb
+++ b/test/plugin/test_out_stdout.rb
@@ -1,3 +1,4 @@
+require 'helper'
 require 'fluent/test'
 
 class StdoutOutputTest < Test::Unit::TestCase

--- a/test/plugin/test_out_stream.rb
+++ b/test/plugin/test_out_stream.rb
@@ -1,5 +1,5 @@
-require 'fluent/test'
 require 'helper'
+require 'fluent/test'
 
 module StreamOutputTest
   def setup

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/helper'
+require 'helper'
 require 'fluent/config'
 require 'fluent/config/parser'
 require 'fluent/supervisor'

--- a/test/test_configdsl.rb
+++ b/test/test_configdsl.rb
@@ -1,6 +1,6 @@
+require 'helper'
 require 'fluent/config/dsl'
 require 'fluent/test'
-require 'helper'
 
 class ConfigDSLTest < Test::Unit::TestCase
   # TEST_CONFIG1 = %[

--- a/test/test_match.rb
+++ b/test/test_match.rb
@@ -1,5 +1,4 @@
-require File.dirname(__FILE__) + '/helper'
-
+require 'helper'
 require 'fluent/match'
 
 class MatchTest < Test::Unit::TestCase


### PR DESCRIPTION
Measure lib/\* coverage based on test execution in addition to spec.
Test and spec changes are for satisfying generic rules below.
- simplecov requires target code to be loaded before invoking
  SimpleCov.start.
- Invoke SimpleCov.start once. Multiple call works if use_merging =
  true (default) but unnecessarily complex.

Report from 'rake coverage' at this point.

  All Files (69.33% covered at 842.16 hits/line)
  64 files in total. 5931 relevant lines. 4112 lines covered and 1819 lines missed
