### PR TITLE
standardize logging level for source configs

### DIFF
--- a/lib/fluent/plugin/in_stream.rb
+++ b/lib/fluent/plugin/in_stream.rb
@@ -179,7 +179,7 @@ module Fluent
         File.unlink(@path)
       end
       FileUtils.mkdir_p File.dirname(@path)
-      log.debug "listening fluent socket on #{@path}"
+      log.info "listening fluent socket on #{@path}"
       s = Coolio::UNIXServer.new(@path, Handler, log, method(:on_message))
       s.listen(@backlog) unless @backlog.nil?
       s

--- a/lib/fluent/plugin/in_syslog.rb
+++ b/lib/fluent/plugin/in_syslog.rb
@@ -173,7 +173,7 @@ module Fluent
     private
 
     def listen(callback)
-      log.debug "listening syslog socket on #{@bind}:#{@port} with #{@protocol_type}"
+      log.info "listening syslog socket on #{@bind}:#{@port} with #{@protocol_type}"
       if @protocol_type == :udp
         @usock = SocketUtil.create_udp_socket(@bind)
         @usock.bind(@bind, @port)

--- a/lib/fluent/plugin/in_tcp.rb
+++ b/lib/fluent/plugin/in_tcp.rb
@@ -25,7 +25,7 @@ module Fluent
     config_param :delimiter, :string, :default => "\n" # syslog family add "\n" to each message and this seems only way to split messages in tcp stream
 
     def listen(callback)
-      log.debug "listening tcp socket on #{@bind}:#{@port}"
+      log.info "listening tcp socket on #{@bind}:#{@port}"
       Coolio::TCPServer.new(@bind, @port, SocketUtil::TcpHandler, log, @delimiter, callback)
     end
   end

--- a/lib/fluent/plugin/in_udp.rb
+++ b/lib/fluent/plugin/in_udp.rb
@@ -24,7 +24,7 @@ module Fluent
     config_param :body_size_limit, :size, :default => 4096
 
     def listen(callback)
-      log.debug "listening udp socket on #{@bind}:#{@port}"
+      log.info "listening udp socket on #{@bind}:#{@port}"
       @usock = SocketUtil.create_udp_socket(@bind)
       @usock.bind(@bind, @port)
       SocketUtil::UdpHandler.new(@usock, log, @body_size_limit, callback)


### PR DESCRIPTION
I've found the in_forward standard of logging, at startup, where it is
expecting incoming msgs to be very helpful.