### PR TITLE
Add missing require

### DIFF
--- a/lib/fluent/output.rb
+++ b/lib/fluent/output.rb
@@ -21,6 +21,7 @@ require 'fluent/configurable'
 require 'fluent/engine'
 require 'fluent/log'
 require 'fluent/plugin'
+require 'fluent/status'
 require 'fluent/timezone'
 
 module Fluent


### PR DESCRIPTION
fluent/output uses fluent/status.