### PR TITLE
Support formatter plugins in out_stdout

### DIFF
--- a/test/plugin/test_out_stdout.rb
+++ b/test/plugin/test_out_stdout.rb
@@ -15,15 +15,15 @@ class StdoutOutputTest < Test::Unit::TestCase
 
   def test_configure
     d = create_driver
-    assert_equal :json, d.instance.output_type
+    assert_equal 'json', d.instance.output_type
   end
 
   def test_configure_output_type
     d = create_driver(CONFIG + "\noutput_type json")
-    assert_equal :json, d.instance.output_type
+    assert_equal 'json', d.instance.output_type
 
     d = create_driver(CONFIG + "\noutput_type hash")
-    assert_equal :hash, d.instance.output_type
+    assert_equal 'hash', d.instance.output_type
 
     assert_raise(Fluent::ConfigError) do
       d = create_driver(CONFIG + "\noutput_type foo")


### PR DESCRIPTION
Make `output_type` option of `out_stdout` accept not only `json` or `hash` but also any other formatter plugin.