### PR TITLE
Register plugin into registry

### DIFF
--- a/lib/fluent/agent.rb
+++ b/lib/fluent/agent.rb
@@ -81,7 +81,7 @@ module Fluent
       @started_filters.map { |f|
         Thread.new do
           begin
-            log.info "shutting down filter#{@context.nil? ? '' : " in #{@context}"}", type: Plugin.lookup_name_from_class(f.class), plugin_id: f.plugin_id
+            log.info "shutting down filter#{@context.nil? ? '' : " in #{@context}"}", type: Plugin.lookup_type_from_class(f.class), plugin_id: f.plugin_id
             f.shutdown
           rescue => e
             log.warn "unexpected error while shutting down filter plugins", plugin: f.class, plugin_id: f.plugin_id, error_class: e.class, error: e
@@ -95,7 +95,7 @@ module Fluent
       @started_outputs.map { |o|
         Thread.new do
           begin
-            log.info "shutting down output#{@context.nil? ? '' : " in #{@context}"}", type: Plugin.lookup_name_from_class(o.class), plugin_id: o.plugin_id
+            log.info "shutting down output#{@context.nil? ? '' : " in #{@context}"}", type: Plugin.lookup_type_from_class(o.class), plugin_id: o.plugin_id
             o.shutdown
           rescue => e
             log.warn "unexpected error while shutting down output plugins", plugin: o.class, plugin_id: o.plugin_id, error_class: e.class, error: e

--- a/lib/fluent/buffer.rb
+++ b/lib/fluent/buffer.rb
@@ -18,6 +18,7 @@ require 'monitor'
 require 'fileutils'
 
 require 'fluent/configurable'
+require 'fluent/plugin' # to register itself to registry
 
 module Fluent
   class BufferError < StandardError

--- a/lib/fluent/configurable.rb
+++ b/lib/fluent/configurable.rb
@@ -52,7 +52,7 @@ module Fluent
       conf.corresponding_proxies << proxy
 
       # In the nested section, can't get plugin class through proxies so get plugin class here
-      plugin_class = Fluent::Plugin.lookup_name_from_class(proxy.name.to_s)
+      plugin_class = Fluent::Plugin.lookup_type_from_class(proxy.name.to_s)
       root = Fluent::Config::SectionGenerator.generate(proxy, conf, logger, plugin_class)
       @config_root_section = root
 

--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -58,7 +58,6 @@ module Fluent
       @system_config = system_config
 
       BasicSocket.do_not_reverse_lookup = true
-      Plugin.load_plugins
       if defined?(Encoding)
         Encoding.default_internal = 'ASCII-8BIT' if Encoding.respond_to?(:default_internal)
         Encoding.default_external = 'ASCII-8BIT' if Encoding.respond_to?(:default_external)
@@ -126,8 +125,8 @@ module Fluent
       end
     end
 
-    def load_plugin_dir(dir)
-      Plugin.load_plugin_dir(dir)
+    def add_plugin_dir(dir)
+      Plugin.add_plugin_dir(dir)
     end
 
     def emit(tag, time, record)

--- a/lib/fluent/filter.rb
+++ b/lib/fluent/filter.rb
@@ -18,6 +18,7 @@ require 'fluent/config'
 require 'fluent/configurable'
 require 'fluent/engine'
 require 'fluent/event'
+require 'fluent/plugin' # to register itself to registry
 require 'fluent/log'
 
 module Fluent

--- a/lib/fluent/input.rb
+++ b/lib/fluent/input.rb
@@ -17,6 +17,7 @@
 require 'fluent/config'
 require 'fluent/configurable'
 require 'fluent/engine'
+require 'fluent/plugin' # to register itself to registry
 require 'fluent/log'
 
 module Fluent

--- a/lib/fluent/plugin.rb
+++ b/lib/fluent/plugin.rb
@@ -136,10 +136,10 @@ module Fluent
       case
       when obj.is_a?(Class)
         obj.new
-      when obj.respond_to?(:call)
+      when obj.respond_to?(:call) && obj.arity == 0
         obj.call
       else
-        raise Fluent::ConfigError, "#{kind} plugin '#{type}' is not a Class nor callable."
+        raise Fluent::ConfigError, "#{kind} plugin '#{type}' is not a Class nor callable (without arguments)."
       end
     end
   end

--- a/lib/fluent/plugin.rb
+++ b/lib/fluent/plugin.rb
@@ -14,166 +14,133 @@
 #    limitations under the License.
 #
 
+require 'fluent/registry'
 require 'fluent/config/error'
 
 module Fluent
-  class PluginClass
-    # This class is refactored using Fluent::Registry at v0.14
+  class Plugin
+    SEARCH_PATHS = []
 
-    def initialize
-      @input = {}
-      @output = {}
-      @filter = {}
-      @buffer = {}
-    end
+    # plugins for fluentd:         fluent/plugin/type_NAME.rb
+    # plugins for fluentd plugins: fluent/plugin/type/NAME.rb
+    #   ex: storage, buffer chunk, ...
 
-    def register_input(type, klass)
-      register_impl('input', @input, type, klass)
-    end
+    INPUT_REGISTRY     = Registry.new(:input,     'fluent/plugin/in_')
+    OUTPUT_REGISTRY    = Registry.new(:output,    'fluent/plugin/out_')
+    FILTER_REGISTRY    = Registry.new(:filter,    'fluent/plugin/filter_')
+    BUFFER_REGISTRY    = Registry.new(:buffer,    'fluent/plugin/buf_')
+    PARSER_REGISTRY    = Registry.new(:parser,    'fluent/plugin/parser_')
+    FORMATTER_REGISTRY = Registry.new(:formatter, 'fluent/plugin/formatter_')
+    # TODO: plugin storage
 
-    def register_output(type, klass)
-      register_impl('output', @output, type, klass)
-    end
+    REGISTRIES = [INPUT_REGISTRY, OUTPUT_REGISTRY, FILTER_REGISTRY, BUFFER_REGISTRY, PARSER_REGISTRY, FORMATTER_REGISTRY]
 
-    def register_filter(type, klass)
-      register_impl('filter', @filter, type, klass)
-    end
-
-    def register_buffer(type, klass)
-      register_impl('buffer', @buffer, type, klass)
-    end
-
-    def register_parser(type, klass)
-      TextParser.register_template(type, klass)
-    end
-
-    def register_formatter(type, klass)
-      TextFormatter.register_template(type, klass)
-    end
-
-    def new_input(type)
-      new_impl('input', @input, type)
-    end
-
-    def new_output(type)
-      new_impl('output', @output, type)
-    end
-
-    def new_filter(type)
-      new_impl('filter', @filter, type)
-    end
-
-    def new_buffer(type)
-      new_impl('buffer', @buffer, type)
-    end
-
-    def new_parser(type)
-      require 'fluent/parser'
-      TextParser.lookup(type)
-    end
-
-    def new_formatter(type)
-      require 'fluent/formatter'
-      TextFormatter.lookup(type)
-    end
-
-    def load_plugins
-      dir = File.join(File.dirname(__FILE__), "plugin")
-      load_plugin_dir(dir)
-    end
-
-    def load_plugin_dir(dir)
-      dir = File.expand_path(dir)
-      Dir.entries(dir).sort.each {|fname|
-        if fname =~ /\.rb$/
-          require File.join(dir, fname)
-        end
-      }
-      nil
-    end
-
-    def load_plugin(type, name)
-      try_load_plugin(name, type)
-    end
-
-    def lookup_name_from_class(klass_or_str)
-      klass = if klass_or_str.class == String
-                eval(klass_or_str) # const_get can't handle A::B
+    def self.lookup_type_from_class(klass_or_its_name)
+      klass = if klass_or_its_name.is_a? Class
+                klass_or_its_name
+              elsif klass_or_its_name.is_a? String
+                eval(klass_or_its_name) # const_get can't handle qualified klass name (ex: A::B)
               else
-                klass_or_str
+                raise ArgumentError, "invalid argument type #{klass_or_its_name.class}: #{klass_or_its_name}"
               end
+      REGISTRIES.reduce(nil){|a, r| a || r.reverse_lookup(klass) }
+    end
 
-      @input.each { |name, plugin|
-        return name if plugin == klass
-      }
-      @output.each { |name, plugin|
-        return name if plugin == klass
-      }
-      @filter.each { |name, plugin|
-        return name if plugin == klass
-      }
-
+    def self.add_plugin_dir(dir)
+      REGISTRIES.each do |r|
+        r.paths.push(dir)
+      end
       nil
     end
 
-    private
-    def register_impl(name, map, type, klass)
-      map[type] = klass
-      $log.trace { "registered #{name} plugin '#{type}'" }
-      nil
+    def self.register_input(type, klass)
+      register_impl('input', INPUT_REGISTRY, type, klass)
     end
 
-    def new_impl(name, map, type)
-      if klass = map[type]
-        return klass.new
-      end
-      try_load_plugin(name, type)
-      if klass = map[type]
-        return klass.new
-      end
-      raise ConfigError, "Unknown #{name} plugin '#{type}'. Run 'gem search -rd fluent-plugin' to find plugins"
+    def self.register_output(type, klass)
+      register_impl('output', OUTPUT_REGISTRY, type, klass)
     end
 
-    def try_load_plugin(name, type)
-      case name
-      when 'input'
-        path = "fluent/plugin/in_#{type}"
-      when 'output'
-        path = "fluent/plugin/out_#{type}"
-      when 'filter'
-        path = "fluent/plugin/filter_#{type}"
-      when 'buffer'
-        path = "fluent/plugin/buf_#{type}"
+    def self.register_filter(type, klass)
+      register_impl('filter', FILTER_REGISTRY, type, klass)
+    end
+
+    def self.register_buffer(type, klass)
+      register_impl('buffer', BUFFER_REGISTRY, type, klass)
+    end
+
+    def self.register_parser(type, klass_or_proc)
+      if klass_or_proc.is_a?(Regexp)
+        # This usage is not recommended for new API
+        require 'fluent/parser'
+        register_impl('parser', PARSER_REGISTRY, type, Proc.new { Fluent::TextParser::RegexpParser.new(klass_or_proc) })
       else
-        return
+        register_impl('parser', PARSER_REGISTRY, type, klass_or_proc)
       end
+    end
 
-      # prefer LOAD_PATH than gems
-      files = $LOAD_PATH.map {|lp|
-        lpath = File.join(lp, "#{path}.rb")
-        File.exist?(lpath) ? lpath : nil
-      }.compact
-      unless files.empty?
-        # prefer newer version
-        require File.expand_path(files.sort.last)
-        return
+    def self.register_formatter(type, klass_or_proc)
+      if klass_or_proc.respond_to?(:call) && klass_or_proc.arity == 3 # Proc.new { |tag, time, record| }
+        # This usage is not recommended for new API
+        require 'fluent/formatter'
+        register_impl('formatter', FORMATTER_REGISTRY, type, Proc.new { Fluent::TextFormatter::ProcWrappedFormatter.new(klass_or_proc) })
+      else
+        register_impl('formatter', FORMATTER_REGISTRY, type, klass_or_proc)
       end
+    end
 
-      # search gems
-      specs = Gem::Specification.find_all { |spec|
-        spec.contains_requirable_file? path
-      }
+    def self.new_input(type)
+      new_impl('input', INPUT_REGISTRY, type)
+    end
 
-      # prefer newer version
-      specs = specs.sort_by { |spec| spec.version }
-      if spec = specs.last
-        spec.require_paths.each { |lib|
-          file = "#{spec.full_gem_path}/#{lib}/#{path}"
-          require file
-        }
+    def self.new_output(type)
+      new_impl('output', OUTPUT_REGISTRY, type)
+    end
+
+    def self.new_filter(type)
+      new_impl('filter', FILTER_REGISTRY, type)
+    end
+
+    def self.new_buffer(type)
+      new_impl('buffer', BUFFER_REGISTRY, type)
+    end
+
+    def self.new_parser(type)
+      require 'fluent/parser'
+
+      if type[0] == '/' && type[-1] == '/'
+        # This usage is not recommended for new API... create RegexpParser directly
+        require 'fluent/parser'
+        Fluent::TextParser.lookup(type)
+      else
+        new_impl('parser', PARSER_REGISTRY, type)
+      end
+    end
+
+    def self.new_formatter(type)
+      new_impl('formatter', FORMATTER_REGISTRY, type)
+    end
+
+    def self.register_impl(kind, registry, type, value)
+      if !value.is_a?(Class) && !value.respond_to?(:call)
+        raise Fluent::ConfigError, "Invalid implementation as #{kind} plugin: '#{type}'. It must be a Class, or callable."
+      end
+      registry.register(type, value)
+      $log.trace "registered #{kind} plugin '#{type}'" if $log
+      nil
+    end
+
+    def self.new_impl(kind, registry, type)
+      # "'type' not found" is handled by registry
+      obj = registry.lookup(type)
+      case
+      when obj.is_a?(Class)
+        obj.new
+      when obj.respond_to?(:call)
+        obj.call
+      else
+        raise Fluent::ConfigError, "#{kind} plugin '#{type}' is not a Class nor callable."
       end
     end
   end
-
-  Plugin = PluginClass.new
 end

--- a/lib/fluent/registry.rb
+++ b/lib/fluent/registry.rb
@@ -57,14 +57,16 @@ module Fluent
       path = "#{@search_prefix}#{type}"
 
       # prefer LOAD_PATH than gems
-      files = ($LOAD_PATH + @paths).map { |lp|
-        lpath = File.expand_path(File.join(lp, "#{path}.rb"))
-        File.exist?(lpath) ? lpath : nil
-      }.compact
-      unless files.empty?
-        # prefer newer version
-        require files.sort.last
-        return
+      [@paths, $LOAD_PATH].each do |paths|
+        files = paths.map { |lp|
+          lpath = File.expand_path(File.join(lp, "#{path}.rb"))
+          File.exist?(lpath) ? lpath : nil
+        }.compact
+        unless files.empty?
+          # prefer newer version
+          require files.sort.last
+          return
+        end
       end
 
       specs = Gem::Specification.find_all { |spec|

--- a/lib/fluent/registry.rb
+++ b/lib/fluent/registry.rb
@@ -18,13 +18,16 @@ require 'fluent/config/error'
 
 module Fluent
   class Registry
+    DEFAULT_PLUGIN_PATH = File.expand_path('plugin', __FILE__)
+
     def initialize(kind, search_prefix)
       @kind = kind
       @search_prefix = search_prefix
       @map = {}
+      @paths = [DEFAULT_PLUGIN_PATH]
     end
 
-    attr_reader :kind
+    attr_reader :kind, :paths
 
     def register(type, value)
       type = type.to_sym
@@ -43,11 +46,18 @@ module Fluent
       raise ConfigError, "Unknown #{@kind} plugin '#{type}'. Run 'gem search -rd fluentd-plugin' to find plugins"  # TODO error class
     end
 
+    def reverse_lookup(value)
+      @map.each do |k, v|
+        return k if v == value
+      end
+      nil
+    end
+
     def search(type)
       path = "#{@search_prefix}#{type}"
 
       # prefer LOAD_PATH than gems
-      files = $LOAD_PATH.map { |lp|
+      files = ($LOAD_PATH + @paths).map { |lp|
         lpath = File.expand_path(File.join(lp, "#{path}.rb"))
         File.exist?(lpath) ? lpath : nil
       }.compact

--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -122,7 +122,7 @@ module Fluent
       @started_inputs.map { |i|
         Thread.new do
           begin
-            log.info "shutting down input", type: Plugin.lookup_name_from_class(i.class), plugin_id: i.plugin_id
+            log.info "shutting down input", type: Plugin.lookup_type_from_class(i.class), plugin_id: i.plugin_id
             i.shutdown
           rescue => e
             log.warn "unexpected error while shutting down input plugin", plugin: i.class, plugin_id: i.plugin_id, error_class: e.class, error: e

--- a/lib/fluent/test/formatter_test.rb
+++ b/lib/fluent/test/formatter_test.rb
@@ -16,6 +16,7 @@
 
 require 'fluent/formatter'
 require 'fluent/config'
+require 'fluent/plugin'
 
 module Fluent
   module Test
@@ -30,7 +31,7 @@ module Fluent
           end
           @instance = klass_or_str.new
         elsif klass_or_str.is_a?(String)
-          @instance = TextFormatter::TEMPLATE_REGISTRY.lookup(klass_or_str).call
+          @instance = Fluent::Plugin.new_formatter(klass_or_str)
         else
           @instance = klass_or_str
         end

--- a/lib/fluent/test/parser_test.rb
+++ b/lib/fluent/test/parser_test.rb
@@ -36,7 +36,7 @@ module Fluent
             @instance = klass_or_str.new(format, conf)
           end
         elsif klass_or_str.is_a?(String)
-          @instance = TextParser::TEMPLATE_REGISTRY.lookup(klass_or_str).call
+          @instance = Fluent::Plugin.new_parser(klass_or_str)
         else
           @instance = klass_or_str
         end

--- a/test/plugin/test_in_debug_agent.rb
+++ b/test/plugin/test_in_debug_agent.rb
@@ -1,4 +1,6 @@
 require_relative '../helper'
+require 'fluent/test'
+require 'fluent/plugin/in_debug_agent'
 require 'fileutils'
 
 class DebugAgentInputTest < Test::Unit::TestCase

--- a/test/plugin/test_in_dummy.rb
+++ b/test/plugin/test_in_dummy.rb
@@ -1,5 +1,6 @@
 require_relative '../helper'
 require 'fluent/test'
+require 'fluent/plugin/in_dummy'
 
 class DummyTest < Test::Unit::TestCase
   def setup

--- a/test/plugin/test_in_exec.rb
+++ b/test/plugin/test_in_exec.rb
@@ -1,5 +1,6 @@
 require_relative '../helper'
 require 'fluent/test'
+require 'fluent/plugin/in_exec'
 require 'net/http'
 
 class ExecInputTest < Test::Unit::TestCase

--- a/test/plugin/test_in_gc_stat.rb
+++ b/test/plugin/test_in_gc_stat.rb
@@ -1,5 +1,6 @@
 require_relative '../helper'
 require 'fluent/test'
+require 'fluent/plugin/in_gc_stat'
 
 class GCStatInputTest < Test::Unit::TestCase
   def setup

--- a/test/plugin/test_in_http.rb
+++ b/test/plugin/test_in_http.rb
@@ -1,5 +1,6 @@
 require_relative '../helper'
 require 'fluent/test'
+require 'fluent/plugin/in_http'
 require 'net/http'
 
 class HttpInputTest < Test::Unit::TestCase

--- a/test/plugin/test_in_object_space.rb
+++ b/test/plugin/test_in_object_space.rb
@@ -1,5 +1,6 @@
 require_relative '../helper'
 require 'fluent/test'
+require 'fluent/plugin/in_object_space'
 
 class ObjectSpaceInputTest < Test::Unit::TestCase
   class FailObject

--- a/test/plugin/test_in_stream.rb
+++ b/test/plugin/test_in_stream.rb
@@ -1,5 +1,6 @@
 require_relative '../helper'
 require 'fluent/test'
+require 'fluent/plugin/in_stream'
 
 module StreamInputTest
   def setup

--- a/test/plugin/test_in_syslog.rb
+++ b/test/plugin/test_in_syslog.rb
@@ -1,5 +1,6 @@
 require_relative '../helper'
 require 'fluent/test'
+require 'fluent/plugin/in_syslog'
 
 class SyslogInputTest < Test::Unit::TestCase
   def setup

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -1,5 +1,6 @@
 require_relative '../helper'
 require 'fluent/test'
+require 'fluent/plugin/in_tail'
 require 'net/http'
 require 'flexmock'
 

--- a/test/plugin/test_in_tcp.rb
+++ b/test/plugin/test_in_tcp.rb
@@ -1,5 +1,6 @@
 require_relative '../helper'
 require 'fluent/test'
+require 'fluent/plugin/in_tcp'
 
 class TcpInputTest < Test::Unit::TestCase
   def setup

--- a/test/plugin/test_in_udp.rb
+++ b/test/plugin/test_in_udp.rb
@@ -1,5 +1,6 @@
 require_relative '../helper'
 require 'fluent/test'
+require 'fluent/plugin/in_udp'
 
 class UdpInputTest < Test::Unit::TestCase
   def setup

--- a/test/plugin/test_out_copy.rb
+++ b/test/plugin/test_out_copy.rb
@@ -1,5 +1,6 @@
 require_relative '../helper'
 require 'fluent/test'
+require 'fluent/plugin/out_copy'
 
 class CopyOutputTest < Test::Unit::TestCase
   class << self

--- a/test/plugin/test_out_exec.rb
+++ b/test/plugin/test_out_exec.rb
@@ -1,5 +1,6 @@
 require_relative '../helper'
 require 'fluent/test'
+require 'fluent/plugin/out_exec'
 require 'fileutils'
 
 class ExecOutputTest < Test::Unit::TestCase

--- a/test/plugin/test_out_exec_filter.rb
+++ b/test/plugin/test_out_exec_filter.rb
@@ -1,5 +1,6 @@
 require_relative '../helper'
 require 'fluent/test'
+require 'fluent/plugin/out_exec_filter'
 require 'fileutils'
 
 class ExecFilterOutputTest < Test::Unit::TestCase

--- a/test/plugin/test_out_file.rb
+++ b/test/plugin/test_out_file.rb
@@ -1,5 +1,6 @@
 require_relative '../helper'
 require 'fluent/test'
+require 'fluent/plugin/out_file'
 require 'fileutils'
 require 'time'
 

--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -1,5 +1,6 @@
 require_relative '../helper'
 require 'fluent/test'
+require 'fluent/plugin/out_forward'
 
 class ForwardOutputTest < Test::Unit::TestCase
   def setup

--- a/test/plugin/test_out_roundrobin.rb
+++ b/test/plugin/test_out_roundrobin.rb
@@ -1,5 +1,6 @@
 require_relative '../helper'
 require 'fluent/test'
+require 'fluent/plugin/out_roundrobin'
 
 class RoundRobinOutputTest < Test::Unit::TestCase
   class << self

--- a/test/plugin/test_out_stdout.rb
+++ b/test/plugin/test_out_stdout.rb
@@ -1,5 +1,6 @@
 require_relative '../helper'
 require 'fluent/test'
+require 'fluent/plugin/out_stdout'
 
 class StdoutOutputTest < Test::Unit::TestCase
   def setup

--- a/test/plugin/test_out_stream.rb
+++ b/test/plugin/test_out_stream.rb
@@ -1,5 +1,6 @@
 require_relative '../helper'
 require 'fluent/test'
+require 'fluent/plugin/out_stream'
 
 module StreamOutputTest
   def setup

--- a/test/test_formatter.rb
+++ b/test/test_formatter.rb
@@ -390,13 +390,13 @@ module FormatterTest
     end
 
     def test_format
-      formatter = TextFormatter::TEMPLATE_REGISTRY.lookup('single_value').call
+      formatter = Fluent::Plugin.new_formatter('single_value')
       formatted = formatter.format('tag', Engine.now, {'message' => 'awesome'})
       assert_equal("awesome\n", formatted)
     end
 
     def test_format_without_newline
-      formatter = TextFormatter::TEMPLATE_REGISTRY.lookup('single_value').call
+      formatter = Fluent::Plugin.new_formatter('single_value')
       formatter.configure('add_newline' => 'false')
       formatted = formatter.format('tag', Engine.now, {'message' => 'awesome'})
       assert_equal("awesome", formatted)
@@ -416,7 +416,7 @@ module FormatterTest
 
     def test_unknown_format
       assert_raise ConfigError do
-        TextFormatter::TEMPLATE_REGISTRY.lookup('unknown')
+        Fluent::Plugin.new_formatter('unknown')
       end
     end
 
@@ -424,7 +424,7 @@ module FormatterTest
     def test_find_formatter(data)
       $LOAD_PATH.unshift(File.join(File.expand_path(File.dirname(__FILE__)), 'scripts'))
       assert_nothing_raised ConfigError do
-        TextFormatter::TEMPLATE_REGISTRY.lookup(data)
+        Fluent::Plugin.new_formatter(data)
       end
       $LOAD_PATH.shift
     end

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -216,7 +216,7 @@ module ParserTest
     include ParserTest
 
     def setup
-      @parser = TextParser::TEMPLATE_REGISTRY.lookup('apache').call
+      @parser = Fluent::Plugin.new_parser('apache')
     end
 
     data('parse' => :parse, 'call' => :call)
@@ -252,7 +252,7 @@ module ParserTest
     include ParserTest
 
     def setup
-      @parser = TextParser::TEMPLATE_REGISTRY.lookup('apache_error').call
+      @parser = Fluent::Plugin.new_parser('apache_error')
       @expected = {
         'level' => 'error',
         'client' => '127.0.0.1',
@@ -493,7 +493,7 @@ module ParserTest
     include ParserTest
 
     def setup
-      @parser = TextParser::TEMPLATE_REGISTRY.lookup('nginx').call
+      @parser = Fluent::Plugin.new_parser('nginx')
       @expected = {
         'remote'  => '127.0.0.1',
         'host'    => '192.168.0.1',
@@ -875,7 +875,7 @@ module ParserTest
     end
 
     def test_parse
-      parser = TextParser::TEMPLATE_REGISTRY.lookup('none').call
+      parser = Fluent::Plugin.new_parser('none')
       parser.configure({})
       parser.parse('log message!') { |time, record|
         assert_equal({'message' => 'log message!'}, record)
@@ -893,14 +893,14 @@ module ParserTest
     def test_parse_without_default_time
       time_at_start = Time.now.to_i
 
-      parser = TextParser::TEMPLATE_REGISTRY.lookup('none').call
+      parser = Fluent::Plugin.new_parser('none')
       parser.configure({})
       parser.parse('log message!') { |time, record|
         assert time && time >= time_at_start, "parser puts current time without time input"
         assert_equal({'message' => 'log message!'}, record)
       }
 
-      parser = TextParser::TEMPLATE_REGISTRY.lookup('none').call
+      parser = Fluent::Plugin.new_parser('none')
       parser.estimate_current_event = false
       parser.configure({})
       parser.parse('log message!') { |time, record|
@@ -914,7 +914,7 @@ module ParserTest
     include ParserTest
 
     def create_parser(conf)
-      parser = TextParser::TEMPLATE_REGISTRY.lookup('multiline').call
+      parser = Fluent::Plugin.new_parser('multiline')
       parser.configure(conf)
       parser
     end
@@ -1027,7 +1027,7 @@ EOS
 
     def test_lookup_unknown_format
       assert_raise ConfigError do
-        TextParser::TEMPLATE_REGISTRY.lookup('unknown')
+        Fluent::Plugin.new_parser('unknown')
       end
     end
 
@@ -1035,7 +1035,7 @@ EOS
     def test_lookup_known_parser(data)
       $LOAD_PATH.unshift(File.join(File.expand_path(File.dirname(__FILE__)), 'scripts'))
       assert_nothing_raised ConfigError do
-        TextParser::TEMPLATE_REGISTRY.lookup(data)
+        Fluent::Plugin.new_parser(data)
       end
       $LOAD_PATH.shift
     end


### PR DESCRIPTION
To make straightforward dependencies from kinds of plugins to plugin.rb, and reduce duplicated implementation between plugin.rb and registry.rb.
