### PR TITLE
Refix subsection merging rule

### DIFF
--- a/lib/fluent/config/configure_proxy.rb
+++ b/lib/fluent/config/configure_proxy.rb
@@ -60,29 +60,16 @@ module Fluent
 
       def merge(other) # self is base class, other is subclass
         options = {
-          param_name: other.param_name, # param_name is used not to ovewrite plugin's instance varible, so this should be able to be overwritten
-          required: (@required.nil? ? other.required : self.required), # subclass cannot overwrite base class's definition
-          multi: (@multi.nil? ? other.multi : self.multi),
-          alias: (@alias.nil? ? other.alias : self.alias),
+          param_name: other.param_name,
+          required: (other.required.nil? ? self.required : other.required),
+          multi: (other.multi.nil? ? self.multi : other.multi)
         }
         merged = self.class.new(other.name, options)
 
         merged.argument = other.argument || self.argument
-        merged.params = other.params.merge(self.params)
+        merged.params = self.params.merge(other.params)
         merged.defaults = self.defaults.merge(other.defaults)
-        merged.sections = {}
-        (self.sections.keys + other.sections.keys).uniq.each do |section_key|
-          self_section = self.sections[section_key]
-          other_section = other.sections[section_key]
-          merged_section = if self_section && other_section
-                             self_section.merge(other_section)
-                           elsif self_section || other_section
-                             self_section || other_section
-                           else
-                             raise "BUG: both of self and other section are nil"
-                           end
-          merged.sections[section_key] = merged_section
-        end
+        merged.sections = self.sections.merge(other.sections)
 
         merged
       end

--- a/lib/fluent/config/configure_proxy.rb
+++ b/lib/fluent/config/configure_proxy.rb
@@ -69,7 +69,19 @@ module Fluent
         merged.argument = other.argument || self.argument
         merged.params = self.params.merge(other.params)
         merged.defaults = self.defaults.merge(other.defaults)
-        merged.sections = self.sections.merge(other.sections)
+        merged.sections = {}
+        (self.sections.keys + other.sections.keys).uniq.each do |section_key|
+          self_section = self.sections[section_key]
+          other_section = other.sections[section_key]
+          merged_section = if self_section && other_section
+                             self_section.merge(other_section)
+                           elsif self_section || other_section
+                             self_section || other_section
+                           else
+                             raise "BUG: both of self and other section are nil"
+                           end
+          merged.sections[section_key] = merged_section
+        end
 
         merged
       end

--- a/lib/fluent/config/configure_proxy.rb
+++ b/lib/fluent/config/configure_proxy.rb
@@ -17,7 +17,7 @@
 module Fluent
   module Config
     class ConfigureProxy
-      attr_accessor :name, :param_name, :required, :multi, :alias, :argument, :params, :defaults, :sections
+      attr_accessor :name, :final, :param_name, :required, :multi, :alias, :argument, :params, :defaults, :sections
       # config_param :desc, :string, :default => '....'
       # config_set_default :buffer_type, :memory
       #
@@ -38,6 +38,7 @@ module Fluent
 
       def initialize(name, opts = {})
         @name = name.to_sym
+        @final = opts.fetch(:final, false)
 
         @param_name = (opts[:param_name] || @name).to_sym
         @required = opts[:required]
@@ -58,7 +59,13 @@ module Fluent
         @multi.nil? ? true : @multi
       end
 
+      def final?
+        @final
+      end
+
       def merge(other) # self is base class, other is subclass
