### PR TITLE
fixed problem in watch multiple file by "*" on Windows

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -106,6 +106,11 @@ module Fluent
       @paths.each { |path|
         path = date.strftime(path)
         if path.include?('*')
+          #if this is file path of windows
+          if(path =~ /^\s*[C-Z]:\\/)
+            #fix folder watch issue of windows
+            path.gsub!("\\","/")
+          end
           paths += Dir.glob(path)
         else
           # When file is not created yet, Dir.glob returns an empty array. So just add when path is static.


### PR DESCRIPTION
HI , I found a problem in Windows.

When I using tail plugin on window for watch files in a folder.it's not work.
ex. C:\test\*.csv 
that cause of the "\" making Dir parse the file path error. and when I  change the path to "C:/test/*.csv".
It's works well now, so I add a if condition for checking if it's a File-path of Windows will automatic fix the file path.
```
  #if this is file path of windows
  if(path =~ /^\s*[C-Z]:\\/)
    #fix folder watch issue of windows
    path.gsub!("\\","/")
  end
  paths += Dir.glob(path)
```