### PR TITLE
Log shutdown plugin info to check shutdown sequence

### DIFF
--- a/lib/fluent/agent.rb
+++ b/lib/fluent/agent.rb
@@ -78,6 +78,7 @@ module Fluent
       @started_filters.map { |f|
         Thread.new do
           begin
+            log.info "shutting down filter#{@context.nil? ? '' : " in #{@context}"}", type: Plugin.lookup_name_from_class(f.class), plugin_id: f.plugin_id
             f.shutdown
           rescue => e
             log.warn "unexpected error while shutting down filter plugins", :plugin => f.class, :plugin_id => f.plugin_id, :error_class => e.class, :error => e
@@ -91,6 +92,7 @@ module Fluent
       @started_outputs.map { |o|
         Thread.new do
           begin
+            log.info "shutting down output#{@context.nil? ? '' : " in #{@context}"}", type: Plugin.lookup_name_from_class(o.class), plugin_id: o.plugin_id
             o.shutdown
           rescue => e
             log.warn "unexpected error while shutting down output plugins", :plugin => o.class, :plugin_id => o.plugin_id, :error_class => e.class, :error => e

--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -118,6 +118,7 @@ module Fluent
       @started_inputs.map { |i|
         Thread.new do
           begin
+            log.info "shutting down input", type: Plugin.lookup_name_from_class(i.class), plugin_id: i.plugin_id
             i.shutdown
           rescue => e
             log.warn "unexpected error while shutting down input plugin", :plugin => i.class, :plugin_id => i.plugin_id, :error_class => e.class, :error => e


### PR DESCRIPTION
This helps what the plugin takes time during fluentd shutdown process.

Log example:

```sh
2015-10-27 18:36:52 +0900 [info]: reading config file path="test.conf"
2015-10-27 18:36:52 +0900 [info]: starting fluentd-0.12.16
2015-10-27 18:36:52 +0900 [info]: gem 'fluent-plugin-elasticsearch' version '1.1.0'
2015-10-27 18:36:52 +0900 [info]: gem 'fluentd' version '0.12.16'
2015-10-27 18:36:52 +0900 [info]: adding filter in @FOO pattern="**" type="grep"
2015-10-27 18:36:52 +0900 [info]: adding match in @FOO pattern="foo.**" type="stdout"
2015-10-27 18:36:52 +0900 [info]: adding filter pattern="**" type="record_transformer"
2015-10-27 18:36:52 +0900 [info]: adding match pattern="test.**" type="stdout"
2015-10-27 18:36:52 +0900 [info]: adding source type="forward"
2015-10-27 18:36:52 +0900 [info]: using configuration file: <ROOT>
  <source>
    type forward
    id foo
  </source>
  <filter>
    type record_transformer
  </filter>
  <match test.**>
    type stdout
  </match>
  <label @FOO>
    <filter>
      type grep
    </filter>
    <match foo.**>
      type stdout
    </match>
  </label>
</ROOT>
2015-10-27 18:36:52 +0900 [info]: listening fluent socket on 0.0.0.0:24224
^C2015-10-27 18:36:53 +0900 [info]: shutting down fluentd
2015-10-27 18:36:53 +0900 [info]: shutting down input type="forward" plugin_id="foo"
2015-10-27 18:36:53 +0900 [info]: shutting down filter in @FOO type="grep" plugin_id="object:3fe8b48ffef8"
2015-10-27 18:36:53 +0900 [info]: shutting down output in @FOO type="stdout" plugin_id="object:3fe8b48fbd44"
2015-10-27 18:36:53 +0900 [info]: shutting down filter type="record_transformer" plugin_id="object:3fe8b48f3ec8"
2015-10-27 18:36:53 +0900 [info]: shutting down output type="stdout" plugin_id="object:3fe8b48f2dac"
2015-10-27 18:36:54 +0900 [info]: process finished code=0
```