### PR TITLE
Add missing license in gemspec

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
   gem.has_rdoc = false
+  gem.license = "Apache-2.0"
 
   gem.required_ruby_version = '>= 1.9.3'
 


### PR DESCRIPTION
Currently, fluentd's license is displayed N/A in rubygems.org.

ref: http://spdx.org/licenses/