### PR TITLE
add self.name to configure_proxy error message

### DIFF
--- a/lib/fluent/config/configure_proxy.rb
+++ b/lib/fluent/config/configure_proxy.rb
@@ -84,13 +84,13 @@ module Fluent
           elsif a.is_a?(Hash)
             opts.merge!(a)
           else
-            raise ArgumentError, "wrong number of arguments (#{1 + args.length} for #{block ? 2 : 3})"
+            raise ArgumentError, "#{self.name}: wrong number of arguments (#{1 + args.length} for #{block ? 2 : 3})"
           end
         }
 
         type = opts[:type]
         if block && type
-          raise ArgumentError, "both of block and type cannot be specified"
+          raise ArgumentError, "#{self.name}: both of block and type cannot be specified"
         end
 
         begin
@@ -98,7 +98,7 @@ module Fluent
           block ||= Configurable.lookup_type(type)
         rescue ConfigError
           # override error message
-          raise ArgumentError, "unknown config_argument type `#{type}'"
+          raise ArgumentError, "#{self.name}: unknown config_argument type `#{type}'"
         end
 
         if opts.has_key?(:default)
@@ -110,7 +110,7 @@ module Fluent
 
       def config_argument(name, *args, &block)
         if @argument
-          raise ArgumentError, "config_argument called twice"
+          raise ArgumentError, "#{self.name}: config_argument called twice"
         end
         name, block, opts = parameter_configuration(name, *args, &block)
 
@@ -130,7 +130,7 @@ module Fluent
         name = name.to_sym
 
         if @defaults.has_key?(name)
-          raise ArgumentError, "default value specified twice for #{name}"
+          raise ArgumentError, "#{self.name}: default value specified twice for #{name}"
         end
 
         @defaults[name] = defval
@@ -139,13 +139,13 @@ module Fluent
 
       def config_section(name, *args, &block)
         unless block_given?
-          raise ArgumentError, "config_section requires block parameter"
+          raise ArgumentError, "#{self.name}: config_section requires block parameter"
         end
         name = name.to_sym
 
         opts = {}
         unless args.empty? || args.size == 1 && args.first.is_a?(Hash)
-          raise ArgumentError, "unknown config_section arguments: #{args.inspect}"
+          raise ArgumentError, "#{self.name}: unknown config_section arguments: #{args.inspect}"
         end
 
         sub_proxy = ConfigureProxy.new(name, *args)


### PR DESCRIPTION
For example, writing a plugin mastakenly like:

```
# out_stdout.rb
config_param :foo, :default => true
config_param :foo, :default => false
```

Before: error message shows as:

```
2014-11-25 18:44:14 +0900 [error]: unexpected error error="default value specified twice for foo"
```

After: 

```
2014-11-25 18:44:14 +0900 [error]: unexpected error error="Fluent::StdoutOutput: default value specified twice for foo"
```

We ~~can not~~ can find which plugin is doing bad easily now. 

Just same thing for others. 
