### PR TITLE
Fix to do `require` for required files straightforward, per files

### DIFF
--- a/lib/fluent/agent.rb
+++ b/lib/fluent/agent.rb
@@ -13,10 +13,13 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
-module Fluent
-  require 'fluent/configurable'
-  require 'fluent/engine'
 
+require 'fluent/configurable'
+require 'fluent/engine'
+require 'fluent/plugin'
+require 'fluent/output'
+
+module Fluent
   #
   # Agent is a resource unit who manages emittable plugins
   #

--- a/lib/fluent/buffer.rb
+++ b/lib/fluent/buffer.rb
@@ -13,6 +13,12 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
+
+require 'monitor'
+require 'fileutils'
+
+require 'fluent/configurable'
+
 module Fluent
   class BufferError < StandardError
   end

--- a/lib/fluent/command/bundler_injection.rb
+++ b/lib/fluent/command/bundler_injection.rb
@@ -14,6 +14,9 @@
 #    limitations under the License.
 #
 
+require 'rbconfig'
+require 'rubygems'
+
 if ENV['BUNDLE_BIN_PATH']
   puts 'error: You seem to use `bundle exec` already.'
   exit 1

--- a/lib/fluent/command/cat.rb
+++ b/lib/fluent/command/cat.rb
@@ -66,7 +66,7 @@ op.on('--message-key KEY', "key field for none format (default: #{message_key})"
   message_key = s
 }
 
-(class<<self;self;end).module_eval do
+(class << self; self; end).module_eval do
   define_method(:usage) do |msg|
     puts op.to_s
     puts "error: #{msg}" if msg

--- a/lib/fluent/command/debug.rb
+++ b/lib/fluent/command/debug.rb
@@ -34,7 +34,7 @@ op.on('-u', '--unix PATH', "use unix socket instead of tcp") {|b|
   unix = b
 }
 
-(class<<self;self;end).module_eval do
+(class << self; self; end).module_eval do
   define_method(:usage) do |msg|
     puts op.to_s
     puts "error: #{msg}" if msg
@@ -60,7 +60,8 @@ else
   uri = "druby://#{host}:#{port}"
 end
 
-require 'fluent/load'
+require 'fluent/log'
+require 'fluent/engine'
 
 $log = Fluent::Log.new(STDERR, Fluent::Log::LEVEL_TRACE)
 Fluent::Engine.init

--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -15,6 +15,7 @@
 #
 
 require 'optparse'
+
 require 'fluent/supervisor'
 
 op = OptionParser.new
@@ -119,7 +120,7 @@ op.on('-G', '--gem-path GEM_INSTALL_PATH', "Gemfile install path (default: $(dir
   opts[:gem_install_path] = s
 }
 
-(class<<self;self;end).module_eval do
+(class << self; self; end).module_eval do
   define_method(:usage) do |msg|
     puts op.to_s
     puts "error: #{msg}" if msg

--- a/lib/fluent/config.rb
+++ b/lib/fluent/config.rb
@@ -14,10 +14,11 @@
 #    limitations under the License.
 #
 
-module Fluent
-  require 'fluent/config/error'
-  require 'fluent/config/element'
+require 'fluent/config/error'
+require 'fluent/config/element'
+require 'fluent/configurable'
 
+module Fluent
   module Config
     def self.parse(str, fname, basepath = Dir.pwd, v1_config = false)
       if fname =~ /\.rb$/
@@ -38,8 +39,6 @@ module Fluent
       Element.new(name, '', {}, [])
     end
   end
-
-  require 'fluent/configurable'
 
   module PluginId
     def configure(conf)

--- a/lib/fluent/config/basic_parser.rb
+++ b/lib/fluent/config/basic_parser.rb
@@ -14,12 +14,11 @@
 #    limitations under the License.
 #
 
+require 'stringio'
+require 'fluent/config/error'
+
 module Fluent
   module Config
-
-    require 'stringio'
-    require 'fluent/config/error'
-
     class BasicParser
       def initialize(strscan)
         @ss = strscan

--- a/lib/fluent/config/configure_proxy.rb
+++ b/lib/fluent/config/configure_proxy.rb
@@ -14,6 +14,8 @@
 #    limitations under the License.
 #
 
+require 'fluent/configurable'
+
 module Fluent
   module Config
     class ConfigureProxy

--- a/lib/fluent/config/dsl.rb
+++ b/lib/fluent/config/dsl.rb
@@ -14,7 +14,10 @@
 #    limitations under the License.
 #
 
+require 'json'
+
 require 'fluent/config'
