### PR TITLE
Import "auto_typecast" to filter_record_transformer from fluent-plugin-record-reformer 0.7.0

### DIFF
--- a/lib/fluent/plugin/filter_record_transformer.rb
+++ b/lib/fluent/plugin/filter_record_transformer.rb
@@ -30,6 +30,7 @@ module Fluent
     config_param :renew_record, :bool, :default => false
     config_param :renew_time_key, :string, :default => nil
     config_param :enable_ruby, :bool, :default => false
+    config_param :auto_typecast, :bool, :default => false # false for lower version compatibility
 
     def configure(conf)
       super
@@ -52,15 +53,19 @@ module Fluent
         @keep_keys = @keep_keys.split(',')
       end
 
+      placeholder_expander_params = {
+        :log           => log,
+        :auto_typecast => @auto_typecast,
+      }
       @placeholder_expander =
         if @enable_ruby
           # require utilities which would be used in ruby placeholders
           require 'pathname'
           require 'uri'
           require 'cgi'
-          RubyPlaceholderExpander.new(log)
+          RubyPlaceholderExpander.new(placeholder_expander_params)
         else
-          PlaceholderExpander.new(log)
+          PlaceholderExpander.new(placeholder_expander_params)
         end
 
       @hostname = Socket.gethostname
@@ -124,7 +129,7 @@ module Fluent
       elsif value.is_a?(Hash)
         new_value = {}
         value.each_pair do |k, v|
-          new_value[@placeholder_expander.expand(k)] = expand_placeholders(v)
+          new_value[@placeholder_expander.expand(k, true)] = expand_placeholders(v)
         end
       elsif value.is_a?(Array)
         new_value = []
@@ -159,8 +164,9 @@ module Fluent
     class PlaceholderExpander
       attr_reader :placeholders, :log
 
-      def initialize(log)
-        @log = log
+      def initialize(params)
+        @log = params[:log]
+        @auto_typecast = params[:auto_typecast]
       end
 
       def prepare_placeholders(time, record, opts)
@@ -182,19 +188,34 @@ module Fluent
         @placeholders = placeholders
       end
 
-      def expand(str)
+      def expand(str, force_stringify=false)
+        if @auto_typecast and !force_stringify
+          single_placeholder_matched = str.match(/\A(\${[^}]+}|__[A-Z_]+__)\z/)
+          if single_placeholder_matched
+            log_unknown_placeholder($1)
+            return @placeholders[single_placeholder_matched[1]]
+          end
+        end
         str.gsub(/(\${[^}]+}|__[A-Z_]+__)/) {
-          log.warn "unknown placeholder `#{$1}` found" unless @placeholders.include?($1)
+          log_unknown_placeholder($1)
           @placeholders[$1]
         }
+      end
+
+      private
+      def log_unknown_placeholder(placeholder)
+        unless @placeholders.include?(placeholder)
+          log.warn "unknown placeholder `#{placeholder}` found"
+        end
       end
     end
 
     class RubyPlaceholderExpander
       attr_reader :placeholders, :log
 
-      def initialize(log)
-        @log = log
+      def initialize(params)
+        @log = params[:log]
+        @auto_typecast = params[:auto_typecast]
       end
 
       # Get placeholders as a struct
@@ -209,8 +230,15 @@ module Fluent
         @placeholders = struct
       end
 
-      def expand(str)
-        interpolated = str.gsub(/\$\{([^}]+)\}/, '#{\1}') # ${..} => #{..} 
+      def expand(str, force_stringify=false)
+        if @auto_typecast and !force_stringify
+          single_placeholder_matched = str.match(/\A\${([^}]+)}\z/)
+          if single_placeholder_matched
+            code = single_placeholder_matched[1]
+            return eval code, @placeholders.instance_eval { binding }
+          end
+        end
+        interpolated = str.gsub(/\$\{([^}]+)\}/, '#{\1}') # ${..} => #{..}
         eval "\"#{interpolated}\"", @placeholders.instance_eval { binding }
       rescue => e
         log.warn "failed to expand `#{str}`", :error_class => e.class, :error => e.message

--- a/test/plugin/test_filter_record_transformer.rb
+++ b/test/plugin/test_filter_record_transformer.rb
@@ -172,7 +172,12 @@ class RecordTransformerFilterTest < Test::Unit::TestCase
       yield d if block_given?
       d.run {
         msgs.each do |msg|
-          d.emit({'eventType0' => 'bar', 'message' => msg}, @time)
+          record = {
+            'eventType0' => 'bar',
+            'message'    => msg,
+          }
+          record = record.merge(msg) if msg.is_a?(Hash)
+          d.emit(record, @time)
         end
       }.filtered
     end
