### PR TITLE
add --stop-source option

### DIFF
--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -83,6 +83,14 @@ op.on('--without-source', "invoke a fluentd without input plugins", TrueClass) {
   opts[:without_source] = b
 }
 
+op.on('--stop-source PATH', "stop input plugins if specified file exists") {|s|
+  opts[:stop_source] = s
+}
+
+op.on('--stop-source-interval SECONDS', "check the stop file every specified seconds") {|s|
+  opts[:stop_source_interval] = s.to_i
+}
+
 op.on('--use-v1-config', "Use v1 configuration format (default)", TrueClass) {|b|
   opts[:use_v1_config] = b
 }

--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -79,16 +79,14 @@ op.on('--suppress-repeated-stacktrace [VALUE]', "suppress repeated stacktrace", 
   opts[:suppress_repeated_stacktrace] = b
 }
 
-op.on('--without-source', "invoke a fluentd without input plugins", TrueClass) {|b|
-  opts[:without_source] = b
+op.on('--without-source [PATH]', "invoke a fluentd without input plugins. if a file is given, stop input plugins if the file appears, and restarts if the file disappears") {|s|
+  # empty:     invoke without input plugins
+  # file path: check file existence in interval seconds
+  opts[:without_source] = s || ""
 }
 
-op.on('--stop-source PATH', "stop input plugins if specified file exists") {|s|
-  opts[:stop_source] = s
-}
-
-op.on('--stop-source-interval SECONDS', "check the stop file every specified seconds") {|s|
-  opts[:stop_source_interval] = s.to_i
+op.on('--without-source-interval SECONDS', "check the file given by --without-source option every specified seconds") {|s|
+  opts[:without_source_interval] = s.to_i
 }
 
 op.on('--use-v1-config', "Use v1 configuration format (default)", TrueClass) {|b|

--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -49,8 +49,7 @@ module Fluent
       suppress_interval(opts[:suppress_interval]) if opts[:suppress_interval]
       @suppress_config_dump = opts[:suppress_config_dump] if opts[:suppress_config_dump]
       @without_source = opts[:without_source] if opts[:without_source]
-      @stop_source = opts[:stop_source] if opts[:stop_source]
-      @stop_source_interval = opts[:stop_source_interval]
+      @without_source_interval = opts[:without_source_interval]
 
       @root_agent = RootAgent.new(opts)
 

--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -49,6 +49,8 @@ module Fluent
       suppress_interval(opts[:suppress_interval]) if opts[:suppress_interval]
       @suppress_config_dump = opts[:suppress_config_dump] if opts[:suppress_config_dump]
       @without_source = opts[:without_source] if opts[:without_source]
+      @stop_source = opts[:stop_source] if opts[:stop_source]
+      @stop_source_interval = opts[:stop_source_interval]
 
       @root_agent = RootAgent.new(opts)
 

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -91,9 +91,8 @@ module Fluent
         :chgroup => nil,
         :suppress_interval => 0,
         :suppress_repeated_stacktrace => true,
-        :without_source => false,
-        :stop_source => nil,
-        :stop_source_interval => 5,
+        :without_source => nil,
+        :without_source_interval => 5,
         :use_v1_config => true,
         :supervise => true,
       }
@@ -116,8 +115,7 @@ module Fluent
       @suppress_interval = opt[:suppress_interval]
       @suppress_config_dump = opt[:suppress_config_dump]
       @without_source = opt[:without_source]
-      @stop_source = opt[:stop_source]
-      @stop_source_interval = opt[:stop_source_interval]
+      @without_source_interval = opt[:without_source_interval]
 
       log_opts = {:suppress_repeated_stacktrace => opt[:suppress_repeated_stacktrace]}
       @log = LoggerInitializer.new(@log_path, @log_level, @chuser, @chgroup, log_opts)
@@ -370,8 +368,7 @@ module Fluent
       config_param :emit_error_log_interval, :time, :default => nil
       config_param :suppress_config_dump, :bool, :default => nil
       config_param :without_source, :bool, :default => nil
-      config_param :stop_source, :string, :default => nil
-      config_param :stop_source_interval, :time, :default => nil
+      config_param :without_source_interval, :time, :default => nil
 
       def initialize(conf)
         super()
@@ -386,8 +383,7 @@ module Fluent
           @suppress_config_dump = system.suppress_config_dump unless system.suppress_config_dump.nil?
           @suppress_repeated_stacktrace = system.suppress_repeated_stacktrace unless system.suppress_repeated_stacktrace.nil?
           @without_source = system.without_source unless system.without_source.nil?
-          @stop_source = system.stop_source unless system.stop_source.nil?
-          @stop_source_interval = system.stop_source_interval
+          @without_source_interval = system.without_source_interval
         }
       end
     end
@@ -429,8 +425,7 @@ module Fluent
         :suppress_interval => @suppress_interval,
         :suppress_config_dump => @suppress_config_dump,
         :without_source => @without_source,
-        :stop_source => @stop_source,
-        :stop_source_interval => @stop_source_interval,
+        :without_source_interval => @without_source_interval,
       }
       Fluent::Engine.init(init_opts)
 

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -92,6 +92,8 @@ module Fluent
         :suppress_interval => 0,
         :suppress_repeated_stacktrace => true,
         :without_source => false,
