### PR TITLE
Add process_name parameter in system to change fluentd's process name

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -121,6 +121,7 @@ module Fluent
       @chgroup = opt[:chgroup]
       @chuser = opt[:chuser]
       @rpc_server = nil
+      @process_name = nil
 
       @log_level = opt[:log_level]
       @suppress_interval = opt[:suppress_interval]
@@ -325,6 +326,7 @@ module Fluent
     def supervise(&block)
       start_time = Time.now
 
+      Process.setproctitle("supervisor:#{@process_name}") if @process_name
       $log.info "starting fluentd-#{Fluent::VERSION}"
 
       if !Fluent.windows?
@@ -371,6 +373,8 @@ module Fluent
     end
 
     def main_process(&block)
+      Process.setproctitle("worker:#{@process_name}") if @process_name
+
       begin
         block.call
         if Fluent.windows?
@@ -514,6 +518,7 @@ module Fluent
       config_param :without_source, :bool, :default => nil
       config_param :rpc_endpoint, :string, :default => nil
       config_param :enable_get_dump, :bool, :default => nil
+      config_param :process_name, :default => nil
 
       def initialize(conf)
         super()
@@ -530,6 +535,7 @@ module Fluent
           @without_source = system.without_source unless system.without_source.nil?
           @rpc_endpoint = system.rpc_endpoint unless system.rpc_endpoint.nil?
           @enable_get_dump = system.enable_get_dump unless system.enable_get_dump.nil?
+          @process_name = system.process_name unless system.process_name.nil?
         }
       end
     end


### PR DESCRIPTION
Like https://github.com/cubicdaiya/fluent-plugin-setproctitle plugin.
Set `process_name`,

```aconf
<system>
  process_name foo
</system>
```

ps result is below.

```
% ps aux | grep foo
repeatedly      45673   0.4  0.2  2523252  38620 s001  S+    7:04AM   0:00.44 worker:foo
repeatedly      45647   0.0  0.1  2481260  23700 s001  S+    7:04AM   0:00.40 supervisor:foo
```