+        return merge_for_finalized(other) if self.final?
+
         options = {
           param_name: other.param_name,
           required: (other.required.nil? ? self.required : other.required),
@@ -75,6 +82,39 @@ module Fluent
           other_section = other.sections[section_key]
           merged_section = if self_section && other_section
                              self_section.merge(other_section)
+                           elsif self_section || other_section
+                             self_section || other_section
+                           else
+                             raise "BUG: both of self and other section are nil"
+                           end
+          merged.sections[section_key] = merged_section
+        end
+
+        merged
+      end
+
+      def merge_for_finalized(other)
+        # list what subclass can do for finalized section
+        #  * overwrite param_name to escape duplicated name of instance variable
+        #  * append params/defaults/sections which are missing in superclass
+
+        options = {
+          param_name: other.param_name,
+          required: (self.required.nil? ? other.required : self.required),
+          multi: (self.multi.nil? ? other.multi : self.multi),
+          final: true,
+        }
+        merged = self.class.new(other.name, options)
+
+        merged.argument = self.argument || other.argument
+        merged.params = other.params.merge(self.params)
+        merged.defaults = other.defaults.merge(self.defaults)
+        merged.sections = {}
+        (self.sections.keys + other.sections.keys).uniq.each do |section_key|
+          self_section = self.sections[section_key]
+          other_section = other.sections[section_key]
+          merged_section = if self_section && other_section
+                             other_section.merge(self_section)
                            elsif self_section || other_section
                              self_section || other_section
                            else

--- a/test/config/test_configurable.rb
+++ b/test/config/test_configurable.rb
@@ -108,12 +108,6 @@ module ConfigurableSpec
       [@name, @detail]
     end
   end
-
-  class Example2 < Example1
-    config_section :detail, required: false, multi: false, alias: "information2" do
-      config_param :phone_no, :string
-    end
-  end
 end
 
 module Fluent::Config
@@ -497,59 +491,6 @@ module Fluent::Config
 
           ex5 = ConfigurableSpec::Example0.new.configure(conf.merge({"boolvalue" => false}))
           assert_false(ex5.boolvalue)
-        end
-      end
-
-      sub_test_case '.config_section' do
-        def e(name, arg = '', attrs = {}, elements = [])
-          attrs_str_keys = {}
-          attrs.each{|key, value| attrs_str_keys[key.to_s] = value }
-          Fluent::Config::Element.new(name, arg, attrs_str_keys, elements)
-        end
-
-        test 'adds only config_param definitions into configuration without overwriting existing configuration elements' do
-          # conf0 = e('ROOT', '', {}, [])
-
-          conf1 = e('ROOT', '', {
-              'name' => 'tagomoris',
-              'bool' => true,
-            },
-          )
-          # <detail> section is required by Example1 config_section spec
-          assert_raise(Fluent::ConfigError.new("'<detail>' sections are required")) { ConfigurableSpec::Example1.new.configure(conf1) }
-          assert_raise(Fluent::ConfigError.new("'<detail>' sections are required")) { ConfigurableSpec::Example2.new.configure(conf1) }
-
-          conf2 = e('ROOT', '', {
-              'name' => 'tagomoris',
-              'bool' => true,
-            },
-            [e('detail', '', { 'phone_no' => "+81-00-0000-0000" }, [])],
-          )
-          # <detail> address </detail> is required by Example1 config_param spec
-          assert_raise(Fluent::ConfigError.new("'address' parameter is required, in section detail")) { ConfigurableSpec::Example2.new.configure(conf2) }
-
-          conf3 = e('ROOT', '', {
-              'name' => 'tagomoris',
-              'bool' => true,
-            },
-            [e('detail', '', { 'address' => "Chiyoda Tokyo Japan" }, [])],
-          )
-          # <detail> phone_no </detail> is required by Example2 config_param spec
-          assert_nothing_raised { ConfigurableSpec::Example1.new.configure(conf3) }
-          assert_raise(Fluent::ConfigError.new("'phone_no' parameter is required, in section detail")) { ConfigurableSpec::Example2.new.configure(conf3) }
-
-          conf4 = e('ROOT', '', {
-              'name' => 'tagomoris',
-              'bool' => true,
-            },
-            [e('detail', '', { 'address' => "Chiyoda Tokyo Japan", 'phone_no' => '+81-00-0000-0000' }, [])],
-          )
-          assert_nothing_raised { ConfigurableSpec::Example1.new.configure(conf4) } # phone_no is not used
-          assert_nothing_raised { ConfigurableSpec::Example2.new.configure(conf4) }
-
-          ex2 = ConfigurableSpec::Example2.new.configure(conf4)
-          assert_equal "Chiyoda Tokyo Japan", ex2.detail.address
-          assert_equal "+81-00-0000-0000", ex2.detail.phone_no
         end
       end
     end

--- a/test/config/test_configurable.rb
+++ b/test/config/test_configurable.rb
@@ -100,12 +100,19 @@ module ConfigurableSpec
 
     config_param :name, :string, alias: :fullname
     config_param :bool, :bool, alias: :flag
-    config_section :detail, required: true, multi: false, alias: "information" do
-      config_param :address, :string
+    config_section :detail, required: false, multi: false, alias: "information" do
+      config_param :address, :string, default: "x"
     end
 
     def get_all
       [@name, @detail]
+    end
+  end
+
+  class Example2 < Example1
+    config_section :detail, required: true, multi: false, alias: "information2" do
+      config_param :address, :string, default: "y"
+      config_param :phone_no, :string
     end
   end
 end
@@ -491,6 +498,64 @@ module Fluent::Config
 
           ex5 = ConfigurableSpec::Example0.new.configure(conf.merge({"boolvalue" => false}))
           assert_false(ex5.boolvalue)
+        end
+      end
+
+      sub_test_case '.config_section' do
+        def e(name, arg = '', attrs = {}, elements = [])
+          attrs_str_keys = {}
+          attrs.each{|key, value| attrs_str_keys[key.to_s] = value }
+          Fluent::Config::Element.new(name, arg, attrs_str_keys, elements)
+        end
+
+        test 'adds only config_param definitions into configuration without overwriting existing configuration elements' do
+          # conf0 = e('ROOT', '', {}, [])
+
+          conf1 = e('ROOT', '', {
+              'name' => 'tagomoris',
+              'bool' => true,
+            },
+          )
+          # <detail> section is required by overwriting of Example2 config_section spec
+          assert_nothing_raised { ConfigurableSpec::Example1.new.configure(conf1) }
+          assert_raise(Fluent::ConfigError.new("'<detail>' sections are required")) { ConfigurableSpec::Example2.new.configure(conf1) }
+
+          conf2 = e('ROOT', '', {
+              'name' => 'tagomoris',
+              'bool' => true,
+            },
+            [e('detail', '', { 'phone_no' => "+81-00-0000-0000" }, [])],
+          )
+          # <detail> address </detail> default is overwritten by Example2
+          assert_nothing_raised { ConfigurableSpec::Example1.new.configure(conf2) }
+          assert_nothing_raised { ConfigurableSpec::Example2.new.configure(conf2) }
+          ex1 = ConfigurableSpec::Example1.new.configure(conf2)
+          assert_equal "x", ex1.detail.address
+          ex2 = ConfigurableSpec::Example2.new.configure(conf2)
+          assert_equal "y", ex2.detail.address
+
+          conf3 = e('ROOT', '', {
+              'name' => 'tagomoris',
+              'bool' => true,
+            },
+            [e('detail', '', { 'address' => "Chiyoda Tokyo Japan" }, [])],
+          )
+          # <detail> phone_no </detail> is required by Example2 config_param spec
+          assert_nothing_raised { ConfigurableSpec::Example1.new.configure(conf3) }
+          assert_raise(Fluent::ConfigError.new("'phone_no' parameter is required, in section detail")) { ConfigurableSpec::Example2.new.configure(conf3) }
+
+          conf4 = e('ROOT', '', {
+              'name' => 'tagomoris',
+              'bool' => true,
+            },
+            [e('detail', '', { 'address' => "Chiyoda Tokyo Japan", 'phone_no' => '+81-00-0000-0000' }, [])],
+          )
+          assert_nothing_raised { ConfigurableSpec::Example1.new.configure(conf4) } # phone_no is not used
+          assert_nothing_raised { ConfigurableSpec::Example2.new.configure(conf4) }
+
+          ex2 = ConfigurableSpec::Example2.new.configure(conf4)
+          assert_equal "Chiyoda Tokyo Japan", ex2.detail.address
+          assert_equal "+81-00-0000-0000", ex2.detail.phone_no
         end
       end
     end


### PR DESCRIPTION
#582 shows that #571 breaks compatibility of existing 3rd party plugins.
This pull-request does:
* revert #582 at first
* add tests for past behavior
* add `final` option to specify sections not to be overwritten

3rd party plugins should be able to overwrite super-class's behavior. But some should prohibit overwriting by sub classes. Ex: `<buffer>`.
Plugin authors should specify `final: true` for these sections.
