### PR TITLE
Add time_key option for RegexpParser

### DIFF
--- a/lib/fluent/parser.rb
+++ b/lib/fluent/parser.rb
@@ -160,6 +160,7 @@ module Fluent
     class RegexpParser < Parser
       include TypeConverter
 
+      config_param :time_key, :string, :default => 'time'
       config_param :time_format, :string, :default => nil
 
       def initialize(regexp, conf={})
@@ -199,7 +200,7 @@ module Fluent
         m.names.each {|name|
           if value = m[name]
             case name
-            when "time"
+            when @time_key
               time = @mutex.synchronize { @time_parser.parse(value) }
             else
               record[name] = if @type_converters.nil?

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -105,6 +105,18 @@ module ParserTest
       internal_test_case(TextParser::RegexpParser.new(Regexp.new(%q!^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] \[(?<date>[^\]]*)\] "(?<flag>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)$!), 'time_format'=>"%d/%b/%Y:%H:%M:%S %z", 'types'=>'user|string,date|time|%d/%b/%Y:%H:%M:%S %z,flag|bool,path|array,code|float,size|integer', 'types_label_delimiter'=>'|'))
     end
 
+    def test_parse_with_time_key
+      parser = TextParser::RegexpParser.new(/(?<logtime>[^\]]*)/)
+      parser.configure(
+        'time_format'=>"%Y-%m-%d %H:%M:%S %z",
+        'time_key'=>'logtime',
+      )
+      text = '2013-02-28 12:00:00 +0900'
+      parser.parse(text) do |time, record|
+        assert_equal Time.parse(text).to_i, time
+      end
+    end
+
     def test_parse_without_time
       time_at_start = Time.now.to_i
       text = "tagomori_satoshi tagomoris 34\n"


### PR DESCRIPTION
RegexpParser does not have `time_key` option currently, but it is useful if it has it. 

EDIT: `time_key` option is useful in two aspects:

１. We add `keep_time_key` option at https://github.com/fluent/fluentd/pull/587. However, without `time_key` option for RegexpParser, we still have to write a conf as follows when we need to change the time field name from `time` to `logtime` (or anything). 

```apache
<source>
  type tail
  format /^\[(?<time>[^\]]*)\]$/
  tag accesslog
</source>

<filter accesslog>
  type record_transformer
  enable_ruby true
  <record>
    logtime ${time.to_i}
  </record>
</filter>

<filter accesslog>
  type typecast
  types logtime:integer
</filter>

<match accesslog>
  type stdout
  #=> {"logtime":123456789}
</match>
```

By adding `time_key` option, this conf becomes as follows, which is pretty simple:

```apache
<source>
  type tail
  format /^\[(?<logtime>[^\]]*)\]$/
  tag accesslog
  time_key logtime
  types logtime:time
</source>

<match accesslog>
  type stdout
  #=> {"logtime":123456789}
</match>

```

２. `time_key` option allows to skip `Time.parse` (`Time.parse` in ruby is slow)

```apache
<source>
  type tail
  format /^\[(?<time>[^\]]*)\]$/
  time_key foo
  tag accesslog
</source>
```

The main purpose of this PR is 1, though. 