+require 'fluent/config/element'
 
 module Fluent
   module Config

--- a/lib/fluent/config/element.rb
+++ b/lib/fluent/config/element.rb
@@ -14,9 +14,10 @@
 #    limitations under the License.
 #
 
-module Fluent
-  require 'fluent/config/error'
+require 'fluent/config/error'
+require 'fluent/config/literal_parser'
 
+module Fluent
   module Config
     class Element < Hash
       def initialize(name, arg, attrs, elements, unused = nil)

--- a/lib/fluent/config/literal_parser.rb
+++ b/lib/fluent/config/literal_parser.rb
@@ -14,13 +14,16 @@
 #    limitations under the License.
 #
 
+require 'stringio'
+
+require 'json'
+require 'yajl'
+require 'irb/ruby-lex'  # RubyLex
+
+require 'fluent/config/basic_parser'
+
 module Fluent
   module Config
-
-    require 'yajl'
-    require 'fluent/config/basic_parser'
-    require 'irb/ruby-lex'  # RubyLex
-
     class LiteralParser < BasicParser
       def self.unescape_char(c)
         case c

--- a/lib/fluent/config/parser.rb
+++ b/lib/fluent/config/parser.rb
@@ -14,11 +14,13 @@
 #    limitations under the License.
 #
 
+require 'uri'
+
+require 'fluent/config/error'
+require 'fluent/config/element'
+
 module Fluent
   module Config
-    require 'fluent/config/error'
-    require 'fluent/config/element'
-
     class Parser
       def self.parse(io, fname, basepath = Dir.pwd)
         attrs, elems = Parser.new(basepath, io.each_line, fname).parse!(true)

--- a/lib/fluent/config/section.rb
+++ b/lib/fluent/config/section.rb
@@ -16,10 +16,10 @@
 
 require 'json'
 
-module Fluent
-  require 'fluent/config/error'
-  require 'fluent/config/v1_parser'
+require 'fluent/config/error'
+require 'fluent/config/v1_parser'
 
+module Fluent
   module Config
     class Section < BasicObject
       def self.name

--- a/lib/fluent/config/types.rb
+++ b/lib/fluent/config/types.rb
@@ -14,9 +14,12 @@
 #    limitations under the License.
 #
 
-module Fluent
-  require 'json'
+require 'json'
 
+require 'fluent/config/error'
+require 'fluent/configurable'
+
+module Fluent
   module Config
     def self.size_value(str)
       case str.to_s

--- a/lib/fluent/config/v1_parser.rb
+++ b/lib/fluent/config/v1_parser.rb
@@ -14,14 +14,16 @@
 #    limitations under the License.
 #
 
+require 'strscan'
+require 'uri'
+
+require 'fluent/config/error'
+require 'fluent/config/basic_parser'
+require 'fluent/config/literal_parser'
+require 'fluent/config/element'
+
 module Fluent
   module Config
-
-    require 'strscan'
-    require 'fluent/config/error'
-    require 'fluent/config/literal_parser'
-    require 'fluent/config/element'
-
     class V1Parser < LiteralParser
       ELEMENT_NAME = /[a-zA-Z0-9_]+/
 

--- a/lib/fluent/configurable.rb
+++ b/lib/fluent/configurable.rb
@@ -14,13 +14,13 @@
 #    limitations under the License.
 #
 
-module Fluent
-  require 'fluent/config/configure_proxy'
-  require 'fluent/config/section'
-  require 'fluent/config/error'
-  require 'fluent/registry'
-  require 'fluent/plugin'
+require 'fluent/config/configure_proxy'
+require 'fluent/config/section'
+require 'fluent/config/error'
+require 'fluent/registry'
+require 'fluent/plugin'
 
+module Fluent
   module Configurable
     def self.included(mod)
       mod.extend(ClassMethods)

--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -14,12 +14,21 @@
 #    limitations under the License.
 #
 
-module Fluent
-  require 'fluent/event_router'
-  require 'fluent/root_agent'
-  require 'fluent/time'
-  require 'fluent/system_config'
+require 'socket'
+require 'rubygems'
 
+require 'msgpack'
+require 'cool.io'
+
+require 'fluent/config'
+require 'fluent/event'
+require 'fluent/event_router'
+require 'fluent/root_agent'
+require 'fluent/time'
+require 'fluent/system_config'
+require 'fluent/plugin'
+
+module Fluent
   class EngineClass
     class DummyMessagePackFactory
       def packer(*args)

--- a/lib/fluent/event.rb
+++ b/lib/fluent/event.rb
@@ -14,6 +14,8 @@
 #    limitations under the License.
 #
 
