### PR TITLE
in_forward: Fixed a problem where connections are not closed on fluentd's shutdown.

### DIFF
--- a/lib/fluent/plugin/in_forward.rb
+++ b/lib/fluent/plugin/in_forward.rb
@@ -57,6 +57,7 @@ module Fluent
 
       @lsock = listen
       @loop.attach(@lsock)
+      @connections = []
 
       @usock = SocketUtil.create_udp_socket(@bind)
       @usock.bind(@bind, @port)
@@ -82,11 +83,15 @@ module Fluent
       @usock.close
       @thread.join
       @lsock.close
+      @connections.each { |c| c.close }
     end
 
     def listen
       log.info "listening fluent socket on #{@bind}:#{@port}"
-      s = Coolio::TCPServer.new(@bind, @port, Handler, @linger_timeout, log, method(:on_message))
+      s = Coolio::TCPServer.new(@bind, @port, Handler, @linger_timeout, log, method(:on_message)) do |connection|
+        @connections.reject! { |conn| conn.closed? }
+        @connections << connection
+      end
       s.listen(@backlog) unless @backlog.nil?
       s
     end


### PR DESCRIPTION
At shutdown, `in_forward` plugin doesn't close connections accepted by Coolio::TCPServer, so clients continue to sending requests which main process cannot recognize and are to be lost until the process exits. (I think https://github.com/fluent/fluentd/issues/801 arises from the same cause as this)

I have fixed this problem by keeping accepted connections and closing them at shutdown.
