### PR TITLE
BufferedOutputTestDriver must use correct buffer chunk type

### DIFF
--- a/lib/fluent/test/output_test.rb
+++ b/lib/fluent/test/output_test.rb
@@ -52,6 +52,10 @@ module Fluent
         @entries = []
         @expected_buffer = nil
         @tag = tag
+
+        def @instance.buffer
+          @buffer
+        end
       end
 
       attr_accessor :tag
@@ -83,8 +87,13 @@ module Fluent
             time, record = @entries.first
             key = @instance.time_slicer.call(time)
           end
-          chunk = MemoryBufferChunk.new(key, buffer)
-          result = @instance.write(chunk)
+          chunk = @instance.buffer.new_chunk(key)
+          chunk << buffer
+          begin
+            result = @instance.write(chunk)
+          ensure
+            chunk.purge
+          end
         }
         result
       end


### PR DESCRIPTION
Only MemoryBufferChunk is not good for plugin test.