### PR TITLE
require 'spec_helper'

### DIFF
--- a/spec/config/config_parser_spec.rb
+++ b/spec/config/config_parser_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require "json"
 require "config/helper"
 require "fluent/config/error"

--- a/spec/config/configurable_spec.rb
+++ b/spec/config/configurable_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require 'fluent/configurable'
 require 'fluent/config/element'
 require 'fluent/config/section'

--- a/spec/config/configure_proxy_spec.rb
+++ b/spec/config/configure_proxy_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require 'fluent/config/configure_proxy'
 
 describe Fluent::Config::ConfigureProxy do

--- a/spec/config/dsl_spec.rb
+++ b/spec/config/dsl_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require_relative "./helper"
 
 require 'fluent/config/element'

--- a/spec/config/literal_parser_spec.rb
+++ b/spec/config/literal_parser_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require "config/helper"
 require "fluent/config/error"
 require "fluent/config/literal_parser"

--- a/spec/config/section_spec.rb
+++ b/spec/config/section_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require 'fluent/config/section'
 
 describe Fluent::Config::Section do

--- a/spec/config/system_config_spec.rb
+++ b/spec/config/system_config_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require 'fluent/configurable'
 require 'fluent/config/element'
 require 'fluent/config/section'


### PR DESCRIPTION
Let me add `require 'spec_helper'`, otherwise, running tests for a specific file fails, for example

```
$ bundle exec rspec spec/config/config_parser_spec.rb
Failures:

  1) Fluent::Config::V1Parser @include parsing parses @include / include correctly
     Failure/Error: Fluent::Config::V1Parser.parse(data, File.basename(path), File.dirname(path))
     NoMethodError:
       private method `warn' called for nil:NilClass
     # ./lib/fluent/config/v1_parser.rb:97:in `parse_element'
     # ./lib/fluent/config/v1_parser.rb:41:in `parse!'
     # ./lib/fluent/config/v1_parser.rb:31:in `parse'
     # ./spec/config/config_parser_spec.rb:14:in `read_config'
     # ./spec/config/config_parser_spec.rb:311:in `block (3 levels) in <top (required)>'
```

This makes me feel bad to do TDD. 
