### PR TITLE
Add null_value_pattern and null_empty_string option for LabeledTSVParser, CSVParser, TSVParser.

### DIFF
--- a/lib/fluent/parser.rb
+++ b/lib/fluent/parser.rb
@@ -354,10 +354,10 @@ module Fluent
       end
 
       def convert_value_to_nil(value)
-        if @null_empty_string
+        if value and @null_empty_string
           value = (value == '') ? nil : value
         end
-        if @null_value_pattern
+        if value and @null_value_pattern
           value = (@null_value_pattern.match(value)) ? nil : value
         end
         value

--- a/lib/fluent/parser.rb
+++ b/lib/fluent/parser.rb
@@ -367,7 +367,8 @@ module Fluent
     class LabeledTSVParser < ValuesParser
       config_param :delimiter,       :string, :default => "\t"
       config_param :label_delimiter, :string, :default =>  ":"
-      config_param :null_value, :string, :default => nil
+      config_param :null_value_pattern, :string, :default => nil
+      config_param :null_empty_string, :bool, :default => false
       config_param :time_key, :string, :default =>  "time"
 
       def configure(conf)
@@ -382,8 +383,11 @@ module Fluent
         text.split(delimiter).each do |pair|
           key, value = pair.split(label_delimiter, 2)
           @keys.push(key)
