### PR TITLE
Add missing requires

### DIFF
--- a/lib/fluent/event_router.rb
+++ b/lib/fluent/event_router.rb
@@ -16,6 +16,7 @@
 
 require 'fluent/match'
 require 'fluent/event'
+require 'fluent/filter'
 
 module Fluent
   #

--- a/lib/fluent/output.rb
+++ b/lib/fluent/output.rb
@@ -23,6 +23,7 @@ require 'fluent/log'
 require 'fluent/output_chain'
 require 'fluent/plugin'
 require 'fluent/timezone'
+require 'fluent/formatter'
 
 module Fluent
   class Output


### PR DESCRIPTION
* `Filter` constant is used in `event_router`.
* `Output` class should know filter registry with `require 'filter'`.