### PR TITLE
Add msgpack format to built-in Formatter to dump records

### DIFF
--- a/lib/fluent/formatter.rb
+++ b/lib/fluent/formatter.rb
@@ -114,6 +114,16 @@ module Fluent
       end
     end
 
+    class MessagePackFormatter
+      include Configurable
+      include HandleTagAndTimeMixin
+      include StructuredFormatMixin
+
+      def format_record(record)
+        record.to_msgpack
+      end
+    end
+
     class LabeledTSVFormatter
       include Configurable
       include HandleTagAndTimeMixin
@@ -149,6 +159,7 @@ module Fluent
     {
       'out_file' => Proc.new { OutFileFormatter.new },
       'json' => Proc.new { JSONFormatter.new },
+      'msgpack' => Proc.new { MessagePackFormatter.new },
       'ltsv' => Proc.new { LabeledTSVFormatter.new },
       'single_value' => Proc.new { SingleValueFormatter.new },
     }.each { |name, factory|

--- a/test/test_formatter.rb
+++ b/test/test_formatter.rb
@@ -120,6 +120,49 @@ module FormatterTest
     end
   end
 
+  class MessagePackFormatterTest < ::Test::Unit::TestCase
+    include FormatterTest
+
+    def setup
+      @formatter = TextFormatter::MessagePackFormatter.new
+      @time = Engine.now
+    end
+
+    def test_format
+      @formatter.configure({})
+      formatted = @formatter.format(tag, @time, record)
+
+      assert_equal(record.to_msgpack, formatted)
+    end
+
+    def test_format_with_include_tag
+      @formatter.configure('include_tag_key' => 'true', 'tag_key' => 'foo')
+      formatted = @formatter.format(tag, @time, record.dup)
+
+      r = record
+      r['foo'] = tag
+      assert_equal(r.to_msgpack, formatted)
+    end
+
+    def test_format_with_include_time
+      @formatter.configure('include_time_key' => 'true', 'localtime' => '')
+      formatted = @formatter.format(tag, @time, record.dup)
+
+      r = record
+      r['time'] = time2str(@time, true)
+      assert_equal(r.to_msgpack, formatted)
+    end
+
+    def test_format_with_include_time_as_number
+      @formatter.configure('include_time_key' => 'true', 'time_as_epoch' => 'true', 'time_key' => 'epoch')
+      formatted = @formatter.format(tag, @time, record.dup)
+
+      r = record
+      r['epoch'] = @time
+      assert_equal(r.to_msgpack, formatted)
+    end
+  end
+
   class LabeledTSVFormatterTest < ::Test::Unit::TestCase
     include FormatterTest
 


### PR DESCRIPTION
It is useful to dump records to file or something.
