### PR TITLE
Rakefile: Suppress warnings from ruby, enabled by rake 11

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,8 +14,8 @@ Rake::TestTask.new(:base_test) do |t|
   #  $ bundle exec rake base_test TEST=test/test_*.rb
   t.libs << "test"
   t.test_files = Dir["test/**/test_*.rb"].sort
-  t.verbose = true
-  #t.warning = true
+  t.verbose = false
+  t.warning = false
 end
 
 task :parallel_test do


### PR DESCRIPTION
In Rake 11.0.1 or later, `t.warning = true` is by default. This behavior had been introduced in https://github.com/ruby/rake/pull/97.
Should we suppress warnings from the new rake?
Or should we resolve warnings in Fluentd side?

IMO, concealing warnings is not good for Fluend. It reports potential problem which should be fixed in the future.