### PR TITLE
out_forward: Support dns round robin

### DIFF
--- a/example/in_forward.conf
+++ b/example/in_forward.conf
@@ -1,0 +1,7 @@
+<source>
+  type forward
+</source>
+
+<match test>
+  type stdout
+</match>

--- a/example/out_forward.conf
+++ b/example/out_forward.conf
@@ -1,5 +1,6 @@
 <source>
-  type forward
+  type dummy
+  tag test
 </source>
 
 <match test>
@@ -7,18 +8,22 @@
 
   <server>
     # first server
+    host localhost
     port 24224
   </server>
   <server>
     # second server
+    host localhost
     port 24225
   </server>
   <server>
     # second server
+    host localhost
     port 24226
     standby
   </server>
 
+  flush_interval 1
   send_timeout 60
   heartbeat_type udp
   heartbeat_interval 1

--- a/lib/fluent/load.rb
+++ b/lib/fluent/load.rb
@@ -1,5 +1,6 @@
 require 'thread'
 require 'socket'
+require 'resolv'
 require 'fcntl'
 require 'time'
 require 'monitor'

--- a/lib/fluent/load.rb
+++ b/lib/fluent/load.rb
@@ -1,6 +1,5 @@
 require 'thread'
 require 'socket'
-require 'resolv'
 require 'fcntl'
 require 'time'
 require 'monitor'

--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -460,9 +460,8 @@ module Fluent
       end
 
       def resolve_dns!
-        @sockaddr = Socket.pack_sockaddr_in(@port, @host)
-        port, resolved_host = Socket.unpack_sockaddr_in(@sockaddr)
-        return resolved_host
+        # shuffle to support dns round robin
+        Resolv.getaddresses(@host).shuffle!.first
       end
       private :resolve_dns!
 

--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -460,8 +460,8 @@ module Fluent
       end
 
       def resolve_dns!
-        # shuffle to support dns round robin
-        Resolv.getaddresses(@host).shuffle!.first
+        # sample to support dns round robin
+        Socket.getaddrinfo(@host, @port).sample[3]
       end
       private :resolve_dns!
 


### PR DESCRIPTION
I want to support DNS round robin.

Ruby's `Socket.pack_sockaddr_in` or `Resolv.getaddress` or `IPSocket.getaddress`, and so on does not support DNS round robin. To do it, we have to `Resolv.getaddresses(hostname).shuffle!.first`. 

This code still works on non dns round robin environment, so I did not add any new options. 

EDIT: Writing tests is difficult because we need to set up a DNS round robin environment, but existing tests passed, and I verified this works manually. 