### PR TITLE
Add Engine#msgpack_factory for v0.14 compatibility

### DIFF
--- a/lib/fluent/buffer.rb
+++ b/lib/fluent/buffer.rb
@@ -112,7 +112,7 @@ module Fluent
 
     def msgpack_each(&block)
       open {|io|
-        u = MessagePack::Unpacker.new(io)
+        u = Fluent::Engine.msgpack_factory.unpacker(io)
         begin
           u.each(&block)
         rescue EOFError

--- a/lib/fluent/command/cat.rb
+++ b/lib/fluent/command/cat.rb
@@ -289,7 +289,7 @@ when 'json'
 
 when 'msgpack'
   begin
-    u = MessagePack::Unpacker.new($stdin)
+    u = Fluent::Engine.msgpack_factory.unpacker($stdin)
     u.each {|record|
       w.write(record)
     }

--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -19,6 +19,16 @@ module Fluent
   require 'fluent/root_agent'
 
   class EngineClass
+    class DummyMessagePackFactory
+      def packer(io = nil)
+        MessagePack::Packer.new(io)
+      end
+
+      def unpacker(io = nil)
+        MessagePack::Unpacker.new(io)
+      end
+    end
+
     def initialize
       @root_agent = nil
       @event_router = nil
@@ -30,6 +40,8 @@ module Fluent
       @log_event_queue = []
 
       @suppress_config_dump = false
+
+      @msgpack_factory = DummyMessagePackFactory.new
     end
 
     MATCH_CACHE_SIZE = 1024
@@ -37,6 +49,7 @@ module Fluent
 
     attr_reader :root_agent
     attr_reader :matches, :sources
+    attr_reader :msgpack_factory
 
     def init(opts = {})
       BasicSocket.do_not_reverse_lookup = true

--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -20,12 +20,12 @@ module Fluent
 
   class EngineClass
     class DummyMessagePackFactory
-      def packer(io = nil)
-        MessagePack::Packer.new(io)
+      def packer(*args)
+        MessagePack::Packer.new(*args)
       end
 
-      def unpacker(io = nil)
-        MessagePack::Unpacker.new(io)
+      def unpacker(*args)
+        MessagePack::Unpacker.new(*args)
       end
     end
 

--- a/lib/fluent/event.rb
+++ b/lib/fluent/event.rb
@@ -27,7 +27,7 @@ module Fluent
     end
 
     def to_msgpack_stream
-      out = MessagePack::Packer.new # MessagePack::Packer is fastest way to serialize events
+      out = Fluent::Engine.msgpack_factory.packer
       each {|time,record|
         out.write([time,record])
       }
@@ -143,7 +143,7 @@ module Fluent
 
     def each(&block)
       # TODO format check
-      unpacker = MessagePack::Unpacker.new
+      unpacker = Fluent::Engine.msgpack_factory.unpacker
       unpacker.feed_each(@data, &block)
       nil
     end

--- a/lib/fluent/plugin/buf_memory.rb
+++ b/lib/fluent/plugin/buf_memory.rb
@@ -57,7 +57,7 @@ module Fluent
 
     # optimize
     def msgpack_each(&block)
-      u = MessagePack::Unpacker.new
+      u = Fluent::Engine.msgpack_factory.unpacker
       u.feed_each(@data, &block)
     end
   end

--- a/lib/fluent/plugin/exec_util.rb
+++ b/lib/fluent/plugin/exec_util.rb
@@ -58,7 +58,7 @@ module Fluent
 
     class MessagePackParser < Parser
       def call(io)
-        @u = MessagePack::Unpacker.new(io)
+        @u = Fluent::Engine.msgpack_factory.unpacker(io)
         begin
           @u.each(&@on_message)
         rescue EOFError

--- a/lib/fluent/plugin/in_forward.rb
+++ b/lib/fluent/plugin/in_forward.rb
@@ -219,7 +219,7 @@ module Fluent
         else
           m = method(:on_read_msgpack)
           @serializer = :to_msgpack.to_proc
-          @u = MessagePack::Unpacker.new
+          @u = Fluent::Engine.msgpack_factory.unpacker
         end
 
         (class << self; self; end).module_eval do

--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -191,7 +191,7 @@ module Fluent
 
     def parse_params_default(params)
       record = if msgpack = params['msgpack']
-                 MessagePack.unpack(msgpack)
+                 Engine.msgpack_factory.unpacker.feed(msgpack).read
                elsif js = params['json']
                  JSON.parse(js)
                else

--- a/lib/fluent/plugin/in_stream.rb
+++ b/lib/fluent/plugin/in_stream.rb
@@ -130,7 +130,7 @@ module Fluent
           @y.on_parse_complete = @on_message
         else
           m = method(:on_read_msgpack)
-          @u = MessagePack::Unpacker.new
+          @u = Fluent::Engine.msgpack_factory.unpacker
         end
 
         (class << self; self; end).module_eval do

--- a/lib/fluent/plugin/out_stream.rb
+++ b/lib/fluent/plugin/out_stream.rb
@@ -65,7 +65,7 @@ module Fluent
         chain = NullOutputChain.instance
         chunk.open {|io|
           # TODO use MessagePackIoEventStream
-          u = MessagePack::Unpacker.new(io)
+          u = Fluent::Engine.msgpack_factory.unpacker(io)
           begin
             u.each {|(tag,entries)|
               es = MultiEventStream.new

--- a/lib/fluent/process.rb
+++ b/lib/fluent/process.rb
@@ -176,7 +176,7 @@ module Fluent
     end
 
     def read_event_stream(r, &block)
-      u = MessagePack::Unpacker.new(r)
+      u = Fluent::Engine.msgpack_factory.unpacker(r)
       begin
         #buf = ''
         #map = {}

--- a/test/plugin/test_in_forward.rb
+++ b/test/plugin/test_in_forward.rb
@@ -59,7 +59,7 @@ class ForwardInputTest < Test::Unit::TestCase
 
     d.run do
       d.expected_emits.each {|tag,time,record|
-        send_data [tag, time, record].to_msgpack
+        send_data Fluent::Engine.msgpack_factory.packer.write([tag, time, record]).to_s
       }
     end
   end
@@ -77,7 +77,7 @@ class ForwardInputTest < Test::Unit::TestCase
       d.expected_emits.each {|tag,time,record|
         entries << [time, record]
       }
-      send_data ["tag1", entries].to_msgpack
+      send_data Fluent::Engine.msgpack_factory.packer.write(["tag1", entries]).to_s
     end
   end
 
@@ -92,9 +92,9 @@ class ForwardInputTest < Test::Unit::TestCase
     d.run do
       entries = ''
       d.expected_emits.each {|tag,time,record|
-        [time, record].to_msgpack(entries)
+        Fluent::Engine.msgpack_factory.packer(entries).write([time, record]).flush
       }
-      send_data ["tag1", entries].to_msgpack
+      send_data Fluent::Engine.msgpack_factory.packer.write(["tag1", entries]).to_s
     end
   end
 
@@ -128,7 +128,7 @@ class ForwardInputTest < Test::Unit::TestCase
     assert chunk.size < (32 * 1024 * 1024)
 
     d.run do
-      MessagePack::Unpacker.new.feed_each(chunk) do |obj|
+      Fluent::Engine.msgpack_factory.unpacker.feed_each(chunk) do |obj|
         d.instance.send(:on_message, obj, chunk.size, "host: 127.0.0.1, addr: 127.0.0.1, port: 0000")
       end
     end
@@ -157,7 +157,7 @@ class ForwardInputTest < Test::Unit::TestCase
     chunk = [ "test.tag", (0...16).map{|i| [time + i, {"data" => str}] } ].to_msgpack
 
     d.run do
-      MessagePack::Unpacker.new.feed_each(chunk) do |obj|
+      Fluent::Engine.msgpack_factory.unpacker.feed_each(chunk) do |obj|
         d.instance.send(:on_message, obj, chunk.size, "host: 127.0.0.1, addr: 127.0.0.1, port: 0000")
       end
     end
@@ -184,7 +184,7 @@ class ForwardInputTest < Test::Unit::TestCase
 
     # d.run => send_data
     d.run do
-      MessagePack::Unpacker.new.feed_each(chunk) do |obj|
+      Fluent::Engine.msgpack_factory.unpacker.feed_each(chunk) do |obj|
         d.instance.send(:on_message, obj, chunk.size, "host: 127.0.0.1, addr: 127.0.0.1, port: 0000")
       end
     end

--- a/test/plugin/test_in_stream.rb
+++ b/test/plugin/test_in_stream.rb
@@ -17,7 +17,7 @@ module StreamInputTest
 
     d.run do
       d.expected_emits.each {|tag,time,record|
-        send_data [tag, 0, record].to_msgpack
+        send_data Fluent::Engine.msgpack_factory.packer.write([tag, 0, record]).to_s
       }
     end
   end
@@ -32,7 +32,7 @@ module StreamInputTest
 
     d.run do
       d.expected_emits.each {|tag,time,record|
-        send_data [tag, time, record].to_msgpack
+        send_data Fluent::Engine.msgpack_factory.packer.write([tag, time, record]).to_s
       }
     end
   end
@@ -50,7 +50,7 @@ module StreamInputTest
       d.expected_emits.each {|tag,time,record|
         entries << [time, record]
       }
-      send_data ["tag1", entries].to_msgpack
+      send_data Fluent::Engine.msgpack_factory.packer.write(["tag1", entries]).to_s
     end
   end
 
@@ -65,9 +65,9 @@ module StreamInputTest
     d.run do
       entries = ''
       d.expected_emits.each {|tag,time,record|
-        [time, record].to_msgpack(entries)
+        Fluent::Engine.msgpack_factory.packer(entries).write([time, record]).flush
       }
-      send_data ["tag1", entries].to_msgpack
+      send_data Fluent::Engine.msgpack_factory.packer.write(["tag1", entries]).to_s
     end
   end
 

--- a/test/plugin/test_out_copy.rb
+++ b/test/plugin/test_out_copy.rb
@@ -86,7 +86,7 @@ class CopyOutputTest < Test::Unit::TestCase
 
     es = if defined?(MessagePack::Packer)
            time = Time.parse("2013-05-26 06:37:22 UTC").to_i
-           packer = MessagePack::Packer.new
+           packer = Fluent::Engine.msgpack_factory.packer
            packer.pack([time, {"a" => 1}])
            packer.pack([time, {"a" => 2}])
            Fluent::MessagePackEventStream.new(packer.to_s)


### PR DESCRIPTION
In v0.14, core and plugin use `Engine#msgpack_factory` for creating MessagePack Packer / Unpacker.
For supporting v0.12 and v0.14 in plugin code, providing same API is better.

Related to https://github.com/fluent/fluentd/pull/653