### PR TITLE
add filter_typecast plugin

### DIFF
--- a/example/filter_typecast.conf
+++ b/example/filter_typecast.conf
@@ -1,0 +1,14 @@
+<source>
+  type dummy
+  tag dummy
+  dummy {"field1":"1","field2":"2","field3":"2013-02-12 22:04:14 UTC","field4":"true","field5":"a,b,c","other":"other"}
+</source>
+
+<filter **>
+  type typecast
+  types field1:integer,field2:string,field3:time,field4:bool,field5:array
+</filter>
+
+<match **>
+  type stdout
+</match>

--- a/lib/fluent/plugin/filter_typecast.rb
+++ b/lib/fluent/plugin/filter_typecast.rb
@@ -1,0 +1,14 @@
+module Fluent
+  class TypecastFilter < Filter
+    Fluent::Plugin.register_filter('typecast', self)
+
+    include ::Fluent::TextParser::TypeConverter
+
+    def filter(tag, time, record)
+      filtered = record.map do |key, val|
+        [key, convert_type(key, val)]
+      end
+      Hash[*filtered.flatten(1)]
+    end
+  end
+end

--- a/test/plugin/test_filter_typecast.rb
+++ b/test/plugin/test_filter_typecast.rb
@@ -1,0 +1,71 @@
+require_relative '../helper'
+require 'fluent/plugin/filter_typecast'
+
+class DupFilterTest < Test::Unit::TestCase
+  include Fluent
+
+  setup do
+    Fluent::Test.setup
+    @time = Fluent::Engine.now
+  end
+
+  def create_driver(conf = '')
+    Test::FilterTestDriver.new(TypecastFilter).configure(conf, true)
+  end
+
+  def filter(d, msg)
+    d.run { d.filter(msg, @time) }
+    d.filtered_as_array.first[2]
+  end
+
+  sub_test_case 'configure' do
+    def test_types
+      d = create_driver(%[
+        types string:string,integer:integer,float:float,bool:bool,time:time,array:array
+      ])
+      types = d.instance.instance_variable_get(:@type_converters)
+      converters = ::Fluent::TextParser::TypeConverter::Converters
+      assert_equal converters['string'],  types['string']
+      assert_equal converters['integer'], types['integer']
+      assert_equal converters['float'],   types['float']
+      assert_equal converters['bool'],    types['bool']
+    end
+  end
+
+  sub_test_case 'test_type_cast' do
+    def test_types
+      d = create_driver(%[
+        types string:string,integer:integer,float:float,bool:bool,time:time,array:array
+      ])
+      msg = {
+        'integer' => '1',
+        'string'  => 'foo',
+        'time'    => '2013-02-12 22:01:15 UTC',
+        'bool'    => 'true',
+        'array'   => 'a,b,c',
+        'other'   => 'other',
+      }
+      filtered = filter(d, msg)
+      assert_equal 1, filtered['integer']
+      assert_equal 'foo', filtered['string']
+      assert_equal 1360706475, filtered['time']
+      assert_equal true, filtered['bool']
+      assert_equal ['a', 'b', 'c'], filtered['array']
+      assert_equal 'other', filtered['other']
+    end
+
+    def test_time_format
+      d = create_driver(%[types time:time:%d/%b/%Y:%H:%M:%S %z])
+      msg = { 'time' => '12/Dec/2014:19:37:37 +0900' }
+      filtered = filter(d, msg)
+      assert_equal 1418380657, filtered['time']
+    end
+
+    def test_array_delimiter
+      d = create_driver(%[types array:array:.])
+      msg = { 'array' => 'a.b.c' }
+      filtered = filter(d, msg)
+      assert_equal ['a','b','c'], filtered['array']
+    end
+  end
+end


### PR DESCRIPTION
I created https://github.com/sonots/fluent-plugin-filter_typecast a few days ago, and it seems very useful. 

I want to propose to have filter_typecast plugin as a built-in plugin because this plugin is just using `Fluent::TextParser::TypeConverter` which Fluentd has for `in_tail` plugin. 

I will make obsolete the above my plugin if this PR is merged. 