### PR TITLE
filter_record_transformer: Relax conditions which auto_typecast is applied for enable_ruby yes

### DIFF
--- a/lib/fluent/plugin/filter_record_transformer.rb
+++ b/lib/fluent/plugin/filter_record_transformer.rb
@@ -264,12 +264,13 @@ module Fluent
         new_value = nil
         if value.is_a?(String)
           if @auto_typecast and !force_stringify
-            if single_placeholder_matched = value.match(/\A\${([^}]+)}\z/) # ${..} => ..
-              new_value = single_placeholder_matched[1]
+            num_placeholders = value.scan('${').size
+            if num_placeholders == 1 and value.start_with?('${') && value.end_with?('}')
+              new_value = value[2..-2] # ${..} => ..
             end
           end
           unless new_value
-            new_value = %Q{%Q[#{value.gsub(/\$\{([^}]+)\}/, '#{\1}')}]} # xx${..}xx => %Q[xx#{..}xx]
+            new_value = "%Q[#{value.gsub('${', '#{')}]" # xx${..}xx => %Q[xx#{..}xx]
           end
         elsif value.is_a?(Hash)
           new_value = {}

--- a/test/plugin/test_filter_record_transformer.rb
+++ b/test/plugin/test_filter_record_transformer.rb
@@ -509,6 +509,23 @@ class RecordTransformerFilterTest < Test::Unit::TestCase
       end
     end
 
+    test 'auto_typecast placeholder containing {} (enable_ruby yes)' do
+      config = %[
+        tag tag
+        enable_ruby yes
+        auto_typecast yes
+        <record>
+          foo ${record.map{|k,v|v}}
+        </record>
+      ]
+      d = create_driver(config)
+      message = {"@timestamp" => "foo"}
+      es = d.run { d.emit(message, @time) }.filtered
+      es.each do |t, r|
+        assert_equal([message["@timestamp"]], r['foo'])
+      end
+    end
+
     test 'expand fields starting with @ (enable_ruby yes)' do
       config = %[
         enable_ruby yes
@@ -523,7 +540,7 @@ class RecordTransformerFilterTest < Test::Unit::TestCase
         assert_equal(message["@timestamp"], r['foo'])
       end
     end
-  end
+  end # test placeholders
 
   test "compatibility test (enable_ruby yes)" do
     config = %[


### PR DESCRIPTION
Same thing with https://github.com/sonots/fluent-plugin-record-reformer/pull/36