### PR TITLE
in_http: Fix to check keepalive enabled explicitly

### DIFF
--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -232,6 +232,8 @@ module Fluent
     end
 
     class Handler < Coolio::Socket
+      attr_reader :content_type
+
       def initialize(io, km, callback, body_size_limit, format, log, cors_allow_origins)
         super(io)
         @km = km


### PR DESCRIPTION
This PR contains imported patch which are from https://github.com/fluent/fluentd/commit/4ebce91bdaa2fbc8ca61fafe38256ef731b6bcbc partially and https://github.com/fluent/fluentd/commit/67f9825853a692d99075e9e67d0a87272f4a19ed.
Note that this imported patch is rewritten to adopt without new v0.14 API and with current master.

Related to this developers TODO:

> * in_http test fix to check HTTP keepalive is enabled explicitly
https://github.com/fluent/fluentd/commit/67f9825853a692d99075e9e67d0a87272f4a19ed

ref: https://github.com/fluent/fluentd/wiki/Developer-notes-for-fixes-on-v0.14#plugin-miscellaneous 