### PR TITLE
Add descriptions to Fluent::SocketUtil::BaseInput

### DIFF
--- a/lib/fluent/plugin/socket_util.rb
+++ b/lib/fluent/plugin/socket_util.rb
@@ -94,10 +94,15 @@ module Fluent
         require 'fluent/parser'
       end
 
+      desc 'Tag of output events.'
       config_param :tag, :string
+      desc 'The format of the payload.'
       config_param :format, :string
+      desc 'The port to listen to.'
       config_param :port, :integer, :default => 5150
+      desc 'The bind address to listen to.'
       config_param :bind, :string, :default => '0.0.0.0'
+      desc "The field name of the client's hostname."
       config_param :source_host_key, :string, :default => nil
       config_param :blocking_timeout, :time, :default => 0.5
 


### PR DESCRIPTION
See followings:

  * http://docs.fluentd.org/articles/in_tcp
  * http://docs.fluentd.org/articles/in_udp

I cannot find description for `blocking_timeout`