### PR TITLE
Fix secret option to support config_section

### DIFF
--- a/lib/fluent/config/element.rb
+++ b/lib/fluent/config/element.rb
@@ -118,11 +118,12 @@ module Fluent
       end
 
       def to_masked_element
-        element = Element.new(@name, @arg, {}, @elements, @unused)
+        new_elems = @elements.map { |e| e.to_masked_element }
+        new_elem = Element.new(@name, @arg, {}, new_elems, @unused)
         each_pair { |k, v|
-          element[k] = secret_param?(k) ? 'xxxxxx' : v
+          new_elem[k] = secret_param?(k) ? 'xxxxxx' : v
         }
-        element
+        new_elem
       end
 
       def secret_param?(key)

--- a/lib/fluent/config/section.rb
+++ b/lib/fluent/config/section.rb
@@ -121,6 +121,10 @@ module Fluent
         proxy.sections.each do |name, subproxy|
           varname = subproxy.param_name.to_sym
           elements = (conf.respond_to?(:elements) ? conf.elements : []).select{ |e| e.name == subproxy.name.to_s || e.name == subproxy.alias.to_s }
+          # set subproxy for secret option
+          elements.each { |element|
+            element.corresponding_proxies << subproxy
+          }
 
           if subproxy.required? && elements.size < 1
             logger.error "config error in:\n#{conf}"

--- a/lib/fluent/configurable.rb
+++ b/lib/fluent/configurable.rb
@@ -45,12 +45,10 @@ module Fluent
 
     def configure(conf)
       @config = conf
-      if class_name = self.class.name # Class.new in tests returns nil so it should be skipped.
-        @config.corresponding_proxies << self.class.configure_proxy(class_name)
-      end
 
       logger = self.respond_to?(:log) ? log : $log
       proxy = self.class.merged_configure_proxy
+      conf.corresponding_proxies << proxy
 
       root = Fluent::Config::SectionGenerator.generate(proxy, conf, logger)
       @config_root_section = root


### PR DESCRIPTION
Currently, config_section's secret is ignored.

@sonots Could you test this with your large configuration file? This increases memory usage.