### PR TITLE
filter_record_transformer: support fields starting with @

### DIFF
--- a/lib/fluent/plugin/filter_record_transformer.rb
+++ b/lib/fluent/plugin/filter_record_transformer.rb
@@ -179,7 +179,7 @@ module Fluent
       end
 
       def expand(str)
-        str.gsub(/(\${[a-zA-Z0-9_]+(\[-?[0-9]+\])?}|__[A-Z_]+__)/) {
+        str.gsub(/(\${[^}]+}|__[A-Z_]+__)/) {
           log.warn "unknown placeholder `#{$1}` found" unless @placeholders.include?($1)
           @placeholders[$1]
         }

--- a/test/plugin/test_filter_record_transformer.rb
+++ b/test/plugin/test_filter_record_transformer.rb
@@ -343,5 +343,35 @@ class RecordTransformerFilterTest < Test::Unit::TestCase
         assert_nil(r['message'])
       end
     end
+
+    test 'expand fields starting with @ (enable_ruby no)' do
+      config = %[
+        enable_ruby no
+        <record>
+          foo ${@timestamp}
+        </record>
+      ]
+      d = create_driver(config)
+      message = {"@timestamp" => "foo"}
+      es = d.run { d.emit(message, @time) }.filtered
+      es.each do |t, r|
+        assert_equal(message["@timestamp"], r['foo'])
+      end
+    end
+
+    test 'expand fields starting with @ (enable_ruby yes)' do
+      config = %[
+        enable_ruby yes
+        <record>
+          foo ${__send__("@timestamp")}
+        </record>
+      ]
+      d = create_driver(config)
+      message = {"@timestamp" => "foo"}
+      es = d.run { d.emit(message, @time) }.filtered
+      es.each do |t, r|
+        assert_equal(message["@timestamp"], r['foo'])
+      end
+    end
   end
 end


### PR DESCRIPTION
and any field names in `enable_ruby false`.

fluent-plugin-record-reformer supported the same thing in v0.6.0.

cf. https://groups.google.com/forum/#!topic/fluentd/jFXBZws5mqg