-          if null_value
-            value = (null_value == value) ? nil : value
+          if null_empty_string
+            value = (value == '') ? nil : value
+          end
+          if null_value_pattern
+            value = (value =~ /#{null_value_pattern}/) ? nil : value
           end
           values.push(value)
         end

--- a/lib/fluent/parser.rb
+++ b/lib/fluent/parser.rb
@@ -367,6 +367,7 @@ module Fluent
     class LabeledTSVParser < ValuesParser
       config_param :delimiter,       :string, :default => "\t"
       config_param :label_delimiter, :string, :default =>  ":"
+      config_param :null_value, :string, :default => nil
       config_param :time_key, :string, :default =>  "time"
 
       def configure(conf)
@@ -381,6 +382,9 @@ module Fluent
         text.split(delimiter).each do |pair|
           key, value = pair.split(label_delimiter, 2)
           @keys.push(key)
+          if null_value
+            value = (null_value == value) ? nil : value
+          end
           values.push(value)
         end
 

--- a/lib/fluent/parser.rb
+++ b/lib/fluent/parser.rb
@@ -358,21 +358,9 @@ module Fluent
           value = (value == '') ? nil : value
         end
         if value and @null_value_pattern
-          value = match(value) ? nil : value
+          value = ::Fluent::StringUtil.match_regexp(@null_value_pattern, value) ? nil : value
         end
         value
-      end
-
-      def match(string)
-       begin
-         return @null_value_pattern.match(string)
-       rescue ArgumentError => e
-         raise e unless e.message.index("invalid byte sequence in".freeze).zero?
-         log.info "invalid byte sequence is replaced in `#{string}`"
-         string = string.scrub('?')
-         retry
-       end
-       return true
       end
     end
 

--- a/lib/fluent/parser.rb
+++ b/lib/fluent/parser.rb
@@ -358,9 +358,21 @@ module Fluent
           value = (value == '') ? nil : value
         end
         if value and @null_value_pattern
-          value = (@null_value_pattern.match(value)) ? nil : value
+          value = match(value) ? nil : value
         end
         value
+      end
+
+      def match(string)
+       begin
+         return @null_value_pattern.match(string)
+       rescue ArgumentError => e
+         raise e unless e.message.index("invalid byte sequence in".freeze).zero?
+         log.info "invalid byte sequence is replaced in `#{string}`"
+         string = string.scrub('?')
+         retry
+       end
+       return true
       end
     end
 

--- a/lib/fluent/parser.rb
+++ b/lib/fluent/parser.rb
@@ -312,7 +312,7 @@ module Fluent
         @time_parser = TimeParser.new(@time_format)
 
         if @null_value_pattern
-          @null_value_pattern = /#{@null_value_pattern}/
+          @null_value_pattern = Regexp.new(@null_value_pattern)
         end
 
         @mutex = Mutex.new
@@ -358,7 +358,7 @@ module Fluent
           value = (value == '') ? nil : value
         end
         if @null_value_pattern
-          value = (value =~ @null_value_pattern) ? nil : value
+          value = (@null_value_pattern.match(value)) ? nil : value
         end
         value
       end

--- a/lib/fluent/plugin/string_util.rb
+++ b/lib/fluent/plugin/string_util.rb
@@ -1,0 +1,32 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+module Fluent
+  module StringUtil
+    def match_regexp(regexp, string)
+      begin
+        return regexp.match(string)
+      rescue ArgumentError => e
+        raise e unless e.message.index("invalid byte sequence in".freeze).zero?
+        log.info "invalid byte sequence is replaced in `#{string}`"
+        string = string.scrub('?')
+        retry
+      end
+      return true
+    end
+    module_function :match_regexp
+  end
+end

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -529,6 +529,38 @@ module ParserTest
         assert_equal text, record['time']
       end
     end
+
+    data('array param' => '["a","b","c","d","e","f"]', 'string param' => 'a,b,c,d,e,f')
+    def test_parse_with_null_value_pattern
+      parser = TextParser::TSVParser.new
+      parser.configure(
+        'keys'=>param,
+        'time_key'=>'time',
+        'null_value_pattern'=>'^(-|null|NULL)$'
+      )
+      parser.parse("-\tnull\tNULL\t\t--\tnuLL") do |time, record|
+        assert_nil record['a']
+        assert_nil record['b']
+        assert_nil record['c']
+        assert_equal record['d'], ''
+        assert_equal record['e'], '--'
+        assert_equal record['f'], 'nuLL'
+      end
+    end
+
+    data('array param' => '["a","b"]', 'string param' => 'a,b')
+    def test_parse_with_null_empty_string
+      parser = TextParser::TSVParser.new
+      parser.configure(
+        'keys'=>param,
+        'time_key'=>'time',
+        'null_empty_string'=>true
+      )
+      parser.parse("\t ") do |time, record|
+        assert_nil record['a']
+        assert_equal record['b'], ' '
+      end
+    end
   end
 
   class CSVParserTest < ::Test::Unit::TestCase
@@ -584,6 +616,38 @@ module ParserTest
       text = '28/Feb/2013:12:00:00 +0900'
       parser.parse(text) do |time, record|
         assert_equal text, record['time']
+      end
+    end
+
+    data('array param' => '["a","b","c","d","e","f"]', 'string param' => 'a,b,c,d,e,f')
+    def test_parse_with_null_value_pattern
+      parser = TextParser::CSVParser.new
+      parser.configure(
+        'keys'=>param,
+        'time_key'=>'time',
+        'null_value_pattern'=>'^(-|null|NULL)$'
+      )
+      parser.parse("-,null,NULL,,--,nuLL") do |time, record|
+        assert_nil record['a']
+        assert_nil record['b']
+        assert_nil record['c']
+        assert_equal record['d'], ''
+        assert_equal record['e'], '--'
+        assert_equal record['f'], 'nuLL'
+      end
+    end
+
+    data('array param' => '["a","b"]', 'string param' => 'a,b')
+    def test_parse_with_null_empty_string
+      parser = TextParser::CSVParser.new
+      parser.configure(
+        'keys'=>param,
+        'time_key'=>'time',
+        'null_empty_string'=>true
+      )
+      parser.parse(", ") do |time, record|
+        assert_nil record['a']
+        assert_equal record['b'], ' '
       end
     end
   end

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -684,6 +684,16 @@ module ParserTest
         assert_equal text, record['time']
       end
     end
+
+    def test_parse_with_nil_string
+      parser = TextParser::LabeledTSVParser.new
+      parser.configure(
+        'null_value'=>'-'
+      )
+      parser.parse("user_id:-") do |time, record|
+        assert_nil record['user_id']
+      end
+    end
   end
 
   class NoneParserTest < ::Test::Unit::TestCase

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -685,13 +685,29 @@ module ParserTest
       end
     end
 
-    def test_parse_with_nil_string
+    def test_parse_with_null_value_pattern
       parser = TextParser::LabeledTSVParser.new
       parser.configure(
-        'null_value'=>'-'
+        'null_value_pattern'=>'^(-|null|NULL)$'
       )
-      parser.parse("user_id:-") do |time, record|
-        assert_nil record['user_id']
+      parser.parse("a:-\tb:null\tc:NULL\td:\te:--\tf:nuLL") do |time, record|
+        assert_nil record['a']
+        assert_nil record['b']
+        assert_nil record['c']
+        assert_equal record['d'], ''
+        assert_equal record['e'], '--'
+        assert_equal record['f'], 'nuLL'
+      end
+    end
+
+    def test_parse_with_null_empty_string
+      parser = TextParser::LabeledTSVParser.new
+      parser.configure(
+        'null_empty_string'=>true
+      )
+      parser.parse("a:\tb: ") do |time, record|
+        assert_nil record['a']
+        assert_equal record['b'], ' '
       end
     end
   end


### PR DESCRIPTION
Hello.

Cannot express NULL in LTSV.

ltsv library for Ruby blank to NULL.
https://github.com/condor/ltsv/blob/master/lib/ltsv.rb#L97

I use LTSV with apache.
Apache log is If value not exists with hyphen('-').

I think hyphens to null, any of the following methods.

1. LabeledTSVParser add parameter with @null_value
※this PR

settings example.
```
<source>
  type tail
  path /var/log/httpd/access_log
  format ltsv
  time_key time
  null_value -
  time_format %d/%b/%Y:%H:%M:%S %z
  tag td.apache.access
  pos_file /var/log/td-agent/apache_access.pos
</source>
```

2. specifications similar to the Ruby library(blank to null)

3. Make your own filter plugin.


Which one is good?
