### PR TITLE
Use rr instead of flexmock

### DIFF
--- a/test/plugin/test_filter_stdout.rb
+++ b/test/plugin/test_filter_stdout.rb
@@ -62,8 +62,15 @@ class StdoutFilterTest < Test::Unit::TestCase
 
     # NOTE: Float::NAN is not jsonable
     d = create_driver(CONFIG + "\noutput_type json")
-    stub(d.instance.router).emit_error_event
-    emit(d, {'test' => Float::NAN}, time)
+    stub(Fluent::EventRouter) do |routerclass|
+      routerclass.new(is_a(Fluent::Agent::NoMatchMatch), anything) do
+        mock('EventRouter') do |router|
+          router.emit_error_event('filter.test', is_a(Fluent::EventTime),
+                                  anything, anything).once
+        end
+      end
+      emit(d, {'test' => Float::NAN}, time)
+    end
   end
 
   def test_output_type_hash
@@ -107,4 +114,3 @@ class StdoutFilterTest < Test::Unit::TestCase
     d.instance.log = tmp
   end
 end
-

--- a/test/plugin/test_filter_stdout.rb
+++ b/test/plugin/test_filter_stdout.rb
@@ -1,11 +1,9 @@
 require_relative '../helper'
 require 'fluent/plugin/filter_stdout'
 require 'timecop'
-require 'flexmock'
 
 class StdoutFilterTest < Test::Unit::TestCase
   include Fluent
-  include FlexMock::TestCase
 
   def setup
     Fluent::Test.setup
@@ -64,7 +62,7 @@ class StdoutFilterTest < Test::Unit::TestCase
 
     # NOTE: Float::NAN is not jsonable
     d = create_driver(CONFIG + "\noutput_type json")
-    flexmock(d.instance.router).should_receive(:emit_error_event)
+    stub(d.instance.router).emit_error_event
     emit(d, {'test' => Float::NAN}, time)
   end
 

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -1,10 +1,8 @@
 require_relative '../helper'
 require 'fluent/test'
 require 'net/http'
-require 'flexmock'
 
 class TailInputTest < Test::Unit::TestCase
-  include FlexMock::TestCase
 
   def setup
     Fluent::Test.setup

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -468,8 +468,8 @@ class TailInputTest < Test::Unit::TestCase
 
   def test_expand_paths
     plugin = create_driver(EX_CONFIG, false).instance
-    flexstub(Time) do |timeclass|
-      timeclass.should_receive(:now).with_no_args.and_return(Time.new(2010, 1, 2, 3, 4, 5))
+    stub(Time) do |timeclass|
+      timeclass.now.returns(Time.new(2010, 1, 2, 3, 4, 5))
       assert_equal EX_PATHS, plugin.expand_paths.sort
     end
 
@@ -518,8 +518,8 @@ class TailInputTest < Test::Unit::TestCase
         plugin.refresh_watchers
       end
 
-      flexstub(Fluent::NewTailInput::TailWatcher) do |watcherclass|
-        watcherclass.should_receive(:new).never
+      stub(Fluent::NewTailInput::TailWatcher) do |watcherclass|
+        watcherclass.new.never
         plugin.refresh_watchers
       end
     end
@@ -529,8 +529,8 @@ class TailInputTest < Test::Unit::TestCase
 
   def test_receive_lines
     plugin = create_driver(EX_CONFIG, false).instance
-    flexstub(plugin.router) do |engineclass|
-      engineclass.should_receive(:emit_stream).with('tail', any).once
+    stub(plugin.router) do |engineclass|
+      engineclass.emit_stream('tail', anything).once
       plugin.receive_lines(['foo', 'bar'], DummyWatcher.new('foo.bar.log'))
     end
 
@@ -541,8 +541,8 @@ class TailInputTest < Test::Unit::TestCase
       read_from_head true
     ]
     plugin = create_driver(config, false).instance
-    flexstub(plugin.router) do |engineclass|
-      engineclass.should_receive(:emit_stream).with('pre.foo.bar.log', any).once
+    stub(plugin.router) do |engineclass|
+      engineclass.emit_stream('pre.foo.bar.log', anything).once
       plugin.receive_lines(['foo', 'bar'], DummyWatcher.new('foo.bar.log'))
     end
 
@@ -553,8 +553,8 @@ class TailInputTest < Test::Unit::TestCase
       read_from_head true
     ]
     plugin = create_driver(config, false).instance
-    flexstub(plugin.router) do |engineclass|
-      engineclass.should_receive(:emit_stream).with('foo.bar.log.post', any).once
+    stub(plugin.router) do |engineclass|
+      engineclass.emit_stream('foo.bar.log.post', anything).once
       plugin.receive_lines(['foo', 'bar'], DummyWatcher.new('foo.bar.log'))
     end
 
@@ -565,8 +565,8 @@ class TailInputTest < Test::Unit::TestCase
       read_from_head true
     ]
     plugin = create_driver(config, false).instance
