### PR TITLE
fix SIGHUP does not reload config

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -321,6 +321,8 @@ module Fluent
       trap :HUP do
         $log.debug "fluentd supervisor process get SIGHUP"
         $log.info "restarting"
+        read_config
+        apply_system_config
         if pid = @main_pid
           Process.kill(:TERM, pid)
           # don't resuce Erro::ESRSH here (invalid status)


### PR DESCRIPTION
Reported by https://groups.google.com/forum/#!topic/fluentd/jFQTeNONmCA
Fix a bug by https://github.com/fluent/fluentd/pull/496

This patch makes system config be also reloadable (it was not before).