### PR TITLE
Fix SingleValueFormatter to prevent record from modified

### DIFF
--- a/lib/fluent/formatter.rb
+++ b/lib/fluent/formatter.rb
@@ -206,7 +206,7 @@ module Fluent
       config_param :add_newline, :bool, :default => true
 
       def format(tag, time, record)
-        text = record[@message_key].to_s
+        text = record[@message_key].to_s.dup
         text << "\n" if @add_newline
         text
       end


### PR DESCRIPTION
when i use `out_copy` plugin to copy events to multiple outputs, I found out that even when I set the `deep_copy` to be true, original data would still  be modified.
The reason for such behavior is that when use `<<` to append new_line code to text, original record would also be modified.
So in order to keep original record unmodified, duplicate is need.