### PR TITLE
Fix Nginx and Apache2 format to parse access log without http-version

### DIFF
--- a/lib/fluent/parser.rb
+++ b/lib/fluent/parser.rb
@@ -407,7 +407,7 @@ module Fluent
     end
 
     class ApacheParser < Parser
-      REGEXP = /^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$/
+      REGEXP = /^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$/
       TIME_FORMAT = "%d/%b/%Y:%H:%M:%S %z"
 
       def initialize
@@ -631,7 +631,7 @@ module Fluent
       'tsv' => Proc.new { TSVParser.new },
       'ltsv' => Proc.new { LabeledTSVParser.new },
       'csv' => Proc.new { CSVParser.new },
-      'nginx' => Proc.new { RegexpParser.new(/^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$/,  {'time_format'=>"%d/%b/%Y:%H:%M:%S %z"}) },
+      'nginx' => Proc.new { RegexpParser.new(/^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$/,  {'time_format'=>"%d/%b/%Y:%H:%M:%S %z"}) },
       'none' => Proc.new { NoneParser.new },
       'multiline' => Proc.new { MultilineParser.new },
     }.each { |name, factory|

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -199,24 +199,32 @@ module ParserTest
 
     def setup
       @parser = TextParser::ApacheParser.new
+      @expected = {
+        'user'    => nil,
+        'method'  => 'GET',
+        'code'    => 200,
+        'size'    => 777,
+        'host'    => '192.168.0.1',
+        'path'    => '/',
+        'referer' => nil,
+        'agent'   => 'Opera/12.0'
+      }
     end
 
     def test_parse
       @parser.parse('192.168.0.1 - - [28/Feb/2013:12:00:00 +0900] "GET / HTTP/1.1" 200 777 "-" "Opera/12.0"') { |time, record|
         assert_equal(str2time('28/Feb/2013:12:00:00 +0900', '%d/%b/%Y:%H:%M:%S %z'), time)
-        assert_equal({
-          'user'    => nil,
-          'method'  => 'GET',
-          'code'    => 200,
-          'size'    => 777,
-          'host'    => '192.168.0.1',
-          'path'    => '/',
-          'referer' => nil,
-          'agent'   => 'Opera/12.0'
-        }, record)
+        assert_equal(@expected, record)
       }
       assert_equal(TextParser::ApacheParser::REGEXP, @parser.patterns['format'])
       assert_equal(TextParser::ApacheParser::TIME_FORMAT, @parser.patterns['time_format'])
+    end
+
+    def test_parse_without_http_version
+      @parser.parse('192.168.0.1 - - [28/Feb/2013:12:00:00 +0900] "GET /" 200 777 "-" "Opera/12.0"') { |time, record|
+        assert_equal(str2time('28/Feb/2013:12:00:00 +0900', '%d/%b/%Y:%H:%M:%S %z'), time)
+        assert_equal(@expected, record)
+      }
     end
   end
 
@@ -352,6 +360,13 @@ module ParserTest
       @parser.parse('127.0.0.1 192.168.0.1 - [28/Feb/2013:12:00:00 +0900] "GET /a[ ]b HTTP/1.1" 200 777 "-" "Opera/12.0"') { |time, record|
         assert_equal(str2time('28/Feb/2013:12:00:00 +0900', '%d/%b/%Y:%H:%M:%S %z'), time)
         assert_equal(@expected.merge('path' => '/a[ ]b'), record)
+      }
+    end
+
+    def test_parse_without_http_version
+      @parser.parse('127.0.0.1 192.168.0.1 - [28/Feb/2013:12:00:00 +0900] "GET /" 200 777 "-" "Opera/12.0"') { |time, record|
+        assert_equal(str2time('28/Feb/2013:12:00:00 +0900', '%d/%b/%Y:%H:%M:%S %z'), time)
+        assert_equal(@expected, record)
       }
     end
   end


### PR DESCRIPTION
Some hardwares such as LoadBalancer access to http servers without http-version in Request-Line. It's like following:

```
$ telnet localhost 80
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
GET /index.html
```

The access generates a log for Nginx and Apach2 servers.
```
# for Nginx
127.0.0.1 - - [10/Jan/2015:17:52:50 +0900] "GET /index.html" 200 612 "-" "-"
# for Aapache2
127.0.0.1 - - [10/Jan/2015:19:17:08 +0900] "GET /index.html" 200 11510 "-" "-"
```

Embedded parser format for Nginx and Aapach2 cannot parse these logs. This request fixes the regexps to parse correctly.