+require 'fluent/engine'
+
 module Fluent
   class EventStream
     include Enumerable

--- a/lib/fluent/event_router.rb
+++ b/lib/fluent/event_router.rb
@@ -13,9 +13,11 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
-module Fluent
-  require 'fluent/match'
 
+require 'fluent/match'
+require 'fluent/event'
+
+module Fluent
   #
   # EventRouter is responsible to route events to a collector.
   #

--- a/lib/fluent/filter.rb
+++ b/lib/fluent/filter.rb
@@ -14,6 +14,12 @@
 #    limitations under the License.
 #
 
+require 'fluent/config'
+require 'fluent/configurable'
+require 'fluent/engine'
+require 'fluent/event'
+require 'fluent/log'
+
 module Fluent
   class Filter
     include Configurable

--- a/lib/fluent/formatter.rb
+++ b/lib/fluent/formatter.rb
@@ -14,9 +14,11 @@
 #    limitations under the License.
 #
 
-module Fluent
-  require 'fluent/registry'
+require 'fluent/configurable'
+require 'fluent/registry'
+require 'fluent/mixin'
 
+module Fluent
   class Formatter
     include Configurable
 

--- a/lib/fluent/input.rb
+++ b/lib/fluent/input.rb
@@ -14,6 +14,11 @@
 #    limitations under the License.
 #
 
+require 'fluent/config'
+require 'fluent/configurable'
+require 'fluent/engine'
+require 'fluent/log'
+
 module Fluent
   class Input
     include Configurable

--- a/lib/fluent/label.rb
+++ b/lib/fluent/label.rb
@@ -14,9 +14,9 @@
 #    limitations under the License.
 #
 
-module Fluent
-  require 'fluent/agent'
+require 'fluent/agent'
 
+module Fluent
   class Label < Agent
     def initialize(name, opts = {})
       super(opts)

--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -65,6 +65,9 @@ module Fluent
       # TODO: This variable name is unclear so we should change to better name.
       @threads_exclude_events = []
 
+      # Fluent::Engine requires Fluent::Log, so we must take that object lazily
+      @engine = Fluent.const_get('Engine')
+
       if opts.has_key?(:suppress_repeated_stacktrace)
         @suppress_repeated_stacktrace = opts[:suppress_repeated_stacktrace]
       end
@@ -285,7 +288,7 @@ module Fluent
           record[key] = record[key].inspect unless record[key].respond_to?(:to_msgpack)
         }
         record['message'] = message.dup
-        Engine.push_log_event("#{@tag}.#{level}", time.to_i, record)
+        @engine.push_log_event("#{@tag}.#{level}", time.to_i, record)
       end
 
       return time, message

--- a/lib/fluent/mixin.rb
+++ b/lib/fluent/mixin.rb
@@ -14,10 +14,12 @@
 #    limitations under the License.
 #
 
+require 'fluent/timezone'
+require 'fluent/time'
+require 'fluent/config/error'
+
 module Fluent
   class TimeFormatter
-    require 'fluent/timezone'
-
     def initialize(format, localtime, timezone = nil)
       @tc1 = 0
       @tc1_str = nil

--- a/lib/fluent/output.rb
+++ b/lib/fluent/output.rb
@@ -14,6 +14,15 @@
 #    limitations under the License.
 #
 
+require 'thread'
+
+require 'fluent/config'
+require 'fluent/configurable'
+require 'fluent/engine'
+require 'fluent/log'
+require 'fluent/plugin'
+require 'fluent/timezone'
+
 module Fluent
   class OutputChain
     def initialize(array, tag, es, chain=NullOutputChain.instance)
@@ -92,7 +101,6 @@ module Fluent
       end
     end
   end
-
 
   class OutputThread
     def initialize(output)

--- a/lib/fluent/parser.rb
+++ b/lib/fluent/parser.rb
@@ -14,9 +14,19 @@
 #    limitations under the License.
 #
 
-module Fluent
-  require 'fluent/registry'
+require 'time'
+require 'json'
 
+require 'yajl'
+
+require 'fluent/config/error'
+require 'fluent/config/element'
+require 'fluent/configurable'
+require 'fluent/engine'
+require 'fluent/registry'
+require 'fluent/time'
+
+module Fluent
   class ParserError < StandardError
   end
 

--- a/lib/fluent/plugin.rb
+++ b/lib/fluent/plugin.rb
@@ -14,6 +14,10 @@
 #    limitations under the License.
 #
 
+require 'rubygems'
+
+require 'fluent/config/error'
+
 module Fluent
   class PluginClass
     # This class is refactored using Fluent::Registry at v0.14
