### PR TITLE
Fixed the error handling upon exception at heartbeat with TCP

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -361,7 +361,7 @@ module Fluent
           else
             @usock.send "\0", 0, Socket.pack_sockaddr_in(n.port, n.resolved_host)
           end
-        rescue Errno::EAGAIN, Errno::EWOULDBLOCK, Errno::EINTR
+        rescue Errno::EAGAIN, Errno::EWOULDBLOCK, Errno::EINTR, Errno::ECONNREFUSED
           # TODO log
           log.debug "failed to send heartbeat packet to #{n.host}:#{n.port}", :error=>$!.to_s
         end


### PR DESCRIPTION
If the fluentd process of the destination node is not running, `ForwardOutput#send_heartbeat_tcp` throws `Errno::ECONNREFUSED`. If the exception at line 364 was not rescued, it would be excluded from `@nodes.each{}` and fall to send heartbeats to subsequent nodes. For this reason, if the fluentd process of a destination node stops, the fluentd process of the localhost detaches from subsequent nodes.
