### PR TITLE
Stop in_exec immediately at shutdown

### DIFF
--- a/lib/fluent/plugin/in_exec.rb
+++ b/lib/fluent/plugin/in_exec.rb
@@ -99,6 +99,7 @@ module Fluent
     def shutdown
       if @run_interval
         @finished = true
+        # call Thread#run which interupts sleep in order to stop run_periodic thread immediately.
         @thread.run
         @thread.join
       else

--- a/lib/fluent/plugin/in_exec.rb
+++ b/lib/fluent/plugin/in_exec.rb
@@ -99,6 +99,7 @@ module Fluent
     def shutdown
       if @run_interval
         @finished = true
+        @thread.run
         @thread.join
       else
         begin
@@ -122,12 +123,13 @@ module Fluent
     end
 
     def run_periodic
+      sleep @run_interval
       until @finished
         begin
-          sleep @run_interval
           io = IO.popen(@command, "r")
           @parser.call(io)
           Process.waitpid(io.pid)
+          sleep @run_interval
         rescue
           log.error "exec failed to run or shutdown child process", :error => $!.to_s, :error_class => $!.class.to_s
           log.warn_backtrace $!.backtrace


### PR DESCRIPTION
in_exec plugin with `run_interval` option does not stop immediately when sending shutdown signal.
It waits at most `run_interval` seconds because the process is sleeping and not interrupted.
`Thread#run` interrupts sleep, so this fixes the problem.