### PR TITLE
literal_parser.rb: fix scan_embeded_code

### DIFF
--- a/lib/fluent/config/literal_parser.rb
+++ b/lib/fluent/config/literal_parser.rb
@@ -147,7 +147,7 @@ module Fluent
 
         @ss.pos += code.length
 
-        code
+        '"#{' + code + '}"'
       end
 
       def eval_embedded_code(code)

--- a/test/config/test_literal_parser.rb
+++ b/test/config/test_literal_parser.rb
@@ -228,6 +228,8 @@ module Fluent::Config
       test('"#{"}"}"') { assert_text_parsed_as("}", '"#{"}"}"') }
       test('"#{#}"') { assert_parse_error('"#{#}"') }  # error in embedded ruby code
       test("\"\#{\n=begin\n}\"") { assert_parse_error("\"\#{\n=begin\n}\"") }  # error in embedded ruby code
+      test('"#{v1}foo#{v2}"') { assert_text_parsed_as("#{v1}foo#{v2}", '"#{v1}foo#{v2}"') }
+      test('"#{1+1}foo#{2+2}bar"') { assert_text_parsed_as("#{1+1}foo#{2+2}bar", '"#{1+1}foo#{2+2}bar"') }
     end
 
     sub_test_case 'array parsing' do


### PR DESCRIPTION
Writing conf like:

```
<source>
  type dummy
  tag "#{ENV['HOGE']}foo#{ENV['MOGE']}"
</source>
```

results in a error:

```
/home/sonots/src/github.com/fluent/fluentd/lib/fluent/config/literal_parser.rb:157:in `instance_eval': (eval):1: syntax error, unexpected tSTRING_DEND, expecting end-of-input (SyntaxError)
ENV['HOGE']}foo#{ENV['MOGE']
            ^
        from /home/sonots/src/github.com/fluent/fluentd/lib/fluent/config/literal_parser.rb:157:in `eval_embedded_code'
        from /home/sonots/src/github.com/fluent/fluentd/lib/fluent/config/literal_parser.rb:84:in `scan_double_quoted_string'
        from /home/sonots/src/github.com/fluent/fluentd/lib/fluent/config/literal_parser.rb:68:in `scan_string'
        from /home/sonots/src/github.com/fluent/fluentd/lib/fluent/config/literal_parser.rb:61:in `parse_literal'
        from /home/sonots/src/github.com/fluent/fluentd/lib/fluent/config/v1_parser.rb:128:in `parse_element'
        from /home/sonots/src/github.com/fluent/fluentd/lib/fluent/config/v1_parser.rb:93:in `parse_element'
        from /home/sonots/src/github.com/fluent/fluentd/lib/fluent/config/v1_parser.rb:41:in `parse!'
        from /home/sonots/src/github.com/fluent/fluentd/lib/fluent/config/v1_parser.rb:31:in `parse'
        from /home/sonots/src/github.com/fluent/fluentd/lib/fluent/config.rb:29:in `parse'
        from /home/sonots/src/github.com/fluent/fluentd/lib/fluent/supervisor.rb:356:in `read_config'
        from /home/sonots/src/github.com/fluent/fluentd/lib/fluent/supervisor.rb:126:in `start'
        from /home/sonots/src/github.com/fluent/fluentd/lib/fluent/command/fluentd.rb:167:in `<top (required)>'
        from /home/sonots/src/github.com/fluent/fluentd/bin/fluentd:6:in `require'
        from /home/sonots/src/github.com/fluent/fluentd/bin/fluentd:6:in `<top (required)>'
        from /home/sonots/.rbenv/versions/haikanko/lib/ruby/gems/2.1.0/bin/fluentd:23:in `load'
        from /home/sonots/.rbenv/versions/haikanko/lib/ruby/gems/2.1.0/bin/fluentd:23:in `<main>'
```

This patch fixes this issue. 