### PR TITLE
fix watch folder failed issue of winodws

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -112,6 +112,11 @@ module Fluent
       @paths.each { |path|
         path = date.strftime(path)
         if path.include?('*')
+          #if this is file path of windows
+          if(path =~ /^\s*[C-Z]:\\/)
+            #fix folder watch issue of windows
+            path.gsub!("\\","/")
+          end
           paths += Dir.glob(path)
         else
           # When file is not created yet, Dir.glob returns an empty array. So just add when path is static.


### PR DESCRIPTION
if we set "c:\test\*.csv" as path of tail plugin, fluentd can't get watch files list.
user need change "/" to "\" on windows. this patch is for fixed this problem.