### PR TITLE
Add on_exit_process(i) hook point

### DIFF
--- a/lib/fluent/process.rb
+++ b/lib/fluent/process.rb
@@ -289,6 +289,9 @@ module Fluent
     def on_detach_process(i)
     end
 
+    def on_exit_process(i)
+    end
+
     private
 
     def detach_process_impl(num, &block)
@@ -326,6 +329,7 @@ module Fluent
           #forward_thread.join  # TODO this thread won't stop because parent doesn't close pipe
           fin.wait
 
+          on_exit_process(i)
           exit! 0
         ensure
           $log.error "unknown error while shutting down this child process", :error=>$!.to_s, :pid=>Process.pid


### PR DESCRIPTION
Hi,

I wonder how to call `shutdown` method before the child process exits when I use `detach_process` because I'd like to shutdown my plugin properly.

After looking the code, I hope this hook point just before `exit!`. Then I can call any logic before exiting like below:
```
def on_exit_process(i)
  shutdown
end
```

Is there any better way to do this?

Best,