### PR TITLE
Fix the regression of unused parameter warning inside sub section

### DIFF
--- a/lib/fluent/config/element.rb
+++ b/lib/fluent/config/element.rb
@@ -75,11 +75,13 @@ module Fluent
       end
 
       def has_key?(key)
+        @unused_in = false # some sections, e.g. <store> in copy, is not defined by config_section so clear unused flag for better warning message in chgeck_not_fetched.
         @unused.delete(key)
         super
       end
 
       def [](key)
+        @unused_in = false # ditto
         @unused.delete(key)
         super
       end


### PR DESCRIPTION
Related to #629 and original reported is https://github.com/treasure-data/omnibus-td-agent/issues/61
Added following copy match to above 629 issue config.

```aconf
  <match copy_test>
    @type copy
    <store>
      @type stdout
      foo bar
    </store>
    <test>
      param v
    </test>
  </match>
```

Current:

```
2016-01-04 18:07:50 +0900 [warn]: section <foo> is not used in <user> of secure_forward plugin
2016-01-04 18:07:50 +0900 [warn]: section <test> is not used in <source> of secure_forward plugin
2016-01-04 18:07:50 +0900 [warn]: section <test> is not used in <match debug.**>
2016-01-04 18:07:50 +0900 [warn]: section <fil> is not used in <ROOT>
2016-01-04 18:07:50 +0900 [warn]: section <store> is not used in <match copy_test> of copy plugin
2016-01-04 18:07:50 +0900 [warn]: section <test> is not used in <match copy_test> of copy plugin
```

After this patch:

```
2016-01-04 18:11:14 +0900 [warn]: section <foo> is not used in <user> of secure_forward plugin
2016-01-04 18:11:14 +0900 [warn]: section <test> is not used in <source> of secure_forward plugin
2016-01-04 18:11:14 +0900 [warn]: section <test> is not used in <match debug.**>
2016-01-04 18:11:14 +0900 [warn]: section <fil> is not used in <ROOT>
2016-01-04 18:11:14 +0900 [warn]: parameter 'foo' in <store>
  @type stdout
  foo bar
</store> is not used.
2016-01-04 18:11:14 +0900 [warn]: section <test> is not used in <match copy_test> of copy plugin
```