@@ -66,10 +70,12 @@ module Fluent
     end
 
     def new_parser(type)
+      require 'fluent/parser'
       TextParser.lookup(type)
     end
 
     def new_formatter(type)
+      require 'fluent/formatter'
       TextFormatter.lookup(type)
     end
 

--- a/lib/fluent/plugin/buf_file.rb
+++ b/lib/fluent/plugin/buf_file.rb
@@ -14,6 +14,13 @@
 #    limitations under the License.
 #
 
+require 'fileutils'
+require 'uri'
+
+require 'fluent/env'
+require 'fluent/plugin'
+require 'fluent/buffer'
+
 module Fluent
   class FileBufferChunk < BufferChunk
     def initialize(key, path, unique_id, mode="a+", symlink_path = nil)

--- a/lib/fluent/plugin/buf_memory.rb
+++ b/lib/fluent/plugin/buf_memory.rb
@@ -14,6 +14,12 @@
 #    limitations under the License.
 #
 
+require 'stringio'
+
+require 'fluent/engine'
+require 'fluent/plugin'
+require 'fluent/buffer'
+
 module Fluent
   class MemoryBufferChunk < BufferChunk
     def initialize(key, data='')

--- a/lib/fluent/plugin/exec_util.rb
+++ b/lib/fluent/plugin/exec_util.rb
@@ -14,10 +14,15 @@
 #    limitations under the License.
 #
 
+require 'msgpack'
+require 'yajl'
+
+require 'fluent/engine'
+require 'fluent/plugin'
+require 'fluent/parser'
+
 module Fluent
   module ExecUtil
