### PR TITLE
add new Plugin::Base class and PluginHelper modules

### DIFF
--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -245,6 +245,10 @@ module Fluent
       @out.flush
     end
 
+    def reset
+      @out.reset if @out.respond_to?(:reset)
+    end
+
     private
 
     def dump_stacktrace(backtrace, level)

--- a/lib/fluent/plugin.rb
+++ b/lib/fluent/plugin.rb
@@ -18,7 +18,7 @@ require 'fluent/registry'
 require 'fluent/config/error'
 
 module Fluent
-  class Plugin
+  module Plugin
     SEARCH_PATHS = []
 
     # plugins for fluentd:         fluent/plugin/type_NAME.rb
@@ -34,24 +34,6 @@ module Fluent
     # TODO: plugin storage
 
     REGISTRIES = [INPUT_REGISTRY, OUTPUT_REGISTRY, FILTER_REGISTRY, BUFFER_REGISTRY, PARSER_REGISTRY, FORMATTER_REGISTRY]
-
-    def self.lookup_type_from_class(klass_or_its_name)
-      klass = if klass_or_its_name.is_a? Class
-                klass_or_its_name
-              elsif klass_or_its_name.is_a? String
-                eval(klass_or_its_name) # const_get can't handle qualified klass name (ex: A::B)
-              else
-                raise ArgumentError, "invalid argument type #{klass_or_its_name.class}: #{klass_or_its_name}"
-              end
-      REGISTRIES.reduce(nil){|a, r| a || r.reverse_lookup(klass) }
-    end
-
-    def self.add_plugin_dir(dir)
-      REGISTRIES.each do |r|
-        r.paths.push(dir)
-      end
-      nil
-    end
 
     def self.register_input(type, klass)
       register_impl('input', INPUT_REGISTRY, type, klass)
@@ -87,6 +69,24 @@ module Fluent
       else
         register_impl('formatter', FORMATTER_REGISTRY, type, klass_or_proc)
       end
+    end
+
+    def self.lookup_type_from_class(klass_or_its_name)
+      klass = if klass_or_its_name.is_a? Class
+                klass_or_its_name
+              elsif klass_or_its_name.is_a? String
+                eval(klass_or_its_name) # const_get can't handle qualified klass name (ex: A::B)
+              else
+                raise ArgumentError, "invalid argument type #{klass_or_its_name.class}: #{klass_or_its_name}"
+              end
+      REGISTRIES.reduce(nil){|a, r| a || r.reverse_lookup(klass) }
+    end
+
+    def self.add_plugin_dir(dir)
+      REGISTRIES.each do |r|
+        r.paths.push(dir)
+      end
+      nil
     end
 
     def self.new_input(type)

--- a/lib/fluent/plugin/base.rb
+++ b/lib/fluent/plugin/base.rb
@@ -28,13 +28,73 @@ module Fluent
       include PluginLoggerMixin
       include PluginHelper::Mixin
 
-      def initialize; end
-      def configure(conf); end
-      def start; end
-      def stop; end
-      def shutdown; end
-      def close; end
-      def terminate; end
+      State = Struct.new(:configure, :start, :stop, :shutdown, :close, :terminate)
+
+      def initialize
+        super
+        @state = State.new(false, false, false, false, false, false)
+      end
+
+      def has_router?
+        false
+      end
+
+      def configure(conf)
+        super
+        @state.configure = true
+        self
+      end
+
+      def start
+        @log.reset
+        @state.start = true
+        self
+      end
+
+      def stop
+        @state.stop = true
+        self
+      end
+
+      def shutdown
+        @state.shutdown = true
+        self
+      end
+
+      def close
+        @state.close = true
+        self
+      end
+
+      def terminate
+        @state.terminate = true
+        @log.reset
+        self
+      end
+
+      def configured?
+        @state.configure
+      end
+
+      def started?
+        @state.start
+      end
+
+      def stopped?
+        @state.stop
+      end
+
+      def shutdown?
+        @state.shutdown
+      end
+
+      def closed?
+        @state.close
+      end
+
+      def terminated?
+        @state.terminate
+      end
     end
   end
 end

--- a/lib/fluent/plugin/base.rb
+++ b/lib/fluent/plugin/base.rb
@@ -1,0 +1,40 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'fluent/plugin'
+require 'fluent/configurable'
+require 'fluent/plugin_id'
+require 'fluent/log'
+require 'fluent/plugin_helper'
+
+module Fluent
+  module Plugin
+    class Base
+      include Configurable
+      include PluginId
+      include PluginLoggerMixin
+      include PluginHelper::Mixin
+
+      def initialize; end
+      def configure(conf); end
+      def start; end
+      def stop; end
+      def shutdown; end
+      def close; end
+      def terminate; end
+    end
+  end
+end

--- a/lib/fluent/plugin_helper.rb
+++ b/lib/fluent/plugin_helper.rb
@@ -1,0 +1,36 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'fluent/plugin_helper/event_emitter'
+require 'fluent/plugin_helper/thread'
+require 'fluent/plugin_helper/event_loop'
+require 'fluent/plugin_helper/timer'
+require 'fluent/plugin_helper/child_process'
+
+module Fluent
+  module PluginHelper
+    module Mixin
+      def self.included(mod)
+        mod.extend(Fluent::PluginHelper)
+      end
+    end
+
+    def helpers(*snake_case_symbols)
+      helper_modules = snake_case_symbols.map{|name| Fluent::PluginHelper.const_get(name.to_s.split('_').map(&:capitalize).join) }
+      include *helper_modules
+    end
+  end
+end

--- a/lib/fluent/plugin_helper/child_process.rb
+++ b/lib/fluent/plugin_helper/child_process.rb
@@ -1,0 +1,183 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'fluent/plugin_helper/thread'
+require 'fluent/plugin_helper/timer'
+
+module Fluent
+  module PluginHelper
+    module ChildProcess
+      include Fluent::PluginHelper::Thread
+      include Fluent::PluginHelper::Timer
+
+      CHILD_PROCESS_LOOP_CHECK_INTERVAL = 0.2 # sec
+      CHILD_PROCESS_DEFAULT_KILL_TIMEOUT = 60 # sec
+
+      # stop     : [-]
+      # shutdown : send TERM to all child processes
+      # close    : close all I/O objects for child processes
+      # terminate: send TERM again and again if processes stil exist, and KILL after timeout
+
+      def child_process_execute(title, command, arguments: nil, subprocess_name: nil, read: true, write: true, encoding: 'utf-8', interval: nil, immediate: false, &block)
+        raise ArgumentError, "BUG: title must be a symbol" unless title.is_a? Symbol
+        raise ArgumentError, "BUG: both of input and output are disabled" if !read && !write
+        raise ArgumentError, "BUG: block not specified which receive i/o object" unless block_given?
+        raise ArgumentError, "BUG: block must have an argument for io" unless block.arity == 1
+
+        if interval
+          if immediate
+            child_process_execute_once(title, command, arguments, subprocess_name, read, write, encoding, &block)
+          end
+          timer_execute(:child_process_execute, interval, repeat: true) do
+            child_process_execute_once(title, command, arguments, subprocess_name, read, write, encoding, &block)
+          end
+        else
+          child_process_execute_once(title, command, arguments, subprocess_name, read, write, encoding, &block)
+        end
+      end
+
+      def initialize
+        super
+        # plugins MAY configure this parameter
+        @_child_process_kill_timeout = CHILD_PROCESS_DEFAULT_KILL_TIMEOUT
+      end
+
+      def start
+        super
+        @_child_process_processes = {} # pid => thread
+      end
+
+      def shutdown
+        @_child_process_processes.keys.each do |pid|
+          begin
+            if Process.waitpid(pid, Process::WNOHANG)
+              @_child_process_processes[pid].alive = false
+            else
+              Process.kill(:TERM, pid) rescue nil
+            end
+          rescue Errno::ECHILD, Errno::ESRCH, Errno::EPERM => e
+            @_child_process_processes[pid].alive = false
+          end
+        end
+
+        super
+      end
+
+      def close
+        super
+
+        @_child_process_processes.keys.each do |pid|
+          io = @_child_process_processes[pid].io
+          io.close rescue nil
+        end
+      end
+
+      def terminate
+        alive_process_exist = true
+        timeout = Time.now + @_child_process_kill_timeout
+
+        while alive_process_exist
+          @_child_process_processes.keys.each do |pid|
+            process = @_child_process_processes[pid]
+            next unless process.alive
+            begin
+              if Process.waitpid(pid, Process::WNOHANG)
+                process.alive = false
+              else
+                Process.kill(:TERM, pid) rescue nil
+              end
+            rescue Errno::ECHILD, Errno::ESRCH, Errno::EPERM => e
+              process.alive = false
+            end
+          end
+
+          alive_process_found = false
+          @_child_process_processes.each_pair do |pid, process|
+            alive_process_found = true if process.alive
+          end
+
+          if alive_process_found
+            sleep CHILD_PROCESS_LOOP_CHECK_INTERVAL
+          else
+            alive_process_exist = false
+          end
+        end
+
+        @_child_process_processes.keys.each do |pid|
+          begin
+            Process.kill(:KILL, pid) unless Process.waitpid(pid, Process::WNOHANG)
+          rescue => e
+            # ignore all errors
+          end
+          @_child_process_processes.delete(pid)
+        end
+
+        super
+      end
+
+      ProcessInfo = Struct.new(:thread, :io, :alive)
+
+      def child_process_execute_once(title, command, arguments, subprocess_name, read, write, encoding, &block)
+        ext_enc = encoding
+        int_enc = "utf-8"
+        mode = case
+               when read && write then "r+"
+               when read then "r"
+               when write then "w"
+               else
+                 raise "BUG: both read and write are false is banned before here"
+               end
+        cmd = command
+        if arguments # if arguments is nil, then command is executed by shell
+          cmd = []
+          if subprocess_name
+            cmd.push [command, subprocess_name]
+          else
+            cmd.push command
+          end
+          cmd += arguments
+        end
+        log.debug "Executing command", title: title, command: command, arguments: arguments, read: read, write: write
+        io = IO.popen(cmd, mode, external_encoding: ext_enc, internal_encoding: int_enc)
+        pid = io.pid
+
+        m = Mutex.new
+        m.lock
+        thread = thread_create do
+          m.lock # run after plugin thread get pid, thread instance and i/o
+          with_error = false
+          m.unlock
+          begin
+            block.call(io)
+          rescue EOFError => e
+            log.debug "Process exit and I/O closed", title: title, pid: pid, command: command, arguments: arguments
+          rescue IOError => e
+            if e.message == 'stream closed'
+              log.debug "Process I/O stream closed", title: title, pid: pid, command: command, arguments: arguments
+            else
+              log.error "Unexpected I/O error for child process", title: title, pid: pid, command: command, arguments: arguments, error_class: e.class, error: e
+            end
+          rescue => e
+            log.warn "Unexpected error while processing I/O for child process", title: title, pid: pid, command: command, error_class: e.class, error: e
+          end
+        end
+        @_child_process_processes[pid] = ProcessInfo.new(thread, io, true)
+        m.unlock
+        pid
+      end
+    end
+  end
+end

