### PR TITLE
out_forward raises ZeroDivisionError when no <server> is available

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -129,6 +129,10 @@ module Fluent
         end
         log.info "adding forwarding server '#{name}'", :host=>host, :port=>port, :weight=>weight, :plugin_id=>plugin_id
       }
+
+      if @nodes.empty?
+        raise ConfigError, "forward output plugin requires at least one <server> is required"
+      end
     end
 
     def start

--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -78,6 +78,12 @@ class ForwardOutputTest < Test::Unit::TestCase
     assert_equal true, d.instance.nodes.first.conf.dns_round_robin
   end
 
+  def test_configure_no_server
+    assert_raise(Fluent::ConfigError, 'forward output plugin requires at least one <server> is required') do
+      create_driver('')
+    end
+  end
+
   def test_phi_failure_detector
     d = create_driver(CONFIG + %[phi_failure_detector false \n phi_threshold 0])
     node = d.instance.nodes.first


### PR DESCRIPTION
When no <server> is set to out_forward plugin,
`Fluent::ForwardOutput#rebuild_weight_array` raises ZeroDivisionError
at `coe = (regular_nodes.size * 6) / weight_array.size`. This change
gives more useful error message to uses instead of unfriendly
ZeroDivisionError message.