### PR TITLE
Use 'oj' for performance improvement when oj is installed

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -43,4 +43,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("timecop", [">= 0.3.0"])
   gem.add_development_dependency("test-unit", ["~> 3.1.4"])
   gem.add_development_dependency("test-unit-rr", ["~> 1.0.3"])
+  gem.add_development_dependency("oj", ["~> 2.14"])
 end

--- a/lib/fluent/formatter.rb
+++ b/lib/fluent/formatter.rb
@@ -139,6 +139,7 @@ module Fluent
         begin
           raise LoadError unless @json_parser == 'oj'
           require 'oj'
+          Oj.default_options = {:mode => :compat}
           @dump_proc = Oj.method(:dump)
         rescue LoadError
           @dump_proc = Yajl.method(:dump)

--- a/lib/fluent/formatter.rb
+++ b/lib/fluent/formatter.rb
@@ -131,13 +131,13 @@ module Fluent
       include HandleTagAndTimeMixin
       include StructuredFormatMixin
 
-      config_param :disable_oj, :bool, :default => false
+      config_param :json_parser, :string, :default => 'oj'
 
       def configure(conf)
         super
 
         begin
-          raise LoadError if @disable_oj
+          raise LoadError unless @json_parser == 'oj'
           require 'oj'
           @dump_proc = Oj.method(:dump)
         rescue LoadError

--- a/lib/fluent/formatter.rb
+++ b/lib/fluent/formatter.rb
@@ -131,8 +131,19 @@ module Fluent
       include HandleTagAndTimeMixin
       include StructuredFormatMixin
 
+      def configure(conf)
+        super
+
+        begin
+          require 'oj'
+          @dump_proc = Oj.method(:dump)
+        rescue LoadError
+          @dump_proc = Yajl.method(:dump)
+        end
+      end
+
       def format_record(record)
-        "#{Yajl.dump(record)}\n"
+        "#{@dump_proc.call(record)}\n"
       end
     end
 

--- a/lib/fluent/formatter.rb
+++ b/lib/fluent/formatter.rb
@@ -131,10 +131,13 @@ module Fluent
       include HandleTagAndTimeMixin
       include StructuredFormatMixin
 
+      config_param :disable_oj, :bool, :default => false
+
       def configure(conf)
         super
 
         begin
+          raise LoadError if @disable_oj
           require 'oj'
           @dump_proc = Oj.method(:dump)
         rescue LoadError

--- a/lib/fluent/parser.rb
+++ b/lib/fluent/parser.rb
@@ -235,7 +235,7 @@ module Fluent
     class JSONParser < Parser
       config_param :time_key, :string, :default => 'time'
       config_param :time_format, :string, :default => nil
-      config_param :disable_oj, :bool, :default => false
+      config_param :json_parser, :string, :default => 'oj'
 
       def configure(conf)
         super
@@ -246,7 +246,7 @@ module Fluent
         end
 
         begin
-          raise LoadError if @disable_oj
+          raise LoadError unless @json_parser == 'oj'
           require 'oj'
           @load_proc = Oj.method(:load)
           @error_class = Oj::ParseError

--- a/lib/fluent/parser.rb
+++ b/lib/fluent/parser.rb
@@ -235,6 +235,7 @@ module Fluent
     class JSONParser < Parser
       config_param :time_key, :string, :default => 'time'
       config_param :time_format, :string, :default => nil
+      config_param :disable_oj, :bool, :default => false
 
       def configure(conf)
         super
@@ -245,6 +246,7 @@ module Fluent
         end
 
         begin
+          raise LoadError if @disable_oj
           require 'oj'
           @load_proc = Oj.method(:load)
           @error_class = Oj::ParseError

--- a/lib/fluent/test/formatter_test.rb
+++ b/lib/fluent/test/formatter_test.rb
@@ -16,6 +16,8 @@
 
 module Fluent
   module Test
+    require 'fluent/config'
+
     class FormatterTestDriver
       def initialize(klass_or_str, proc=nil, &block)
         if klass_or_str.is_a?(Class)
@@ -41,8 +43,7 @@ module Fluent
         when Fluent::Config::Element
           @config = conf
         when String
-          io = StringIO.new(conf)
-          @config = Config::Parser.parse(io, 'fluent.conf')
+          @config = Config.parse(conf, 'fluent.conf')
         when Hash
           @config = Config::Element.new('ROOT', '', conf, [])
         else

--- a/lib/fluent/test/parser_test.rb
+++ b/lib/fluent/test/parser_test.rb
@@ -16,6 +16,8 @@
 
 module Fluent
   module Test
