### PR TITLE
Fix tests to exit correctly/immediately after tests finished

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,8 @@
 version: '{build}'
 
+# init:
+#   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+
 install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - "%devkit%\\devkitvars.bat"

--- a/test/plugin_helper/test_child_process.rb
+++ b/test/plugin_helper/test_child_process.rb
@@ -201,7 +201,8 @@ class ChildProcessTest < Test::Unit::TestCase
     ary = []
     Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
       ran = false
-      @d.child_process_execute(:t3, "ruby -e 'while sleep #{TEST_WAIT_INTERVAL_FOR_LOOP}; puts 1; STDOUT.flush rescue nil; end'", mode: [:read]) do |io|
+      args = ["-e", "while sleep #{TEST_WAIT_INTERVAL_FOR_LOOP}; puts 1; STDOUT.flush; end"]
+      @d.child_process_execute(:t3, "ruby", arguments: args, mode: [:read]) do |io|
         m.lock
         ran = true
         begin


### PR DESCRIPTION
* http://help.appveyor.com/discussions/problems/4371-builds-dont-finish-for-a-long-time-after-all-tests-finished
* http://www.appveyor.com/docs/how-to/rdp-to-build-worker