### PR TITLE
Fix system config using double memory

### DIFF
--- a/test/config/test_system_config.rb
+++ b/test/config/test_system_config.rb
@@ -5,45 +5,95 @@ require 'fluent/config/section'
 require 'fluent/supervisor'
 
 module Fluent::Config
+  class FakeLoggerInitializer
+    attr_accessor :level
+    def initalize
+      @level = nil
+    end
+  end
+
+  class FakeSupervisor
+    def initialize
+      @log = FakeLoggerInitializer.new
+      @log_level = nil
+      @suppress_interval = nil
+      @suppress_config_dump = nil
+      @suppress_repeated_stacktrace = nil
+      @without_source = nil
+    end
+  end
+
   class TestSystemConfig < ::Test::Unit::TestCase
+
     def parse_text(text)
       basepath = File.expand_path(File.dirname(__FILE__) + '/../../')
       Fluent::Config.parse(text, '(test)', basepath, true).elements.find { |e| e.name == 'system' }
     end
 
     test 'should not override default configurations when no parameters' do
-      conf = parse_text(<<EOS)
-<system>
-</system>
-EOS
+      conf = parse_text(<<-EOS)
+        <system>
+        </system>
+      EOS
+      s = FakeSupervisor.new
       sc = Fluent::Supervisor::SystemConfig.new(conf)
+      sc.apply(s)
       assert_nil(sc.log_level)
       assert_nil(sc.suppress_repeated_stacktrace)
       assert_nil(sc.emit_error_log_interval)
       assert_nil(sc.suppress_config_dump)
       assert_nil(sc.without_source)
-      assert_empty(sc.to_opt)
+      assert_nil(s.instance_variable_get(:@log_level))
+      assert_nil(s.instance_variable_get(:@suppress_repeated_stacktrace))
+      assert_nil(s.instance_variable_get(:@emit_error_log_interval))
+      assert_nil(s.instance_variable_get(:@suppress_config_dump))
+      assert_nil(s.instance_variable_get(:@without_source))
     end
 
-    {'log_level' => 'error', 'suppress_repeated_stacktrace' => true, 'emit_error_log_interval' => 60, 'suppress_config_dump' => true, 'without_source' => true}.each { |k, v|
+    {'log_level' => 'error',
+     'suppress_repeated_stacktrace' => true,
+     'emit_error_log_interval' => 60,
+     'suppress_config_dump' => true,
+     'without_source' => true,
+    }.each { |k, v|
       test "accepts #{k} parameter" do
-        conf = parse_text(<<EOS)
-<system>
-  #{k} #{v}
-</system>
-EOS
+        conf = parse_text(<<-EOS)
+          <system>
+            #{k} #{v}
+          </system>
+        EOS
+        s = FakeSupervisor.new
         sc = Fluent::Supervisor::SystemConfig.new(conf)
+        sc.apply(s)
         assert_not_nil(sc.instance_variable_get("@#{k}"))
-        key = (k == 'emit_error_log_interval' ? :suppress_interval : k.to_sym)
-        assert_include(sc.to_opt, key)
+        key = (k == 'emit_error_log_interval' ? 'suppress_interval' : k)
+        assert_not_nil(s.instance_variable_get("@#{key}"))
       end
     }
 
     {'foo' => 'bar', 'hoge' => 'fuga'}.each { |k, v|
       test "should not affect settable parameters with unknown #{k} parameter" do
+        s = FakeSupervisor.new
         sc = Fluent::Supervisor::SystemConfig.new({k => v})
-        assert_empty(sc.to_opt)
+        sc.apply(s)
+        assert_nil(s.instance_variable_get(:@log_level))
+        assert_nil(s.instance_variable_get(:@suppress_repeated_stacktrace))
+        assert_nil(s.instance_variable_get(:@emit_error_log_interval))
+        assert_nil(s.instance_variable_get(:@suppress_config_dump))
+        assert_nil(s.instance_variable_get(:@without_source))
       end
     }
+
+    test 'log_level' do
+      conf = parse_text(<<-EOS)
+        <system>
+          log_level warn
+        </system>
+      EOS
+      s = FakeSupervisor.new
+      sc = Fluent::Supervisor::SystemConfig.new(conf)
+      sc.apply(s)
+      assert_equal(Fluent::Log::LEVEL_WARN, s.instance_variable_get("@log").level)
+    end
   end
 end


### PR DESCRIPTION
The current code calls `read_config` twice on the parent (supervisor) process and the child (main) process. Because the member variable `@config_data` is overwritten in the child process, the memory usage for `@config_data` becomes double. This causes a problem on an environment whose conf file is large like 10,000 lines. 

Commenting out this line https://github.com/fluent/fluentd/blob/50a90ac1cdc92860411be52280d5e1d0ec8bbbdb/lib/fluent/supervisor.rb#L108 suppressed this issue. 

This patch fixes the problem without removing the system config feature.  
