### PR TITLE
dns_round_robin option

### DIFF
--- a/lib/fluent/config/section.rb
+++ b/lib/fluent/config/section.rb
@@ -18,6 +18,7 @@ require 'json'
 
 module Fluent
   require 'fluent/config/error'
+  require 'fluent/config/v1_parser'
 
   module Config
     class Section < BasicObject

--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -472,7 +472,9 @@ module Fluent
 
       def resolve_dns!
         # sample to support dns round robin
-        Socket.getaddrinfo(@host, @port, nil, Socket::SOCK_STREAM).sample[3]
+        addrinfo = Socket.getaddrinfo(@host, @port, nil, Socket::SOCK_STREAM).sample
+        @sockaddr = Socket.pack_sockaddr_in(addrinfo[1], addrinfo[3])
+        addrinfo[3]
       end
       private :resolve_dns!
 

--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -64,6 +64,20 @@ class ForwardOutputTest < Test::Unit::TestCase
     assert_equal :none, d.instance.heartbeat_type
   end
 
+  def test_configure_dns_round_robin
+    assert_raise(Fluent::ConfigError) do
+      create_driver(CONFIG + "\nheartbeat_type udp\ndns_round_robin true")
+    end
+
+    d = create_driver(CONFIG + "\nheartbeat_type tcp\ndns_round_robin true")
+    assert_equal true, d.instance.dns_round_robin
+    assert_equal true, d.instance.nodes.first.conf.dns_round_robin
+
+    d = create_driver(CONFIG + "\nheartbeat_type none\ndns_round_robin true")
+    assert_equal true, d.instance.dns_round_robin
+    assert_equal true, d.instance.nodes.first.conf.dns_round_robin
+  end
+
   def test_phi_failure_detector
     d = create_driver(CONFIG + %[phi_failure_detector false \n phi_threshold 0])
     node = d.instance.nodes.first


### PR DESCRIPTION
See https://github.com/fluent/fluentd/pull/631. I added `dns_round_robin` option to prevent using dns round robin with udp heartbeat. 