### PR TITLE
Require flexmock/test_unit explicitly for flexmock >= 2.0.0

### DIFF
--- a/test/plugin/test_filter_stdout.rb
+++ b/test/plugin/test_filter_stdout.rb
@@ -1,7 +1,7 @@
 require_relative '../helper'
 require 'fluent/plugin/filter_stdout'
 require 'timecop'
-require 'flexmock'
+require 'flexmock/test_unit'
 
 class StdoutFilterTest < Test::Unit::TestCase
   include Fluent

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -1,7 +1,7 @@
 require_relative '../helper'
 require 'fluent/test'
 require 'net/http'
-require 'flexmock'
+require 'flexmock/test_unit'
 
 class TailInputTest < Test::Unit::TestCase
   include FlexMock::TestCase

--- a/test/test_output.rb
+++ b/test/test_output.rb
@@ -2,7 +2,7 @@ require_relative 'helper'
 require 'fluent/test'
 require 'fluent/output'
 require 'timecop'
-require 'flexmock'
+require 'flexmock/test_unit'
 
 module FluentOutputTest
   include Fluent


### PR DESCRIPTION
In flexmock 2.0.0, `flexmock.rb` doesn't require `flexmock/test_unit_integration`, so we need to require 'flexmock/test_unit' explicitly.
This works well with flexmock < 2.0.0 too. (flexmock 2.0.0 only supports ruby >= 2.0)