### PR TITLE
Add ParserTestDriver

### DIFF
--- a/lib/fluent/test.rb
+++ b/lib/fluent/test.rb
@@ -20,5 +20,6 @@ require 'fluent/test/base'
 require 'fluent/test/input_test'
 require 'fluent/test/output_test'
 require 'fluent/test/filter_test'
+require 'fluent/test/parser_test'
 
 $log ||= Fluent::Log.new(Fluent::Test::DummyLogDevice.new)

--- a/lib/fluent/test/parser_test.rb
+++ b/lib/fluent/test/parser_test.rb
@@ -34,7 +34,7 @@ module Fluent
 
       attr_reader :instance, :config
 
-      def configure(conf, use_v1 = false)
+      def configure(conf)
         if conf.is_a?(Fluent::Config::Element)
           @config = conf
         else

--- a/lib/fluent/test/parser_test.rb
+++ b/lib/fluent/test/parser_test.rb
@@ -17,7 +17,7 @@
 module Fluent
   module Test
     class ParserTestDriver
-      def initialize(klass_or_str, format=nil, conf={},  &block)
+      def initialize(klass_or_str, format=nil, conf={}, &block)
         if klass_or_str.is_a?(Class)
           if block
             # Create new class for test w/ overwritten methods

--- a/lib/fluent/test/parser_test.rb
+++ b/lib/fluent/test/parser_test.rb
@@ -1,0 +1,57 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+module Fluent
+  module Test
+    class ParserTestDriver
+      def initialize(klass, &block)
+        if klass.is_a?(Class)
+          if block
+            # Create new class for test w/ overwritten methods
+            #   klass.dup is worse because its ancestors does NOT include original class name
+            klass = Class.new(klass)
+            klass.module_eval(&block)
+          end
+          @instance = klass.new
+        else
+          @instance = klass
+        end
+        @config = Config.new
+      end
+
+      attr_reader :instance, :config
+
+      def configure(conf, use_v1 = false)
+        if conf.is_a?(Fluent::Config::Element)
+          @config = conf
+        else
+          @config = Config::Element.new('ROOT', '', conf, [])
+        end
+        @instance.configure(@config)
+        self
+      end
+
+      # for existing plugins
+      def call(*a, &b)
+        @instance.call(*a, &b)
+      end
+
+      def parse(text)
+        @instance.parse(text)
+      end
+    end
+  end
+end

--- a/lib/fluent/test/parser_test.rb
+++ b/lib/fluent/test/parser_test.rb
@@ -43,10 +43,16 @@ module Fluent
       attr_reader :instance, :config
 
       def configure(conf)
-        if conf.is_a?(Fluent::Config::Element)
+        case conf
+        when Fluent::Config::Element
           @config = conf
-        else
+        when String
+          io = StringIO.new(conf)
+          @config = Config::Parser.parse(io, 'fluent.conf')
+        when Hash
           @config = Config::Element.new('ROOT', '', conf, [])
+        else
+          raise "Unknown type... #{conf}"
         end
         @instance.configure(@config)
         self

--- a/lib/fluent/test/parser_test.rb
+++ b/lib/fluent/test/parser_test.rb
@@ -44,11 +44,6 @@ module Fluent
         self
       end
 
-      # for existing plugins
-      def call(*a, &b)
-        @instance.call(*a, &b)
-      end
-
       def parse(text)
         @instance.parse(text)
       end

--- a/lib/fluent/test/parser_test.rb
+++ b/lib/fluent/test/parser_test.rb
@@ -17,19 +17,19 @@
 module Fluent
   module Test
     class ParserTestDriver
-      def initialize(klass, &block)
-        if klass.is_a?(Class)
+      def initialize(klass_or_str, &block)
+        if klass_or_str.is_a?(Class)
           if block
             # Create new class for test w/ overwritten methods
             #   klass.dup is worse because its ancestors does NOT include original class name
-            klass = Class.new(klass)
-            klass.module_eval(&block)
+            klass_or_str = Class.new(klass_or_str)
+            klass_or_str.module_eval(&block)
           end
-          @instance = klass.new
-        elsif klass.is_a?(String)
-          @instance = TextParser::TEMPLATE_REGISTRY.lookup(klass).call
+          @instance = klass_or_str.new
+        elsif klass_or_str.is_a?(String)
+          @instance = TextParser::TEMPLATE_REGISTRY.lookup(klass_or_str).call
         else
