### PR TITLE
Update msgpack dependency to avoid incompatible encoding problem

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 1.9.3'
 
-  gem.add_runtime_dependency("msgpack", [">= 0.5.4", "< 0.6.0"])
+  gem.add_runtime_dependency("msgpack", [">= 0.5.11", "< 0.6.0"])
   gem.add_runtime_dependency("json", [">= 1.4.3"])
   gem.add_runtime_dependency("yajl-ruby", ["~> 1.0"])
   gem.add_runtime_dependency("cool.io", [">= 1.2.2", "< 2.0.0"])


### PR DESCRIPTION
See v0.5.11 ChangeLog: https://github.com/msgpack/msgpack-ruby/commit/412d29dbb175903c844d4e97621886c74c893565