### PR TITLE
separate PluginId module from config.rb

### DIFF
--- a/lib/fluent/config.rb
+++ b/lib/fluent/config.rb
@@ -39,15 +39,4 @@ module Fluent
       Element.new(name, '', {}, [])
     end
   end
-
-  module PluginId
-    def configure(conf)
-      @id = conf['@id'] || conf['id']
-      super
-    end
-
-    def plugin_id
-      @id ? @id : "object:#{object_id.to_s(16)}"
-    end
-  end
 end

--- a/lib/fluent/filter.rb
+++ b/lib/fluent/filter.rb
@@ -14,8 +14,8 @@
 #    limitations under the License.
 #
 
-require 'fluent/config'
 require 'fluent/configurable'
+require 'fluent/plugin_id'
 require 'fluent/engine'
 require 'fluent/event'
 require 'fluent/log'

--- a/lib/fluent/input.rb
+++ b/lib/fluent/input.rb
@@ -14,8 +14,8 @@
 #    limitations under the License.
 #
 
-require 'fluent/config'
 require 'fluent/configurable'
+require 'fluent/plugin_id'
 require 'fluent/engine'
 require 'fluent/log'
 

--- a/lib/fluent/output.rb
+++ b/lib/fluent/output.rb
@@ -16,8 +16,8 @@
 
 require 'thread'
 
-require 'fluent/config'
 require 'fluent/configurable'
+require 'fluent/plugin_id'
 require 'fluent/engine'
 require 'fluent/log'
 require 'fluent/plugin'

--- a/lib/fluent/plugin_id.rb
+++ b/lib/fluent/plugin_id.rb
@@ -1,0 +1,57 @@
+#
+# Fluent
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'set'
+
+module Fluent
+  module PluginId
+    @@configured_ids = Set.new
+
+    def configure(conf)
+      @id = conf['@id'] || conf['id']
+      @_id_configured = !!@id # plugin id is explicitly configured by users (or not)
+      if @id
+        @id = @id.to_s
+        if @@configured_ids.include?(@id) && !plugin_id_for_test?
+          raise Fluent::ConfigError, "Duplicated plugin id `#{@id}`. Check whole configuration and fix it."
+        end
+        @@configured_ids.add(@id)
+      end
+
+      super
+    end
+
+    def plugin_id_for_test?
+      caller_locations.each do |location|
+        # Thread::Backtrace::Location#path returns base filename or absolute path.
+        # #absolute_path returns absolute_path always.
+        # https://bugs.ruby-lang.org/issues/12159
+        if location.absolute_path =~ /\/test_[^\/]+\.rb$/ # location.path =~ /test_.+\.rb$/
+          return true
+        end
+      end
+      false
+    end
+
+    def plugin_id_configured?
+      @_id_configured
+    end
+
+    def plugin_id
+      @id ? @id : "object:#{object_id.to_s(16)}"
+    end
+  end
+end


### PR DESCRIPTION
* simply speaking, it's wrong file to write it
* added a feature to check whether id is intentionally set by user or not
  * it's important to check whether we can create many thing depends on id or not
  * for example, id-based auto generated buffer path, and plugin storage on local filesystem