-          @instance = klass
+          @instance = klass_or_str
         end
         @config = Config.new
       end

--- a/lib/fluent/test/parser_test.rb
+++ b/lib/fluent/test/parser_test.rb
@@ -17,7 +17,7 @@
 module Fluent
   module Test
     class ParserTestDriver
-      def initialize(klass_or_str, format=nil, &block)
+      def initialize(klass_or_str, format=nil, conf={},  &block)
         if klass_or_str.is_a?(Class)
           if block
             # Create new class for test w/ overwritten methods
@@ -27,6 +27,8 @@ module Fluent
               klass_or_str = Class.new(klass_or_str)
             when 1
               klass_or_str = Class.new(klass_or_str, format)
+            when -2
+              klass_or_str = Class.new(klass_or_str, format, conf)
             end
             klass_or_str.module_eval(&block)
           end
@@ -35,6 +37,8 @@ module Fluent
             @instance = klass_or_str.new
           when 1
             @instance = klass_or_str.new(format)
+          when -2
+            @instance = klass_or_str.new(format, conf)
           end
         elsif klass_or_str.is_a?(String)
           @instance = TextParser::TEMPLATE_REGISTRY.lookup(klass_or_str).call

--- a/lib/fluent/test/parser_test.rb
+++ b/lib/fluent/test/parser_test.rb
@@ -22,12 +22,7 @@ module Fluent
           if block
             # Create new class for test w/ overwritten methods
             #   klass.dup is worse because its ancestors does NOT include original class name
-            case klass_or_str.instance_method(:initialize).arity
-            when 0
-              klass_or_str = Class.new(klass_or_str)
-            when -2
-              klass_or_str = Class.new(klass_or_str, format, conf)
-            end
+            klass_or_str = Class.new(klass_or_str)
             klass_or_str.module_eval(&block)
           end
           case klass_or_str.instance_method(:initialize).arity

--- a/lib/fluent/test/parser_test.rb
+++ b/lib/fluent/test/parser_test.rb
@@ -25,8 +25,6 @@ module Fluent
             case klass_or_str.instance_method(:initialize).arity
             when 0
               klass_or_str = Class.new(klass_or_str)
-            when 1
-              klass_or_str = Class.new(klass_or_str, format)
             when -2
               klass_or_str = Class.new(klass_or_str, format, conf)
             end
@@ -35,8 +33,6 @@ module Fluent
           case klass_or_str.instance_method(:initialize).arity
           when 0
             @instance = klass_or_str.new
-          when 1
-            @instance = klass_or_str.new(format)
           when -2
             @instance = klass_or_str.new(format, conf)
           end

--- a/lib/fluent/test/parser_test.rb
+++ b/lib/fluent/test/parser_test.rb
@@ -29,6 +29,7 @@ module Fluent
           when 0
             @instance = klass_or_str.new
           when -2
+            # for RegexpParser
             @instance = klass_or_str.new(format, conf)
           end
         elsif klass_or_str.is_a?(String)

--- a/lib/fluent/test/parser_test.rb
+++ b/lib/fluent/test/parser_test.rb
@@ -44,8 +44,8 @@ module Fluent
         self
       end
 
-      def parse(text)
-        @instance.parse(text)
+      def parse(text, &block)
+        @instance.parse(text, &block)
       end
     end
   end

--- a/lib/fluent/test/parser_test.rb
+++ b/lib/fluent/test/parser_test.rb
@@ -26,6 +26,8 @@ module Fluent
             klass.module_eval(&block)
           end
           @instance = klass.new
+        elsif klass.is_a?(String)
+          @instance = TextParser::TEMPLATE_REGISTRY.lookup(klass).call
         else
           @instance = klass
         end

--- a/lib/fluent/test/parser_test.rb
+++ b/lib/fluent/test/parser_test.rb
@@ -17,15 +17,25 @@
 module Fluent
   module Test
     class ParserTestDriver
-      def initialize(klass_or_str, &block)
+      def initialize(klass_or_str, format=nil, &block)
         if klass_or_str.is_a?(Class)
           if block
             # Create new class for test w/ overwritten methods
             #   klass.dup is worse because its ancestors does NOT include original class name
-            klass_or_str = Class.new(klass_or_str)
+            case klass_or_str.instance_method(:initialize).arity
+            when 0
+              klass_or_str = Class.new(klass_or_str)
+            when 1
+              klass_or_str = Class.new(klass_or_str, format)
+            end
             klass_or_str.module_eval(&block)
           end
