### PR TITLE
Separate msgpack_factory from Engine to a file

### DIFF
--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -16,12 +16,12 @@
 
 require 'socket'
 
-require 'msgpack'
 require 'cool.io'
 
 require 'fluent/config'
 require 'fluent/event'
 require 'fluent/event_router'
+require 'fluent/msgpack_factory'
 require 'fluent/root_agent'
 require 'fluent/time'
 require 'fluent/system_config'
@@ -29,6 +29,8 @@ require 'fluent/plugin'
 
 module Fluent
   class EngineClass
+    include Fluent::MessagePackFactory::Mixin
+
     def initialize
       @root_agent = nil
       @event_router = nil
@@ -41,8 +43,6 @@ module Fluent
 
       @suppress_config_dump = false
 
-      @msgpack_factory = MessagePack::Factory.new
-      @msgpack_factory.register_type(Fluent::EventTime::TYPE, Fluent::EventTime)
       @system_config = SystemConfig.new
     end
 
@@ -51,7 +51,6 @@ module Fluent
 
     attr_reader :root_agent
     attr_reader :matches, :sources
-    attr_reader :msgpack_factory
     attr_reader :system_config
 
     def init(system_config)
@@ -68,6 +67,8 @@ module Fluent
       @without_source = system_config.without_source unless system_config.without_source.nil?
 
       @root_agent = RootAgent.new(@system_config)
+
+      MessagePackFactory.init
 
       self
     end

--- a/lib/fluent/msgpack_factory.rb
+++ b/lib/fluent/msgpack_factory.rb
@@ -1,0 +1,62 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'msgpack'
+require 'fluent/time'
+
+module Fluent
+  module MessagePackFactory
+    @@engine_factory = nil
+
+    module Mixin
+      def msgpack_factory
+        MessagePackFactory.engine_factory
+      end
+
+      def msgpack_packer(*args)
+        msgpack_factory.packer(*args)
+      end
+
+      def msgpack_unpacker(*args)
+        msgpack_factory.unpacker(*args)
+      end
+    end
+
+    def self.engine_factory
+      @@engine_factory || factory
+    end
+
+    def self.factory
+      factory = MessagePack::Factory.new
+      factory.register_type(Fluent::EventTime::TYPE, Fluent::EventTime)
+      factory
+    end
+
+    def self.packer(*args)
+      factory.packer(*args)
+    end
+
+    def self.unpacker(*args)
+      factory.unpacker(*args)
+    end
+
+    def self.init
+      factory = MessagePack::Factory.new
+      factory.register_type(Fluent::EventTime::TYPE, Fluent::EventTime)
+      @@engine_factory = factory
+    end
+  end
+end


### PR DESCRIPTION
* to make it available from many classes without loading whole Engine
* Many classes/plugins requires accessibility for msgpack_factory to handle Fluent::EventTime
  * but Engine is too big to load every time (especially in tests)
* This patch make it possible to use msgpack_factory from anywhere using Mixin
  * and fetched msgpack_factory is the same instance for Engine after Engine.init
  * to make it possible to use other ext types registered via Engine
* There're another methods to create factory instances without Engine effects
  * it should be required especially for tests