### PR TITLE
In http: Use RFC suggested character cases of HTTP response header

### DIFF
--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -384,7 +384,7 @@ module Fluent
       end
 
       def send_response(code, header, body)
-        header['Content-length'] ||= body.bytesize
+        header['Content-Length'] ||= body.bytesize
         header['Content-Type'] ||= 'text/plain'
 
         data = %[HTTP/1.1 #{code}\r\n]

--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -143,9 +143,9 @@ module Fluent
         # Skip nil record
         if record.nil?
           if @respond_with_empty_img
-            return ["200 OK", {'Content-type'=>'image/gif; charset=utf-8'}, EMPTY_GIF_IMAGE]
+            return ["200 OK", {'Content-Type'=>'image/gif; charset=utf-8'}, EMPTY_GIF_IMAGE]
           else
-            return ["200 OK", {'Content-type'=>'text/plain'}, ""]
+            return ["200 OK", {'Content-Type'=>'text/plain'}, ""]
           end
         end
 
@@ -168,7 +168,7 @@ module Fluent
                  record_time.nil? ? Engine.now : record_time
                end
       rescue
-        return ["400 Bad Request", {'Content-type'=>'text/plain'}, "400 Bad Request\n#{$!}\n"]
+        return ["400 Bad Request", {'Content-Type'=>'text/plain'}, "400 Bad Request\n#{$!}\n"]
       end
 
       # TODO server error
@@ -195,13 +195,13 @@ module Fluent
           router.emit(tag, time, record)
         end
       rescue
-        return ["500 Internal Server Error", {'Content-type'=>'text/plain'}, "500 Internal Server Error\n#{$!}\n"]
+        return ["500 Internal Server Error", {'Content-Type'=>'text/plain'}, "500 Internal Server Error\n#{$!}\n"]
       end
 
       if @respond_with_empty_img
-        return ["200 OK", {'Content-type'=>'image/gif; charset=utf-8'}, EMPTY_GIF_IMAGE]
+        return ["200 OK", {'Content-Type'=>'image/gif; charset=utf-8'}, EMPTY_GIF_IMAGE]
       else
-        return ["200 OK", {'Content-type'=>'text/plain'}, ""]
+        return ["200 OK", {'Content-Type'=>'text/plain'}, ""]
       end
     end
 
@@ -385,7 +385,7 @@ module Fluent
 
       def send_response(code, header, body)
         header['Content-length'] ||= body.bytesize
-        header['Content-type'] ||= 'text/plain'
+        header['Content-Type'] ||= 'text/plain'
 
         data = %[HTTP/1.1 #{code}\r\n]
         header.each_pair {|k,v|

--- a/test/plugin/test_in_http.rb
+++ b/test/plugin/test_in_http.rb
@@ -323,7 +323,7 @@ class HttpInputTest < Test::Unit::TestCase
       d.run do
         # Send two requests the second one has no Content-Type in Keep-Alive
         Net::HTTP.start("127.0.0.1", PORT) do |http|
-          req = Net::HTTP::Post.new("/foodb/bartbl", {"connection" => "keepalive", "content-type" => "application/json"})
+          req = Net::HTTP::Post.new("/foodb/bartbl", {"connection" => "keepalive", "content-Type" => "application/json"})
           res = http.request(req)
 
           req = Net::HTTP::Get.new("/foodb/bartbl", {"connection" => "keepalive"})

--- a/test/plugin/test_in_http.rb
+++ b/test/plugin/test_in_http.rb
@@ -181,7 +181,7 @@ class HttpInputTest < Test::Unit::TestCase
 
     d.run do
       d.expected_emits.each {|tag,time,record|
-        res = post("/#{tag}?time=#{time.to_s}", record.to_json, {"content-type"=>"application/json; charset=utf-8"})
+        res = post("/#{tag}?time=#{time.to_s}", record.to_json, {"Content-Type"=>"application/json; charset=utf-8"})
         assert_equal "200", res.code
       }
     end
@@ -323,7 +323,7 @@ class HttpInputTest < Test::Unit::TestCase
       d.run do
         # Send two requests the second one has no Content-Type in Keep-Alive
         Net::HTTP.start("127.0.0.1", PORT) do |http|
-          req = Net::HTTP::Post.new("/foodb/bartbl", {"connection" => "keepalive", "content-Type" => "application/json"})
+          req = Net::HTTP::Post.new("/foodb/bartbl", {"connection" => "keepalive", "Content-Type" => "application/json"})
           res = http.request(req)
 
           req = Net::HTTP::Get.new("/foodb/bartbl", {"connection" => "keepalive"})


### PR DESCRIPTION
* In RFC 7230, content length header is described as [Content-**L**ength](http://tools.ietf.org/html/rfc7230#section-3.3.2).
* In RFC 7231, content type header is described as [Content-**T**ype](http://tools.ietf.org/html/rfc7231#section-3.1.1.5).

Note that `Content-type` is already corrected into `Content-Type` in internally by Net::HTTP: https://github.com/ruby/ruby/blob/5728783a0458357105c1943a4b0a9e04c1879a04/lib/net/http/header.rb#L171.

So, this change is only code appearance.