### PR TITLE
Add register_xxx API to parser and formatter plugins

### DIFF
--- a/lib/fluent/formatter.rb
+++ b/lib/fluent/formatter.rb
@@ -199,9 +199,11 @@ module Fluent
     }
 
     def self.register_template(name, factory_or_proc)
-      factory = if factory_or_proc.arity == 3
+      factory = if factory_or_proc.is_a?(Class) # XXXFormatter
+                  Proc.new { factory_or_proc.new }
+                elsif factory_or_proc.arity == 3 # Proc.new { |tag, time, record| }
                   Proc.new { factory_or_proc }
-                else
+                else # Proc.new { XXXFormatter.new }
                   factory_or_proc
                 end
 
@@ -222,7 +224,9 @@ module Fluent
       end
 
       formatter = factory.call
-      formatter.configure(conf)
+      if formatter.respond_to?(:configure)
+        formatter.configure(conf)
+      end
       formatter
     end
   end

--- a/lib/fluent/parser.rb
+++ b/lib/fluent/parser.rb
@@ -647,7 +647,9 @@ module Fluent
     }
 
     def self.register_template(name, regexp_or_proc, time_format=nil)
-      if regexp_or_proc.is_a?(Regexp)
+      if regexp_or_proc.is_a?(Class)
+        factory = Proc.new { regexp_or_proc.new }
+      elsif regexp_or_proc.is_a?(Regexp)
         regexp = regexp_or_proc
         factory = Proc.new { RegexpParser.new(regexp, {'time_format'=>time_format}) }
       else

--- a/lib/fluent/plugin.rb
+++ b/lib/fluent/plugin.rb
@@ -16,6 +16,8 @@
 
 module Fluent
   class PluginClass
+    # This class is refactored using Fluent::Registry at v0.14
+
     def initialize
       @input = {}
       @output = {}
@@ -37,6 +39,14 @@ module Fluent
 
     def register_buffer(type, klass)
       register_impl('buffer', @buffer, type, klass)
+    end
+
+    def register_parser(type, klass)
+      TextParser.register_template(type, klass)
+    end
+
+    def register_formatter(type, klass)
+      TextFormatter.register_template(type, klass)
     end
 
     def new_input(type)

--- a/test/scripts/fluent/plugin/formatter_known.rb
+++ b/test/scripts/fluent/plugin/formatter_known.rb
@@ -1,5 +1,8 @@
 module Fluent
-  TextFormatter.register_template('known', Proc.new { |tag, time, record|
+  TextFormatter.register_template('known_old', Proc.new { |tag, time, record|
+      "#{tag}:#{time}:#{record.size}"
+    })
+  Plugin.register_formatter('known', Proc.new { |tag, time, record|
       "#{tag}:#{time}:#{record.size}"
     })
 end

--- a/test/scripts/fluent/plugin/parser_known.rb
+++ b/test/scripts/fluent/plugin/parser_known.rb
@@ -1,3 +1,4 @@
 module Fluent
-  TextParser.register_template('known', /^(?<message>.*)$/)
+  TextParser.register_template('known_old', /^(?<message>.*)$/)
+  Plugin.register_parser('known', /^(?<message>.*)$/)
 end

--- a/test/test_formatter.rb
+++ b/test/test_formatter.rb
@@ -371,11 +371,13 @@ module FormatterTest
       end
     end
 
-    def test_find_formatter
+    data('register_formatter' => 'known', 'register_template' => 'known_old')
+    def test_find_formatter(data)
       $LOAD_PATH.unshift(File.join(File.expand_path(File.dirname(__FILE__)), 'scripts'))
       assert_nothing_raised ConfigError do
-        TextFormatter::TEMPLATE_REGISTRY.lookup('known')
+        TextFormatter::TEMPLATE_REGISTRY.lookup(data)
       end
+      $LOAD_PATH.shift
     end
   end
 

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -667,11 +667,13 @@ EOS
       end
     end
 
-    def test_lookup_known_parser
+    data('register_formatter' => 'known', 'register_template' => 'known_old')
+    def test_lookup_known_parser(data)
       $LOAD_PATH.unshift(File.join(File.expand_path(File.dirname(__FILE__)), 'scripts'))
       assert_nothing_raised ConfigError do
-        TextParser::TEMPLATE_REGISTRY.lookup('known')
+        TextParser::TEMPLATE_REGISTRY.lookup(data)
       end
+      $LOAD_PATH.shift
     end
 
     def test_parse_with_return


### PR DESCRIPTION
Currently parser and formatter call 'TextParser.register_template(...)'to register plugin.
This is different from Input/Filter/Output plugins. So adding same API to parser and formatter.
