### PR TITLE
Modify TimeSlicedOutput#emit mechanizm to fit BufferedOutput#emit way

### DIFF
--- a/lib/fluent/output.rb
+++ b/lib/fluent/output.rb
@@ -539,6 +539,7 @@ module Fluent
 
     def emit(tag, es, chain)
       @emit_count += 1
+      formatted_data = {}
       es.each {|time,record|
         tc = time / @time_slice_cache_interval
         if @before_tc == tc
@@ -548,7 +549,10 @@ module Fluent
           key = @time_slicer.call(time)
           @before_key = key
         end
-        data = format(tag, time, record)
+        formatted_data[key] ||= ''
+        formatted_data[key] << format(tag, time, record)
+      }
+      formatted_data.each { |key, data|
         if @buffer.emit(key, data, chain)
           submit_flush
         end


### PR DESCRIPTION
Current TimeSlicedOutput#emit emits records to buffer one by one.
It causes inconsistent state when queue has a problem.
For example, some records are stored into buffers and
raises BufferQueueLimitError. In this situation,
logs are duplicated if input plugin retries.
BufferedOutput and ObjectBufferedOutput uses another way.
These outputs format all records into data chunk first.
New behaviour is more safer than current TimeSlicedOutput way.

@sonots @tagomoris Could you check this patch? It increases temporary memory usage but current behaviour should be fixed.