--- a/lib/fluent/plugin_helper/child_process.rb
+++ b/lib/fluent/plugin_helper/child_process.rb
@@ -17,6 +17,9 @@
 require 'fluent/plugin_helper/thread'
 require 'fluent/plugin_helper/timer'
 
+require 'open3'
+require 'timeout'
+
 module Fluent
   module PluginHelper
     module ChildProcess
@@ -24,38 +27,61 @@ module Fluent
       include Fluent::PluginHelper::Timer
 
       CHILD_PROCESS_LOOP_CHECK_INTERVAL = 0.2 # sec
+      CHILD_PROCESS_DEFAULT_EXIT_TIMEOUT = 10 # sec
       CHILD_PROCESS_DEFAULT_KILL_TIMEOUT = 60 # sec
 
-      # stop     : [-]
-      # shutdown : send TERM to all child processes
-      # close    : close all I/O objects for child processes, send TERM and then KILL after timeout
+      MODE_PARAMS = [:read, :write, :stderr, :read_with_stderr]
+      STDERR_OPTIONS = [:discard, :connect]
+
+      # stop     : mark callback thread as stopped
+      # shutdown : close write IO to child processes (STDIN of child processes), send TERM (KILL for Windows) to all child processes
+      # close    : send KILL to all child processes
       # terminate: [-]
 
       attr_reader :_child_process_processes # for tests
 
+      def child_process_running?
+        # checker for code in callback of child_process_execute
+        ::Thread.current[:_fluentd_plugin_helper_child_process_running] || false
+      end
+
+      def child_process_id
+        ::Thread.current[:_fluentd_plugin_helper_child_process_pid]
+      end
+
+      def child_process_exit_status
+        ::Thread.current[:_fluentd_plugin_helper_child_process_exit_status]
+      end
+
       def child_process_execute(
           title, command,
           arguments: nil, subprocess_name: nil, interval: nil, immediate: false, parallel: false,
-          read: true, write: true, internal_encoding: 'utf-8', external_encoding: 'utf-8', &block
+          mode: [:read, :write], stderr: :discard, env: {}, unsetenv: false, chdir: nil,
+          internal_encoding: 'utf-8', external_encoding: 'utf-8', scrub: true, replace_string: nil,
+          &block
       )
         raise ArgumentError, "BUG: title must be a symbol" unless title.is_a? Symbol
         raise ArgumentError, "BUG: arguments required if subprocess name is replaced" if subprocess_name && !arguments
-        raise ArgumentError, "BUG: both of input and output are disabled" if !read && !write
+
+        raise ArgumentError, "BUG: invalid mode specification" unless mode.all?{|m| MODE_PARAMS.include?(m) }
+        raise ArgumentError, "BUG: read_with_stderr is exclusive with :read and :stderr" if mode.include?(:read_with_stderr) && (mode.include?(:read) || mode.include?(:stderr))
+        raise ArgumentError, "BUG: invalid stderr handling specification" unless STDERR_OPTIONS.include?(stderr)
+
         raise ArgumentError, "BUG: block not specified which receive i/o object" unless block_given?
-        raise ArgumentError, "BUG: block must have an argument for io" unless block.arity == 1
+        raise ArgumentError, "BUG: number of block arguments are different from size of mode" unless block.arity == mode.size
 
         running = false
