### PR TITLE
Implement RPC to dump in memory config

### DIFF
--- a/lib/fluent/rpc.rb
+++ b/lib/fluent/rpc.rb
@@ -41,7 +41,7 @@ module Fluent
       def mount_proc(path, &block)
         @server.mount_proc(path) { |req, res|
           begin
-            code, header, body = block.call(req, res)
+            code, header, response = block.call(req, res)
           rescue => e
             @log.warn "failed to handle RPC request", :path => path, :error => e.to_s
             @log.warn_backtrace e.backtrace
@@ -56,11 +56,11 @@ module Fluent
 
           code = 200 if code.nil?
           header = {'Content-Type' => 'application/json'} if header.nil?
-          body = if body.nil?
+          body = if response.nil?
                    '{"ok":true}'
                  else
-                   body['ok'] = code == 200
-                   body.to_json
+                   response.body['ok'] = code == 200
+                   response.body.to_json
                  end
 
           res.status = code

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -263,6 +263,12 @@ module Fluent
         supervisor_sighup_handler
         nil
       }
+      @rpc_server.mount_proc('/api/config.dump') { |req, res|
+        $log.debug "fluentd RPC got /api/config.dump request"
+        $log.info "dump in-memory config"
+        supervisor_dump_config_handler
+        nil
+      }
     end
 
     def run_rpc_server
@@ -397,6 +403,10 @@ module Fluent
         Process.kill(:USR1, pid)
         # don't resuce Erro::ESRSH here (invalid status)
       end
+    end
+
+    def supervisor_dump_config_handler
+      $log.info @conf.to_s
     end
 
     def read_config

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -269,6 +269,12 @@ module Fluent
         supervisor_dump_config_handler
         nil
       }
+      @rpc_server.mount_proc('/api/config.getDump') { |req, res|
+        $log.debug "fluentd RPC got /api/config.dump request"
+        $log.info "get dump in-memory config via HTTP"
+        res.body = supervisor_get_dump_config_handler
+        [nil, nil, res]
+      }
     end
 
     def run_rpc_server
@@ -407,6 +413,10 @@ module Fluent
 
     def supervisor_dump_config_handler
       $log.info @conf.to_s
+    end
+
+    def supervisor_get_dump_config_handler
+      {conf: @conf.to_s}
     end
 
     def read_config

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -448,7 +448,7 @@ module Fluent
       config_param :suppress_config_dump, :bool, :default => nil
       config_param :without_source, :bool, :default => nil
       config_param :rpc_endpoint, :string, :default => nil
-      config_param :enable_get_dump, :bool, :default => false
+      config_param :enable_get_dump, :bool, :default => nil
 
       def initialize(conf)
         super()

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -130,6 +130,8 @@ module Fluent
       dry_run if @dry_run
       start_daemonize if @daemonize
       setup_rpc_server if @rpc_endpoint
+      setup_rpc_get_dump if @enable_get_dump
+
       if @supervise
         install_supervisor_signal_handlers
         run_rpc_server if @rpc_endpoint
@@ -269,6 +271,9 @@ module Fluent
         supervisor_dump_config_handler
         nil
       }
+    end
+
+    def setup_rpc_get_dump
       @rpc_server.mount_proc('/api/config.getDump') { |req, res|
         $log.debug "fluentd RPC got /api/config.dump request"
         $log.info "get dump in-memory config via HTTP"
@@ -443,6 +448,7 @@ module Fluent
       config_param :suppress_config_dump, :bool, :default => nil
       config_param :without_source, :bool, :default => nil
       config_param :rpc_endpoint, :string, :default => nil
+      config_param :enable_get_dump, :bool, :default => false
 
       def initialize(conf)
         super()
@@ -458,6 +464,7 @@ module Fluent
           @suppress_repeated_stacktrace = system.suppress_repeated_stacktrace unless system.suppress_repeated_stacktrace.nil?
           @without_source = system.without_source unless system.without_source.nil?
           @rpc_endpoint = system.rpc_endpoint unless system.rpc_endpoint.nil?
+          @enable_get_dump = system.enable_get_dump unless system.enable_get_dump.nil?
         }
       end
     end


### PR DESCRIPTION
Related to #633.

Add `<endpoint>/api/config.dump` to RPC.

e.g)

example conf:

```conf
<source>
  type http
  bind 0.0.0.0
  port 9880
  body_size_limit 32MB
  keepalive_timeout 10
  # backlog 0
  add_http_headers false
  format default
</source>

<match test>
  type stdout
</match>
<system>
  rpc_endpoint 127.0.0.1:9000
</system>
```

### Dump API

```bash
$ curl http://127.0.0.1:9000//api/config.dump
{"ok":true}
```

then, got:

```log
2015-08-28 15:45:28 +0900 [info]: dump in-memory config
2015-08-28 15:45:28 +0900 [info]: <ROOT>
  <source>
    type http
    bind 0.0.0.0
    port 9880
    body_size_limit 32MB
    keepalive_timeout 10
    add_http_headers false
    format default
  </source>
  <match test>
    type stdout
  </match>
  <system>
    rpc_endpoint 127.0.0.1:9000
  </system>
</ROOT>
```

### via HTTP

```bash
$ curl http://127.0.0.1:9000/api/config.getDump
{"conf":"<ROOT>\n  <source>\n    type http\n    bind 0.0.0.0\n    port 9880\n    body_size_limit 32MB\n    keepalive_timeout 10\n    add_http_headers false\n    format default\n  </source>\n  <match test>\n    type stdout\n  </match>\n  <system>\n    rpc_endpoint 127.0.0.1:9000\n  </system>\n</ROOT>\n","ok":true}
```