### PR TITLE
Add nginx_error Parser

### DIFF
--- a/lib/fluent/parser.rb
+++ b/lib/fluent/parser.rb
@@ -632,6 +632,7 @@ module Fluent
       'ltsv' => Proc.new { LabeledTSVParser.new },
       'csv' => Proc.new { CSVParser.new },
       'nginx' => Proc.new { RegexpParser.new(/^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$/,  {'time_format'=>"%d/%b/%Y:%H:%M:%S %z"}) },
+      'nginx_error' => Proc.new { RegexpParser.new(/^(?<time>[^ ]+ [^ ]+) \[(?<level>.*)\] (?<pid>\d*).(?<tid>[^:]*): (?<message>.*)$/) },
       'none' => Proc.new { NoneParser.new },
       'multiline' => Proc.new { MultilineParser.new },
     }.each { |name, factory|

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -356,6 +356,38 @@ module ParserTest
     end
   end
 
+  class NginxErrorParserTest < ::Test::Unit::TestCase
+    include ParserTest
+
+    def setup
+      @parser = TextParser::TEMPLATE_REGISTRY.lookup('nginx_error').call
+    end
+
+    def test_parse_access_error
+      @parser.parse('2015/01/10 19:30:53 [error] 21229#0: *1 open() "/usr/share/nginx/html/not_found" failed (2: No such file or directory), client: 127.0.0.1, server: localhost, request: "GET /not_found HTTP/1.1", host: "localhost"') { |time, record|
+        assert_equal(str2time('2015/01/10 19:30:53'), time)
+        assert_equal({
+          'level' => 'error',
+          'pid' => '21229',
+          'tid' => '0',
+          'message' => '*1 open() "/usr/share/nginx/html/not_found" failed (2: No such file or directory), client: 127.0.0.1, server: localhost, request: "GET /not_found HTTP/1.1", host: "localhost"'
+        }, record)
+      }
+    end
+
+    def test_parse_config_error
+      @parser.parse('2015/01/10 19:31:12 [emerg] 21317#0: unexpected "}" in /etc/nginx/sites-enabled/default:73') { |time, record|
+        assert_equal(str2time('2015/01/10 19:31:12'), time)
+        assert_equal({
+          'level' => 'emerg',
+          'pid' => '21317',
+          'tid' => '0',
+          'message' => 'unexpected "}" in /etc/nginx/sites-enabled/default:73'
+        }, record)
+      }
+    end
+  end
+
   class TSVParserTest < ::Test::Unit::TestCase
     include ParserTest
 


### PR DESCRIPTION
Embedded parser supports both access and error logs for  Apache in `apache` and `apache_error`, but only access log for Nginx.  This patch adds support to parse error log for Nginx.
