### PR TITLE
add router.emit and router= for compatibility with v0.12

### DIFF
--- a/lib/fluent/input.rb
+++ b/lib/fluent/input.rb
@@ -21,12 +21,16 @@ module Fluent
     include PluginId
     include PluginLoggerMixin
 
+    attr_accessor :router
+
     def initialize
       super
     end
 
     def configure(conf)
       super
+
+      @router = Engine
     end
 
     def start

--- a/lib/fluent/output.rb
+++ b/lib/fluent/output.rb
@@ -61,12 +61,16 @@ module Fluent
     include PluginId
     include PluginLoggerMixin
 
+    attr_accessor :router
+
     def initialize
       super
     end
 
     def configure(conf)
       super
+
+      @router = Engine
     end
 
     def start

--- a/test/test_input.rb
+++ b/test/test_input.rb
@@ -1,0 +1,21 @@
+require_relative 'helper'
+require 'fluent/test'
+require 'fluent/input'
+
+class FluentInputTest < ::Test::Unit::TestCase
+  def setup
+    Fluent::Test.setup
+  end
+
+  def create_driver(conf = '')
+    Fluent::Test::InputTestDriver.new(Fluent::Input).configure(conf)
+  end
+
+  # for v0.12 compatibility
+  def test_router_emit
+    d = create_driver
+    assert_true d.instance.respond_to?(:router)
+    assert_true d.instance.respond_to?(:router=)
+    assert_true d.instance.router.respond_to?(:emit)
+  end
+end

--- a/test/test_output.rb
+++ b/test/test_output.rb
@@ -138,5 +138,13 @@ module FluentOutputTest
       d.instance.shutdown
       assert (d.instance.submit_flush_threads.size > 1), "fails if only one thread works to submit flush"
     end
+
+    # for v0.12 compatibility
+    def test_router_emit
+      d = create_driver
+      assert_true d.instance.respond_to?(:router)
+      assert_true d.instance.respond_to?(:router=)
+      assert_true d.instance.router.respond_to?(:emit)
+    end
   end
 end


### PR DESCRIPTION
To support the label feature implemented in v0.12, input/output plugins must be modified as:

``` diff
- Engine.emit
+ router.emit
```

Also, kinds of MultiOutput plugin such as config-expander must be modified like:

``` diff
        output = Plugin.new_output(type)
+       output.router = router
        output.configure(e)
```

This patch makes the above modification works in both v0.12 and v0.10 branch. 
