### PR TITLE
Don't require rubygems

### DIFF
--- a/bin/fluent-cat
+++ b/bin/fluent-cat
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 # -*- coding: utf-8 -*-
-require 'rubygems' unless defined?(gem)
 here = File.dirname(__FILE__)
 $LOAD_PATH << File.expand_path(File.join(here, '..', 'lib'))
 require 'fluent/command/cat'

--- a/bin/fluent-debug
+++ b/bin/fluent-debug
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 # -*- coding: utf-8 -*-
-require 'rubygems' unless defined?(gem)
 here = File.dirname(__FILE__)
 $LOAD_PATH << File.expand_path(File.join(here, '..', 'lib'))
 require 'fluent/command/debug'

--- a/bin/fluent-gem
+++ b/bin/fluent-gem
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 # -*- coding: utf-8 -*-
-require 'rubygems' unless defined?(gem)
 require 'rubygems/gem_runner'
 require 'rubygems/exceptions'
 begin

--- a/bin/fluentd
+++ b/bin/fluentd
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 # -*- coding: utf-8 -*-
-require 'rubygems' unless defined?(gem)
 here = File.dirname(__FILE__)
 $LOAD_PATH << File.expand_path(File.join(here, '..', 'lib'))
 require 'fluent/command/fluentd'

--- a/lib/fluent/command/bundler_injection.rb
+++ b/lib/fluent/command/bundler_injection.rb
@@ -15,7 +15,6 @@
 #
 
 require 'rbconfig'
-require 'rubygems'
 
 if ENV['BUNDLE_BIN_PATH']
   puts 'error: You seem to use `bundle exec` already.'

--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -15,7 +15,6 @@
 #
 
 require 'socket'
-require 'rubygems'
 
 require 'msgpack'
 require 'cool.io'

--- a/lib/fluent/plugin.rb
+++ b/lib/fluent/plugin.rb
@@ -14,8 +14,6 @@
 #    limitations under the License.
 #
 
-require 'rubygems'
-
 require 'fluent/config/error'
 
 module Fluent

--- a/lib/fluent/registry.rb
+++ b/lib/fluent/registry.rb
@@ -14,8 +14,6 @@
 #    limitations under the License.
 #
 
-require 'rubygems'
-
 require 'fluent/config/error'
 
 module Fluent


### PR DESCRIPTION
Recent Ruby loads rubygems automatically, since Ruby 1.9.
