### PR TITLE
Change serialization syntax

### DIFF
--- a/lib/fluent/config/element.rb
+++ b/lib/fluent/config/element.rb
@@ -120,6 +120,7 @@ module Fluent
       def to_masked_element
         new_elems = @elements.map { |e| e.to_masked_element }
         new_elem = Element.new(@name, @arg, {}, new_elems, @unused)
+        new_elem.v1_config = @v1_config
         each_pair { |k, v|
           new_elem[k] = secret_param?(k) ? 'xxxxxx' : v
         }

--- a/lib/fluent/config/element.rb
+++ b/lib/fluent/config/element.rb
@@ -121,6 +121,7 @@ module Fluent
         new_elems = @elements.map { |e| e.to_masked_element }
         new_elem = Element.new(@name, @arg, {}, new_elems, @unused)
         new_elem.v1_config = @v1_config
+        new_elem.corresponding_proxies = @corresponding_proxies
         each_pair { |k, v|
           new_elem[k] = secret_param?(k) ? 'xxxxxx' : v
         }

--- a/lib/fluent/config/element.rb
+++ b/lib/fluent/config/element.rb
@@ -108,21 +108,7 @@ module Fluent
           out << "#{indent}<#{@name} #{@arg}>\n"
         end
         each_pair { |k, v|
-          if secret_param?(k)
-            out << "#{nindent}#{k} xxxxxx\n"
-          else
-            case param_type(k)
-            when :string
-              out << "#{nindent}#{k} \"#{self.class.unescape_parameter(v)}\"\n"
-            when :enum, :integer, :float, :size, :bool, :time
-              out << "#{nindent}#{k} #{v}\n"
-            when :hash, :array
-              out << "#{nindent}#{k} #{v}\n"
-            else
-              # Unknown type
-              out << "#{nindent}#{k} #{v}\n"
-            end
-          end
+          out << dump_value(k, v, indent, nindent)
         }
         @elements.each { |e|
           out << e.to_s(nest + 1)
@@ -164,6 +150,30 @@ module Fluent
         return nil unless proxy
         _block, opts = proxy.params[param_key]
         opts[:type]
+      end
+
+      def dump_value(k, v, indent, nindent)
+        out = ""
+        if secret_param?(k)
+          out << "#{nindent}#{k} xxxxxx\n"
+        else
+          if @v1_config
+            case param_type(k)
+            when :string
+              out << "#{nindent}#{k} \"#{self.class.unescape_parameter(v)}\"\n"
+            when :enum, :integer, :float, :size, :bool, :time
+              out << "#{nindent}#{k} #{v}\n"
+            when :hash, :array
+              out << "#{nindent}#{k} #{v}\n"
+            else
+              # Unknown type
+              out << "#{nindent}#{k} #{v}\n"
+            end
+          else
+            out << "#{nindent}#{k} #{v}\n"
+          end
+        end
+        out
       end
 
       def self.unescape_parameter(v)

--- a/lib/fluent/config/element.rb
+++ b/lib/fluent/config/element.rb
@@ -155,27 +155,25 @@ module Fluent
       end
 
       def dump_value(k, v, indent, nindent)
-        out = ""
         if secret_param?(k)
-          out << "#{nindent}#{k} xxxxxx\n"
+          "#{nindent}#{k} xxxxxx\n"
         else
           if @v1_config
             case param_type(k)
             when :string
-              out << "#{nindent}#{k} \"#{self.class.unescape_parameter(v)}\"\n"
+              "#{nindent}#{k} \"#{self.class.unescape_parameter(v)}\"\n"
             when :enum, :integer, :float, :size, :bool, :time
-              out << "#{nindent}#{k} #{v}\n"
+              "#{nindent}#{k} #{v}\n"
             when :hash, :array
-              out << "#{nindent}#{k} #{v}\n"
+              "#{nindent}#{k} #{v}\n"
             else
               # Unknown type
-              out << "#{nindent}#{k} #{v}\n"
+              "#{nindent}#{k} #{v}\n"
             end
           else
-            out << "#{nindent}#{k} #{v}\n"
+            "#{nindent}#{k} #{v}\n"
           end
         end
-        out
       end
 
       def self.unescape_parameter(v)

--- a/test/config/test_configurable.rb
+++ b/test/config/test_configurable.rb
@@ -926,7 +926,7 @@ module Fluent::Config
       test 'to_s hides secret config_param' do
         @conf.to_s.each_line { |line|
           key, value = line.strip.split(' ', 2)
-          assert_secret_param(key, value, use_to_s: true)
+          assert_secret_param(key, value)
         }
       end
 
@@ -956,14 +956,10 @@ module Fluent::Config
         }
       end
 
-      def assert_secret_param(key, value, use_to_s: false)
+      def assert_secret_param(key, value)
         case key
         when 'normal_param', 'normal_param2'
-          if use_to_s
-            assert_equal '"normal"', value
-          else
-            assert_equal 'normal', value
-          end
+          assert_equal 'normal', value
         when 'secret_param', 'secret_param2'
           assert_equal 'xxxxxx', value
         end

--- a/test/config/test_configurable.rb
+++ b/test/config/test_configurable.rb
@@ -926,7 +926,7 @@ module Fluent::Config
       test 'to_s hides secret config_param' do
         @conf.to_s.each_line { |line|
           key, value = line.strip.split(' ', 2)
-          assert_secret_param(key, value)
+          assert_secret_param(key, value, use_to_s: true)
         }
       end
 
@@ -956,10 +956,14 @@ module Fluent::Config
         }
       end
 
-      def assert_secret_param(key, value)
+      def assert_secret_param(key, value, use_to_s: false)
         case key
         when 'normal_param', 'normal_param2'
-          assert_equal 'normal', value
+          if use_to_s
+            assert_equal '"normal"', value
+          else
+            assert_equal 'normal', value
+          end
         when 'secret_param', 'secret_param2'
           assert_equal 'xxxxxx', value
         end


### PR DESCRIPTION
string as following

In previous version:
   string_param1 string_value
   string_param2 string
value

In this version:
   string_param1 "string_value"
   string_param2 "string\nvalue"

I don't change serialization format for other types.

See #522