### PR TITLE
fluent-cat --format none added

### DIFF
--- a/lib/fluent/command/cat.rb
+++ b/lib/fluent/command/cat.rb
@@ -28,6 +28,7 @@ socket_path = Fluent::DEFAULT_SOCKET_PATH
 
 config_path = Fluent::DEFAULT_CONFIG_PATH
 format = 'json'
+message_key = 'message'
 
 op.on('-p', '--port PORT', "fluent tcp port (default: #{port})", Integer) {|i|
   port = i
@@ -55,6 +56,14 @@ op.on('--json', "same as: -f json", TrueClass) {|b|
 
 op.on('--msgpack', "same as: -f msgpack", TrueClass) {|b|
   format = 'msgpack'
+}
+
+op.on('--none', "same as: -f none", TrueClass) {|b|
+  format = 'none'
+}
+
+op.on('--message-key KEY', "key field for none format (default: #{message_key})") {|s|
+  message_key = s
 }
 
 (class<<self;self;end).module_eval do
@@ -285,6 +294,17 @@ when 'msgpack'
       w.write(record)
     }
   rescue EOFError
+  rescue
+    $stderr.puts $!
+    exit 1
+  end
+
+when 'none'
+  begin
+    while line = $stdin.gets
+      record = { message_key => line.chomp }
+      w.write(record)
+    end
   rescue
     $stderr.puts $!
     exit 1


### PR DESCRIPTION
Input plugins accept `format none` since #182 but fluent-cat doesn't yet. The tiny patch allows fluent-cat accept it.

```sh
echo "a plain text message" | fluent-cat --none debug
echo "another plain text message" | fluent-cat --format none --message-key message debug
```

The structured raw logs comes here again! I rarely agree for fluent-cat to accept rest of all formats as it should be kept simple and light weighted as it were. I guess, however, that the plain text format is enough convenient for plain simple usages expected for fluent-cat. 

The optional `--message-key` parameter could be removed to keep it simple.

It seems that `-f message` or `-f plain` could be more clear rather than `-f none` at this usage above, by the way. It should follow the vocabulary at `format` parameter at input plugins.