### PR TITLE
Use error stream in TimeSlicedOutput#emit

### DIFF
--- a/lib/fluent/output.rb
+++ b/lib/fluent/output.rb
@@ -566,11 +566,12 @@ module Fluent
             key = @time_slicer.call(time)
             @before_key = key
           end
-          formatted_data[key] ||= ''
-          formatted_data[key] << format(tag, time, record)
         rescue => e
           @router.emit_error_event(tag, Engine.now, {'time' => time, 'record' => record}, e)
         end
+
+        formatted_data[key] ||= ''
+        formatted_data[key] << format(tag, time, record)
       }
       formatted_data.each { |key, data|
         if @buffer.emit(key, data, chain)

--- a/lib/fluent/test/base.rb
+++ b/lib/fluent/test/base.rb
@@ -54,6 +54,7 @@ module Fluent
         end
         @instance.router = Engine.root_agent.event_router
         @instance.log = TestLogger.new
+        Engine.root_agent.instance_variable_set(:@log, @instance.log)
 
         @config = Config.new
       end

--- a/test/test_output.rb
+++ b/test/test_output.rb
@@ -241,7 +241,7 @@ module FluentOutputTest
       Fluent::Test::TimeSlicedOutputTestDriver.new(Fluent::TimeSlicedOutput).configure(conf, true)
     end
 
-    sub_test_case "test_force_flush" do
+    sub_test_case "force_flush test" do
       setup do
         time = Time.parse("2011-01-02 13:14:15 UTC")
         Timecop.freeze(time)
@@ -266,7 +266,7 @@ module FluentOutputTest
       end
     end
 
-    sub_test_case "emit check" do
+    sub_test_case "test emit" do
       setup do
         @time = Time.parse("2011-01-02 13:14:15 UTC")
         Timecop.freeze(@time)

--- a/test/test_output.rb
+++ b/test/test_output.rb
@@ -235,7 +235,7 @@ module FluentOutputTest
 
     TMP_DIR = File.expand_path(File.dirname(__FILE__) + "/tmp/time_sliced_output")
 
-    CONFIG = %[]
+    CONFIG = %[buffer_path #{TMP_DIR}/foo]
 
     def create_driver(conf=CONFIG)
       Fluent::Test::TimeSlicedOutputTestDriver.new(Fluent::TimeSlicedOutput).configure(conf, true)
@@ -255,7 +255,6 @@ module FluentOutputTest
       test "force_flush immediately flushes" do
         d = create_driver(CONFIG + %[
           time_format %Y%m%d%H%M%S
-          buffer_path #{TMP_DIR}/foo
         ])
         d.instance.start
         # buffer should be popped (flushed) immediately
@@ -264,6 +263,31 @@ module FluentOutputTest
         d.instance.emit('test', @es, NullOutputChain.instance)
         d.instance.force_flush
         10.times { sleep 0.05 }
+      end
+    end
+
+    sub_test_case "emit check" do
+      setup do
+        @time = Time.parse("2011-01-02 13:14:15 UTC")
+        Timecop.freeze(@time)
+      end
+
+      teardown do
+        Timecop.return
+      end
+
+      test "emit with valid event" do
+        d = create_driver
+        d.instance.start
+        d.instance.emit('test', OneEventStream.new(@time.to_i, {"message" => "foo"}), NullOutputChain.instance)
+        assert_equal 0, d.instance.log.logs.size
+      end
+
+      test "emit with invalid event" do
+        d = create_driver
+        d.instance.start
+        d.instance.emit('test', OneEventStream.new('string', 10), NullOutputChain.instance)
+        assert_equal 1, d.instance.log.logs.count { |line| line =~ /dump an error event/ }
       end
     end
   end


### PR DESCRIPTION
Currently, TimeSlicedOutput#emit raises an exeception when one event is invalid.
If one event in event stream has a problem, it should be treated as an error event instead of entire error.
Input plugins hard to handle such error because input plugins don't know how to recover invalid event.
So send it to error stream is better.
