### PR TITLE
Buffered plugins for tests

### DIFF
--- a/example/out_buffered_null.conf
+++ b/example/out_buffered_null.conf
@@ -1,0 +1,32 @@
+#
+# bundle exec bin/fluentd -c example/out_buffered_null.conf
+#   (+ --emit-error-log-interval 10)
+<source>
+  @type dummy
+  tag dummy
+  rate 500000000
+  dummy [
+    {"message": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+    {"message": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+    {"message": "ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"}
+  ]
+</source>
+
+<match dummy.**>
+  @type buffered_null
+  try_flush_interval 60
+  flush_interval 60
+  buffer_chunk_limit 1k
+  buffer_queue_limit 2
+</match>
+
+<label error_log>
+  <match **>
+    @type stdout # or buffered_stdout
+  </match>
+</label>
+
+<match fluent.**>
+  @type relabel
+  @label error_log
+</match>

--- a/lib/fluent/plugin/in_dummy.rb
+++ b/lib/fluent/plugin/in_dummy.rb
@@ -75,7 +75,11 @@ module Fluent
     end
 
     def emit(num)
-      num.times { router.emit(@tag, Fluent::Engine.now, generate()) }
+      begin
+        num.times { router.emit(@tag, Fluent::Engine.now, generate()) }
+      rescue => e
+        # ignore all errors not to stop emits by emit errors
+      end
     end
 
     def generate

--- a/lib/fluent/plugin/out_buffered_null.rb
+++ b/lib/fluent/plugin/out_buffered_null.rb
@@ -1,0 +1,30 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+module Fluent
+  class BufferedNullOutput < BufferedOutput
+    Plugin.register_output('buffered_null', self)
+
+    def format_stream(tag, es)
+      # PackedForward
+      [tag, es.to_msgpack_stream].to_msgpack
+    end
+
+    def write(chunk)
+      # do nothing to drop chunk
+    end
+  end
+end

--- a/lib/fluent/plugin/out_buffered_stdout.rb
+++ b/lib/fluent/plugin/out_buffered_stdout.rb
@@ -1,0 +1,57 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+module Fluent
+  class BufferedStdoutOutput < BufferedOutput
+    Plugin.register_output('buffered_stdout', self)
+
+    OUTPUT_PROCS = {
+      :json => Proc.new {|record| Yajl.dump(record) },
+      :hash => Proc.new {|record| record.to_s },
+    }
+
+    config_param :output_type, :default => :json do |val|
+      case val.downcase
+      when 'json'
+        :json
+      when 'hash'
+        :hash
+      else
+        raise ConfigError, "stdout output output_type should be 'json' or 'hash'"
+      end
+    end
+
+    def configure(conf)
+      super
+      @output_proc = OUTPUT_PROCS[@output_type]
+    end
+
+    def format_stream(tag, es)
+      out = ''
+      es.each do |time, record|
+        out << [Time.at(time).localtime.to_s, tag, @output_proc.call(record)].to_msgpack
+      end
+      out
+    end
+
+    def write(chunk)
+      chunk.msgpack_each do |time, tag, record|
+        log.write "#{time} #{tag}: #{record}\n"
+      end
+      log.flush
+    end
+  end
+end


### PR DESCRIPTION
Add buffered output plugins to test buffer plugins
 * buffered_stdout: show records in log console w/ buffering
 * buffered_null: show errors only brought by buffer plugins

These plugins are useful to develop 3rd party buffer plugins, so should be included in fluent/plugin/ directory.

And fix in_dummy not to stop to emit records beside any errors of buffer/output plugins to reproduce emit errors continuously.