+    require 'fluent/config'
+
     class ParserTestDriver
       def initialize(klass_or_str, format=nil, conf={}, &block)
         if klass_or_str.is_a?(Class)
@@ -47,8 +49,7 @@ module Fluent
         when Fluent::Config::Element
           @config = conf
         when String
-          io = StringIO.new(conf)
-          @config = Config::Parser.parse(io, 'fluent.conf')
+          @config = Config.parse(conf, 'fluent.conf')
         when Hash
           @config = Config::Element.new('ROOT', '', conf, [])
         else

--- a/test/test_formatter.rb
+++ b/test/test_formatter.rb
@@ -130,15 +130,17 @@ module FormatterTest
       @time = Engine.now
     end
 
-    def test_format
-      @formatter.configure({})
+    data('oj' => 'oj', 'yajl' => 'yajl')
+    def test_format(data)
+      @formatter.configure('json_parser' => data)
       formatted = @formatter.format(tag, @time, record)
 
       assert_equal("#{Yajl.dump(record)}\n", formatted)
     end
 
-    def test_format_with_include_tag
-      @formatter.configure('include_tag_key' => 'true', 'tag_key' => 'foo')
+    data('oj' => 'oj', 'yajl' => 'yajl')
+    def test_format_with_include_tag(data)
+      @formatter.configure('include_tag_key' => 'true', 'tag_key' => 'foo', 'json_parser' => data)
       formatted = @formatter.format(tag, @time, record.dup)
 
       r = record
@@ -146,8 +148,9 @@ module FormatterTest
       assert_equal("#{Yajl.dump(r)}\n", formatted)
     end
 
-    def test_format_with_include_time
-      @formatter.configure('include_time_key' => 'true', 'localtime' => '')
+    data('oj' => 'oj', 'yajl' => 'yajl')
+    def test_format_with_include_time(data)
+      @formatter.configure('include_time_key' => 'true', 'localtime' => '', 'json_parser' => data)
       formatted = @formatter.format(tag, @time, record.dup)
 
       r = record
@@ -155,8 +158,9 @@ module FormatterTest
       assert_equal("#{Yajl.dump(r)}\n", formatted)
     end
 
-    def test_format_with_include_time_as_number
-      @formatter.configure('include_time_key' => 'true', 'time_as_epoch' => 'true', 'time_key' => 'epoch')
+    data('oj' => 'oj', 'yajl' => 'yajl')
+    def test_format_with_include_time_as_number(data)
+      @formatter.configure('include_time_key' => 'true', 'time_as_epoch' => 'true', 'time_key' => 'epoch', 'json_parser' => data)
       formatted = @formatter.format(tag, @time, record.dup)
 
       r = record

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -388,10 +388,11 @@ module ParserTest
 
     def setup
       @parser = TextParser::JSONParser.new
-      @parser.configure({})
     end
 
