### PR TITLE
fix try_flush_interval < 1 and queued_chunk_flush_interval < 1 to work

### DIFF
--- a/lib/fluent/output.rb
+++ b/lib/fluent/output.rb
@@ -98,7 +98,7 @@ module Fluent
     def initialize(output)
       @output = output
       @finish = false
-      @next_time = Engine.now + 1.0
+      @next_time = Time.now.to_f + 1.0
     end
 
     def configure(conf)
@@ -132,7 +132,7 @@ module Fluent
       @mutex.lock
       begin
         until @finish
-          time = Engine.now
+          time = Time.now.to_f
 
           if @next_time <= time
             @mutex.unlock
@@ -141,7 +141,7 @@ module Fluent
             ensure
               @mutex.lock
             end
-            next_wait = @next_time - Engine.now
+            next_wait = @next_time - Time.now.to_f
           else
             next_wait = @next_time - time
           end
@@ -231,7 +231,7 @@ module Fluent
     end
 
     def start
-      @next_flush_time = Engine.now + @flush_interval
+      @next_flush_time = Time.now.to_f + @flush_interval
       @buffer.start
       @secondary.start if @secondary
       @writers.each {|writer| writer.start }
@@ -280,10 +280,10 @@ module Fluent
     end
 
     def try_flush
-      time = Engine.now
+      time = Time.now.to_f
 
       empty = @buffer.queue_size == 0
-      if empty && @next_flush_time < (now = Engine.now)
+      if empty && @next_flush_time < (now = Time.now.to_f)
         @buffer.synchronize do
           if @next_flush_time < now
             enqueue_buffer
@@ -330,7 +330,7 @@ module Fluent
         end
 
         if has_next
-          return Engine.now + @queued_chunk_flush_interval
+          return Time.now.to_f + @queued_chunk_flush_interval
         else
           return time + @try_flush_interval
         end
@@ -385,7 +385,7 @@ module Fluent
 
     def force_flush
       @num_errors_lock.synchronize do
-        @next_retry_time = Engine.now - 1
+        @next_retry_time = Time.now.to_f - 1
       end
       enqueue_buffer(true)
       submit_flush


### PR DESCRIPTION
We were supposed to support `try_flush_interval < 1` and `queue_chunk_flush_interval < 1`, but the interval to call `try_flush` was still minimum 1 sec because `Engine.now` is `Time.now.to_i`. 

Illustration: The problem of the old logic:

```ruby
        until @finish
          time = Engine.now

          if @next_time <= time # (4) have to wait to be 1427488240.1 <= 1427488241
            @mutex.unlock
            begin
              @next_time = @output.try_flush # (1) 1427488240.1
            ensure
              @mutex.lock
            end
            next_wait = @next_time - Engine.now # (2) 0.1
          else
            next_wait = @next_time - time
          end

          # (3) will wait 0.1 sec
          cond_wait(next_wait) if next_wait > 0
        end
```

`@next_time` can be like `1427488240.1` when `queued_chunk_flush_interval 0.1`. 
But, `time` exceeds the `@next_time` only when it became `1427488241` (1 sec passed) because `Engine.now` is integer. 
