### PR TITLE
Make BasicBuffer#total_queued_chunk_size thread-safe to avoid Hash related RuntimeError

### DIFF
--- a/lib/fluent/buffer.rb
+++ b/lib/fluent/buffer.rb
@@ -237,11 +237,15 @@ module Fluent
 
     def total_queued_chunk_size
       total = 0
-      @map.each_value {|c|
-        total += c.size
-      }
-      @queue.each {|c|
-        total += c.size
+      synchronize {
+        @map.each_value {|c|
+          total += c.size
+        }
+        @queue.synchronize {
+          @queue.each {|c|
+            total += c.size
+          }
+        }
       }
       total
     end


### PR DESCRIPTION
Report from this thread: https://groups.google.com/forum/#!topic/fluentd/NC9Zo2bM46Q
