### PR TITLE
Add chunk_key_type option with buffered_time support for TimeSlicedOutput

### DIFF
--- a/test/test_output.rb
+++ b/test/test_output.rb
@@ -266,5 +266,56 @@ module FluentOutputTest
         10.times { sleep 0.05 }
       end
     end
+
+    sub_test_case "test_chunk_key_type" do
+      setup do
+        @event_time    = Time.parse("2010-01-02 13:14:15 UTC")
+        @buffered_time = Time.parse("2011-01-02 13:14:15 UTC")
+        Timecop.freeze(@buffered_time)
+        @es = OneEventStream.new(@event_time.to_i, {"message" => "foo"})
+      end
+
+      teardown do
+        Timecop.return
+      end
+
+      test "chunk_key_type configure" do
+        assert_raise(ConfigError) do
+          d = create_driver(CONFIG + %[
+            chunk_key_type something_wrong
+            time_slice_format %Y%m%d%H%M%S
+            buffer_path #{TMP_DIR}/foo
+          ])
+        end
+      end
+
+      test "chunk_key_type event_time" do
+        d = create_driver(CONFIG + %[
+          chunk_key_type event_time
+          time_slice_format %Y%m%d%H%M%S
+          buffer_path #{TMP_DIR}/foo
+          utc true
+        ])
+        d.instance.start
+        d.instance.emit('test', @es, NullOutputChain.instance)
+        chunk_key = d.instance.instance_variable_get(:@buffer).keys.first
+        assert { @event_time.strftime("%Y%m%d%H%M%S") == chunk_key }
+        d.instance.shutdown
+      end
+
+      test "chunk_key_type buffered_time" do
+        d = create_driver(CONFIG + %[
+          chunk_key_type buffered_time
+          time_slice_format %Y%m%d%H%M%S
+          buffer_path #{TMP_DIR}/foo
+          utc true
+        ])
+        d.instance.start
+        d.instance.emit('test', @es, NullOutputChain.instance)
+        chunk_key = d.instance.instance_variable_get(:@buffer).keys.first
+        assert { @buffered_time.strftime("%Y%m%d%H%M%S") == chunk_key }
+        d.instance.shutdown
+      end
+    end
   end
 end

--- a/test/test_output.rb
+++ b/test/test_output.rb
@@ -287,6 +287,15 @@ module FluentOutputTest
             buffer_path #{TMP_DIR}/foo
           ])
         end
+
+        # need to override `support_chunk_key_type_buffered_time?` to return true
+        assert_raise(ConfigError) do
+          d = create_driver(CONFIG + %[
+            chunk_key_type buffered_time
+            time_slice_format %Y%m%d%H%M%S
+            buffer_path #{TMP_DIR}/foo
+          ])
+        end
       end
 
       test "chunk_key_type event_time" do
@@ -304,6 +313,7 @@ module FluentOutputTest
       end
 
       test "chunk_key_type buffered_time" do
+        stub(TimeSlicedOutput).support_chunk_key_type_buffered_time? { true }
         d = create_driver(CONFIG + %[
           chunk_key_type buffered_time
           time_slice_format %Y%m%d%H%M%S


### PR DESCRIPTION
Originally, chunk keys of TimeSlicedOutput are generated based on event times.
This option allows us to genearte chunk keys based on buffering time,
i.e., TimeSlicedOutput#emit.

USE CASE:
1) fluent-plugin-s3

out_s3 allows us to use chunk key for s3 object path. But, with event-time
based chunk keys, out_s3 would put objects to old dated directories if
dalayed events arrive. This makes us difficult to decide when we should collect
s3 objects from a dated directory.

With `chunk_key_type buffered_time`, chunk keys are generated based on
buffering time (that is, TimeSlicedOutput#emit). This assures out_s3
does not put objects to old dated directories, thus, we can easily
decide when we should collect s3 objects.

cf. https://twitter.com/sonots/status/667568964575236096