### PR TITLE
in_dummy plugin

### DIFF
--- a/lib/fluent/plugin/in_dummy.rb
+++ b/lib/fluent/plugin/in_dummy.rb
@@ -21,9 +21,9 @@ module Fluent
     BIN_NUM = 10
 
     config_param :tag, :string
-    config_param :rate, :integer
+    config_param :rate, :integer, :default => 1
     config_param :auto_increment_key, :string, :default => nil
-    config_param :dummy do |val|
+    config_param :dummy, :default => [{"message"=>"dummy"}] do |val|
       begin
         parsed = JSON.parse(val)
       rescue JSON::ParserError => e
@@ -38,8 +38,6 @@ module Fluent
       end
       dummy
     end
-
-    attr_reader :dummy
 
     def configure(conf)
       super

--- a/test/plugin/test_in_dummy.rb
+++ b/test/plugin/test_in_dummy.rb
@@ -13,45 +13,36 @@ class DummyTest < Test::Unit::TestCase
   sub_test_case 'configure' do
     test 'required parameters' do
       assert_raise_message("'tag' parameter is required") do
-        create_driver(%[
-          rate 10
-          dummy {"foo":"bar"}
-        ])
-      end
-
-      assert_raise_message("'rate' parameter is required") do
-        create_driver(%[
-          tag dummy
-          dummy {"foo":"bar"}
-        ])
-      end
-
-      assert_raise_message("'dummy' parameter is required") do
-        create_driver(%[
-          tag dummy
-          rate 10
-        ])
+        create_driver('')
       end
     end
 
-    test 'optional prameters' do
-      config = %[
+    test 'tag' do
+      d = create_driver(%[
         tag dummy
-        rate 10
-        dummy {"foo":"bar"}
-      ]
+      ])
+      assert_equal "dummy", d.instance.tag
+    end
+
+    config = %[
+      tag dummy
+    ]
+
+    test 'auto_increment_key' do
       d = create_driver(config + %[
         auto_increment_key id
       ])
       assert_equal "id", d.instance.auto_increment_key
     end
 
-    test 'format of dummy' do
-      config = %[
-        tag dummy
+    test 'rate' do
+      d = create_driver(config + %[
         rate 10
-      ]
+      ])
+      assert_equal 10, d.instance.rate
+    end
 
+    test 'dummy' do
       # hash is okay
       d = create_driver(config + %[dummy {"foo":"bar"}])
       assert_equal [{"foo"=>"bar"}], d.instance.dummy
@@ -71,14 +62,14 @@ class DummyTest < Test::Unit::TestCase
   end
 
   sub_test_case "emit" do
-    CONFIG = %[
+    config = %[
       tag dummy
       rate 10
       dummy {"foo":"bar"}
     ]
 
     test 'simple' do
-      d = create_driver(CONFIG)
+      d = create_driver(config)
       d.run {
         # d.run sleeps 0.5 sec
       }
@@ -90,7 +81,7 @@ class DummyTest < Test::Unit::TestCase
     end
 
     test 'with auto_increment_key' do
-      d = create_driver(CONFIG + %[auto_increment_key id])
+      d = create_driver(config + %[auto_increment_key id])
       d.run {
         # d.run sleeps 0.5 sec
       }


### PR DESCRIPTION
This pull request is aimed for importing https://github.com/tagomoris/fluent-plugin-dummydata-producer to fluentd itself. Importing this plugin helps us to show examples of config in ML or docs easily, and to test fluentd and plugins manually without fluent-cat.
## Difference with original
1. Renamed to `in_dummy` plugin
2. `dummydata#{num}` parameter is now `dummy` parameter which accepts JSON hash or Array of JSON hash. 
3. Remove dependency with `fluent-mixin-config-placeholders`
4. [dummer](https://github.com/sonots/dummer/blob/5b22ad5b430ef297c52f3327e32506bbcea7d8a4/lib/dummer/worker.rb#L38-L52) is also a reference.
## Usage

```
<source>
  type dummy
  tag  dummy.data
  rate 500        # messages per second
  dummy  [
    {"type":"sample","code":50,"format":"json string allowed"},
    {"message":"other format needed?"},
    {"comment":"N of dummydataN is number and not limited"}
  ]
</source>
```

With this configuration, this plugin emits  message in 1 second (0 -> 1 -> 2 -> 0 -> ...).

NOTE: multiline array format can be used only with --use-v1-format. With --use-v0-format, `dummy` parameter must be written in one line.

If you need message id for acknowledgement tests, incremental id feature available.

```
<source>
  type dummy
  tag  dummy.data
  rate 500        # messages per second
  dummy {"type":"sample","code":50,"format":"json string allowed"}
  auto_increment_key id
</source>
```