-          @instance = klass_or_str.new
+          case klass_or_str.instance_method(:initialize).arity
+          when 0
+            @instance = klass_or_str.new
+          when 1
+            @instance = klass_or_str.new(format)
+          end
         elsif klass_or_str.is_a?(String)
           @instance = TextParser::TEMPLATE_REGISTRY.lookup(klass_or_str).call
         else

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -43,6 +43,33 @@ module ParserTest
     end
   end
 
+  class BaseParserTestWithTestDriver < ::Test::Unit::TestCase
+    include ParserTest
+
+    def create_driver(conf={})
+      Fluent::Test::ParserTestDriver.new(Fluent::Parser).configure(conf)
+    end
+
+    def test_init
+      d = create_driver
+      assert_true d.instance.estimate_current_event
+    end
+
+    def test_parse
+      d = create_driver
+      assert_raise NotImplementedError do
+        d.parse('')
+      end
+    end
+
+    def test_call
+      d = create_driver
+      assert_raise NotImplementedError do
+        d.call('')
+      end
+    end
+  end
+
   class TimeParserTest < ::Test::Unit::TestCase
     include ParserTest
 

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -131,19 +131,19 @@ module ParserTest
     def test_parse_with_configure
       # Specify conf by configure method instaed of intializer
       regexp = Regexp.new(%q!^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] \[(?<date>[^\]]*)\] "(?<flag>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)$!)
-      parser = TextParser::RegexpParser.new(regexp)
+      parser = Fluent::Test::ParserTestDriver.new(TextParser::RegexpParser, regexp)
       parser.configure('time_format'=>"%d/%b/%Y:%H:%M:%S %z", 'types'=>'user:string,date:time:%d/%b/%Y:%H:%M:%S %z,flag:bool,path:array,code:float,size:integer')
       internal_test_case(parser)
-      assert_equal(regexp, parser.patterns['format'])
-      assert_equal("%d/%b/%Y:%H:%M:%S %z", parser.patterns['time_format'])
+      assert_equal(regexp, parser.instance.patterns['format'])
+      assert_equal("%d/%b/%Y:%H:%M:%S %z", parser.instance.patterns['time_format'])
     end
 
     def test_parse_with_typed_and_name_separator
-      internal_test_case(TextParser::RegexpParser.new(Regexp.new(%q!^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] \[(?<date>[^\]]*)\] "(?<flag>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)$!), 'time_format'=>"%d/%b/%Y:%H:%M:%S %z", 'types'=>'user|string,date|time|%d/%b/%Y:%H:%M:%S %z,flag|bool,path|array,code|float,size|integer', 'types_label_delimiter'=>'|'))
+      internal_test_case(Fluent::Test::ParserTestDriver.new(TextParser::RegexpParser, Regexp.new(%q!^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] \[(?<date>[^\]]*)\] "(?<flag>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)$!), 'time_format'=>"%d/%b/%Y:%H:%M:%S %z", 'types'=>'user|string,date|time|%d/%b/%Y:%H:%M:%S %z,flag|bool,path|array,code|float,size|integer', 'types_label_delimiter'=>'|'))
     end
 
     def test_parse_with_time_key
-      parser = TextParser::RegexpParser.new(/(?<logtime>[^\]]*)/)
+      parser = Fluent::Test::ParserTestDriver.new(TextParser::RegexpParser, /(?<logtime>[^\]]*)/)
       parser.configure(
         'time_format'=>"%Y-%m-%d %H:%M:%S %z",
         'time_key'=>'logtime',
@@ -168,9 +168,9 @@ module ParserTest
         assert_equal 34, record["age"]
       }
 
-      parser2 = TextParser::RegexpParser.new(Regexp.new(%q!^(?<name>[^ ]*) (?<user>[^ ]*) (?<age>\d*)$!))
+      parser2 = Fluent::Test::ParserTestDriver.new(TextParser::RegexpParser, Regexp.new(%q!^(?<name>[^ ]*) (?<user>[^ ]*) (?<age>\d*)$!))
       parser2.configure('types'=>'name:string,user:string,age:integer')
