### PR TITLE
Use `Timeout.timeout` instead of `Object#timeout`

### DIFF
--- a/test/test_buffer.rb
+++ b/test/test_buffer.rb
@@ -574,7 +574,7 @@ module FluentBufferTest
 
         begin
           # with block, emit events to full queue causes sleep loop
-          timeout(1) {
+          Timeout.timeout(1) {
             assert db.emit('key', data, chain)
           }
           flunk("timeout must happen")


### PR DESCRIPTION
Because Object#timeout has been deprecated since Ruby 2.3.0.