### PR TITLE
Add descriptions to out_file plugin parameters

### DIFF
--- a/lib/fluent/plugin/out_file.rb
+++ b/lib/fluent/plugin/out_file.rb
@@ -23,11 +23,11 @@ module Fluent
       'gzip' => :gz,
     }
 
-    desc "Specify filepath to output."
+    desc "The Path of the file."
     config_param :path, :string
-    desc "Choose output format. You can choose it from registered formatter plugins."
+    desc "The format of the file content. The default is out_file."
     config_param :format, :string, :default => 'out_file'
-    desc "Disable path increment."
+    desc "The flushed chunk is appended to existence file or not."
     config_param :append, :bool, :default => false
     desc "Compress flushed file."
     config_param :compress, :default => nil do |val|

--- a/lib/fluent/plugin/out_file.rb
+++ b/lib/fluent/plugin/out_file.rb
@@ -29,7 +29,7 @@ module Fluent
     config_param :format, :string, :default => 'out_file'
     desc "Disable path increment."
     config_param :append, :bool, :default => false
-    desc "Compress chunks with specified compression algorithm."
+    desc "Compress flushed file."
     config_param :compress, :default => nil do |val|
       c = SUPPORTED_COMPRESS[val]
       unless c
@@ -37,7 +37,7 @@ module Fluent
       end
       c
     end
-    desc "A parameter is used for pointing to latest written file."
+    desc "Create symlink to temporary buffered file when buffer_type is file."
     config_param :symlink_path, :string, :default => nil
 
     def initialize

--- a/lib/fluent/plugin/out_file.rb
+++ b/lib/fluent/plugin/out_file.rb
@@ -23,9 +23,13 @@ module Fluent
       'gzip' => :gz,
     }
 
+    desc "Specify filepath to output."
     config_param :path, :string
+    desc "Choose output format. You can choose it from registered formatter plugins."
     config_param :format, :string, :default => 'out_file'
+    desc "Disable path increment."
     config_param :append, :bool, :default => false
+    desc "Compress chunks with specified compression algorithm."
     config_param :compress, :default => nil do |val|
       c = SUPPORTED_COMPRESS[val]
       unless c
@@ -33,6 +37,7 @@ module Fluent
       end
       c
     end
+    desc "A parameter is used for pointing to latest written file."
     config_param :symlink_path, :string, :default => nil
 
     def initialize


### PR DESCRIPTION
I tried to add descriptions in out_file plugin.

Related to #584.