-    def test_parse
+    data('oj' => 'oj', 'yajl' => 'yajl')
+    def test_parse(data)
+      @parser.configure('json_parser' => data)
       @parser.parse('{"time":1362020400,"host":"192.168.0.1","size":777,"method":"PUT"}') { |time, record|
         assert_equal(str2time('2013-02-28 12:00:00 +0900').to_i, time)
         assert_equal({
@@ -402,9 +403,11 @@ module ParserTest
       }
     end
 
-    def test_parse_without_time
+    data('oj' => 'oj', 'yajl' => 'yajl')
+    def test_parse_without_time(data)
       time_at_start = Time.now.to_i
 
+      @parser.configure('json_parser' => data)
       @parser.parse('{"host":"192.168.0.1","size":777,"method":"PUT"}') { |time, record|
         assert time && time >= time_at_start, "parser puts current time without time input"
         assert_equal({
@@ -416,7 +419,7 @@ module ParserTest
 
       parser = TextParser::JSONParser.new
       parser.estimate_current_event = false
-      parser.configure({})
+      parser.configure('json_parser' => data)
       parser.parse('{"host":"192.168.0.1","size":777,"method":"PUT"}') { |time, record|
         assert_equal({
           'host'   => '192.168.0.1',
@@ -427,15 +430,18 @@ module ParserTest
       }
     end
 
-    def test_parse_with_invalid_time
+    data('oj' => 'oj', 'yajl' => 'yajl')
+    def test_parse_with_invalid_time(data)
+      @parser.configure('json_parser' => data)
       assert_raise Fluent::ParserError do
         @parser.parse('{"time":[],"k":"v"}') { |time, record| }
       end
     end
 
-    def test_parse_float_time
+    data('oj' => 'oj', 'yajl' => 'yajl')
+    def test_parse_float_time(data)
       parser = TextParser::JSONParser.new
-      parser.configure({})
+      parser.configure('json_parser' => data)
       format = "%d/%b/%Y:%H:%M:%S %z"
       text = "100.1"
       parser.parse("{\"time\":\"#{text}\"}") do |time, record|
@@ -444,12 +450,14 @@ module ParserTest
       end
     end
 
-    def test_parse_with_keep_time_key
+    data('oj' => 'oj', 'yajl' => 'yajl')
+    def test_parse_with_keep_time_key(data)
       parser = TextParser::JSONParser.new
       format = "%d/%b/%Y:%H:%M:%S %z"
       parser.configure(
-        'time_format'=>format,
-        'keep_time_key'=>'true',
+        'time_format' => format,
+        'keep_time_key' => 'true',
+        'json_parser' => data
       )
       text = "28/Feb/2013:12:00:00 +0900"
       parser.parse("{\"time\":\"#{text}\"}") do |time, record|
@@ -458,10 +466,12 @@ module ParserTest
       end
     end
 
-    def test_parse_with_keep_time_key_without_time_format
+    data('oj' => 'oj', 'yajl' => 'yajl')
+    def test_parse_with_keep_time_key_without_time_format(data)
       parser = TextParser::JSONParser.new
       parser.configure(
-        'keep_time_key'=>'true',
+        'keep_time_key' => 'true',
+        'json_parser' => data
       )
       text = "100"
       parser.parse("{\"time\":\"#{text}\"}") do |time, record|

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -388,6 +388,7 @@ module ParserTest
 
     def setup
       @parser = TextParser::JSONParser.new
+      @parser.configure({})
     end
 
     def test_parse
@@ -434,6 +435,7 @@ module ParserTest
 
     def test_parse_float_time
       parser = TextParser::JSONParser.new
+      parser.configure({})
       format = "%d/%b/%Y:%H:%M:%S %z"
       text = "100.1"
       parser.parse("{\"time\":\"#{text}\"}") do |time, record|


### PR DESCRIPTION
oj is faster json library and it improves `JSONParser` performance.
I tested in_tail with following json.

```js
{"_id":"5671172e7ba230441460f011","index":0,"guid":"3d18838a-ae85-4986-83c7-e4a4acdd7f01","isActive":false,"balance":"$3,929.20","picture":"http://placehold.it/32x32","age":40,"eyeColor":"green","company":"MEDMEX","email":"hardin.sargent@medmex.org","phone":"+1 (865) 468-2885","address":"302 Buffalo Avenue, Bend, Louisiana, 635","latitude":"89.385551","longitude":"75.132185","greeting":"Hello, Hardin! You have 5 unread messages.","favoriteFruit":"banana"}
```

Result is

- Yajl

```
2015-12-16 18:23:37 +0900 [info]: following tail of /Users/repeatedly/tmp/fluentd/json.log
2015-12-16 18:23:38 +0900 [info]: plugin:out_flowcounter_simple count:2003      indicator:num   unit:second
2015-12-16 18:23:39 +0900 [info]: plugin:out_flowcounter_simple count:21037     indicator:num   unit:second
2015-12-16 18:23:40 +0900 [info]: plugin:out_flowcounter_simple count:19033     indicator:num   unit:second
2015-12-16 18:23:41 +0900 [info]: plugin:out_flowcounter_simple count:20034     indicator:num   unit:second
2015-12-16 18:23:42 +0900 [info]: plugin:out_flowcounter_simple count:19033     indicator:num   unit:second
2015-12-16 18:23:43 +0900 [info]: plugin:out_flowcounter_simple count:21037     indicator:num   unit:second
2015-12-16 18:23:44 +0900 [info]: plugin:out_flowcounter_simple count:18031     indicator:num   unit:second
2015-12-16 18:23:45 +0900 [info]: plugin:out_flowcounter_simple count:20035     indicator:num   unit:second
2015-12-16 18:23:46 +0900 [info]: plugin:out_flowcounter_simple count:19033     indicator:num   unit:second
2015-12-16 18:23:47 +0900 [info]: plugin:out_flowcounter_simple count:20035     indicator:num   unit:second
2015-12-16 18:23:48 +0900 [info]: plugin:out_flowcounter_simple count:20035     indicator:num   unit:second
2015-12-16 18:23:49 +0900 [info]: plugin:out_flowcounter_simple count:20034     indicator:num   unit:second
2015-12-16 18:23:50 +0900 [info]: plugin:out_flowcounter_simple count:19033     indicator:num   unit:second
2015-12-16 18:23:51 +0900 [info]: plugin:out_flowcounter_simple count:20035     indicator:num   unit:second
2015-12-16 18:23:52 +0900 [info]: plugin:out_flowcounter_simple count:19033     indicator:num   unit:second
2015-12-16 18:23:53 +0900 [info]: plugin:out_flowcounter_simple count:20035     indicator:num   unit:second
2015-12-16 18:23:54 +0900 [info]: plugin:out_flowcounter_simple count:21037     indicator:num   unit:second
2015-12-16 18:23:55 +0900 [info]: plugin:out_flowcounter_simple count:19033     indicator:num   unit:second
2015-12-16 18:23:56 +0900 [info]: plugin:out_flowcounter_simple count:19033     indicator:num   unit:second
2015-12-16 18:23:57 +0900 [info]: plugin:out_flowcounter_simple count:18031     indicator:num   unit:second
2015-12-16 18:23:58 +0900 [info]: plugin:out_flowcounter_simple count:20035     indicator:num   unit:second
2015-12-16 18:23:59 +0900 [info]: plugin:out_flowcounter_simple count:21036     indicator:num   unit:second
2015-12-16 18:24:00 +0900 [info]: plugin:out_flowcounter_simple count:18032     indicator:num   unit:second
2015-12-16 18:24:01 +0900 [info]: plugin:out_flowcounter_simple count:20034     indicator:num   unit:second
2015-12-16 18:24:02 +0900 [info]: plugin:out_flowcounter_simple count:18032     indicator:num   unit:second
```

- Oj

```
2015-12-16 18:25:09 +0900 [info]: following tail of /Users/repeatedly/tmp/fluentd/json.log
2015-12-16 18:25:10 +0900 [info]: plugin:out_flowcounter_simple count:19033     indicator:num   unit:second
2015-12-16 18:25:11 +0900 [info]: plugin:out_flowcounter_simple count:28048     indicator:num   unit:second
2015-12-16 18:25:12 +0900 [info]: plugin:out_flowcounter_simple count:33058     indicator:num   unit:second
2015-12-16 18:25:13 +0900 [info]: plugin:out_flowcounter_simple count:25043     indicator:num   unit:second
2015-12-16 18:25:14 +0900 [info]: plugin:out_flowcounter_simple count:31054     indicator:num   unit:second
2015-12-16 18:25:15 +0900 [info]: plugin:out_flowcounter_simple count:29050     indicator:num   unit:second
2015-12-16 18:25:16 +0900 [info]: plugin:out_flowcounter_simple count:30053     indicator:num   unit:second
2015-12-16 18:25:17 +0900 [info]: plugin:out_flowcounter_simple count:33057     indicator:num   unit:second
2015-12-16 18:25:18 +0900 [info]: plugin:out_flowcounter_simple count:27047     indicator:num   unit:second
2015-12-16 18:25:19 +0900 [info]: plugin:out_flowcounter_simple count:32056     indicator:num   unit:second
2015-12-16 18:25:20 +0900 [info]: plugin:out_flowcounter_simple count:29050     indicator:num   unit:second
2015-12-16 18:25:21 +0900 [info]: plugin:out_flowcounter_simple count:31054     indicator:num   unit:second
2015-12-16 18:25:22 +0900 [info]: plugin:out_flowcounter_simple count:32056     indicator:num   unit:second
2015-12-16 18:25:23 +0900 [info]: plugin:out_flowcounter_simple count:26045     indicator:num   unit:second
2015-12-16 18:25:24 +0900 [info]: plugin:out_flowcounter_simple count:32056     indicator:num   unit:second
2015-12-16 18:25:25 +0900 [info]: plugin:out_flowcounter_simple count:34059     indicator:num   unit:second
2015-12-16 18:25:26 +0900 [info]: plugin:out_flowcounter_simple count:37064     indicator:num   unit:second
2015-12-16 18:25:27 +0900 [info]: plugin:out_flowcounter_simple count:32056     indicator:num   unit:second
2015-12-16 18:25:28 +0900 [info]: plugin:out_flowcounter_simple count:37064     indicator:num   unit:second
2015-12-16 18:25:29 +0900 [info]: plugin:out_flowcounter_simple count:34059     indicator:num   unit:second
2015-12-16 18:25:30 +0900 [info]: plugin:out_flowcounter_simple count:35061     indicator:num   unit:second
2015-12-16 18:25:31 +0900 [info]: plugin:out_flowcounter_simple count:35061     indicator:num   unit:second
2015-12-16 18:25:32 +0900 [info]: plugin:out_flowcounter_simple count:33057     indicator:num   unit:second
```

Oj result is better than Yajl so using oj is better when oj is installed.