-      parser2.estimate_current_event = false
+      parser2.instance.estimate_current_event = false
 
       parser2.parse(text) { |time, record|
         assert_equal "tagomori_satoshi", record["name"]
@@ -182,7 +182,7 @@ module ParserTest
     end
 
     def test_parse_with_keep_time_key
-      parser = TextParser::RegexpParser.new(
+      parser = Fluent::Test::ParserTestDriver.new(TextParser::RegexpParser,
         Regexp.new(%q!(?<time>.*)!),
         'time_format'=>"%d/%b/%Y:%H:%M:%S %z",
         'keep_time_key'=>'true',
@@ -194,7 +194,7 @@ module ParserTest
     end
 
     def test_parse_with_keep_time_key_with_typecast
-      parser = TextParser::RegexpParser.new(
+      parser = Fluent::Test::ParserTestDriver.new(TextParser::RegexpParser,
         Regexp.new(%q!(?<time>.*)!),
         'time_format'=>"%d/%b/%Y:%H:%M:%S %z",
         'keep_time_key'=>'true',

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -55,6 +55,11 @@ module ParserTest
       assert_true d.instance.estimate_current_event
     end
 
+    def test_configure_against_string_literal
+      d = create_driver('keep_time_key true')
+      assert_true d.instance.keep_time_key
+    end
+
     def test_parse
       d = create_driver
       assert_raise NotImplementedError do

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -61,13 +61,6 @@ module ParserTest
         d.parse('')
       end
     end
-
-    def test_call
-      d = create_driver
-      assert_raise NotImplementedError do
-        d.call('')
-      end
-    end
   end
 
   class TimeParserTest < ::Test::Unit::TestCase

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -318,7 +318,7 @@ module ParserTest
     include ParserTest
 
     def setup
-      @parser = TextParser::TEMPLATE_REGISTRY.lookup('syslog').call
+      @parser = Fluent::Test::ParserTestDriver.new('syslog')
       @expected = {
         'host'    => '192.168.0.1',
         'ident'   => 'fluentd',
@@ -333,8 +333,8 @@ module ParserTest
         assert_equal(str2time('Feb 28 12:00:00', '%b %d %H:%M:%S'), time)
         assert_equal(@expected, record)
       }
-      assert_equal(TextParser::SyslogParser::REGEXP, @parser.patterns['format'])
-      assert_equal("%b %d %H:%M:%S", @parser.patterns['time_format'])
+      assert_equal(TextParser::SyslogParser::REGEXP, @parser.instance.patterns['format'])
+      assert_equal("%b %d %H:%M:%S", @parser.instance.patterns['time_format'])
     end
 
     def test_parse_with_time_format
@@ -343,7 +343,7 @@ module ParserTest
         assert_equal(str2time('Feb 28 12:00:00', '%b %d %H:%M:%S'), time)
         assert_equal(@expected, record)
       }
-      assert_equal('%b %d %M:%S:%H', @parser.patterns['time_format'])
+      assert_equal('%b %d %M:%S:%H', @parser.instance.patterns['time_format'])
     end
 
     def test_parse_with_priority
@@ -352,8 +352,8 @@ module ParserTest
         assert_equal(str2time('Feb 28 12:00:00', '%b %d %H:%M:%S'), time)
         assert_equal(@expected.merge('pri' => 6), record)
       }
-      assert_equal(TextParser::SyslogParser::REGEXP_WITH_PRI, @parser.patterns['format'])
-      assert_equal("%b %d %H:%M:%S", @parser.patterns['time_format'])
+      assert_equal(TextParser::SyslogParser::REGEXP_WITH_PRI, @parser.instance.patterns['format'])
+      assert_equal("%b %d %H:%M:%S", @parser.instance.patterns['time_format'])
     end
 
     def test_parse_without_colon
@@ -362,8 +362,8 @@ module ParserTest
         assert_equal(str2time('Feb 28 12:00:00', '%b %d %H:%M:%S'), time)
         assert_equal(@expected, record)
       }
-      assert_equal(TextParser::SyslogParser::REGEXP, @parser.patterns['format'])
-      assert_equal("%b %d %H:%M:%S", @parser.patterns['time_format'])
+      assert_equal(TextParser::SyslogParser::REGEXP, @parser.instance.patterns['format'])
+      assert_equal("%b %d %H:%M:%S", @parser.instance.patterns['time_format'])
     end
 
     def test_parse_with_keep_time_key


### PR DESCRIPTION
Currently, fluentd does not have `ParserTestDriver`.
This PR adds this test driver.

### Remaining tasks

- [x] Frozen ParserTestDriver API
  - [x] ~~Decide whether to include utility methods such as `str2time` or not.~~
- [x] Replace a few parser test cases with `ParserTestDriver`
- [ ] Documentations?