### PR TITLE
Override default variables with SystemConfig

### DIFF
--- a/lib/fluent/env.rb
+++ b/lib/fluent/env.rb
@@ -19,8 +19,8 @@ module Fluent
   DEFAULT_PLUGIN_DIR = ENV['FLUENT_PLUGIN'] || '/etc/fluent/plugin'
   DEFAULT_SOCKET_PATH = ENV['FLUENT_SOCKET'] || '/var/run/fluent/fluent.sock'
   DEFAULT_LISTEN_PORT = 24224 # TODO: obsolete
-  DEFAULT_FILE_PERMISSION = 0644
-  DEFAULT_DIR_PERMISSION = 0755
+  DEFAULT_FILE_PERMISSION = 0644 # TODO: configurable w/ <system>
+  DEFAULT_DIR_PERMISSION = 0755 # TODO: configurable w/ <system>
   IS_WINDOWS = /mswin|mingw/ === RUBY_PLATFORM
   private_constant :IS_WINDOWS
 

--- a/lib/fluent/env.rb
+++ b/lib/fluent/env.rb
@@ -18,7 +18,7 @@ module Fluent
   DEFAULT_CONFIG_PATH = ENV['FLUENT_CONF'] || '/etc/fluent/fluent.conf'
   DEFAULT_PLUGIN_DIR = ENV['FLUENT_PLUGIN'] || '/etc/fluent/plugin'
   DEFAULT_SOCKET_PATH = ENV['FLUENT_SOCKET'] || '/var/run/fluent/fluent.sock'
-  DEFAULT_LISTEN_PORT = 24224
+  DEFAULT_LISTEN_PORT = 24224 # TODO: obsolete
   DEFAULT_FILE_PERMISSION = 0644
   DEFAULT_DIR_PERMISSION = 0755
   IS_WINDOWS = /mswin|mingw/ === RUBY_PLATFORM

--- a/lib/fluent/env.rb
+++ b/lib/fluent/env.rb
@@ -18,9 +18,6 @@ module Fluent
   DEFAULT_CONFIG_PATH = ENV['FLUENT_CONF'] || '/etc/fluent/fluent.conf'
   DEFAULT_PLUGIN_DIR = ENV['FLUENT_PLUGIN'] || '/etc/fluent/plugin'
   DEFAULT_SOCKET_PATH = ENV['FLUENT_SOCKET'] || '/var/run/fluent/fluent.sock'
-  DEFAULT_LISTEN_PORT = 24224 # TODO: obsolete
-  DEFAULT_FILE_PERMISSION = 0644 # TODO: configurable w/ <system>
-  DEFAULT_DIR_PERMISSION = 0755 # TODO: configurable w/ <system>
   IS_WINDOWS = /mswin|mingw/ === RUBY_PLATFORM
   private_constant :IS_WINDOWS
 

--- a/lib/fluent/plugin/buf_file.rb
+++ b/lib/fluent/plugin/buf_file.rb
@@ -23,11 +23,16 @@ require 'fluent/buffer'
 
 module Fluent
   class FileBufferChunk < BufferChunk
+    include SystemConfigMixin
+
+    FILE_PERMISSION = 0644
+
     def initialize(key, path, unique_id, mode="a+", symlink_path = nil)
       super(key)
       @path = path
       @unique_id = unique_id
-      @file = File.open(@path, mode, DEFAULT_FILE_PERMISSION)
+      @file_permission = system_config.file_permission || FILE_PERMISSION
+      @file = File.open(@path, mode, @file_permission)
       @file.binmode
       @file.sync = true
       @size = @file.stat.size
@@ -78,7 +83,7 @@ module Fluent
         @file.close
         File.rename(@path, path)
         @path = path
-        @file = File.open(@path, 'rb', DEFAULT_FILE_PERMISSION)
+        @file = File.open(@path, 'rb', @file_permission)
         @file.sync = true
         @size = @file.size
         @file.pos = pos
@@ -91,7 +96,11 @@ module Fluent
   end
 
   class FileBuffer < BasicBuffer
+    include SystemConfigMixin
+
     Plugin.register_buffer('file', self)
