### PR TITLE
Support Gemfile.local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ pkg/*
 test/tmp/*
 test/config/tmp/*
 make_dist.sh
+Gemfile.local

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,9 @@
 source 'https://rubygems.org/'
 
 gemspec
+
+local_gemfile = File.join(File.dirname(__FILE__), "Gemfile.local")
+if File.exist?(local_gemfile)
+  puts "Loading Gemfile.local ..." if $DEBUG # `ruby -d` or `bundle -v`
+  instance_eval File.read(local_gemfile)
+end


### PR DESCRIPTION
@repeatedly @tagomoris 

I often want to include my favorite development gems like `pry` and `pry-nav` for development of Fluentd. 

I recently heard some ruby developers are doing a good practice for this situation, supporting `Gemfile.local`. 
See https://github.com/tdiary/tdiary-core/blob/fd2b250792a54bf23216e4b75ecbef8e17fcb79f/Gemfile#L36-L40 for an example. 

The Gemfile.local file is ignored by .gitignore, and Gemfile includes Gemfile.local if it exists so that we can add favorite gems freely only on local. 

```
# Gemfile.local
gem 'pry'
gem 'pry-nav'
```