### PR TITLE
Added possibility to exclude labels and tag from the LTSV

### DIFF
--- a/lib/fluent/formatter.rb
+++ b/lib/fluent/formatter.rb
@@ -115,13 +115,12 @@ module Fluent
       def format(tag, time, record)
         filter_record(tag, time, record)
         formatted = record.inject('') { |result, pair|
-          if @output_tag == false && pair.first == 'tag'
-            result = ''
-          else
+          unless @output_tag == false && pair.first == 'tag'
             result << @delimiter if result.length.nonzero?
             result << "#{pair.first}#{@label_delimiter}" if @include_label
             result << "#{pair.last}"
           end
+          result
         }
         formatted << "\n"
         formatted


### PR DESCRIPTION
If you would like to store original JSON data in simple text format without additional labels and tags now you can use the following options for ltsv format:

```
include_label false
output_tag false
```
