### PR TITLE
add tests for path with time_slice_format (out_file)

### DIFF
--- a/lib/fluent/output.rb
+++ b/lib/fluent/output.rb
@@ -475,6 +475,7 @@ module Fluent
     config_set_default :flush_interval, nil
 
     attr_accessor :localtime
+    attr_reader :time_slicer # for test
 
     def configure(conf)
       super

--- a/lib/fluent/test/output_test.rb
+++ b/lib/fluent/test/output_test.rb
@@ -77,7 +77,13 @@ module Fluent
             assert_equal(@expected_buffer, buffer)
           end
 
-          chunk = MemoryBufferChunk.new('', buffer)
+          key = ''
+          if @instance.respond_to?(:time_slicer)
+            # this block is only for test_out_file
+            time, record = @entries.first
+            key = @instance.time_slicer.call(time)
+          end
+          chunk = MemoryBufferChunk.new(key, buffer)
           result = @instance.write(chunk)
         }
         result

--- a/test/plugin/test_out_file.rb
+++ b/test/plugin/test_out_file.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative '../helper'
 require 'fluent/test'
 require 'fileutils'
 require 'time'
@@ -126,7 +126,7 @@ class FileOutputTest < Test::Unit::TestCase
 
     # FileOutput#write returns path
     path = d.run
-    expect_path = "#{TMP_DIR}/out_file_test._0.log.gz"
+    expect_path = "#{TMP_DIR}/out_file_test.20110102_0.log.gz"
     assert_equal expect_path, path
 
     check_gzipped_result(path, %[2011-01-02T13:14:15Z\ttest\t{"a":1}\n] + %[2011-01-02T13:14:15Z\ttest\t{"a":2}\n])
@@ -178,13 +178,13 @@ class FileOutputTest < Test::Unit::TestCase
 
     # FileOutput#write returns path
     path = d.run
-    assert_equal "#{TMP_DIR}/out_file_test._0.log.gz", path
+    assert_equal "#{TMP_DIR}/out_file_test.20110102_0.log.gz", path
     check_gzipped_result(path, formatted_lines)
     path = d.run
-    assert_equal "#{TMP_DIR}/out_file_test._1.log.gz", path
+    assert_equal "#{TMP_DIR}/out_file_test.20110102_1.log.gz", path
     check_gzipped_result(path, formatted_lines)
     path = d.run
-    assert_equal "#{TMP_DIR}/out_file_test._2.log.gz", path
+    assert_equal "#{TMP_DIR}/out_file_test.20110102_2.log.gz", path
     check_gzipped_result(path, formatted_lines)
   end
 
@@ -203,13 +203,13 @@ class FileOutputTest < Test::Unit::TestCase
 
     # FileOutput#write returns path
     path = d.run
-    assert_equal "#{TMP_DIR}/out_file_test..log.gz", path
+    assert_equal "#{TMP_DIR}/out_file_test.20110102.log.gz", path
     check_gzipped_result(path, formatted_lines)
     path = d.run
-    assert_equal "#{TMP_DIR}/out_file_test..log.gz", path
+    assert_equal "#{TMP_DIR}/out_file_test.20110102.log.gz", path
     check_gzipped_result(path, formatted_lines * 2)
     path = d.run
-    assert_equal "#{TMP_DIR}/out_file_test..log.gz", path
+    assert_equal "#{TMP_DIR}/out_file_test.20110102.log.gz", path
     check_gzipped_result(path, formatted_lines * 3)
   end
 
@@ -239,6 +239,59 @@ class FileOutputTest < Test::Unit::TestCase
     ensure
       d.instance.shutdown
       FileUtils.rm_rf(symlink_path)
+    end
+  end
+
+  sub_test_case 'path' do
+    test 'normal' do
+      d = create_driver(%[
+        path #{TMP_DIR}/out_file_test
+        time_slice_format %Y-%m-%d-%H
+        utc true
+      ])
+      time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+      d.emit({"a"=>1}, time)
+      # FileOutput#write returns path
+      path = d.run
+      assert_equal "#{TMP_DIR}/out_file_test.2011-01-02-13_0.log", path
+    end
+
+    test 'normal with append' do
+      d = create_driver(%[
+        path #{TMP_DIR}/out_file_test
+        time_slice_format %Y-%m-%d-%H
+        utc true
+        append true
+      ])
+      time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+      d.emit({"a"=>1}, time)
+      path = d.run
+      assert_equal "#{TMP_DIR}/out_file_test.2011-01-02-13.log", path
+    end
+
+    test '*' do
+      d = create_driver(%[
+        path #{TMP_DIR}/out_file_test.*.txt
+        time_slice_format %Y-%m-%d-%H
+        utc true
+      ])
+      time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+      d.emit({"a"=>1}, time)
+      path = d.run
+      assert_equal "#{TMP_DIR}/out_file_test.2011-01-02-13_0.txt", path
+    end
+
+    test '* with append' do
+      d = create_driver(%[
+        path #{TMP_DIR}/out_file_test.*.txt
+        time_slice_format %Y-%m-%d-%H
+        utc true
+        append true
+      ])
+      time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+      d.emit({"a"=>1}, time)
+      path = d.run
+      assert_equal "#{TMP_DIR}/out_file_test.2011-01-02-13.txt", path
     end
   end
 end


### PR DESCRIPTION
`test_out_file` does not test the effect of `time_slice_format` parameter until now. 
This pull request adds tests for `path` parameter with `time_slice_format` parameter. 

To do this, I had to modify `BufferedOutputTestDriver`. I don't know why `test_out_file` is using `BufferedOutputTestDriver` rather than `TimeSlicedOutputTestDriver` though (I actually tried to use `TimeSlicedOutputTestDriver` for `test_out_file`, but it looked the test driver is lacking some of features to test `out_file`). 
