### PR TITLE
WIP - DO NOT MERGE - Supports RFC 5425 and RFC 6587 msg-len fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ test/config/tmp/*
 make_dist.sh
 Gemfile.local
 .ruby-version
+.idea

--- a/lib/fluent/plugin/in_tcp.rb
+++ b/lib/fluent/plugin/in_tcp.rb
@@ -21,11 +21,16 @@ module Fluent
     Plugin.register_input('tcp', self)
 
     config_set_default :port, 5170
-    config_param :delimiter, :string, :default => "\n" # syslog family add "\n" to each message and this seems only way to split messages in tcp stream
+    config_param :delimiter, :string, :default => "\n"
+
+    def test(buffer, offset)
+      i = buffer.index(@delimiter, offset)
+      i ? [i, i + @delimiter.length] :  [nil, nil]
+    end
 
     def listen(callback)
       log.debug "listening tcp socket on #{@bind}:#{@port}"
-      Coolio::TCPServer.new(@bind, @port, SocketUtil::TcpHandler, log, @delimiter, callback)
+      Coolio::TCPServer.new(@bind, @port, SocketUtil::TcpHandler, log, method(:test), callback)
     end
   end
 end

--- a/test/plugin/test_in_syslog.rb
+++ b/test/plugin/test_in_syslog.rb
@@ -150,10 +150,10 @@ class SyslogInputTest < Test::Unit::TestCase
   end
 
   def create_test_case
-    # actual syslog message has "\n"
+    # actual syslog message has "\n" unless there is a message length header as per RFC 5425 and RFC 6587
     [
       {'msg' => '<6>Sep 10 00:00:00 localhost logger: ' + 'x' * 100 + "\n", 'expected' => 'x' * 100},
-      {'msg' => '<6>Sep 10 00:00:00 localhost logger: ' + 'x' * 1024 + "\n", 'expected' => 'x' * 1024},
+      {'msg' => '1043 <6>Sep 10 00:00:00 localhost logger: ' + 'x' * 1024, 'expected' => 'x' * 1024},
     ]
   end
 


### PR DESCRIPTION
In order to support long messages, and messages containing the full range of UTF-8 messages a message length may be conveyed at the beginning of a message. As defined by the following RFCs:

  https://tools.ietf.org/html/rfc5425
  https://tools.ietf.org/html/rfc6587

The enhancement changes the behaviour of fluentd's TcpHandler to accept a function that determines whether the tcp message has been completely read. In the absence of a message length field in the message, the original behaviour of using a delimiter ("\n") is used. Otherwise the message length is honoured.