### PR TITLE
Enable multiline mode if format contains 'multiline'

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -49,7 +49,7 @@ module Fluent
       configure_parser(conf)
       configure_tag
 
-      @multiline_mode = conf['format'] == 'multiline'
+      @multiline_mode = conf['format'] =~ /multiline/
       @receive_handler = if @multiline_mode
                            method(:parse_multilines)
                          else


### PR DESCRIPTION
Enable multiline mode if format contains 'multiline'.