-    flexstub(plugin.router) do |engineclass|
-      engineclass.should_receive(:emit_stream).with('pre.foo.bar.log.post', any).once
+    stub(plugin.router) do |engineclass|
+      engineclass.emit_stream('pre.foo.bar.log.post', anything).once
       plugin.receive_lines(['foo', 'bar'], DummyWatcher.new('foo.bar.log'))
     end
 
@@ -577,8 +577,8 @@ class TailInputTest < Test::Unit::TestCase
       read_from_head true
     ]
     plugin = create_driver(config, false).instance
-    flexstub(plugin.router) do |engineclass|
-      engineclass.should_receive(:emit_stream).with('pre.foo.bar.log.post', any).once
+    stub(plugin.router) do |engineclass|
+      engineclass.emit_stream('pre.foo.bar.log.post', anything).once
       plugin.receive_lines(['foo', 'bar'], DummyWatcher.new('foo.bar.log'))
     end
   end

--- a/test/test_output.rb
+++ b/test/test_output.rb
@@ -2,11 +2,9 @@ require_relative 'helper'
 require 'fluent/test'
 require 'fluent/output'
 require 'timecop'
-require 'flexmock'
 
 module FluentOutputTest
   include Fluent
-  include FlexMock::TestCase
 
   class BufferedOutputTest < ::Test::Unit::TestCase
     include FluentOutputTest
@@ -194,7 +192,7 @@ module FluentOutputTest
         d.instance.instance_variable_set(:@num_errors, 10)
         d.instance.instance_variable_set(:@next_retry_time, @time + d.instance.calc_retry_wait)
         # buffer should be popped (flushed) immediately
-        flexmock(buffer).should_receive(:pop).once
+        stub(buffer).pop.once
         # force_flush
         buffer.emit("test", 'test', NullOutputChain.instance)
         d.instance.force_flush
@@ -225,7 +223,6 @@ module FluentOutputTest
 
   class TimeSlicedOutputTest < ::Test::Unit::TestCase
     include FluentOutputTest
-    include FlexMock::TestCase
 
     def setup
       Fluent::Test.setup
@@ -259,7 +256,7 @@ module FluentOutputTest
         ])
         d.instance.start
         # buffer should be popped (flushed) immediately
-        flexmock(d.instance.instance_variable_get(:@buffer)).should_receive(:pop).once
+        stub(d.instance.instance_variable_get(:@buffer)).pop.once
         # force_flush
         d.instance.emit('test', @es, NullOutputChain.instance)
         d.instance.force_flush

--- a/test/test_output.rb
+++ b/test/test_output.rb
@@ -192,7 +192,14 @@ module FluentOutputTest
         d.instance.instance_variable_set(:@num_errors, 10)
         d.instance.instance_variable_set(:@next_retry_time, @time + d.instance.calc_retry_wait)
         # buffer should be popped (flushed) immediately
-        buffer.pop(self)
+        stub(Fluent::Buffer) do |bufferclass|
+          bufferclass.new do
+            mock('Buffer') do |buffer|
+              buffer.pop(anything).once
+            end
+          end
+          buffer.pop(anything)
+        end
         # force_flush
         buffer.emit("test", 'test', NullOutputChain.instance)
         d.instance.force_flush
@@ -255,8 +262,16 @@ module FluentOutputTest
           buffer_path #{TMP_DIR}/foo
         ])
         d.instance.start
+        buffer = d.instance.instance_variable_get(:@buffer)
         # buffer should be popped (flushed) immediately
-        d.instance.instance_variable_get(:@buffer).pop(self)
+        stub(Fluent::Buffer) do |bufferclass|
+          bufferclass.new do
+            mock('Buffer') do |buffer|
+              buffer.pop(anything).once
+            end
+          end
+          buffer.pop(anything)
+        end
         # force_flush
         d.instance.emit('test', @es, NullOutputChain.instance)
         d.instance.force_flush

--- a/test/test_output.rb
+++ b/test/test_output.rb
@@ -192,7 +192,7 @@ module FluentOutputTest
         d.instance.instance_variable_set(:@num_errors, 10)
         d.instance.instance_variable_set(:@next_retry_time, @time + d.instance.calc_retry_wait)
         # buffer should be popped (flushed) immediately
-        stub(buffer).pop.once
+        buffer.pop(self)
         # force_flush
         buffer.emit("test", 'test', NullOutputChain.instance)
         d.instance.force_flush
@@ -256,7 +256,7 @@ module FluentOutputTest
         ])
         d.instance.start
         # buffer should be popped (flushed) immediately
-        stub(d.instance.instance_variable_get(:@buffer)).pop.once
+        d.instance.instance_variable_get(:@buffer).pop(self)
         # force_flush
         d.instance.emit('test', @es, NullOutputChain.instance)
         d.instance.force_flush


### PR DESCRIPTION
I try to use rr instead of flexmock in tests.
In most cases, using rr is slightly readable than flexmock.

## Current status

- [x] test_filter_stdout
- [x] test_output
- [x] test_in_tail
- [x] use `mock` instead of `stub` as much as possible

## Question

* Should we completely replace flexmock with rr?
    - ~~`test_z_refresh_watchers`'s test case is hard to replace flexmock with rr.~~ → Done.