+
+    DIR_PERMISSION = 0755
 
     @@buffer_paths = {}
 
@@ -129,10 +138,11 @@ module Fluent
         @buffer_path_suffix = ".log"
       end
 
+      @dir_perm = system_config.dir_permission || DIR_PERMISSION
     end
 
     def start
-      FileUtils.mkdir_p File.dirname(@buffer_path_prefix + "path"), mode: DEFAULT_DIR_PERMISSION
+      FileUtils.mkdir_p File.dirname(@buffer_path_prefix + "path"), mode: @dir_perm
       super
     end
 

--- a/lib/fluent/plugin/in_forward.rb
+++ b/lib/fluent/plugin/in_forward.rb
@@ -25,13 +25,15 @@ module Fluent
   class ForwardInput < Input
     Plugin.register_input('forward', self)
 
+    LISTEN_PORT = 24224
+
     def initialize
       super
       require 'fluent/plugin/socket_util'
     end
 
     desc 'The port to listen to.'
-    config_param :port, :integer, default: DEFAULT_LISTEN_PORT
+    config_param :port, :integer, default: LISTEN_PORT
     desc 'The bind address to listen to.'
     config_param :bind, :string, default: '0.0.0.0'
     config_param :backlog, :integer, default: nil

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -28,7 +28,11 @@ end
 
 module Fluent
   class TailInput < Input
+    include SystemConfigMixin
+
     Plugin.register_input('tail', self)
+
+    FILE_PERMISSION = 0644
 
     def initialize
       super
@@ -81,6 +85,7 @@ module Fluent
                          else
                            method(:parse_singleline)
                          end
+      @file_perm = system_config.file_permission || FILE_PERMISSION
     end
 
     def configure_parser(conf)
@@ -100,7 +105,7 @@ module Fluent
 
     def start
       if @pos_file
-        @pf_file = File.open(@pos_file, File::RDWR|File::CREAT|File::BINARY, DEFAULT_FILE_PERMISSION)
+        @pf_file = File.open(@pos_file, File::RDWR|File::CREAT|File::BINARY, @file_perm)
         @pf_file.sync = true
         @pf = PositionFile.parse(@pf_file)
       end

--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -36,6 +36,8 @@ module Fluent
   class ForwardOutput < ObjectBufferedOutput
     Plugin.register_output('forward', self)
 
+    LISTEN_PORT = 24224
+
     def initialize
       super
       require 'fluent/plugin/socket_util'
@@ -84,7 +86,7 @@ module Fluent
     attr_reader :nodes
 
     # backward compatibility
-    config_param :port, :integer, default: DEFAULT_LISTEN_PORT
+    config_param :port, :integer, default: LISTEN_PORT
     config_param :host, :string, default: nil
 
     attr_accessor :extend_internal_protocol
@@ -96,7 +98,7 @@ module Fluent
       if host = conf['host']
         log.warn "'host' option in forward output is obsoleted. Use '<server> host xxx </server>' instead."
         port = conf['port']
-        port = port ? port.to_i : DEFAULT_LISTEN_PORT
+        port = port ? port.to_i : LISTEN_PORT
         e = conf.add_element('server')
         e['host'] = host
         e['port'] = port.to_s
@@ -122,7 +124,7 @@ module Fluent
 
         host = e['host']
         port = e['port']
-        port = port ? port.to_i : DEFAULT_LISTEN_PORT
+        port = port ? port.to_i : LISTEN_PORT
 
         weight = e['weight']
         weight = weight ? weight.to_i : 60

--- a/lib/fluent/plugin/out_stream.rb
+++ b/lib/fluent/plugin/out_stream.rb
@@ -85,13 +85,15 @@ module Fluent
   class TcpOutput < StreamOutput
     Plugin.register_output('tcp', self)
 
+    LISTEN_PORT = 24224
+
     def initialize
       super
       $log.warn "'tcp' output is obsoleted and will be removed. Use 'forward' instead."
       $log.warn "see 'forward' section in http://docs.fluentd.org/ for the high-availability configuration."
     end
 
