### PR TITLE
[WIP] Add explicit test/unit dependency

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("simplecov", ["~> 0.6.4"])
   gem.add_development_dependency("rr", [">= 1.0.0"])
   gem.add_development_dependency("timecop", [">= 0.3.0"])
+  gem.add_development_dependency("test-unit", ["~> 3.0"])
 end


### PR DESCRIPTION
This change needs consultation with CRuby guys.
- CRuby trunk and 2.2.0-preview1 needs this but is this intentional
  change?
- If this change only needs for developers living with CRuby trunk?

FWIW I once heard that this is only needed by the ruby command built
from svn repo but unnecesarry in general ruby installation.

I'll consult @hsbt about this.
