### PR TITLE
RegexpParser#initialize should wrap only Hash conf by Config::Element. fix #646

### DIFF
--- a/lib/fluent/parser.rb
+++ b/lib/fluent/parser.rb
@@ -169,7 +169,7 @@ module Fluent
         super()
         @regexp = regexp
         unless conf.empty?
-          conf = Config::Element.new('default_regexp_conf', '', conf, [])
+          conf = Config::Element.new('default_regexp_conf', '', conf, []) unless conf.is_a?(Config::Element)
           configure(conf)
         end
 


### PR DESCRIPTION
MultilineParser passes own Config::Element to RegexpParser.
RegexpParser should not re-wrap such configuration.