### PR TITLE
Remove unnecessary method call

### DIFF
--- a/lib/fluent/output.rb
+++ b/lib/fluent/output.rb
@@ -527,7 +527,7 @@ module Fluent
       else
         @flush_interval = [60, @time_slice_cache_interval].min
         @enqueue_buffer_proc = Proc.new do
-          nowslice = @time_slicer.call(Engine.now.to_i - @time_slice_wait)
+          nowslice = @time_slicer.call(Engine.now - @time_slice_wait)
           @buffer.keys.each {|key|
             if key < nowslice
               @buffer.push(key)


### PR DESCRIPTION
`Engine.now` returns int.