-    config_param :port, :integer, default: DEFAULT_LISTEN_PORT
+    config_param :port, :integer, default: LISTEN_PORT
     config_param :host, :string
 
     def configure(conf)

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -46,6 +46,12 @@ module Fluent
     config_param :rpc_endpoint, :string, default: nil
     config_param :enable_get_dump, :bool, default: nil
     config_param :process_name, default: nil
+    config_param :file_permission, default: nil do |v|
+      v.to_i(8)
+    end
+    config_param :dir_permission, default: nil do |v|
+      v.to_i(8)
+    end
 
     def self.create(conf)
       systems = conf.elements.select { |e|
@@ -77,6 +83,8 @@ module Fluent
       s.rpc_endpoint = @rpc_endpoint
       s.enable_get_dump = @enable_get_dump
       s.process_name = @process_name
+      s.file_permission = @file_permission
+      s.dir_permission = @dir_permission
 
       s
     end
@@ -92,6 +100,8 @@ module Fluent
         @rpc_endpoint = system.rpc_endpoint unless system.rpc_endpoint.nil?
         @enable_get_dump = system.enable_get_dump unless system.enable_get_dump.nil?
         @process_name = system.process_name unless system.process_name.nil?
+        @file_permission = system.file_permission unless system.file_permission.nil?
+        @dir_permission = system.dir_permission unless system.dir_permission.nil?
       }
     end
   end

--- a/test/config/test_system_config.rb
+++ b/test/config/test_system_config.rb
@@ -48,6 +48,8 @@ module Fluent::Config
       assert_nil(s.instance_variable_get(:@emit_error_log_interval))
       assert_nil(s.instance_variable_get(:@suppress_config_dump))
       assert_nil(s.instance_variable_get(:@without_source))
+      assert_nil(s.instance_variable_get(:@file_permission))
+      assert_nil(s.instance_variable_get(:@dir_permission))
     end
 
     {'log_level' => 'error',
@@ -81,6 +83,8 @@ module Fluent::Config
         assert_nil(s.instance_variable_get(:@emit_error_log_interval))
         assert_nil(s.instance_variable_get(:@suppress_config_dump))
         assert_nil(s.instance_variable_get(:@without_source))
+        assert_nil(s.instance_variable_get(:@file_permission))
+        assert_nil(s.instance_variable_get(:@dir_permission))
       end
     }
 
@@ -94,6 +98,20 @@ module Fluent::Config
       sc = Fluent::SystemConfig.new(conf)
       sc.apply(s)
       assert_equal(Fluent::Log::LEVEL_WARN, s.instance_variable_get("@log").level)
+    end
+
+    test 'process global overridable variables' do
+      conf = parse_text(<<-EOS)
+        <system>
+          file_permission 0655
+          dir_permission 0765
+        </system>
+      EOS
+      s = FakeSupervisor.new
+      sc = Fluent::SystemConfig.new(conf)
+      sc.apply(s)
+      assert_equal(0655, s.instance_variable_get(:@file_permission))
+      assert_equal(0765, s.instance_variable_get(:@dir_permission))
     end
   end
 end


### PR DESCRIPTION
I've implemented to override default variables with system config mechanism.

This PR is related to this developer task: make process global constants obsoleve in fluent/env

ref: https://github.com/fluent/fluentd/wiki/Developer-notes-for-fixes-on-v0.14#plugin-miscellaneous

## Remaining Task(s)

- [x] Write test code to confirm override feature
  - [x] test code for overriding port
  - [x] test code for overriding file permission
  - [x] test code for overriding dir permission
      - [x] out_file
      - [x] buf_file
  - [x] Omit permission related tests when running on Windows
  - [x] remove DEFAULT_* from env.rb & add default values of ports or permissions to each plugins
  - [x] remove  xxx_override methods and use ` perm = @perm_param_of_plugin || system_config.file_permissions || PLUGIN_DEFAULT_PERM` in plugin
  - [x] squash puzzling commits
  - [x] Tidying up tests
  - [x] Remove port number overriding mechanism. Because it is useless.

## Question(s)

- ~~Where is suitable place to put into obsoleted variables? Or, leave them as-is is enough?~~ Solved.