-        callback = ->(io) {
+        callback = ->(*args) {
           running = true
           begin
-            block.call(io)
+            block.call(*args)
           ensure
             running = false
           end
         }
 
         if immediate || !interval
-          child_process_execute_once(title, command, arguments, subprocess_name, read, write, internal_encoding, external_encoding, &callback)
+          child_process_execute_once(title, command, arguments, subprocess_name, mode, stderr, env, unsetenv, chdir, internal_encoding, external_encoding, scrub, replace_string, &callback)
         end
 
         if interval
@@ -63,7 +89,7 @@ module Fluent
             if !parallel && running
               log.warn "previous child process is still running. skipped.", title: title, command: command, arguments: arguments, interval: interval, parallel: parallel
             else
-              child_process_execute_once(title, command, arguments, subprocess_name, read, write, internal_encoding, external_encoding, &callback)
+              child_process_execute_once(title, command, arguments, subprocess_name, mode, stderr, env, unsetenv, chdir, internal_encoding, external_encoding, scrub, replace_string, &callback)
             end
           end
         end
@@ -72,117 +98,174 @@ module Fluent
       def initialize
         super
         # plugins MAY configure this parameter
+        @_child_process_exit_timeout = CHILD_PROCESS_DEFAULT_EXIT_TIMEOUT
         @_child_process_kill_timeout = CHILD_PROCESS_DEFAULT_KILL_TIMEOUT
+        @_child_process_mutex = Mutex.new
       end
 
       def start
         super
-        @_child_process_processes = {} # pid => thread
+        @_child_process_processes = {} # pid => ProcessInfo
+      end
+
+      def stop
+        @_child_process_mutex.synchronize{ @_child_process_processes.keys }.each do |pid|
+          process_info = @_child_process_processes[pid]
+          if process_info
+            process_info.thread[:_fluentd_plugin_helper_child_process_running] = false
+          end
+        end
       end
 
       def shutdown
-        @_child_process_processes.keys.each do |pid|
+        @_child_process_mutex.synchronize{ @_child_process_processes.keys }.each do |pid|
+          process_info = @_child_process_processes[pid]
+          next if !process_info || !process_info.writeio_in_use
           begin
-            if Process.waitpid(pid, Process::WNOHANG)
-              @_child_process_processes[pid].alive = false
-            else
-              Process.kill(:TERM, pid) rescue nil
+            Timeout.timeout(@_child_process_exit_timeout) do
+              process_info.writeio.close
             end
-          rescue Errno::ECHILD, Errno::ESRCH, Errno::EPERM => e
-            @_child_process_processes[pid].alive = false
+          rescue Timeout::Error
+            log.debug "External process #{process_info.title} doesn't exist after STDIN close in timeout #{@_child_process_exit_timeout}sec"
           end
+
+          child_process_kill(process_info)
         end
 
         super
       end
 
       def close
-        super
-
-        # close_write -> kill processes -> close_read
-        # * if ext process continues to write data to it's stdout, io.close_read blocks
-        #   so killing process MUST be done before closing io for read
-
-        @_child_process_processes.keys.each do |pid|
-          io = @_child_process_processes[pid].io
-          io.close_write rescue nil
-        end
-
-        timeout = Time.now + @_child_process_kill_timeout
-
-        while true
-          break if Time.now > timeout
-
-          @_child_process_processes.keys.each do |pid|
-            process = @_child_process_processes[pid]
-            next unless process.alive
-            begin
-              if Process.waitpid(pid, Process::WNOHANG)
-                process.alive = false
-              else
-                Process.kill(:TERM, pid) rescue nil
-              end
-            rescue Errno::ECHILD, Errno::ESRCH, Errno::EPERM => e
-              process.alive = false
+        while (pids = @_child_process_mutex.synchronize{ @_child_process_processes.keys }).size > 0
+          pids.each do |pid|
+            process_info = @_child_process_processes[pid]
+            if !process_info || !process_info.alive
+              @_child_process_mutex.synchronize{ @_child_process_processes.delete(pid) }
+              next
             end
-          end
 
-          alive_process_found = false
-          @_child_process_processes.each_pair do |pid, process|
-            alive_process_found = true if process.alive
+            process_info.killed_at ||= Time.now # for illegular case (e.g., created after shutdown)
+            next if Time.now < process_info.killed_at + @_child_process_kill_timeout
+
+            child_process_kill(process_info, force: true)
+            @_child_process_mutex.synchronize{ @_child_process_processes.delete(pid) }
           end
-          break unless alive_process_found
 
           sleep CHILD_PROCESS_LOOP_CHECK_INTERVAL
         end
 
-        @_child_process_processes.keys.each do |pid|
-          begin
-            Process.kill(:KILL, pid) unless Process.waitpid(pid, Process::WNOHANG)
-          rescue => e
-            # ignore all errors
-          end
-          @_child_process_processes.delete(pid)
+        super
+      end
+
+      def child_process_kill(process_info, force: false)
+        if !process_info || !process_info.alive
+          return
         end
 
-        @_child_process_processes.keys.each do |pid|
-          io = @_child_process_processes[pid].io
-          io.close_read rescue nil
+        process_info.killed_at = Time.now unless force
+
+        begin
+          pid, status = Process.waitpid2(process_info.pid, Process::WNOHANG)
+          if pid && status
+            process_info.thread[:_fluentd_plugin_helper_child_process_exit_status] = status
+            process_info.alive = false
+          end
+        rescue Errno::ECHILD, Errno::ESRCH, Errno::EPERM
+          process_info.alive = false
+        rescue
+          # ignore
+        end
+        if !process_info.alive
+          return
+        end
+
+        begin
+          signal = (Fluent.windows? || force) ? :KILL : :TERM
+          Process.kill(signal, process_info.pid)
+          if force
+            process_info.alive = false
+          end
+        rescue Errno::ECHILD, Errno::ESRCH
+          process_info.alive = false
         end
       end
 
-      ProcessInfo = Struct.new(:thread, :io, :alive)
+      ProcessInfo = Struct.new(:title, :thread, :pid, :readio, :readio_in_use, :writeio, :writeio_in_use, :stderrio, :stderrio_in_use, :wait_thread, :alive, :killed_at)
 
-      def child_process_execute_once(title, command, arguments, subprocess_name, read, write, internal_encoding, external_encoding, &block)
-        mode = case
-               when read && write then "r+"
-               when read then "r"
-               when write then "w"
-               else
-                 raise "BUG: both read and write are false is banned before here"
-               end
-        cmd = command
-        if arguments || subprocess_name # if arguments is nil, then command is executed by shell
-          cmd = []
-          if subprocess_name
-            cmd.push [command, subprocess_name]
-          else
-            cmd.push command
-          end
-          cmd += (arguments || [])
+      def child_process_execute_once(
+          title, command, arguments, subprocess_name, mode, stderr, env, unsetenv, chdir,
+          internal_encoding, external_encoding, scrub, replace_string, &block
+      )
+        spawn_args = if arguments || subprocess_name
+                       [ env, (subprocess_name ? [command, subprocess_name] : command), *(arguments || []) ]
+                     else
+                       [ env, command ]
+                     end
+        spawn_opts = {
+          unsetenv_others: unsetenv,
+        }
+        if chdir
+          spawn_opts[:chdir] = chdir
         end
-        log.debug "Executing command", title: title, command: command, arguments: arguments, read: read, write: write
-        io = IO.popen(cmd, mode, external_encoding: external_encoding, internal_encoding: internal_encoding)
-        pid = io.pid
+
+        encoding_options = {}
+        if scrub
+          encoding_options[:invalid] = encoding_options[:undef] = :replace
+          if replace_string
+            encoding_options[:replace] = replace_string
+          end
+        end
+
+        log.debug "Executing command", title: title, spawn: spawn_args, mode: mode, stderr: stderr
+
+        readio = writeio = stderrio = wait_thread = nil
+        readio_in_use = writeio_in_use = stderrio_in_use = false
+
+        if !mode.include?(:stderr) && !mode.include?(:read_with_stderr) && stderr != :discard # connect
+          writeio, readio, wait_thread = *Open3.popen2(*spawn_args)
+        elsif mode.include?(:read_with_stderr)
+          writeio, readio, wait_thread = *Open3.popen2e(*spawn_args)
+        else
+          writeio, readio, stderrio, wait_thread = *Open3.popen3(*spawn_args)
+          if !mode.include?(:stderr) # stderr == :discard
+            stderrio.reopen(IO::NULL)
+          end
+        end
+
+        if mode.include?(:write)
+          writeio.set_encoding(external_encoding, internal_encoding, encoding_options)
+          writeio_in_use = true
+        end
+        if mode.include?(:read) || mode.include?(:read_with_stderr)
+          readio.set_encoding(external_encoding, internal_encoding, encoding_options)
+          readio_in_use = true
+        end
+        if mode.include?(:stderr)
+          stderrio.set_encoding(external_encoding, internal_encoding, encoding_options)
+          stderrio_in_use = true
+        end
+
+        pid = wait_thread.pid # wait_thread => Process::Waiter
+
+        io_objects = []
+        mode.each do |m|
+          io_objects << case m
+                        when :read then readio
+                        when :write then writeio
+                        when :read_with_stderr then readio
+                        when :stderr then stderrio
+                        else
+                          raise "BUG: invalid mode must be checked before here: '#{m}'"
+                        end
+        end
 
         m = Mutex.new
         m.lock
         thread = thread_create :child_process_callback do
           m.lock # run after plugin thread get pid, thread instance and i/o
-          with_error = false
           m.unlock
           begin
-            block.call(io)
+            block.call(*io_objects)
           rescue EOFError => e
             log.debug "Process exit and I/O closed", title: title, pid: pid, command: command, arguments: arguments
           rescue IOError => e
@@ -194,10 +277,19 @@ module Fluent
           rescue => e
             log.warn "Unexpected error while processing I/O for child process", title: title, pid: pid, command: command, error_class: e.class, error: e
           end
-          io.close rescue nil
-          @_child_process_processes.delete(pid)
+          process_info = @_child_process_mutex.synchronize do
+            process_info = @_child_process_processes[pid]
+            @_child_process_processes.delete(pid)
+            process_info
+          end
+          child_process_kill(process_info, force: true) if process_info && process_info.alive && ::Thread.current[:_fluentd_plugin_helper_child_process_running]
         end
-        @_child_process_processes[pid] = ProcessInfo.new(thread, io, true)
+        thread[:_fluentd_plugin_helper_child_process_running] = true
+        thread[:_fluentd_plugin_helper_child_process_pid] = pid
+        pinfo = ProcessInfo.new(title, thread, pid, readio, readio_in_use, writeio, writeio_in_use, stderrio, stderrio_in_use, wait_thread, true, nil)
+        @_child_process_mutex.synchronize do
+          @_child_process_processes[pid] = pinfo
+        end
         m.unlock
         pid
       end

--- a/lib/fluent/plugin_helper/event_emitter.rb
+++ b/lib/fluent/plugin_helper/event_emitter.rb
@@ -1,0 +1,56 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'fluent/engine'
+
+module Fluent
+  module PluginHelper
+    module EventEmitter
+      attr_accessor :router
+
+      # stop     : [-]
+      # shutdown : disable @router
+      # close    : [-]
+      # terminate: [-]
+
+      def initialize
+        super
+        @router = nil
+      end
+
+      def configure(conf)
+        super
+
+        if label_name = conf['@label']
+          label = Engine.root_agent.find_label(label_name)
+          @router = label.event_router
+        elsif @router.nil?
+          @router = Engine.root_agent.event_router
+        end
+      end
+
+      def emits?
+        true
+      end
+
+      def shutdown
+        super
+
+        @router = nil # TODO: is it correct shutdown phase to disable router?
+      end
+    end
+  end
+end

--- a/lib/fluent/plugin_helper/event_emitter.rb
+++ b/lib/fluent/plugin_helper/event_emitter.rb
@@ -42,14 +42,13 @@ module Fluent
         end
       end
 
-      def emits?
+      def has_router?
         true
       end
 
-      def shutdown
+      def close
         super
-
-        @router = nil # TODO: is it correct shutdown phase to disable router?
+        @router = nil
       end
     end
   end

--- a/lib/fluent/plugin_helper/event_loop.rb
+++ b/lib/fluent/plugin_helper/event_loop.rb
@@ -20,6 +20,8 @@ require 'fluent/plugin_helper/thread'
 module Fluent
   module PluginHelper
     module EventLoop
+      # Currently this plugin helper is only for other helpers, not plugins.
+      # there's no way to create customized watchers to attach event loops.
       include Fluent::PluginHelper::Thread
 
       # stop     : [-]
@@ -27,12 +29,18 @@ module Fluent
       # close    : stop event loop
       # terminate: initialize internal state
 
-      EVENT_LOOP_RUN_DEFAULT_TIMEOUT = 0.2
+      EVENT_LOOP_RUN_DEFAULT_TIMEOUT = 0.5
+
+      attr_reader :_event_loop # for tests
 
       def event_loop_attach(watcher)
         @_event_loop_mutex.synchronize do
           @_event_loop.attach(watcher)
         end
+      end
+
+      def event_loop_wait_until_start
+        ::Thread.pass until event_loop_running?
       end
 
       def event_loop_running?
@@ -65,6 +73,9 @@ module Fluent
         @_event_loop_mutex.synchronize do
           @_event_loop.watchers.each {|w| w.detach if w.attached? }
         end
+        while @_event_loop_running
+          ::Thread.pass
+        end
 
         super
       end
@@ -85,7 +96,7 @@ module Fluent
         @_event_loop = nil
         @_event_loop_running = false
         @_event_loop_mutex = nil
-        @_event_loop_run_timeout = EVENT_LOOP_RUN_DEFAULT_TIMEOUT
+        @_event_loop_run_timeout = nil
 
         super
       end

--- a/lib/fluent/plugin_helper/event_loop.rb
+++ b/lib/fluent/plugin_helper/event_loop.rb
@@ -1,0 +1,103 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'cool.io'
+require 'fluent/plugin_helper/thread'
+
+module Fluent
+  module PluginHelper
+    module EventLoop
+      include Fluent::PluginHelper::Thread
+
+      # stop     : [-]
+      # shutdown : detach all event watchers on event loop
+      # close    : stop event loop
+      # terminate: initialize internal state
+
+      EVENT_LOOP_RUN_DEFAULT_TIMEOUT = 0.2
+
+      def event_loop_attach(watcher)
+        @_event_loop_mutex.synchronize do
+          @_event_loop.attach(watcher)
+        end
+      end
+
+      def event_loop_running?
+        @_event_loop_running
+      end
+
+      def initialize
+        super
+        @_event_loop = Coolio::Loop.new
+        @_event_loop_running = false
+        @_event_loop_mutex = Mutex.new
+        # plugin MAY configure loop run timeout in #configure
+        @_event_loop_run_timeout = EVENT_LOOP_RUN_DEFAULT_TIMEOUT
+      end
+
+      def start
+        super
+
+        # event loop does not run here, so mutex lock is not required
+        thread_create :event_loop do
+          default_watcher = DefaultWatcher.new
+          @_event_loop.attach(default_watcher)
+          @_event_loop_running = true
+          @_event_loop.run(@_event_loop_run_timeout) # this method blocks
+          @_event_loop_running = false
+        end
+      end
+
+      def shutdown
+        @_event_loop_mutex.synchronize do
+          @_event_loop.watchers.each {|w| w.detach if w.attached? }
+        end
+
+        super
+      end
+
+      def close
+        if @_event_loop_running
+          begin
+            @_event_loop.stop # we cannot check loop is running or not
+          rescue RuntimeError => e
+            raise unless e.message == 'loop not running'
+          end
+        end
+
+        super
+      end
+
+      def terminate
+        @_event_loop = nil
+        @_event_loop_running = false
+        @_event_loop_mutex = nil
+        @_event_loop_run_timeout = EVENT_LOOP_RUN_DEFAULT_TIMEOUT
+
+        super
+      end
+
+      # watcher to block to run event loop until shutdown
+      class DefaultWatcher < Coolio::TimerWatcher
+        def initialize
+          super(1, true) # interval: 1, repeat: true
+        end
+        # do nothing
+        def on_timer; end
+      end
+    end
+  end
+end

--- a/lib/fluent/plugin_helper/thread.rb
+++ b/lib/fluent/plugin_helper/thread.rb
@@ -1,0 +1,99 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+module Fluent
+  module PluginHelper
+    module Thread
+      THREAD_DEFAULT_WAIT_SECONDS = 1
+
+      # stop     : mark thread not to run
+      # shutdown : [-]
+      # close    : correct stopped threads
+      # terminate: kill all threads
+
+      attr_reader :_threads # for test driver
+
+      def thread_current_running?
+        ::Thread.current[:_fluentd_plugin_helper_thread_running] || false
+      end
+
+      def thread_create(title, *args)
+        raise ArgumentError, "BUG: title must be a symbol" unless title.is_a? Symbol
+        m = Mutex.new
+        m.lock
+        thread = ::Thread.new(*args) do |*t_args|
+          m.lock # run thread after that thread is successfully set into @_thread
+          ::Thread.current[:_fluentd_plugin_helper_thread_title] = title
+          ::Thread.current[:_fluentd_plugin_helper_thread_running] = true
+          m.unlock
+          thread_exit = false
+          begin
+            yield *t_args
+            thread_exit = true
+          rescue => e
+            log.warn "thread exited by unexpected error", plugin: self.class, title: title, error_class: e.class, error: e
+            raise
+          ensure
+            unless thread_exit
+              log.warn "thread doesn't exit correctly (killed or other reason)", plugin: self.class, title: title
+            end
+            @_threads.delete(::Thread.current.object_id)
+          end
+        end
+        thread.abort_on_exception = true
+        @_threads[thread.object_id] = thread
+        m.unlock
+        thread
+      end
+
+      def initialize
+        super
+        @_threads = {}
+        @_thread_wait_seconds = THREAD_DEFAULT_WAIT_SECONDS
+      end
+
+      def stop
+        super
+        @_threads.each_pair do |obj_id, thread|
+          thread[:_fluentd_plugin_helper_thread_running] = false
+        end
+      end
+
+      def close
+        @_threads.keys.each do |obj_id|
+          thread = @_threads[obj_id]
+          if !thread || thread.join(@_thread_wait_seconds)
+            @_threads.delete(obj_id)
+          end
+        end
+
+        super
+      end
+
+      def terminate
+        super
+        @_threads.keys.each do |obj_id|
+          thread = @_threads[obj_id]
+          if thread
+            thread.kill
+            thread.join
+          end
+          @_threads.delete(obj_id)
+        end
+      end
+    end
+  end
+end

--- a/lib/fluent/plugin_helper/thread.rb
+++ b/lib/fluent/plugin_helper/thread.rb
@@ -19,7 +19,7 @@ module Fluent
     module Thread
       THREAD_DEFAULT_WAIT_SECONDS = 1
 
-      # stop     : mark thread not to run
+      # stop     : mark callback thread as stopped
       # shutdown : [-]
       # close    : correct stopped threads
       # terminate: kill all threads

--- a/lib/fluent/plugin_helper/timer.rb
+++ b/lib/fluent/plugin_helper/timer.rb
@@ -35,7 +35,11 @@ module Fluent
         event_loop_attach(timer)
       end
 
-      def initialize
+      def timer_running?
+        @_timer_running
+      end
+
+      def start
         super
         @_timer_running = true
       end
@@ -57,7 +61,7 @@ module Fluent
         def on_timer
           @callback.call if @checker.call
         rescue => e
-          @log.error "Unexpected error raised. Stopping this timer.", title: @title, error: e, error_class: e.class
+          @log.error "Unexpected error raised. Stopping the timer.", title: @title, error: e, error_class: e.class
           @log.error_backtrace
           self.detach
           @log.error "Timer detached.", title: @title

--- a/lib/fluent/plugin_helper/timer.rb
+++ b/lib/fluent/plugin_helper/timer.rb
@@ -1,0 +1,68 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'fluent/plugin_helper/event_loop'
+
+module Fluent
+  module PluginHelper
+    module Timer
+      include Fluent::PluginHelper::EventLoop
+
+      # stop     : turn checker into false (callbacks not called anymore)
+      # shutdown : [-]
+      # close    : [-]
+      # terminate: [-]
+
+      # interval: integer/float, repeat: true/false
+      def timer_execute(title, interval, repeat: true, &block)
+        raise ArgumentError, "BUG: title must be a symbol" unless title.is_a? Symbol
+        raise ArgumentError, "BUG: block not specified for callback" unless block_given?
+        checker = ->(){ @_timer_running }
+        timer = TimerWatcher.new(title, interval, repeat, log, checker, &block)
+        event_loop_attach(timer)
+      end
+
+      def initialize
+        super
+        @_timer_running = true
+      end
+
+      def stop
+        super
+        @_timer_running = false
+      end
+
+      class TimerWatcher < Coolio::TimerWatcher
+        def initialize(title, interval, repeat, log, checker, &callback)
+          @title = title
+          @callback = callback
+          @log = log
+          @checker = checker
+          super(interval, repeat)
+        end
+
+        def on_timer
+          @callback.call if @checker.call
+        rescue => e
+          @log.error "Unexpected error raised. Stopping this timer.", title: @title, error: e, error_class: e.class
+          @log.error_backtrace
+          self.detach
+          @log.error "Timer detached.", title: @title
+        end
+      end
+    end
+  end
+end

--- a/lib/fluent/test/base.rb
+++ b/lib/fluent/test/base.rb
@@ -98,6 +98,10 @@ module Fluent
         @logs = []
       end
 
+      def reset
+        @logs = []
+      end
+
       def tty?
         false
       end
@@ -123,6 +127,10 @@ module Fluent
       def initialize
         @logdev = DummyLogDevice.new
         super(Fluent::Log.new(@logdev))
+      end
+
+      def reset
+        @logdev.reset
       end
 
       def logs

--- a/test/plugin_helper/test_child_process.rb
+++ b/test/plugin_helper/test_child_process.rb
@@ -1,0 +1,415 @@
+require_relative '../helper'
+require 'fluent/plugin_helper/child_process'
+require 'fluent/plugin/base'
+require 'timeout'
+
+class ChildProcessTest < Test::Unit::TestCase
+  TEST_DEADLOCK_TIMEOUT = 30
+
+  setup do
+    @d = Dummy.new
+    @d.configure(config_element())
+    @d.start
+  end
+
+  teardown do
+    if @d
+      @d.stop      unless @d.stopped?
+      @d.shutdown  unless @d.shutdown?
+      @d.close     unless @d.closed?
+      @d.terminate unless @d.terminated?
+    end
+  end
+
+  class Dummy < Fluent::Plugin::Base
+    helpers :child_process
+    def configure(conf)
+      super
+      @_child_process_kill_timeout = 1
+    end
+  end
+
+  test 'can be instantiated' do
+    d1 = Dummy.new
+    assert d1.respond_to?(:_child_process_processes)
+  end
+
+  test 'can be configured and started' do
+    d1 = Dummy.new
+    assert_nothing_raised do
+      d1.configure(config_element())
+    end
+    assert d1.plugin_id
+    assert d1.log
+
+    d1.start
+  end
+
+  test 'can execute external command asyncronously' do
+    m = Mutex.new
+    m.lock
+    ary = []
+    Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
+      ran = false
+      @d.child_process_execute(:t0, 'echo', arguments: ['foo', 'bar']) do |io|
+        m.lock
+        io.read # discard
+        ary << 2
+        ran = true
+        m.unlock
+      end
+      ary << 1
+      m.unlock
+      sleep 0.1 until m.locked? || ran
+      m.lock
+      m.unlock
+    end
+    assert_equal [1,2], ary
+  end
+
+  test 'can execute external command at just once, which finishes immediately' do
+    m = Mutex.new
+    t1 = Time.now
+    ary = []
+    Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
+      ran = false
+      @d.child_process_execute(:t1, 'echo', arguments: ['foo', 'bar']) do |io|
+        m.lock
+        ary << io.read
+        assert io.eof?
+        ran = true
+        m.unlock
+      end
+      sleep 0.1 until m.locked? || ran
+      m.lock
+      m.unlock
+    end
+    assert{ Time.now - t1 < 4.0 }
+  end
+
+  test 'can execute external command at just once, which can handle both of read and write' do
+    m = Mutex.new
+    t1 = Time.now
+    ary = []
+    Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
+      ran = false
+      @d.child_process_execute(:t2, "ruby -e 'while !STDIN.eof? && line = STDIN.readline; puts line.chomp; STDOUT.flush rescue nil; end'") do |io|
+        m.lock
+        data = begin
+                 io.read_nonblock(1)
+               rescue Errno::EAGAIN, Errno::EWOULDBLOCK
+                 ""
+               end
+        assert_equal "", data
+
+        [[1,2],[3,4],[5,6]].each do |i,j|
+          io.write "my data#{i}\n"
+          io.write "my data#{j}\n"
+          io.flush
+          ary << io.readline
+          ary << io.readline
+        end
+        io.close_write
+        assert io.eof?
+        io.close_read
+
+        ran = true
+        m.unlock
+      end
+      sleep 0.1 until m.locked? || ran
+      m.lock
+      m.unlock
+    end
+
+    expected = (1..6).map{|i| "my data#{i}\n" }
+    assert_equal expected, ary
+  end
+
+  test 'can execute external command at just once, which runs forever' do
+    m = Mutex.new
+    t1 = Time.now
+    ary = []
+    Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
+      ran = false
+      @d.child_process_execute(:t2, "ruby -e 'while sleep 0.01; puts 1; STDOUT.flush rescue nil; end'") do |io|
+        m.lock
+        ran = true
+        begin
+          while line = (io.readline rescue nil)
+            ary << line
+          end
+        ensure
+          m.unlock
+        end
+      end
+      sleep 0.1 until m.locked? || ran
+      sleep 0.5
+      @d.stop # nothing occures
+      @d.shutdown
+
+      assert{ ary.size > 5 }
+
+      @d.close
+
+      @d.terminate
+      assert @d._child_process_processes.empty?
+    end
+  end
+
+  test 'can execute external command just once, and can terminate it forcedly when shutdown/terminate even if it ignore SIGTERM' do
+    m = Mutex.new
+    t1 = Time.now
+    ary = []
+    Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
+      ran = false
+      @d.child_process_execute(:t2, "ruby -e 'Signal.trap(:TERM, nil); while sleep 0.01; puts 1; STDOUT.flush rescue nil; end'") do |io|
+        m.lock
+        ran = true
+        begin
+          while line = io.readline
+            ary << line
+          end
+        ensure
+          m.unlock
+        end
+      end
+      sleep 0.1 until m.locked? || ran
+
+      @d.stop # nothing occures
+      sleep 0.5
+      lines1 = ary.size
+      assert{ lines1 > 1 }
+
+      pid = @d._child_process_processes.keys.first
+
+      @d.shutdown
+      sleep 0.5
+      lines2 = ary.size
+      assert{ lines2 > lines1 }
+
+      @d.close
+
+      assert_nil((Process.waitpid(pid, Process::WNOHANG) rescue nil))
+
+      @d.terminate
+      assert @d._child_process_processes.empty?
+      begin
+        Process.waitpid(pid)
+      rescue Errno::ECHILD
+      end
+      # Process successfully KILLed if test reaches here
+      assert true
+    end
+  end
+
+  test 'can execute external command many times, which finishes immediately' do
+    ary = []
+    arguments = ['-e', '3.times{ puts "okay"; STDOUT.flush rescue nil; sleep 0.01 }']
+    Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
+      @d.child_process_execute(:t3, "ruby", arguments: arguments, interval: 0.8) do |io|
+        ary << io.read.split("\n").map(&:chomp).join
+      end
+      sleep 4
+      assert_equal [], @d.log.out.logs
+      @d.stop
+      assert_equal [], @d.log.out.logs
+      @d.shutdown; @d.close; @d.terminate
+      assert{ ary.size >= 3 && ary.size <= 5 }
+    end
+  end
+
+  test 'can execute external command many times, with leading once executed immediately' do
+    ary = []
+    arguments = ['-e', '3.times{ puts "okay"; STDOUT.flush rescue nil; sleep 0.01 }']
+    Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
+      @d.child_process_execute(:t4, "ruby", arguments: arguments, interval: 0.8, immediate: true) do |io|
+        ary << io.read.split("\n").map(&:chomp).join
+      end
+      sleep 4
+      @d.stop; @d.shutdown; @d.close; @d.terminate
+      assert{ ary.size >= 4 && ary.size <= 6 }
+      assert_equal [], @d.log.out.logs
+    end
+  end
+
+  test 'does not execute long running external command in parallel in default' do
+    ary = []
+    arguments = ['-e', '100.times{ puts "okay"; STDOUT.flush rescue nil; sleep 0.1 }'] # 10 sec
+    Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
+      @d.child_process_execute(:t5, "ruby", arguments: arguments, interval: 1, immediate: true) do |io|
+        ary << io.read.split("\n").map(&:chomp).join
+      end
+      sleep 4
+      assert_equal 1, @d._child_process_processes.size
+      @d.stop
+      warn_msg = '[warn]: previous child process is still running. skipped. title=:t5 command="ruby" arguments=["-e", "100.times{ puts \\"okay\\"; STDOUT.flush rescue nil; sleep 0.1 }"] interval=1 parallel=false' + "\n"
+      assert{ @d.log.out.logs.first.end_with?(warn_msg) }
+      assert{ @d.log.out.logs.all?{|line| line.end_with?(warn_msg) } }
+      @d.shutdown; @d.close; @d.terminate
+      assert_equal [], @d.log.out.logs
+    end
+  end
+
+  test 'can execute long running external command in parallel if specified' do
+    ary = []
+    arguments = ['-e', '100.times{ puts "okay"; STDOUT.flush rescue nil; sleep 0.1 }'] # 10 sec
+    Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
+      @d.child_process_execute(:t6, "ruby", arguments: arguments, interval: 1, immediate: true, parallel: true) do |io|
+        ary << io.read.split("\n").map(&:chomp).join
+      end
+      sleep 4
+      processes = @d._child_process_processes.size
+      assert{ processes >= 3 && processes <= 5 }
+      @d.stop; @d.shutdown; @d.close; @d.terminate
+      assert_equal [], @d.log.out.logs
+    end
+  end
+
+  test 'execute external processes only for writing' do
+    m = Mutex.new
+    ary = []
+    Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
+      ran = false
+      @d.child_process_execute(:t7, "ruby", arguments: ['-e', 'a=""; while b=(STDIN.readline rescue nil); a+=b; end'], read: false, write: true) do |io|
+        m.lock
+        unreadable = false
+        begin
+          io.read
+        rescue IOError
+          unreadable = true
+        end
+        assert unreadable
+
+        50.times do
+          io.write "hahaha\n"
+        end
+        ran = true
+        m.unlock
+      end
+      sleep 0.1 until m.locked? || ran
+      m.lock
+      m.unlock
+      @d.stop; @d.shutdown; @d.close; @d.terminate
+      assert_equal [], @d.log.out.logs
+    end
+  end
+
+  test 'execute external processes only for reading' do
+    m = Mutex.new
+    ary = []
+    Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
+      ran = false
+      @d.child_process_execute(:t8, "ruby", arguments: ['-e', 'while sleep 0.01; puts 1; STDOUT.flush rescue nil; end'], read: true, write: false) do |io|
+        m.lock
+        unwritable = false
+        begin
+          io.write "foobar"
+        rescue IOError
+          unwritable = true
+        end
+        assert unwritable
+
+        data = io.readline
+
+        ran = true
+        m.unlock
+      end
+      sleep 0.1 until m.locked? || ran
+      m.lock
+      m.unlock
+      @d.stop; @d.shutdown; @d.close; @d.terminate
+      assert_equal [], @d.log.out.logs
+    end
+  end
+
+  test 'can control external encodings' do
+    m = Mutex.new
+    encodings = []
+    Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
+      ran = false
+      @d.child_process_execute(:t9, "ruby -e 'sleep 10'", external_encoding: 'ascii-8bit') do |io|
+        m.lock
+        assert Encoding::ASCII_8BIT, io.external_encoding
+        ran = true
+        m.unlock
+      end
+      sleep 0.1 until m.locked? || ran
+      m.lock
+      assert true
+      @d.stop; @d.shutdown; @d.close; @d.terminate
+    end
+  end
+
+  test 'can control internal encodings' do
+    m = Mutex.new
+    encodings = []
+    Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
+      ran = false
+      @d.child_process_execute(:t9, "ruby -e 'sleep 10'", internal_encoding: 'ascii-8bit') do |io|
+        m.lock
+        assert_equal Encoding::ASCII_8BIT, io.internal_encoding
+        ran = true
+        m.unlock
+      end
+      sleep 0.1 until m.locked? || ran
+      m.lock
+      assert true
+      @d.stop; @d.shutdown; @d.close; @d.terminate
+    end
+  end
+
+  test 'can convert encodings' do
+    m = Mutex.new
+    encodings = []
+    Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
+      ran = false
+      @d.child_process_execute(:t9, "ruby", arguments: ['-e', 'STDOUT.set_encoding("ascii-8bit"); STDOUT.write  "\xA4\xB5\xA4\xC8\xA4\xB7"'], external_encoding: 'euc-jp', internal_encoding: 'windows-31j') do |io|
+        m.lock
+        str = io.read
+        assert_equal Encoding.find('windows-31j'), str.encoding
+
+        expected = "さとし".encoding('windows-31j')
+        assert_equal expected, str
+        ran = true
+        m.unlock
+      end
+      sleep 0.1 until m.locked? || ran
+      m.lock
+      assert true
+      @d.stop; @d.shutdown; @d.close; @d.terminate
+    end
+  end
+
+  unless Fluent.windows?
+    test 'can specify subprocess name' do
+      io = IO.popen([["cat", "caaaaaaaaaaat"], '-'])
+      process_naming_enabled = (open("|ps"){|io| io.readlines }.select{|line| line.include?("caaaaaaaaaaat") }.size > 0)
+      Process.kill(:TERM, io.pid) rescue nil
+      io.close rescue nil
+
+      # Does TravisCI prohibit process renaming?
+      # This test will be passed in such environment
+      pend unless process_naming_enabled
+
+      m = Mutex.new
+      pids = []
+      proc_lines = []
+      Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
+        ran = false
+        @d.child_process_execute(:t10, "ruby", arguments:['-e', 'sleep 10'], subprocess_name: "sleeeeeeeeeper") do |io|
+          m.lock
+          pids << io.pid
+          proc_lines += open("|ps"){|io| io.readlines }
+          ran = true
+          m.unlock
+        end
+        sleep 0.1 until m.locked? || ran
+        m.lock
+        pid = pids.first
+        # 51358 ttys001    0:00.00 sleeper -e sleep 10
+        assert{ proc_lines.select{|line| line =~ /^\s*#{pid}\s/ }.first.strip.split(/\s+/)[3] == "sleeeeeeeeeper" }
+        @d.stop; @d.shutdown; @d.close; @d.terminate
+      end
+    end
+  end
+end

--- a/test/plugin_helper/test_child_process.rb
+++ b/test/plugin_helper/test_child_process.rb
@@ -210,15 +210,15 @@ class ChildProcessTest < Test::Unit::TestCase
     ary = []
     arguments = ['-e', '3.times{ puts "okay"; STDOUT.flush rescue nil; sleep 0.01 }']
     Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
-      @d.child_process_execute(:t5, "ruby", arguments: arguments, interval: 0.8, mode: [:read]) do |io|
+      @d.child_process_execute(:t5, "ruby", arguments: arguments, interval: 1.5, mode: [:read]) do |io|
         ary << io.read.split("\n").map(&:chomp).join
       end
-      sleep 4
+      sleep 7
       assert_equal [], @d.log.out.logs
       @d.stop
       assert_equal [], @d.log.out.logs
       @d.shutdown; @d.close; @d.terminate
-      assert{ ary.size >= 3 && ary.size <= 5 }
+      assert{ ary.size >= 3 && ary.size <= 6 }
     end
   end
 

--- a/test/plugin_helper/test_child_process.rb
+++ b/test/plugin_helper/test_child_process.rb
@@ -97,12 +97,6 @@ class ChildProcessTest < Test::Unit::TestCase
       @d.child_process_execute(:t2, cmd, mode: [:write, :read]) do |writeio, readio|
         m.lock
         ran = true
-        data = begin
-                 readio.read_nonblock(1)
-               rescue Errno::EAGAIN, Errno::EWOULDBLOCK
-                 ""
-               end
-        assert_equal "", data
 
         [[1,2],[3,4],[5,6]].each do |i,j|
           writeio.write "my data#{i}\n"

--- a/test/plugin_helper/test_event_emitter.rb
+++ b/test/plugin_helper/test_event_emitter.rb
@@ -1,0 +1,51 @@
+require_relative '../helper'
+require 'fluent/plugin_helper/event_emitter'
+require 'fluent/plugin/base'
+
+class EventEmitterTest < Test::Unit::TestCase
+  setup do
+    Fluent::Test.setup
+  end
+
+  class Dummy0 < Fluent::Plugin::Base
+  end
+
+  class Dummy < Fluent::Plugin::Base
+    helpers :event_emitter
+  end
+
+  test 'can be instantiated to be able to emit with router' do
+    d0 = Dummy0.new
+    assert d0.respond_to?(:has_router?)
+    assert !d0.has_router?
+    assert !d0.respond_to?(:router)
+
+    d1 = Dummy.new
+    assert d1.respond_to?(:has_router?)
+    assert d1.has_router?
+    assert d1.respond_to?(:router)
+    d1.stop; d1.shutdown; d1.close; d1.terminate
+  end
+
+  test 'can be configured with valid router' do
+    d1 = Dummy.new
+    assert d1.has_router?
+    assert_nil d1.router
+
+    assert_nothing_raised do
+      d1.configure(config_element())
+    end
+
+    assert d1.router
+
+    d1.shutdown
+
+    assert d1.router
+
+    d1.close
+
+    assert_nil d1.router
+
+    d1.terminate
+  end
+end

--- a/test/plugin_helper/test_event_loop.rb
+++ b/test/plugin_helper/test_event_loop.rb
@@ -1,0 +1,52 @@
+require_relative '../helper'
+require 'fluent/plugin_helper/event_loop'
+require 'fluent/plugin/base'
+
+class EventLoopTest < Test::Unit::TestCase
+  class Dummy < Fluent::Plugin::Base
+    helpers :event_loop
+    def configure(conf)
+      super
+      @_event_loop_run_timeout = 0.1
+    end
+  end
+
+  test 'can be instantiated to be able to create event loop' do
+    d1 = Dummy.new
+    assert d1.respond_to?(:event_loop_attach)
+    assert d1.respond_to?(:event_loop_running?)
+    assert d1.respond_to?(:_event_loop)
+    assert d1._event_loop
+    assert !d1.event_loop_running?
+  end
+
+  test 'can be configured' do
+    d1 = Dummy.new
+    assert_nothing_raised do
+      d1.configure(config_element())
+    end
+    assert d1.plugin_id
+    assert d1.log
+  end
+
+  test 'can run event loop by start, stop by shutdown/close and clear by terminate' do
+    d1 = Dummy.new
+    d1.configure(config_element())
+    assert !d1.event_loop_running?
+
+    d1.start
+    d1.event_loop_wait_until_start
+
+    assert d1.event_loop_running?
+    assert_equal 1, d1._event_loop.watchers.size
+
+    d1.shutdown
+    d1.close
+
+    assert !d1.event_loop_running?
+
+    d1.terminate
+
+    assert_nil d1._event_loop
+  end
+end

--- a/test/plugin_helper/test_thread.rb
+++ b/test/plugin_helper/test_thread.rb
@@ -1,0 +1,167 @@
+require_relative '../helper'
+require 'fluent/plugin_helper/thread'
+require 'fluent/plugin/base'
+require 'timeout'
+
+class ThreadTest < Test::Unit::TestCase
+  class Dummy < Fluent::Plugin::Base
+    helpers :thread
+    def configure(conf)
+      super
+      @_thread_wait_seconds = 0.1
+      self
+    end
+  end
+
+  test 'can be instantiated to be able to create threads' do
+    d1 = Dummy.new
+    assert d1.respond_to?(:thread_current_running?)
+    assert d1.respond_to?(:thread_create)
+    assert d1.respond_to?(:_threads)
+    assert !d1.thread_current_running?
+    assert d1._threads.empty?
+  end
+
+  test 'can be configured' do
+    d1 = Dummy.new
+    assert_nothing_raised do
+      d1.configure(config_element())
+    end
+    assert d1.plugin_id
+    assert d1.log
+  end
+
+  test 'can create thread after prepared' do
+    d1 = Dummy.new
+    d1.configure(config_element())
+    d1.start
+
+    thread_arguments = []
+    m1 = Mutex.new
+    m2 = Mutex.new
+
+    m1.lock
+    thread_run = false
+
+    Timeout.timeout(10) do
+      t = d1.thread_create(:test1, 'a', 'b') do |*args|
+        m2.lock
+        thread_arguments += args
+
+        assert !d1._threads.empty? # this must be true always
+        assert d1.thread_current_running?
+
+        thread_run = true
+        m2.unlock
+        m1.lock
+      end
+      Thread.pass until m2.locked? || thread_run
+
+      m2.lock; m2.unlock
+      assert_equal 1, d1._threads.size
+
+      assert_equal :test1, t[:_fluentd_plugin_helper_thread_title]
+      assert t[:_fluentd_plugin_helper_thread_running]
+      assert_equal ['a','b'], thread_arguments
+      assert !d1._threads.empty?
+
+      m1.unlock
+
+      while t[:_fluentd_plugin_helper_thread_running]
+        Thread.pass
+      end
+    end
+
+    assert d1._threads.empty?
+
+    d1.stop; d1.shutdown; d1.close; d1.terminate
+  end
+
+  test 'can wait until all threads start' do
+    d1 = Dummy.new.configure(config_element()).start
+    ary = []
+    t1 = d1.thread_create(:t1) do
+      ary << 1
+    end
+    t2 = d1.thread_create(:t2) do
+      ary << 2
+    end
+    t3 = d1.thread_create(:t3) do
+      ary << 3
+    end
+    Timeout.timeout(10) do
+      d1.thread_wait_until_start
+    end
+    assert_equal [1,2,3], ary.sort
+
+    d1.stop; d1.shutdown; d1.close; d1.terminate
+  end
+
+  test 'can stop threads which is watching thread_current_running?, and then close it' do
+    d1 = Dummy.new.configure(config_element()).start
+
+    m1 = Mutex.new
+    thread_in_run = false
+    Timeout.timeout(10) do
+      t = d1.thread_create(:test2) do
+        thread_in_run = true
+        m1.lock
+        while d1.thread_current_running?
+          Thread.pass
+        end
+        thread_in_run = false
+        m1.unlock
+      end
+      Thread.pass until m1.locked?
+
+      assert thread_in_run
+      assert !d1._threads.empty?
+
+      d1.stop
+      Thread.pass while m1.locked?
+      assert !t[:_fluentd_plugin_helper_thread_running]
+      assert t.stop?
+    end
+
+    assert d1._threads.empty?
+
+    d1.stop; d1.shutdown; d1.close; d1.terminate
+  end
+
+  test 'can terminate threads forcedly which is running forever' do
+    d1 = Dummy.new.configure(config_element()).start
+
+    m1 = Mutex.new
+    thread_in_run = false
+    Timeout.timeout(10) do
+      t = d1.thread_create(:test2) do
+        thread_in_run = true
+        m1.lock
+        while true
+          Thread.pass
+        end
+        thread_in_run = false
+      end
+      Thread.pass until m1.locked?
+
+      assert thread_in_run
+      assert !d1._threads.empty?
+
+      d1.stop
+      assert !t[:_fluentd_plugin_helper_thread_running]
+      assert t.alive?
+
+      d1.shutdown
+      assert t.alive?
+      assert !d1._threads.empty?
+
+      d1.close
+      assert t.alive?
+      assert !d1._threads.empty?
+
+      d1.terminate
+      assert t.stop?
+      assert d1._threads.empty?
+    end
+  end
+end

--- a/test/plugin_helper/test_timer.rb
+++ b/test/plugin_helper/test_timer.rb
@@ -1,0 +1,101 @@
+require_relative '../helper'
+require 'fluent/plugin_helper/timer'
+require 'fluent/plugin/base'
+
+class TimerTest < Test::Unit::TestCase
+  class Dummy < Fluent::Plugin::Base
+    helpers :timer
+  end
+
+  test 'can be instantiated under state that timer is not running' do
+    d1 = Dummy.new
+    assert d1.respond_to?(:timer_running?)
+    assert !d1.timer_running?
+  end
+
+  test 'can be configured' do
+    d1 = Dummy.new
+    assert_nothing_raised do
+      d1.configure(config_element())
+    end
+    assert d1.plugin_id
+    assert d1.log
+  end
+
+  test 'can start timers by start' do
+    d1 = Dummy.new
+    d1.configure(config_element())
+    assert !d1.timer_running?
+    d1.start
+    assert d1.timer_running?
+
+    counter = 0
+    d1.timer_execute(:test, 0.1) do
+      counter += 1
+    end
+
+    sleep 0.55
+
+    d1.stop
+    assert !d1.timer_running?
+
+    assert{ counter >= 4 && counter <= 6 }
+
+    d1.shutdown; d1.close; d1.terminate
+  end
+
+  test 'can run many timers' do
+    d1 = Dummy.new
+    d1.configure(config_element())
+    d1.start
+
+    counter1 = 0
+    counter2 = 0
+
+    d1.timer_execute(:t1, 0.1) do
+      counter1 += 1
+    end
+    d1.timer_execute(:t2, 0.25) do
+      counter2 += 1
+    end
+
+    sleep 0.55
+
+    d1.stop
+
+    assert{ counter1 >= 4 && counter1 <= 6 }
+    assert{ counter2 == 2 }
+
+    d1.shutdown; d1.close; d1.terminate
+  end
+
+  test 'aborts timer which raises exceptions' do
+    d1 = Dummy.new
+    d1.configure(config_element())
+    d1.start
+
+    counter1 = 0
+    counter2 = 0
+
+    d1.timer_execute(:t1, 0.1) do
+      counter1 += 1
+    end
+    d1.timer_execute(:t2, 0.1) do
+      raise "abort!!!!!!" if counter2 > 2
+      counter2 += 1
+    end
+
+    sleep 0.55
+
+    d1.stop
+
+    assert{ counter1 >= 4 && counter1 <= 6 }
+    assert{ counter2 == 3 }
+    msg = "[error]: Unexpected error raised. Stopping the timer. title=:t2 error=#<RuntimeError: abort!!!!!!> error_class=RuntimeError"
+    assert{ d1.log.out.logs.any?{|line| line.include?(msg) } }
+    msg = "[error]: Timer detached. title=:t2"
+    assert{ d1.log.out.logs.any?{|line| line.include?(msg) } }
+
+    d1.shutdown; d1.close; d1.terminate
+  end
+end

--- a/test/test_input.rb
+++ b/test/test_input.rb
@@ -17,7 +17,7 @@ class FluentInputTest < ::Test::Unit::TestCase
     assert_equal Engine.root_agent.event_router, d.instance.router
 
     d = nil
-    assert_nothing_raised { 
+    assert_nothing_raised {
       d = create_driver('@label @known')
     }
     expected = Engine.root_agent.find_label('@known').event_router

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -28,8 +28,8 @@ class ConfigTest < Test::Unit::TestCase
     test 'plugin can include helper event_emitter' do
       assert FluentTest::PluginTest1.include?(Fluent::PluginHelper::EventEmitter)
       p1 = FluentTest::PluginTest1.new
-      assert p1.respond_to?(:emits?)
-      assert p1.emits?
+      assert p1.respond_to?(:has_router?)
+      assert p1.has_router?
     end
 
     test 'plugin can include helper thread' do
@@ -72,7 +72,7 @@ class ConfigTest < Test::Unit::TestCase
       assert p0.respond_to?(:event_loop_running?)
       assert p0.respond_to?(:thread_current_running?)
       assert p0.respond_to?(:thread_create)
-      assert p0.respond_to?(:emits?)
+      assert p0.respond_to?(:has_router?)
     end
   end
 end

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -1,0 +1,78 @@
+require_relative 'helper'
+require 'fluent/plugin_helper'
+require 'fluent/plugin/base'
+
+class ConfigTest < Test::Unit::TestCase
+  module FluentTest; end
+
+  sub_test_case 'Fluent::Plugin::Base.helpers method works as shortcut to include helper modules' do
+    class FluentTest::PluginTest1 < Fluent::Plugin::Base
+      helpers :event_emitter
+    end
+    class FluentTest::PluginTest2 < Fluent::Plugin::Base
+      helpers :thread
+    end
+    class FluentTest::PluginTest3 < Fluent::Plugin::Base
+      helpers :event_loop
+    end
+    class FluentTest::PluginTest4 < Fluent::Plugin::Base
+      helpers :timer
+    end
+    class FluentTest::PluginTest5 < Fluent::Plugin::Base
+      helpers :child_process
+    end
+    class FluentTest::PluginTest0 < Fluent::Plugin::Base
+      helpers :event_emitter, :thread, :event_loop, :timer, :child_process, :child_process
+    end
+
+    test 'plugin can include helper event_emitter' do
+      assert FluentTest::PluginTest1.include?(Fluent::PluginHelper::EventEmitter)
+      p1 = FluentTest::PluginTest1.new
+      assert p1.respond_to?(:emits?)
+      assert p1.emits?
+    end
+
+    test 'plugin can include helper thread' do
+      assert FluentTest::PluginTest2.include?(Fluent::PluginHelper::Thread)
+      p2 = FluentTest::PluginTest2.new
+      assert p2.respond_to?(:thread_current_running?)
+      assert p2.respond_to?(:thread_create)
+    end
+
+    test 'plugin can include helper event_loop' do
+      assert FluentTest::PluginTest3.include?(Fluent::PluginHelper::EventLoop)
+      p3 = FluentTest::PluginTest3.new
+      assert p3.respond_to?(:event_loop_attach)
+      assert p3.respond_to?(:event_loop_running?)
+    end
+
+    test 'plugin can include helper timer' do
+      assert FluentTest::PluginTest4.include?(Fluent::PluginHelper::Timer)
+      p4 = FluentTest::PluginTest4.new
+      assert p4.respond_to?(:timer_execute)
+    end
+
+    test 'plugin can include helper child_process' do
+      assert FluentTest::PluginTest5.include?(Fluent::PluginHelper::ChildProcess)
+      p5 = FluentTest::PluginTest5.new
+      assert p5.respond_to?(:child_process_execute)
+    end
+
+    test 'plugin can 2 or more helpers at once' do
+      assert FluentTest::PluginTest0.include?(Fluent::PluginHelper::EventEmitter)
+      assert FluentTest::PluginTest0.include?(Fluent::PluginHelper::Thread)
+      assert FluentTest::PluginTest0.include?(Fluent::PluginHelper::EventLoop)
+      assert FluentTest::PluginTest0.include?(Fluent::PluginHelper::Timer)
+      assert FluentTest::PluginTest0.include?(Fluent::PluginHelper::ChildProcess)
+
+      p0 = FluentTest::PluginTest0.new
+      assert p0.respond_to?(:child_process_execute)
+      assert p0.respond_to?(:timer_execute)
+      assert p0.respond_to?(:event_loop_attach)
+      assert p0.respond_to?(:event_loop_running?)
+      assert p0.respond_to?(:thread_current_running?)
+      assert p0.respond_to?(:thread_create)
+      assert p0.respond_to?(:emits?)
+    end
+  end
+end


### PR DESCRIPTION
PluginHelper provides utilities to write plugins:
* high level methods to hide underlying features and options (e.g., threads, cool.io, ...)
* pre-configured suite nice to use in plugin code (e.g., threads marked as abort_on_exception in default)
* well organized test driver integration (in future): test code runs after threads start to run correctly (no more sleeps in test code!)

And change Fluent::Plugin from class to module (because it can't be instantiated) and add Fluent::Plugin::Base class as a base class of all plugins, to define methods for plugin life cycles which are used from plugin helpers.