### PR TITLE
fix to dup default values to make it safe if plugins modify provided values

### DIFF
--- a/lib/fluent/config/section.rb
+++ b/lib/fluent/config/section.rb
@@ -88,7 +88,7 @@ module Fluent
 
         proxy.defaults.each_pair do |name, defval|
           varname = name.to_sym
-          section_params[varname] = defval
+          section_params[varname] = (defval.dup rescue defval)
         end
 
         if proxy.argument

--- a/test/config/test_types.rb
+++ b/test/config/test_types.rb
@@ -128,6 +128,12 @@ class TestConfigTypes < ::Test::Unit::TestCase
 
     test 'array' do
       assert_equal(["1","2",1], Config::ARRAY_TYPE.call('["1","2",1]', {}))
+
+      array_options = {
+        default: [],
+      }
+      assert_equal(["1","2"], Config::ARRAY_TYPE.call('["1","2"]', array_options))
+      assert_equal(["3"], Config::ARRAY_TYPE.call('["3"]', array_options))
     end
   end
 end


### PR DESCRIPTION
This problem makes bad effect especially for instantiated/configured twice or more in a process.
The most visible case is testing, but it might affect configuration reloaded with `HUP` signals.