### PR TITLE
calc_retry_wait is broken if Integer is used for retry_wait

### DIFF
--- a/lib/fluent/output.rb
+++ b/lib/fluent/output.rb
@@ -192,6 +192,7 @@ module Fluent
     def configure(conf)
       super
 
+      @retry_wait = @retry_wait.to_f # converted to Float for calc_retry_wait
       @buffer = Plugin.new_buffer(@buffer_type)
       @buffer.configure(conf)
 

--- a/test/test_output.rb
+++ b/test/test_output.rb
@@ -53,6 +53,10 @@ module FluentOutputTest
       # disable_retry_limit
       d = create_driver(CONFIG + %[disable_retry_limit true])
       assert_equal true, d.instance.disable_retry_limit
+
+      # retry_wait is converted to Float for calc_retry_wait
+      d = create_driver(CONFIG + %[retry_wait 1s])
+      assert_equal Float, d.instance.retry_wait.class
     end
 
     def test_calc_retry_wait
@@ -71,6 +75,14 @@ module FluentOutputTest
         d.instance.instance_eval { @num_errors += 1 }
       }
       assert_equal 4, d.instance.calc_retry_wait
+    end
+
+    def test_calc_retry_wait_with_integer_retry_wait
+      d = create_driver(CONFIG + %[retry_wait 2s])
+      d.instance.retry_limit.times {
+        d.instance.instance_eval { @num_errors += 1 }
+      }
+      assert_equal true, d.instance.calc_retry_wait.finite?
     end
 
     def test_large_num_retries


### PR DESCRIPTION
From v0.10.58 or later and v0.12, calc_retry_wait causes an exception if Integer is used for retry_wait.
retry_wait is `time` type, so it can be Integer value. `#finite?` is a method for Float class, not for Integer.