### PR TITLE
in_tail: expand_paths exclude unreadable files

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -131,7 +131,7 @@ module Fluent
         if File.readable?(path)
           true
         else
-          $log.warn "#{path} unreadable. It is excluded and would be examined next time."
+          log.warn "#{path} unreadable. It is excluded and would be examined next time."
           false
         end
       }

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -120,21 +120,20 @@ module Fluent
       @paths.each { |path|
         path = date.strftime(path)
         if path.include?('*')
-          paths += Dir.glob(path)
+          paths += Dir.glob(path).select { |p|
+            if File.readable?(p)
+              true
+            else
+              log.warn "#{p} unreadable. It is excluded and would be examined next time."
+              false
+            end
+          }
         else
           # When file is not created yet, Dir.glob returns an empty array. So just add when path is static.
           paths << path
         end
       }
-
-      (paths - excluded).select { |path|
-        if File.readable?(path)
-          true
-        else
-          log.warn "#{path} unreadable. It is excluded and would be examined next time."
-          false
-        end
-      }
+      paths - excluded
     end
 
     # in_tail with '*' path doesn't check rotation file equality at refresh phase.

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -126,7 +126,15 @@ module Fluent
           paths << path
         end
       }
-      paths - excluded
+
+      (paths - excluded).select { |path|
+        if File.readable?(path)
+          true
+        else
+          $log.warn "#{path} unreadable. It is excluded and would be examined next time."
+          false
+        end
+      }
     end
 
     # in_tail with '*' path doesn't check rotation file equality at refresh phase.


### PR DESCRIPTION
This is to avoid generating too many error messages from file's watcher
(which runs every second.) Each unreadable file will cause a warning.
If it becomes readable, it would be included in the next turn.

See also `refresh_interval` and #726.