### PR TITLE
fix to flush a buffer by USR1 signal on retrying

### DIFF
--- a/lib/fluent/output.rb
+++ b/lib/fluent/output.rb
@@ -384,6 +384,9 @@ module Fluent
     end
 
     def force_flush
+      @num_errors_lock.synchronize do
+        @next_retry_time = Engine.now - 1
+      end
       enqueue_buffer(true)
       submit_flush
     end


### PR DESCRIPTION
Continued from https://github.com/fluent/fluentd/pull/468