### PR TITLE
Add secret option

### DIFF
--- a/lib/fluent/config/element.rb
+++ b/lib/fluent/config/element.rb
@@ -117,6 +117,14 @@ module Fluent
         out
       end
 
+      def to_masked_element
+        element = Element.new(@name, @arg, {}, @elements, @unused)
+        each_pair { |k, v|
+          element[k] = secret_param?(k) ? 'xxxxxx' : v
+        }
+        element
+      end
+
       def secret_param?(key)
         return false if @corresponding_proxies.empty?
 

--- a/lib/fluent/config/element.rb
+++ b/lib/fluent/config/element.rb
@@ -29,9 +29,10 @@ module Fluent
         }
         @unused = unused || attrs.keys
         @v1_config = false
+        @corresponding_proxies = [] # some plugins use flat parameters, e.g. in_http doesn't provide <format> section for parser.
       end
 
-      attr_accessor :name, :arg, :elements, :unused, :v1_config
+      attr_accessor :name, :arg, :elements, :unused, :v1_config, :corresponding_proxies
 
       def add_element(name, arg='')
         e = Element.new(name, arg, {}, [])
@@ -103,13 +104,31 @@ module Fluent
           out << "#{indent}<#{@name} #{@arg}>\n"
         end
         each_pair { |k, v|
-          out << "#{nindent}#{k} #{v}\n"
+          if secret_param?(k)
+            out << "#{nindent}#{k} xxxxxx\n"
+          else
+            out << "#{nindent}#{k} #{v}\n"
+          end
         }
         @elements.each { |e|
           out << e.to_s(nest + 1)
         }
         out << "#{indent}</#{@name}>\n"
         out
+      end
+
+      def secret_param?(key)
+        return false if @corresponding_proxies.empty?
+
+        param_key = key.to_sym
+        @corresponding_proxies.each { |proxy|
+          block, opts = proxy.params[param_key]
+          if opts
+            return opts[:secret]
+          end
+        }
+
+        false
       end
 
       def self.unescape_parameter(v)

--- a/lib/fluent/config/element.rb
+++ b/lib/fluent/config/element.rb
@@ -131,7 +131,7 @@ module Fluent
         param_key = key.to_sym
         @corresponding_proxies.each { |proxy|
           block, opts = proxy.params[param_key]
-          if opts
+          if opts && opts.has_key?(:secret)
             return opts[:secret]
           end
         }

--- a/lib/fluent/configurable.rb
+++ b/lib/fluent/configurable.rb
@@ -21,8 +21,6 @@ module Fluent
   require 'fluent/registry'
 
   module Configurable
-    attr_reader :config
-
     def self.included(mod)
       mod.extend(ClassMethods)
     end
@@ -47,7 +45,9 @@ module Fluent
 
     def configure(conf)
       @config = conf
-      @config.corresponding_proxies << self.class.configure_proxy(self.class.name)
+      if class_name = self.class.name # Class.new in tests returns nil so it should be skipped.
+        @config.corresponding_proxies << self.class.configure_proxy(class_name)
+      end
 
       logger = self.respond_to?(:log) ? log : $log
       proxy = self.class.merged_configure_proxy
@@ -63,6 +63,10 @@ module Fluent
       end
 
       self
+    end
+
+    def config
+      @masked_config ||= @config.to_masked_element
     end
 
     CONFIG_TYPE_REGISTRY = Registry.new(:config_type, 'fluent/plugin/type_')

--- a/lib/fluent/configurable.rb
+++ b/lib/fluent/configurable.rb
@@ -47,6 +47,7 @@ module Fluent
 
     def configure(conf)
       @config = conf
+      @config.corresponding_proxies << self.class.configure_proxy(self.class.name)
 
       logger = self.respond_to?(:log) ? log : $log
       proxy = self.class.merged_configure_proxy

--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -90,12 +90,12 @@ module Fluent
         $log.info "gem '#{spec.name}' version '#{spec.version}'"
       end
 
+      @root_agent.configure(conf)
+      @event_router = @root_agent.event_router
+
       unless @suppress_config_dump
         $log.info "using configuration file: #{conf.to_s.rstrip}"
       end
-
-      @root_agent.configure(conf)
-      @event_router = @root_agent.event_router
     end
 
     def load_plugin_dir(dir)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -23,6 +23,18 @@ if ENV['SIMPLE_COV']
   end
 end
 
+# Some tests use Hash instead of Element for configure.
+# We should rewrite these tests in the future and remove this ad-hoc code
+class Hash
+  def corresponding_proxies
+    @corresponding_proxies ||= []
+  end
+
+  def to_masked_element
+    self
+  end
+end
+
 require 'rr'
 require 'test/unit'
 require 'test/unit/rr'


### PR DESCRIPTION
We sometimes got this feature request.
If plugins add `:secret => true` in `config_param`, the values are masked with `xxxxxx` like below.

```
2015-05-29 19:50:10 +0900 [info]: using configuration file: <ROOT>
  <source>
    type http
    port 8080
    format csv
  </source>
  <match http.**>
    type copy
    deep_copy xxxxxx # for test. deep_copy is not secret
    <store>
      type stdout
      output_type hash
    </store>
  </match>
</ROOT>
```

This changes two existing behaviours.
 
- in_monitor_agent returns masked configuration.
- Log order is changed during fluentd startup. Before: config dump -> register. After: register -> config dump

From my experience, these changes are no problem.