### PR TITLE
Add config_param type `enum` and its tests, Fix #599

### DIFF
--- a/lib/fluent/config/types.rb
+++ b/lib/fluent/config/types.rb
@@ -67,6 +67,14 @@ module Fluent
     val
   })
 
+  Configurable.register_type(:enum, Proc.new { |val, opts|
+    s = val.to_sym
+    unless opts[:list].include?(s)
+      raise ConfigError, "valid options are #{opts[:list].join(',')} but got #{val}"
+    end
+    s
+  })
+
   Configurable.register_type(:integer, Proc.new { |val, opts|
     val.to_i
   })

--- a/lib/fluent/config/types.rb
+++ b/lib/fluent/config/types.rb
@@ -69,6 +69,7 @@ module Fluent
 
   Configurable.register_type(:enum, Proc.new { |val, opts|
     s = val.to_sym
+    raise "Plugin BUG: config type 'enum' requires :list argument" if opts[:list].is_a?(Array)
     unless opts[:list].include?(s)
       raise ConfigError, "valid options are #{opts[:list].join(',')} but got #{val}"
     end


### PR DESCRIPTION
Type `enum` is to:
* handle symbols only for values
* require `list: [symbols]` parameter, which specifies the list of valid options
* raises `Fluent::ConfigError` if specified value in configuration file
