### PR TITLE
Add "string_list" type to get list of strings

### DIFF
--- a/lib/fluent/config/types.rb
+++ b/lib/fluent/config/types.rb
@@ -94,6 +94,17 @@ module Fluent
       end
       param
     }
+    STRING_LIST_TYPE = Proc.new { |val, opts|
+      param = if val.is_a?(String)
+                val.start_with?('[') ? JSON.load(val) : val.strip.split(/\s*,\s*/)
+              else
+                val
+              end
+      unless param.is_a?(Array)
+        raise ConfigError, "string_list required but got #{val.inspect}"
+      end
+      param.map(&:to_s)
+    }
   end
 
   Configurable.register_type(:string,  Config::STRING_TYPE)
@@ -105,4 +116,5 @@ module Fluent
   Configurable.register_type(:time,    Config::TIME_TYPE)
   Configurable.register_type(:hash,    Config::HASH_TYPE)
   Configurable.register_type(:array,   Config::ARRAY_TYPE)
+  Configurable.register_type(:string_list, Config::STRING_LIST_TYPE)
 end

--- a/test/config/test_types.rb
+++ b/test/config/test_types.rb
@@ -135,5 +135,19 @@ class TestConfigTypes < ::Test::Unit::TestCase
       assert_equal(["1","2"], Config::ARRAY_TYPE.call('["1","2"]', array_options))
       assert_equal(["3"], Config::ARRAY_TYPE.call('["3"]', array_options))
     end
+
+    test 'string_list' do
+      assert_equal([], Config::STRING_LIST_TYPE.call('', {}))
+
+      assert_equal(["a","b","1"], Config::STRING_LIST_TYPE.call('a,b,1', {}))
+      assert_equal(["a","b","1"], Config::STRING_LIST_TYPE.call('a, b, 1', {}))
+      assert_equal(["a","b","1"], Config::STRING_LIST_TYPE.call(' a , b , 1 ', {}))
+      assert_equal(["a 1", "2"], Config::STRING_LIST_TYPE.call('a 1, 2', {}))
+
+      assert_equal(["a,b,1"], Config::STRING_LIST_TYPE.call('["a,b,1"]', {}))
+      assert_equal(["a 1", "2"], Config::STRING_LIST_TYPE.call('["a 1", "2"]', {}))
+      assert_equal(["a,1", "2"], Config::STRING_LIST_TYPE.call('["a,1", "2"]', {}))
+      assert_equal(["a,1", "2"], Config::STRING_LIST_TYPE.call('["a,1", 2]', {}))
+    end
   end
 end


### PR DESCRIPTION
* it's very common case for fluentd plugins
* "array" is useful, but it can get various types for values
* this type should support 2 kind of formats at once:
  * comman-separated string values to make input data simple
  * JSON-format arrays for values with comma

This type definition make it possible to reduce # of self-implementation of `str.split`... by 3rd party plugins