+        :stop_source => nil,
+        :stop_source_interval => 5,
         :use_v1_config => true,
         :supervise => true,
       }
@@ -114,6 +116,8 @@ module Fluent
       @suppress_interval = opt[:suppress_interval]
       @suppress_config_dump = opt[:suppress_config_dump]
       @without_source = opt[:without_source]
+      @stop_source = opt[:stop_source]
+      @stop_source_interval = opt[:stop_source_interval]
 
       log_opts = {:suppress_repeated_stacktrace => opt[:suppress_repeated_stacktrace]}
       @log = LoggerInitializer.new(@log_path, @log_level, @chuser, @chgroup, log_opts)
@@ -366,6 +370,8 @@ module Fluent
       config_param :emit_error_log_interval, :time, :default => nil
       config_param :suppress_config_dump, :bool, :default => nil
       config_param :without_source, :bool, :default => nil
+      config_param :stop_source, :string, :default => nil
+      config_param :stop_source_interval, :time, :default => nil
 
       def initialize(conf)
         super()
@@ -380,6 +386,8 @@ module Fluent
           @suppress_config_dump = system.suppress_config_dump unless system.suppress_config_dump.nil?
           @suppress_repeated_stacktrace = system.suppress_repeated_stacktrace unless system.suppress_repeated_stacktrace.nil?
           @without_source = system.without_source unless system.without_source.nil?
+          @stop_source = system.stop_source unless system.stop_source.nil?
+          @stop_source_interval = system.stop_source_interval
         }
       end
     end
@@ -417,7 +425,13 @@ module Fluent
     end
 
     def init_engine