-    require 'fluent/parser'
-
     SUPPORTED_FORMAT = {
       'tsv' => :tsv,
       'json' => :json,

--- a/lib/fluent/plugin/filter_grep.rb
+++ b/lib/fluent/plugin/filter_grep.rb
@@ -14,6 +14,9 @@
 #    limitations under the License.
 #
 
+require 'fluent/filter'
+require 'fluent/config/error'
+
 module Fluent
   class GrepFilter < Filter
     Fluent::Plugin.register_filter('grep', self)

--- a/lib/fluent/plugin/filter_record_transformer.rb
+++ b/lib/fluent/plugin/filter_record_transformer.rb
@@ -14,16 +14,18 @@
 #    limitations under the License.
 #
 
+require 'socket'
+require 'json'
 require 'ostruct'
+
+require 'fluent/filter'
+require 'fluent/config/error'
+require 'fluent/event'
+require 'fluent/time'
 
 module Fluent
   class RecordTransformerFilter < Filter
     Fluent::Plugin.register_filter('record_transformer', self)
-
-    def initialize
-      require 'socket'
-      super
-    end
 
     desc 'A comma-delimited list of keys to delete.'
     config_param :remove_keys, :string, default: nil

--- a/lib/fluent/plugin/filter_stdout.rb
+++ b/lib/fluent/plugin/filter_stdout.rb
@@ -14,6 +14,9 @@
 #    limitations under the License.
 #
 
+require 'fluent/filter'
+require 'fluent/plugin'
+
 module Fluent
   class StdoutFilter < Filter
     Plugin.register_filter('stdout', self)

--- a/lib/fluent/plugin/in_debug_agent.rb
+++ b/lib/fluent/plugin/in_debug_agent.rb
@@ -14,6 +14,8 @@
 #    limitations under the License.
 #
 
+require 'fluent/input'
+
 module Fluent
   class DebugAgentInput < Input
     Plugin.register_input('debug_agent', self)

--- a/lib/fluent/plugin/in_dummy.rb
+++ b/lib/fluent/plugin/in_dummy.rb
@@ -14,6 +14,11 @@
 #    limitations under the License.
 #
 
+require 'json'
+
+require 'fluent/input'
+require 'fluent/config/error'
+
 module Fluent
   class DummyInput < Input
     Fluent::Plugin.register_input('dummy', self)

--- a/lib/fluent/plugin/in_exec.rb
+++ b/lib/fluent/plugin/in_exec.rb
@@ -14,6 +14,13 @@
 #    limitations under the License.
 #
 
+require 'yajl'
+
+require 'fluent/input'
+require 'fluent/time'
+require 'fluent/timezone'
+require 'fluent/config/error'
+
 module Fluent
   class ExecInput < Input
     Plugin.register_input('exec', self)
@@ -21,7 +28,6 @@ module Fluent
     def initialize
       super
       require 'fluent/plugin/exec_util'
-      require 'fluent/timezone'
     end
 
     desc 'The command (program) to execute.'

--- a/lib/fluent/plugin/in_forward.rb
+++ b/lib/fluent/plugin/in_forward.rb
@@ -14,6 +14,13 @@
 #    limitations under the License.
 #
 
+require 'fcntl'
+
+require 'cool.io'
+require 'yajl'
+
+require 'fluent/input'
+
 module Fluent
   class ForwardInput < Input
     Plugin.register_input('forward', self)

--- a/lib/fluent/plugin/in_gc_stat.rb
+++ b/lib/fluent/plugin/in_gc_stat.rb
@@ -14,6 +14,10 @@
 #    limitations under the License.
 #
 
+require 'cool.io'
+
+require 'fluent/input'
+
 module Fluent
   class GCStatInput < Input
     Plugin.register_input('gc_stat', self)

--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -14,6 +14,16 @@
 #    limitations under the License.
 #
 
+require 'uri'
+require 'socket'
+require 'json'
+
+require 'cool.io'
+
+require 'fluent/input'
+require 'fluent/event'
+require 'fluent/process'
+
 module Fluent
   class HttpInput < Input
     Plugin.register_input('http', self)
@@ -24,7 +34,6 @@ module Fluent
 
     def initialize
       require 'webrick/httputils'
-      require 'uri'
       super
     end
 

--- a/lib/fluent/plugin/in_monitor_agent.rb
+++ b/lib/fluent/plugin/in_monitor_agent.rb
@@ -14,16 +14,19 @@
 #    limitations under the License.
 #
 
+require 'json'
+require 'webrick'
+require 'cgi'
+
+require 'cool.io'
+
+require 'fluent/input'
+require 'fluent/output'
+require 'fluent/filter'
+
 module Fluent
   class MonitorAgentInput < Input
     Plugin.register_input('monitor_agent', self)
-
-    require 'webrick'
-
-    def initialize
-      require 'cgi'
-      super
-    end
 
     config_param :bind, :string, default: '0.0.0.0'
     config_param :port, :integer, default: 24220

--- a/lib/fluent/plugin/in_object_space.rb
+++ b/lib/fluent/plugin/in_object_space.rb
@@ -14,6 +14,11 @@
 #    limitations under the License.
 #
 
+require 'cool.io'
+require 'yajl'
+
+require 'fluent/input'
+
 module Fluent
   class ObjectSpaceInput < Input
     Plugin.register_input('object_space', self)

--- a/lib/fluent/plugin/in_stream.rb
+++ b/lib/fluent/plugin/in_stream.rb
@@ -14,6 +14,15 @@
 #    limitations under the License.
 #
 
+require 'fileutils'
+require 'socket'
+
+require 'cool.io'
+require 'yajl'
+
+require 'fluent/input'
+require 'fluent/event'
+
 module Fluent
   # obsolete
   class StreamInput < Input

--- a/lib/fluent/plugin/in_syslog.rb
+++ b/lib/fluent/plugin/in_syslog.rb
@@ -14,6 +14,13 @@
 #    limitations under the License.
 #
 
+require 'cool.io'
+require 'yajl'
+
+require 'fluent/input'
+require 'fluent/config/error'
+require 'fluent/parser'
+
 module Fluent
   class SyslogInput < Input
     Plugin.register_input('syslog', self)
@@ -60,7 +67,6 @@ module Fluent
 
     def initialize
       super
-      require 'cool.io'
       require 'fluent/plugin/socket_util'
     end
 

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -14,6 +14,12 @@
 #    limitations under the License.
 #
 
+require 'cool.io'
+
+require 'fluent/input'
+require 'fluent/config/error'
+require 'fluent/event'
+
 module Fluent
   class NewTailInput < Input
     Plugin.register_input('tail', self)

--- a/lib/fluent/plugin/in_tcp.rb
+++ b/lib/fluent/plugin/in_tcp.rb
@@ -14,6 +14,8 @@
 #    limitations under the License.
 #
 
+require 'cool.io'
+
 require 'fluent/plugin/socket_util'
 
 module Fluent

--- a/lib/fluent/plugin/out_copy.rb
+++ b/lib/fluent/plugin/out_copy.rb
@@ -14,6 +14,10 @@
 #    limitations under the License.
 #
 
+require 'fluent/output'
+require 'fluent/config/error'
+require 'fluent/event'
+
 module Fluent
   class CopyOutput < MultiOutput
     Plugin.register_output('copy', self)

--- a/lib/fluent/plugin/out_exec.rb
+++ b/lib/fluent/plugin/out_exec.rb
@@ -14,6 +14,10 @@
 #    limitations under the License.
 #
 
+require 'tempfile'
+
+require 'fluent/output'
+require 'fluent/config/error'
 require 'fluent/plugin/exec_util'
 
 module Fluent
@@ -22,7 +26,6 @@ module Fluent
 
     def initialize
       super
-      require 'tempfile'
       @localtime = false
     end
 

--- a/lib/fluent/plugin/out_exec_filter.rb
+++ b/lib/fluent/plugin/out_exec_filter.rb
@@ -14,7 +14,14 @@
 #    limitations under the License.
 #
 
+require 'yajl'
+
+require 'fluent/output'
+require 'fluent/env'
+require 'fluent/time'
+require 'fluent/timezone'
 require 'fluent/plugin/exec_util'
+require 'fluent/config/error'
 
 module Fluent
   class ExecFilterOutput < BufferedOutput

--- a/lib/fluent/plugin/out_file.rb
+++ b/lib/fluent/plugin/out_file.rb
@@ -14,6 +14,12 @@
 #    limitations under the License.
 #
 
+require 'fileutils'
+require 'zlib'
+
+require 'fluent/output'
+require 'fluent/config/error'
+
 module Fluent
   class FileOutput < TimeSlicedOutput
     Plugin.register_output('file', self)

--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -14,6 +14,15 @@
 #    limitations under the License.
 #
 
+require 'base64'
+require 'socket'
+require 'fileutils'
+
+require 'cool.io'
+
+require 'fluent/output'
+require 'fluent/config/error'
+
 module Fluent
   class ForwardOutputError < StandardError
   end
@@ -29,9 +38,6 @@ module Fluent
 
     def initialize
       super
-      require "base64"
-      require 'socket'
-      require 'fileutils'
       require 'fluent/plugin/socket_util'
       @nodes = []  #=> [Node]
     end

--- a/lib/fluent/plugin/out_null.rb
+++ b/lib/fluent/plugin/out_null.rb
@@ -14,6 +14,8 @@
 #    limitations under the License.
 #
 
+require 'fluent/output'
+
 module Fluent
   class NullOutput < Output
     Plugin.register_output('null', self)

--- a/lib/fluent/plugin/out_relabel.rb
+++ b/lib/fluent/plugin/out_relabel.rb
@@ -14,6 +14,8 @@
 #    limitations under the License.
 #
 
+require 'fluent/output'
+
 module Fluent
   class RelabelOutput < Output
     Plugin.register_output('relabel', self)

--- a/lib/fluent/plugin/out_roundrobin.rb
+++ b/lib/fluent/plugin/out_roundrobin.rb
@@ -14,6 +14,9 @@
 #    limitations under the License.
 #
 
+require 'fluent/output'
+require 'fluent/config/error'
+
 module Fluent
   class RoundRobinOutput < MultiOutput
     Plugin.register_output('roundrobin', self)

--- a/lib/fluent/plugin/out_stdout.rb
+++ b/lib/fluent/plugin/out_stdout.rb
@@ -14,6 +14,8 @@
 #    limitations under the License.
 #
 
+require 'fluent/output'
+
 module Fluent
   class StdoutOutput < Output
     Plugin.register_output('stdout', self)

--- a/lib/fluent/plugin/out_stream.rb
+++ b/lib/fluent/plugin/out_stream.rb
@@ -14,15 +14,15 @@
 #    limitations under the License.
 #
 
+require 'socket'
+require 'fileutils'
+
+require 'fluent/output'
+require 'fluent/event'
+
 module Fluent
   # obsolete
   class StreamOutput < BufferedOutput
-    def initialize
-      require 'socket'
-      require 'fileutils'
-      super
-    end
-
     config_param :send_timeout, :time, default: 60
 
     def configure(conf)

--- a/lib/fluent/plugin/socket_util.rb
+++ b/lib/fluent/plugin/socket_util.rb
@@ -14,13 +14,15 @@
 #    limitations under the License.
 #
 
+require 'ipaddr'
+
 require 'cool.io'
+
+require 'fluent/plugin'
 
 module Fluent
   module SocketUtil
     def create_udp_socket(host)
-      require 'ipaddr'
-
       if IPAddr.new(IPSocket.getaddress(host)).ipv4?
         UDPSocket.new
       else

--- a/lib/fluent/process.rb
+++ b/lib/fluent/process.rb
@@ -14,6 +14,12 @@
 #    limitations under the License.
 #
 
+require 'thread'
+
+require 'fluent/config'
+require 'fluent/engine'
+require 'fluent/event'
+
 module Fluent
   class DetachProcessManager
     require 'singleton'

--- a/lib/fluent/registry.rb
+++ b/lib/fluent/registry.rb
@@ -14,9 +14,11 @@
 #    limitations under the License.
 #
 
-module Fluent
-  require 'fluent/config/error'
+require 'rubygems'
 
+require 'fluent/config/error'
+
+module Fluent
   class Registry
     def initialize(kind, search_prefix)
       @kind = kind

--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -13,14 +13,17 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
+
+require 'delegate'
+
+require 'fluent/config/error'
+require 'fluent/agent'
+require 'fluent/engine'
+require 'fluent/label'
+require 'fluent/plugin'
+require 'fluent/system_config'
+
 module Fluent
-
-  require 'delegate'
-
-  require 'fluent/agent'
-  require 'fluent/label'
-  require 'fluent/system_config'
-
   #
   # Fluentd forms a tree structure to manage plugins:
   #

--- a/lib/fluent/rpc.rb
+++ b/lib/fluent/rpc.rb
@@ -14,10 +14,10 @@
 #    limitations under the License.
 #
 
+require 'webrick'
+
 module Fluent
   module RPC
-    require 'webrick'
-
     class Server
       def initialize(endpoint, log)
         bind, port = endpoint.split(':')

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -14,9 +14,15 @@
 #    limitations under the License.
 #
 
-require 'fluent/load'
-require 'fluent/system_config'
 require 'etc'
+
+require 'fluent/config'
+require 'fluent/env'
+require 'fluent/engine'
+require 'fluent/log'
+require 'fluent/plugin'
+require 'fluent/rpc'
+require 'fluent/system_config'
 
 module Fluent
   class Supervisor
@@ -466,40 +472,6 @@ module Fluent
         @config_data << "\n" << @inline_config.gsub("\\n","\n")
       end
       @conf = Fluent::Config.parse(@config_data, @config_fname, @config_basedir, @use_v1_config)
-    end
-
-    class SystemConfig
-      include Configurable
-
-      config_param :log_level, default: nil do |level|
-        Log.str_to_level(level)
-      end
-      config_param :suppress_repeated_stacktrace, :bool, default: nil
-      config_param :emit_error_log_interval, :time, default: nil
-      config_param :suppress_config_dump, :bool, default: nil
-      config_param :without_source, :bool, default: nil
-      config_param :rpc_endpoint, :string, default: nil
-      config_param :enable_get_dump, :bool, default: nil
-      config_param :process_name, default: nil
-
-      def initialize(conf)
-        super()
-        configure(conf)
-      end
-
-      def apply(supervisor)
-        system = self
-        supervisor.instance_eval {
-          @log.level = @log_level = system.log_level unless system.log_level.nil?
-          @suppress_interval = system.emit_error_log_interval unless system.emit_error_log_interval.nil?
-          @suppress_config_dump = system.suppress_config_dump unless system.suppress_config_dump.nil?
-          @suppress_repeated_stacktrace = system.suppress_repeated_stacktrace unless system.suppress_repeated_stacktrace.nil?
-          @without_source = system.without_source unless system.without_source.nil?
-          @rpc_endpoint = system.rpc_endpoint unless system.rpc_endpoint.nil?
-          @enable_get_dump = system.enable_get_dump unless system.enable_get_dump.nil?
-          @process_name = system.process_name unless system.process_name.nil?
-        }
-      end
     end
 
     def run_configure

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -14,9 +14,10 @@
 #    limitations under the License.
 #
 
-module Fluent
-  require 'fluent/configurable'
+require 'fluent/configurable'
+require 'fluent/config/element'
 
+module Fluent
   module SystemConfigMixin
     def system_config
       @_system_config || Fluent::Engine.system_config
@@ -56,8 +57,13 @@ module Fluent
       SystemConfig.new(systems.first)
     end
 
-    def initialize(conf={})
+    def self.blank_system_config
+      Fluent::Config::Element.new('<SYSTEM>', '', {}, [])
+    end
+
+    def initialize(conf=nil)
       super()
+      conf ||= SystemConfig.blank_system_config
       configure(conf)
     end
 

--- a/lib/fluent/test.rb
+++ b/lib/fluent/test.rb
@@ -15,7 +15,7 @@
 #
 
 require 'test/unit'
-require 'fluent/load'
+require 'fluent/env' # for Fluent.windows?
 require 'fluent/test/base'
 require 'fluent/test/input_test'
 require 'fluent/test/output_test'

--- a/lib/fluent/test/base.rb
+++ b/lib/fluent/test/base.rb
@@ -14,6 +14,10 @@
 #    limitations under the License.
 #
 
+require 'fluent/engine'
+require 'fluent/system_config'
+require 'fluent/config'
+
 module Fluent
   module Test
     def self.setup

--- a/lib/fluent/test/filter_test.rb
+++ b/lib/fluent/test/filter_test.rb
@@ -14,6 +14,9 @@
 #    limitations under the License.
 #
 
+require 'fluent/test/base'
+require 'fluent/event'
+
 module Fluent
   module Test
     class FilterTestDriver < TestDriver

--- a/lib/fluent/test/formatter_test.rb
+++ b/lib/fluent/test/formatter_test.rb
@@ -14,10 +14,11 @@
 #    limitations under the License.
 #
 
+require 'fluent/formatter'
+require 'fluent/config'
+
 module Fluent
   module Test
-    require 'fluent/config'
-
     class FormatterTestDriver
       def initialize(klass_or_str, proc=nil, &block)
         if klass_or_str.is_a?(Class)

--- a/lib/fluent/test/input_test.rb
+++ b/lib/fluent/test/input_test.rb
@@ -14,6 +14,11 @@
 #    limitations under the License.
 #
 
+require 'fluent/buffer'
+require 'fluent/engine'
+require 'fluent/time'
+require 'fluent/test/base'
+
 module Fluent
   class FileBuffer < BasicBuffer
     def self.clear_buffer_paths

--- a/lib/fluent/test/output_test.rb
+++ b/lib/fluent/test/output_test.rb
@@ -14,6 +14,10 @@
 #    limitations under the License.
 #
 
+require 'fluent/engine'
+require 'fluent/event'
+require 'fluent/test/input_test'
+
 module Fluent
   module Test
     class TestOutputChain

--- a/lib/fluent/test/parser_test.rb
+++ b/lib/fluent/test/parser_test.rb
@@ -14,10 +14,11 @@
 #    limitations under the License.
 #
 
+require 'fluent/parser'
+require 'fluent/config'
+
 module Fluent
   module Test
-    require 'fluent/config'
-
     class ParserTestDriver
       def initialize(klass_or_str, format=nil, conf={}, &block)
         if klass_or_str.is_a?(Class)

--- a/lib/fluent/timezone.rb
+++ b/lib/fluent/timezone.rb
@@ -16,6 +16,8 @@
 
 require 'tzinfo'
 
+require 'fluent/config/error'
+
 module Fluent
   class Timezone
     # [+-]HH:MM, [+-]HHMM, [+-]HH

--- a/test/plugin/test_in_forward.rb
+++ b/test/plugin/test_in_forward.rb
@@ -1,6 +1,10 @@
 require_relative '../helper'
+
 require 'fluent/test'
 require 'base64'
+
+require 'fluent/env'
+require 'fluent/plugin/in_forward'
 
 class ForwardInputTest < Test::Unit::TestCase
   def setup

--- a/test/test_event_router.rb
+++ b/test/test_event_router.rb
@@ -1,3 +1,4 @@
+require_relative 'helper'
 require 'fluent/event_router'
 require_relative 'test_plugin_classes'
 

--- a/test/test_plugin_classes.rb
+++ b/test/test_plugin_classes.rb
@@ -1,4 +1,7 @@
 require_relative 'helper'
+require 'fluent/input'
+require 'fluent/output'
+require 'fluent/filter'
 
 module FluentTest
   class FluentTestInput < ::Fluent::Input

--- a/test/test_process.rb
+++ b/test/test_process.rb
@@ -1,6 +1,7 @@
 require_relative 'helper'
 require 'fluent/test'
 require 'fluent/event'
+require 'fluent/process'
 require 'stringio'
 require 'msgpack'
 

--- a/test/test_root_agent.rb
+++ b/test/test_root_agent.rb
@@ -1,3 +1,4 @@
+require_relative 'helper'
 require 'fluent/event_router'
 require 'fluent/system_config'
 require_relative 'test_plugin_classes'


### PR DESCRIPTION
* Currently, all required files are loaded by `lib/fluent/load.rb` even for tests
  * This file creates the implicit order of files to be loaded
  * There's no explicit dependency definition, and there are many circular dependencies
  * This situation is totally broken
* Without this change, we can't run tests by `bundle exec rake test TEST=test/file.rb`
  * Running whole tests consumes long time, and it's not acceptable

This change is to make straightforward dependency from all files to others.
We can load any file in fluentd source code, make clean dependencies, and
also can run each files itself to test it.

For v0.12 branch,

* I don't merge Windows specific patches
* I don't merge v0.14 specific patches