### PR TITLE
Update upper msgpack bound

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 1.9.3'
 
-  gem.add_runtime_dependency("msgpack", [">= 0.5.11", "< 0.6.0"])
+  gem.add_runtime_dependency("msgpack", [">= 0.5.11", "< 0.7.0"])
   gem.add_runtime_dependency("json", [">= 1.4.3"])
   gem.add_runtime_dependency("yajl-ruby", ["~> 1.0"])
   gem.add_runtime_dependency("cool.io", [">= 1.2.2", "< 2.0.0"])


### PR DESCRIPTION
msgpack 0.6.0 was released with a fix that allows for correct encoding
of binary messages. This is required by a plugin I'm working on.

There is no incompatibilities between the current 0.5 release and the
0.6 release.