-      init_opts = {:suppress_interval => @suppress_interval, :suppress_config_dump => @suppress_config_dump, :without_source => @without_source}
+      init_opts = {
+        :suppress_interval => @suppress_interval,
+        :suppress_config_dump => @suppress_config_dump,
+        :without_source => @without_source,
+        :stop_source => @stop_source,
+        :stop_source_interval => @stop_source_interval,
+      }
       Fluent::Engine.init(init_opts)
 
       @libs.each {|lib|

--- a/test/config/test_system_config.rb
+++ b/test/config/test_system_config.rb
@@ -20,6 +20,8 @@ module Fluent::Config
       @suppress_config_dump = nil
       @suppress_repeated_stacktrace = nil
       @without_source = nil
+      @stop_source = nil
+      @stop_source_interval = nil
     end
   end
 
@@ -43,11 +45,15 @@ module Fluent::Config
       assert_nil(sc.emit_error_log_interval)
       assert_nil(sc.suppress_config_dump)
       assert_nil(sc.without_source)
+      assert_nil(sc.stop_source)
+      assert_nil(sc.stop_source_interval)
       assert_nil(s.instance_variable_get(:@log_level))
       assert_nil(s.instance_variable_get(:@suppress_repeated_stacktrace))
       assert_nil(s.instance_variable_get(:@emit_error_log_interval))
       assert_nil(s.instance_variable_get(:@suppress_config_dump))
       assert_nil(s.instance_variable_get(:@without_source))
+      assert_nil(s.instance_variable_get(:@stop_source))
+      assert_nil(s.instance_variable_get(:@stop_source_interval))
     end
 
     {'log_level' => 'error',
@@ -55,6 +61,8 @@ module Fluent::Config
      'emit_error_log_interval' => 60,
      'suppress_config_dump' => true,
      'without_source' => true,
+     'stop_source' => "/path/to/stop",
+     'stop_source_interval' => 10,
     }.each { |k, v|
       test "accepts #{k} parameter" do
         conf = parse_text(<<-EOS)
@@ -81,6 +89,8 @@ module Fluent::Config
         assert_nil(s.instance_variable_get(:@emit_error_log_interval))
         assert_nil(s.instance_variable_get(:@suppress_config_dump))
         assert_nil(s.instance_variable_get(:@without_source))
+        assert_nil(s.instance_variable_get(:@stop_source))
+        assert_nil(s.instance_variable_get(:@stop_source_interval))
       end
     }
 

--- a/test/config/test_system_config.rb
+++ b/test/config/test_system_config.rb
@@ -20,8 +20,7 @@ module Fluent::Config
       @suppress_config_dump = nil
       @suppress_repeated_stacktrace = nil
       @without_source = nil
-      @stop_source = nil
-      @stop_source_interval = nil
+      @without_source_interval = nil
     end
   end
 
@@ -45,24 +44,21 @@ module Fluent::Config
       assert_nil(sc.emit_error_log_interval)
       assert_nil(sc.suppress_config_dump)
       assert_nil(sc.without_source)
-      assert_nil(sc.stop_source)
-      assert_nil(sc.stop_source_interval)
+      assert_nil(sc.without_source_interval)
       assert_nil(s.instance_variable_get(:@log_level))
       assert_nil(s.instance_variable_get(:@suppress_repeated_stacktrace))
       assert_nil(s.instance_variable_get(:@emit_error_log_interval))
       assert_nil(s.instance_variable_get(:@suppress_config_dump))
       assert_nil(s.instance_variable_get(:@without_source))
-      assert_nil(s.instance_variable_get(:@stop_source))
-      assert_nil(s.instance_variable_get(:@stop_source_interval))
+      assert_nil(s.instance_variable_get(:@without_source_file))
     end
 
     {'log_level' => 'error',
      'suppress_repeated_stacktrace' => true,
      'emit_error_log_interval' => 60,
      'suppress_config_dump' => true,
-     'without_source' => true,
-     'stop_source' => "/path/to/stop",
-     'stop_source_interval' => 10,
+     'without_source' => "",
+     'without_source_interval' => 10,
     }.each { |k, v|
       test "accepts #{k} parameter" do
         conf = parse_text(<<-EOS)
@@ -89,8 +85,7 @@ module Fluent::Config
         assert_nil(s.instance_variable_get(:@emit_error_log_interval))
         assert_nil(s.instance_variable_get(:@suppress_config_dump))
         assert_nil(s.instance_variable_get(:@without_source))
-        assert_nil(s.instance_variable_get(:@stop_source))
-        assert_nil(s.instance_variable_get(:@stop_source_interval))
+        assert_nil(s.instance_variable_get(:@without_source_interval))
       end
     }
 


### PR DESCRIPTION
This is an enhancement version of https://github.com/fluent/fluentd/pull/569

At #569 , I added an option `stop_file` to **in_forward** plugin, but this version adds `--stop-source` option to fluentd command, and generalized its effectiveness to all input plugins. 

-----

This is a kind of an enhancement version of --without-source option.

This --stop-source feature enables to stop all input plugins
by touching the specified file. This feature is useful when users want
to stop receiving new data until users are sure that all buffers were flushed.

Removing the file restarts all input plugins, and the file existing check runs
every --stop-source-interval seconds (default: 5).