### PR TITLE
Fix add_remote_addr and add_http_headers options not working on bulk request

### DIFF
--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -132,7 +132,7 @@ module Fluent
         end
 
         unless record.is_a?(Array)
-          if @add_http_headers and 
+          if @add_http_headers
             params.each_pair { |k,v|
               if k.start_with?("HTTP_")
                 record[k] = v

--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -131,18 +131,18 @@ module Fluent
           end
         end
 
-        if @add_http_headers
-          params.each_pair { |k,v|
-            if k.start_with?("HTTP_")
-              record[k] = v
-            end
-          }
+        if not record.is_a?(Array)
+          if @add_http_headers and 
+            params.each_pair { |k,v|
+              if k.start_with?("HTTP_")
+                record[k] = v
+              end
+            }
+          end
+          if @add_remote_addr
+            record['REMOTE_ADDR'] = params['REMOTE_ADDR']
+          end
         end
-
-        if @add_remote_addr
-          record['REMOTE_ADDR'] = params['REMOTE_ADDR']
-        end
-
         time = if param_time = params['time']
                  param_time = param_time.to_i
                  param_time.zero? ? Engine.now : param_time
@@ -159,11 +159,21 @@ module Fluent
         if record.is_a?(Array)
           mes = MultiEventStream.new
           record.each do |single_record|
+            if @add_http_headers
+              params.each_pair { |k,v|
+                if k.start_with?("HTTP_")
+                  single_record[k] = v
+                end
+              }
+            end
+            if @add_remote_addr
+              single_record['REMOTE_ADDR'] = params['REMOTE_ADDR']
+            end
             single_time = single_record.delete("time") || time
             mes.add(single_time, single_record)
           end
           router.emit_stream(tag, mes)
-	else
+        else
           router.emit(tag, time, record)
         end
       rescue

--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -131,7 +131,7 @@ module Fluent
           end
         end
 
-        if not record.is_a?(Array)
+        unless record.is_a?(Array)
           if @add_http_headers and 
             params.each_pair { |k,v|
               if k.start_with?("HTTP_")

--- a/test/plugin/test_in_http.rb
+++ b/test/plugin/test_in_http.rb
@@ -85,6 +85,24 @@ class HttpInputTest < Test::Unit::TestCase
 
   end
 
+  def test_multi_json_with_add_http_headers
+    d = create_driver(CONFIG + "add_http_headers true")
+
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    events = [{"a"=>1},{"a"=>2}]
+    tag = "tag1"
+
+    d.run do
+      res = post("/#{tag}", {"json"=>events.to_json, "time"=>time.to_s})
+      assert_equal "200", res.code
+    end
+
+    d.emit_streams.each { |tag, es|
+      print es
+      assert include_http_header?(es.first[1])
+    }
+  end
+
   def test_json_with_add_http_headers
     d = create_driver(CONFIG + "add_http_headers true")
 

--- a/test/plugin/test_in_http.rb
+++ b/test/plugin/test_in_http.rb
@@ -1,6 +1,7 @@
 require_relative '../helper'
 require 'fluent/test'
 require 'net/http'
+require 'socket'
 
 class HttpInputTest < Test::Unit::TestCase
   def setup
@@ -77,6 +78,39 @@ class HttpInputTest < Test::Unit::TestCase
     events.each { |ev|
       d.expect_emit tag, time, ev
     }
+
+    d.run do
+      res = post("/#{tag}", {"json"=>events.to_json, "time"=>time.to_s})
+      assert_equal "200", res.code
+    end
+
+  end
+
+  def test_json_with_add_remote_addr
+    d = create_driver(CONFIG + "add_remote_addr true")
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+
+    d.expect_emit "tag1", time, {"REMOTE_ADDR"=>"127.0.0.1", "a"=>1}
+    d.expect_emit "tag2", time, {"REMOTE_ADDR"=>"127.0.0.1", "a"=>2}
+
+    d.run do
+      d.expected_emits.each {|tag,time,record|
+        res = post("/#{tag}", {"json"=>record.to_json, "time"=>time.to_s})
+        assert_equal "200", res.code
+      }
+    end
+
+  end
+
+  def test_multi_json_with_add_remote_addr
+    d = create_driver(CONFIG + "add_remote_addr true")
+
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    events = [{"a"=>1},{"a"=>2}]
+    tag = "tag1"
+
+    d.expect_emit "tag1", time, {"REMOTE_ADDR"=>"127.0.0.1", "a"=>1}
+    d.expect_emit "tag1", time, {"REMOTE_ADDR"=>"127.0.0.1", "a"=>2}
 
     d.run do
       res = post("/#{tag}", {"json"=>events.to_json, "time"=>time.to_s})

--- a/test/plugin/test_in_http.rb
+++ b/test/plugin/test_in_http.rb
@@ -1,7 +1,6 @@
 require_relative '../helper'
 require 'fluent/test'
 require 'net/http'
-require 'socket'
 
 class HttpInputTest < Test::Unit::TestCase
   def setup

--- a/test/plugin/test_in_http.rb
+++ b/test/plugin/test_in_http.rb
@@ -98,7 +98,6 @@ class HttpInputTest < Test::Unit::TestCase
     end
 
     d.emit_streams.each { |tag, es|
-      print es
       assert include_http_header?(es.first[1])
     }
   end


### PR DESCRIPTION
This small patch solve bulk request parsing. Previously the code tried to insert a string into a list
which caused "no implicit conversion of String into Integer".