### PR TITLE
Make it possible to specify a test file to run

### DIFF
--- a/test/config/test_configurable.rb
+++ b/test/config/test_configurable.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative '../helper'
 require 'fluent/configurable'
 require 'fluent/config/element'
 require 'fluent/config/section'

--- a/test/config/test_configure_proxy.rb
+++ b/test/config/test_configure_proxy.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative '../helper'
 require 'fluent/config/configure_proxy'
 
 module Fluent::Config

--- a/test/config/test_dsl.rb
+++ b/test/config/test_dsl.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative '../helper'
 require 'fluent/config/element'
 require "fluent/config/dsl"
 

--- a/test/config/test_literal_parser.rb
+++ b/test/config/test_literal_parser.rb
@@ -1,5 +1,5 @@
-require "helper"
-require 'config/assertions'
+require_relative "../helper"
+require_relative 'assertions'
 require "fluent/config/error"
 require "fluent/config/literal_parser"
 require "fluent/config/v1_parser"

--- a/test/config/test_section.rb
+++ b/test/config/test_section.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative '../helper'
 require 'fluent/config/section'
 
 module Fluent::Config

--- a/test/config/test_system_config.rb
+++ b/test/config/test_system_config.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative '../helper'
 require 'fluent/configurable'
 require 'fluent/config/element'
 require 'fluent/config/section'

--- a/test/plugin/test_buf_file.rb
+++ b/test/plugin/test_buf_file.rb
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-require 'helper'
+require_relative '../helper'
 require 'fluent/test'
 require 'fluent/plugin/buf_file'
 

--- a/test/plugin/test_buf_memory.rb
+++ b/test/plugin/test_buf_memory.rb
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-require 'helper'
+require_relative '../helper'
 require 'fluent/test'
 require 'fluent/plugin/buf_memory'
 

--- a/test/plugin/test_filter_grep.rb
+++ b/test/plugin/test_filter_grep.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative '../helper'
 require 'fluent/test'
 require 'fluent/plugin/filter_grep'
 

--- a/test/plugin/test_in_exec.rb
+++ b/test/plugin/test_in_exec.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative '../helper'
 require 'fluent/test'
 require 'net/http'
 

--- a/test/plugin/test_in_forward.rb
+++ b/test/plugin/test_in_forward.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative '../helper'
 require 'fluent/test'
 require 'base64'
 

--- a/test/plugin/test_in_gc_stat.rb
+++ b/test/plugin/test_in_gc_stat.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative '../helper'
 require 'fluent/test'
 
 class GCStatInputTest < Test::Unit::TestCase

--- a/test/plugin/test_in_http.rb
+++ b/test/plugin/test_in_http.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative '../helper'
 require 'fluent/test'
 require 'net/http'
 

--- a/test/plugin/test_in_object_space.rb
+++ b/test/plugin/test_in_object_space.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative '../helper'
 require 'fluent/test'
 
 class ObjectSpaceInputTest < Test::Unit::TestCase

--- a/test/plugin/test_in_status.rb
+++ b/test/plugin/test_in_status.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative '../helper'
 require 'fluent/test'
 
 class StatusInputTest < Test::Unit::TestCase

--- a/test/plugin/test_in_stream.rb
+++ b/test/plugin/test_in_stream.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative '../helper'
 require 'fluent/test'
 
 module StreamInputTest

--- a/test/plugin/test_in_syslog.rb
+++ b/test/plugin/test_in_syslog.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative '../helper'
 require 'fluent/test'
 
 class SyslogInputTest < Test::Unit::TestCase

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative '../helper'
 require 'fluent/test'
 require 'net/http'
 require 'flexmock'

--- a/test/plugin/test_in_tcp.rb
+++ b/test/plugin/test_in_tcp.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative '../helper'
 require 'fluent/test'
 
 class TcpInputTest < Test::Unit::TestCase

--- a/test/plugin/test_in_udp.rb
+++ b/test/plugin/test_in_udp.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative '../helper'
 require 'fluent/test'
 
 class UdpInputTest < Test::Unit::TestCase

--- a/test/plugin/test_out_copy.rb
+++ b/test/plugin/test_out_copy.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative '../helper'
 require 'fluent/test'
 
 class CopyOutputTest < Test::Unit::TestCase

--- a/test/plugin/test_out_exec.rb
+++ b/test/plugin/test_out_exec.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative '../helper'
 require 'fluent/test'
 require 'fileutils'
 

--- a/test/plugin/test_out_exec_filter.rb
+++ b/test/plugin/test_out_exec_filter.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative '../helper'
 require 'fluent/test'
 require 'fileutils'
 

--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative '../helper'
 require 'fluent/test'
 
 class ForwardOutputTest < Test::Unit::TestCase

--- a/test/plugin/test_out_roundrobin.rb
+++ b/test/plugin/test_out_roundrobin.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative '../helper'
 require 'fluent/test'
 
 class RoundRobinOutputTest < Test::Unit::TestCase

--- a/test/plugin/test_out_stdout.rb
+++ b/test/plugin/test_out_stdout.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative '../helper'
 require 'fluent/test'
 
 class StdoutOutputTest < Test::Unit::TestCase

--- a/test/plugin/test_out_stream.rb
+++ b/test/plugin/test_out_stream.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative '../helper'
 require 'fluent/test'
 
 module StreamOutputTest

--- a/test/test_buffer.rb
+++ b/test/test_buffer.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative 'helper'
 require 'fluent/test'
 require 'fluent/buffer'
 

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative 'helper'
 require 'fluent/config'
 require 'fluent/config/parser'
 require 'fluent/supervisor'

--- a/test/test_configdsl.rb
+++ b/test/test_configdsl.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative 'helper'
 require 'fluent/config/dsl'
 require 'fluent/test'
 

--- a/test/test_formatter.rb
+++ b/test/test_formatter.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative 'helper'
 require 'fluent/test'
 require 'fluent/formatter'
 

--- a/test/test_match.rb
+++ b/test/test_match.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative 'helper'
 require 'fluent/match'
 
 class MatchTest < Test::Unit::TestCase

--- a/test/test_mixin.rb
+++ b/test/test_mixin.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative 'helper'
 require 'fluent/mixin'
 require 'fluent/env'
 require 'fluent/plugin'

--- a/test/test_output.rb
+++ b/test/test_output.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative 'helper'
 require 'fluent/test'
 require 'fluent/output'
 

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative 'helper'
 require 'fluent/test'
 require 'fluent/parser'
 


### PR DESCRIPTION
With this patch, we now are able to run a test like:

```
$ bundle exec ruby test/plugin/test_in_status.rb
```

TIPS:

We can specify a line number like:

```
$ bundle exec ruby test/plugin/test_in_status.rb --location 24
```

We can find help like:

```
$ bundle exec ruby test/plugin/test_in_status.rb -h
```
