### PR TITLE
Enable to control wait period of d.run in input and output test driver

### DIFF
--- a/lib/fluent/test/input_test.rb
+++ b/lib/fluent/test/input_test.rb
@@ -102,7 +102,7 @@ module Fluent
         false
       end
 
-      def run(&block)
+      def run(num_waits = 10, &block)
         m = method(:emit_stream)
         Engine.define_singleton_method(:emit_stream) {|tag,es|
           m.call(tag, es)
@@ -110,7 +110,7 @@ module Fluent
         instance.router.define_singleton_method(:emit_stream) {|tag,es|
           m.call(tag, es)
         }
-        super {
+        super(num_waits) {
           block.call if block
 
           if @expected_emits_length || @expects || @run_post_conditions

--- a/lib/fluent/test/output_test.rb
+++ b/lib/fluent/test/output_test.rb
@@ -69,9 +69,9 @@ module Fluent
         (@expected_buffer ||= '') << str
       end
 
-      def run(&block)
+      def run(num_waits = 10, &block)
         result = nil
-        super {
+        super(num_waits) {
           es = ArrayEventStream.new(@entries)
           buffer = @instance.format_stream(@tag, es)
 


### PR DESCRIPTION
I want to control wait period of d.run in input and output test driver. 

Please see what I am doing every time > https://github.com/sonots/fluent-plugin-grep/blob/master/test/helper.rb. I want to drop this monkey patch. 
