### PR TITLE
Add filter_grep plugin

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("sigdump", ["~> 0.2.2"])
   gem.add_runtime_dependency("tzinfo", [">= 1.0.0"])
   gem.add_runtime_dependency("tzinfo-data", [">= 1.0.0"])
+  gem.add_runtime_dependency("string-scrub", [">= 0.0.3"])
 
   gem.add_development_dependency("rake", [">= 0.9.2"])
   gem.add_development_dependency("flexmock")


### PR DESCRIPTION
`grep` is a general and useful plugin so I ported fluent-plugin-grep as a filter.

We don't have an enough experience for writing Filter test driver so
I wrote tests without test driver. After added several filters,
I will implement test driver for Filter.

@sonots Could you check this PR?
I removed obsoleted parameters.
And I noticed `replace_invalid_sequence` parameter is not used.
Can we remove this parameter?
