### PR TITLE
Add descriptions to in_http

### DIFF
--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -46,6 +46,7 @@ module Fluent
     desc 'The format of the HTTP body.'
     config_param :format, :string, :default => 'default'
     config_param :blocking_timeout, :time, :default => 0.5
+    desc 'Set a white list of domains that can do CORS (Cross-Origin Resource Sharing)'
     config_param :cors_allow_origins, :array, :default => nil
     desc 'Respond with empty gif image of 1x1 pixel.'
     config_param :respond_with_empty_img, :bool, :default => false

--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -30,16 +30,24 @@ module Fluent
 
     EMPTY_GIF_IMAGE = "GIF89a\u0001\u0000\u0001\u0000\x80\xFF\u0000\xFF\xFF\xFF\u0000\u0000\u0000,\u0000\u0000\u0000\u0000\u0001\u0000\u0001\u0000\u0000\u0002\u0002D\u0001\u0000;".force_encoding("UTF-8")
 
+    desc 'The port to listen to.'
     config_param :port, :integer, :default => 9880
+    desc 'The bind address to listen to.'
     config_param :bind, :string, :default => '0.0.0.0'
+    desc 'The size limit of the POSTed element. Default is 32MB.'
     config_param :body_size_limit, :size, :default => 32*1024*1024  # TODO default
+    desc 'The timeout limit for keeping the connection alive.'
     config_param :keepalive_timeout, :time, :default => 10   # TODO default
     config_param :backlog, :integer, :default => nil
+    desc 'Add HTTP_ prefix headers to the record.'
     config_param :add_http_headers, :bool, :default => false
+    desc 'Add REMOTE_ADDR header to the record.'
     config_param :add_remote_addr, :bool, :default => false
+    desc 'The format of the HTTP body.'
     config_param :format, :string, :default => 'default'
     config_param :blocking_timeout, :time, :default => 0.5
     config_param :cors_allow_origins, :array, :default => nil
+    desc 'Respond with empty gif image of 1x1 pixel.'
     config_param :respond_with_empty_img, :bool, :default => false
 
     def configure(conf)


### PR DESCRIPTION
See http://docs.fluentd.org/articles/in_http

I cannot describe some options:

  * backlog
  * blocking_timeout
  * cors_allow_origins