@@ -324,6 +329,112 @@ class RecordTransformerFilterTest < Test::Unit::TestCase
         es.each_with_index do |(t, r), i|
           assert_equal({@hostname=>'hostname',"foo.#{@tag}"=>'tag'}, r)
         end
+      end
+
+      test "disabled typecasting of values with enable_ruby #{enable_ruby}" do
+        config = %[
+          auto_typecast false
+          enable_ruby #{enable_ruby}
+          <record>
+            single      ${source}
+            multiple    ${source}${source}
+            with_prefix prefix-${source}
+            with_suffix ${source}-suffix
+          </record>
+        ]
+        msgs = [
+          { "source" => "string" },
+          { "source" => 123 },
+          { "source" => [1, 2] },
+          { "source" => {a:1, b:2} },
+          { "source" => nil },
+        ]
+        expected_results = [
+          { :single      => "string",
+            :multiple    => "stringstring",
+            :with_prefix => "prefix-string",
+            :with_suffix => "string-suffix" },
+          { :single      => 123.to_s,
+            :multiple    => "#{123.to_s}#{123.to_s}",
+            :with_prefix => "prefix-#{123.to_s}",
+            :with_suffix => "#{123.to_s}-suffix" },
+          { :single      => [1, 2].to_s,
+            :multiple    => "#{[1, 2].to_s}#{[1, 2].to_s}",
+            :with_prefix => "prefix-#{[1, 2].to_s}",
+            :with_suffix => "#{[1, 2].to_s}-suffix" },
+          { :single      => {a:1, b:2}.to_s,
+            :multiple    => "#{{a:1, b:2}.to_s}#{{a:1, b:2}.to_s}",
+            :with_prefix => "prefix-#{{a:1, b:2}.to_s}",
+            :with_suffix => "#{{a:1, b:2}.to_s}-suffix" },
+          { :single      => nil.to_s,
+            :multiple    => "#{nil.to_s}#{nil.to_s}",
+            :with_prefix => "prefix-#{nil.to_s}",
+            :with_suffix => "#{nil.to_s}-suffix" },
+        ]
+        actual_results = []
+        es = emit(config, msgs)
+        es.each_with_index do |(t, r), i|
+          actual_results << {
+            :single      => r["single"],
+            :multiple    => r["multiple"],
+            :with_prefix => r["with_prefix"],
+            :with_suffix => r["with_suffix"],
+          }
+        end
+        assert_equal(expected_results, actual_results)
+      end
+
+      test "enabled typecasting of values with enable_ruby #{enable_ruby}" do
+        config = %[
+          auto_typecast yes
+          enable_ruby #{enable_ruby}
+          <record>
+            single      ${source}
+            multiple    ${source}${source}
+            with_prefix prefix-${source}
+            with_suffix ${source}-suffix
+          </record>
+        ]
+        msgs = [
+          { "source" => "string" },
+          { "source" => 123 },
+          { "source" => [1, 2] },
+          { "source" => {a:1, b:2} },
+          { "source" => nil },
+        ]
+        expected_results = [
+          { :single      => "string",
+            :multiple    => "stringstring",
+            :with_prefix => "prefix-string",
+            :with_suffix => "string-suffix" },
+          { :single      => 123,
+            :multiple    => "#{123.to_s}#{123.to_s}",
+            :with_prefix => "prefix-#{123.to_s}",
+            :with_suffix => "#{123.to_s}-suffix" },
+          { :single      => [1, 2],
+            :multiple    => "#{[1, 2].to_s}#{[1, 2].to_s}",
+            :with_prefix => "prefix-#{[1, 2].to_s}",
+            :with_suffix => "#{[1, 2].to_s}-suffix" },
+          { :single      => {a:1, b:2},
+            :multiple    => "#{{a:1, b:2}.to_s}#{{a:1, b:2}.to_s}",
+            :with_prefix => "prefix-#{{a:1, b:2}.to_s}",
+            :with_suffix => "#{{a:1, b:2}.to_s}-suffix" },
+          { :single      => nil,
+            :multiple    => "#{nil.to_s}#{nil.to_s}",
+            :with_prefix => "prefix-#{nil.to_s}",
+            :with_suffix => "#{nil.to_s}-suffix" },
+        ]
+        actual_results = []
+        es = emit(config, msgs)
+        es.each_with_index do |(t, r), i|
+          actual_results << {
+            :single      => r["single"],
+            :multiple    => r["multiple"],
+            :with_prefix => r["with_prefix"],
+            :with_suffix => r["with_suffix"],
+          }
+        end
+        assert_equal(expected_results, actual_results)
       end
     end
 


### PR DESCRIPTION
fluent-plugin-record-reformer 0.7.0 has a new configuration "auto_typecast" to inherit type of record values if it is originated from the source record. The configuration should be imported from the plugin. This will fix #619. See also: https://github.com/sonots/fluent-plugin-record-reformer/pull/26