### PR TITLE
Add missing require

### DIFF
--- a/lib/fluent/configurable.rb
+++ b/lib/fluent/configurable.rb
@@ -19,6 +19,7 @@ require 'fluent/config/section'
 require 'fluent/config/error'
 require 'fluent/registry'
 require 'fluent/plugin'
+require 'fluent/mixin'
 
 module Fluent
   module Configurable


### PR DESCRIPTION
fluent/mixin should include automatically before requiring plugin.