### PR TITLE
Fix Chunk path regexp and add tests

### DIFF
--- a/lib/fluent/plugin/buf_file.rb
+++ b/lib/fluent/plugin/buf_file.rb
@@ -120,7 +120,7 @@ module Fluent
 
     # Dots are separator for many cases:
     #   we should have to escape dots in keys...
-    PATH_MATCH = /^([-_.%0-9a-zA-Z]+)\.(b|q)([0-9a-fA-F]{1,32})$/
+    PATH_MATCH = /^([-_.%0-9a-zA-Z]*)\.(b|q)([0-9a-fA-F]{1,32})$/
 
     def new_chunk(key)
       encoded_key = encode_key(key)


### PR DESCRIPTION
- for empty string for chunk keys
- empty string as chunk keys are used by BufferedOutput
  - ObjectBufferedOutput uses tag for chunk key
  - TimeSlicedOutput uses time key for chunk key
    This commit fixes #465
