### PR TITLE
socket_util: Add missing require

### DIFF
--- a/lib/fluent/plugin/socket_util.rb
+++ b/lib/fluent/plugin/socket_util.rb
@@ -19,6 +19,7 @@ require 'ipaddr'
 require 'cool.io'
 
 require 'fluent/plugin'
+require 'fluent/input'
 
 module Fluent
   module SocketUtil


### PR DESCRIPTION
Otherwise, I get `NameError: uninitialized constant Fluent::Input` error when I execute `bundle exec ruby test/plugin/test_out_forward.rb`.