### PR TITLE
Add '@' to log_level. Keep log_level for backward compatibility

### DIFF
--- a/lib/fluent/config/v1_parser.rb
+++ b/lib/fluent/config/v1_parser.rb
@@ -51,7 +51,7 @@ module Fluent
       end
 
       ELEM_SYMBOLS = ['match', 'source', 'filter', 'system']
-      RESERVED_PARAMS = %W(@type @id @label)
+      RESERVED_PARAMS = %W(@type @id @label @log_level)
 
       def parse_element(root_element, elem_name, attrs = {}, elems = [])
         while true

--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -343,7 +343,7 @@ module Fluent
   module PluginLoggerMixin
     def self.included(klass)
       klass.instance_eval {
-        config_param :log_level, :string, :default => nil
+        config_param :log_level, :string, :default => nil, :alias => :@log_level
       }
     end
 


### PR DESCRIPTION
Forgot to add `@` :crying_cat_face: 