### PR TITLE
Relax '@' handling in the plugin configuration for backward compatibility

### DIFF
--- a/lib/fluent/config/v1_parser.rb
+++ b/lib/fluent/config/v1_parser.rb
@@ -50,6 +50,8 @@ module Fluent
         return root
       end
 
+      ELEM_SYMBOLS = ['match', 'source', 'filter', 'system']
+
       def parse_element(root_element, elem_name, attrs = {}, elems = [])
         while true
           spacing
@@ -114,7 +116,12 @@ module Fluent
                 attrs[k] = v
               else
                 if k.start_with?('@')
-                  parse_error! "'@' is reserved prefix. Don't use '@' in parameter name"
+                  if root_element || ELEM_SYMBOLS.include?(elem_name)
+                    parse_error! "'@' is the system reserved prefix. Don't use '@' prefix parameter in the configuration: #{k}"
+                  else
+                    # TODO: This is for backward compatibility. It will throw an error in the future.
+                    $log.warn "'@' is the system reserved prefix. It works in the nested configuration for now but it will be rejected: #{k}"
+                  end
                 end
 
                 v = parse_literal

--- a/test/config/test_config_parser.rb
+++ b/test/config/test_config_parser.rb
@@ -154,8 +154,39 @@ module Fluent::Config
         end
       end
 
-      test "rejects @ prefix in parameter name" do
-        assert_parse_error('  @k v')
+      data(
+        "in match" => %[
+          <match>
+            @k v
+          </match>
+        ],
+        "in source" => %[
+          <source>
+            @k v
+          </source>
+        ],
+        "in filter" => %[
+          <filter>
+            @k v
+          </filter>
+        ],
+        "in top-level" => '  @k v '
+        )
+      def test_rejects_at_prefix_in_the_parameter_name(data)
+        assert_parse_error(data)
+      end
+
+      data(
+        "in nested" => %[
+          <match>
+            <record>
+              @k v
+            </record>
+          </match>
+        ]
+        )
+      def test_not_reject_at_prefix_in_the_parameter_name(data)
+        assert_nothing_raised { parse_text(data) }
       end
     end
 


### PR DESCRIPTION
Related to https://github.com/fluent/fluentd/pull/451.
This is ad-hoc but reasonable change for now.

Current implementation can't handle copy or forest like configuration.
Handling this case is hard because it needs the change of configuration mechanizm.
So it is future work. I will implement it after  https://github.com/fluent/fluentd/pull/451 discussion finished.
- nested

``` sh
2014-10-16 05:46:06 +0900 [info]: starting fluentd-0.12.0.pre.1
2014-10-16 05:46:06 +0900 [info]: reading config file path="at_test.conf"
2014-10-16 05:46:07 +0900 [warn]: '@' is the system reserved prefix. It works in the nested configuration for now but it will be rejected: @timestamp
2014-10-16 05:46:07 +0900 [info]: gem 'fluent-plugin-flowcounter-simple' version '0.0.3'
2014-10-16 05:46:07 +0900 [info]: gem 'fluent-plugin-record-reformer' version '0.3.0'
2014-10-16 05:46:07 +0900 [info]: gem 'fluent-plugin-td' version '0.10.21'
2014-10-16 05:46:07 +0900 [info]: gem 'fluentd' version '0.10.53'
2014-10-16 05:46:07 +0900 [info]: using configuration file: <ROOT>
  <match **>
    type record_reformer
    tag foo
    <record>
      @timestamp ${time}
    </record>
  </match>
</ROOT>
2014-10-16 05:46:07 +0900 [info]: adding match pattern="**" type="record_reformer"
^C2014-10-16 05:46:09 +0900 [info]: shutting down fluentd
2014-10-16 05:46:09 +0900 [info]: process finished code=0
```
- top-level

``` sh
/Users/repeatedly/dev/fluentd/fluentd/lib/fluent/config/basic_parser.rb:87:in `parse_error!': '@' is the system reserved prefix. Don't use '@' prefix parameter in the configuration: @foo at at_test.conf line 7,7 (Fluent::ConfigParseError)
  6:   </record>
  7:   @foo bar

     -------^
  8: </match>
        from /Users/repeatedly/dev/fluentd/fluentd/lib/fluent/config/v1_parser.rb:120:in `parse_element'
        from /Users/repeatedly/dev/fluentd/fluentd/lib/fluent/config/v1_parser.rb:92:in `parse_element'
        from /Users/repeatedly/dev/fluentd/fluentd/lib/fluent/config/v1_parser.rb:41:in `parse!'
        from /Users/repeatedly/dev/fluentd/fluentd/lib/fluent/config/v1_parser.rb:31:in `parse'
        from /Users/repeatedly/dev/fluentd/fluentd/lib/fluent/config.rb:29:in `parse'
        from /Users/repeatedly/dev/fluentd/fluentd/lib/fluent/supervisor.rb:367:in `apply_system_config'
        from /Users/repeatedly/dev/fluentd/fluentd/lib/fluent/supervisor.rb:106:in `initialize'
        from /Users/repeatedly/dev/fluentd/fluentd/lib/fluent/command/fluentd.rb:163:in `new'
        from /Users/repeatedly/dev/fluentd/fluentd/lib/fluent/command/fluentd.rb:163:in `<top (required)>'
        from /Users/repeatedly/.rbenv/versions/2.1.3/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:73:in `require'
        from /Users/repeatedly/.rbenv/versions/2.1.3/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:73:in `require'
        from /Users/repeatedly/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/fluentd-0.10.53/bin/fluentd:6:in `<top (required)>'
        from /Users/repeatedly/.rbenv/versions/2.1.3/bin/fluentd:23:in `load'
        from /Users/repeatedly/.rbenv/versions/2.1.3/bin/fluentd:23:in `<main>'
```
