### PR TITLE
Add delimiter option to in_udp plugin

### DIFF
--- a/lib/fluent/plugin/in_udp.rb
+++ b/lib/fluent/plugin/in_udp.rb
@@ -28,15 +28,27 @@ module Fluent
       log.info "listening udp socket on #{@bind}:#{@port}"
       @usock = SocketUtil.create_udp_socket(@bind)
       @usock.bind(@bind, @port)
+      @has_delimiter = @delimiter != ''
       SocketUtil::UdpHandler.new(@usock, log, @body_size_limit, callback)
     end
 
     def on_message(msg, addr)
-      if @delimiter == ''
-        super(msg, addr)
-      else
-        msg.split(@delimiter).each do |m|
+      return super(msg, addr) unless @has_delimiter
+
+      pos = msg.index(@delimiter)
+      return super(msg, addr) if pos.nil?
+
+      start = 0
+      while true
+        m = msg[start, pos - start]
+        super(m, addr)
+
+        start = pos + 1
+        pos = msg.index(@delimiter, start)
+        if pos.nil?
+          m = msg[start, msg.length - start]
           super(m, addr)
+          break
         end
       end
     end

--- a/lib/fluent/plugin/in_udp.rb
+++ b/lib/fluent/plugin/in_udp.rb
@@ -22,12 +22,19 @@ module Fluent
 
     config_set_default :port, 5160
     config_param :body_size_limit, :size, default: 4096
+    config_param :delimiter, :string, :default => "\n"
 
     def listen(callback)
       log.info "listening udp socket on #{@bind}:#{@port}"
       @usock = SocketUtil.create_udp_socket(@bind)
       @usock.bind(@bind, @port)
       SocketUtil::UdpHandler.new(@usock, log, @body_size_limit, callback)
+    end
+
+    def on_message(msg, addr)
+      msg.split(@delimiter).each do |m|
+        super(m, addr)
+      end
     end
   end
 end

--- a/lib/fluent/plugin/in_udp.rb
+++ b/lib/fluent/plugin/in_udp.rb
@@ -22,7 +22,7 @@ module Fluent
 
     config_set_default :port, 5160
     config_param :body_size_limit, :size, default: 4096
-    config_param :delimiter, :string, :default => "\n"
+    config_param :delimiter, :string, :default => ""
 
     def listen(callback)
       log.info "listening udp socket on #{@bind}:#{@port}"
@@ -32,8 +32,12 @@ module Fluent
     end
 
     def on_message(msg, addr)
-      msg.split(@delimiter).each do |m|
-        super(m, addr)
+      if @delimiter == ''
+        super(msg, addr)
+      else
+        msg.split(@delimiter).each do |m|
+          super(m, addr)
+        end
       end
     end
   end

--- a/test/plugin/test_in_udp.rb
+++ b/test/plugin/test_in_udp.rb
@@ -65,36 +65,32 @@ class UdpInputTest < Test::Unit::TestCase
     }
   end
 
-  {
-    'none' => [
-      {'msg' => "tcptest1\n", 'expected' => 'tcptest1'},
-      {'msg' => "tcptest2\n", 'expected' => 'tcptest2'},
-    ],
-    'json' => [
-      {'msg' => {'k' => 123, 'message' => 'tcptest1'}.to_json + "\n", 'expected' => 'tcptest1'},
-      {'msg' => {'k' => 'tcptest2', 'message' => 456}.to_json + "\n", 'expected' => 456},
-    ],
-    '/^\\[(?<time>[^\\]]*)\\] (?<message>.*)/' => [
-      {'msg' => '[Sep 10 00:00:00] localhost: ' + 'x' * 100 + "\n", 'expected' => 'localhost: ' + 'x' * 100},
-      {'msg' => '[Sep 10 00:00:00] localhost: ' + 'x' * 1024 + "\n", 'expected' => 'localhost: ' + 'x' * 1024},
-    ]
-  }.each { |format, test_cases|
-    define_method("test_msg_size_#{format[0] == '/' ? 'regexp' : format}") do
-      d = create_driver(BASE_CONFIG + "format #{format}")
-      tests = test_cases
+  data('none' => {'format' => 'none',
+                  'tests'  => [{'msg' => "tcptest1\n", 'expected' => 'tcptest1'},
+                               {'msg' => "tcptest2\n", 'expected' => 'tcptest2'}]},
+       'json' => {'format' => 'json',
+                  'tests'  => [{'msg' => {'k' => 123, 'message' => 'tcptest1'}.to_json + "\n", 'expected' => 'tcptest1'},
+                               {'msg' => {'k' => 'tcptest2', 'message' => 456}.to_json + "\n", 'expected' => 456}]},
+       'regexp' => {'format' => '/^\\[(?<time>[^\\]]*)\\] (?<message>.*)/',
+                    'tests' => [{'msg' => '[Sep 10 00:00:00] localhost: ' + 'x' * 100 + "\n", 'expected' => 'localhost: ' + 'x' * 100},
+                                {'msg' => '[Sep 10 00:00:00] localhost: ' + 'x' * 1024 + "\n", 'expected' => 'localhost: ' + 'x' * 1024},
+                               ]})
+  test('test_msg_size') do |data|
+    format = data['format']
+    d = create_driver(BASE_CONFIG + "format #{format}")
+    tests = data['tests']
 
-      d.run do
-        u = UDPSocket.new
-        u.connect('127.0.0.1', PORT)
-        tests.each { |test|
-          u.send(test['msg'], 0)
-        }
-        sleep 1
-      end
-
-      compare_test_result(d.emits, tests)
+    d.run do
+      u = UDPSocket.new
+      u.connect('127.0.0.1', PORT)
+      tests.each { |test|
+        u.send(test['msg'], 0)
+      }
+      sleep 0.1
     end
-  }
+
+    compare_test_result(d.emits, tests)
+  end
 
   def compare_test_result(emits, tests)
     assert_equal(2, emits.size)
@@ -104,41 +100,36 @@ class UdpInputTest < Test::Unit::TestCase
     }
   end
 
-  {
-    'none' => [
-      {'msg' => "tcptest3\ntcptest4\n", 'expected' => ['tcptest3', 'tcptest4']},
-    ],
-    'json' => [
-      {'msg' => {'k' => 10, 'message' => 100}.to_json + "\n" +
-                {'k' => 20, 'message' => 200}.to_json + "\n", 'expected' => [100, 200]},
-    ],
-    '/^\\[(?<time>[^\\]]*)\\] (?<message>.*)/' => [
-      {'msg' => "[Sep 10 00:00:00] message1\n[Sep 10 00:00:00] message2\n", 'expected' => ['message1', 'message2']},
-    ]
-  }.each { |format, test_cases|
-    define_method("test_delimiter_#{format[0] == '/' ? 'regexp' : format}") do
-      d = create_driver(BASE_CONFIG + "format #{format}")
-      tests = test_cases
-      expects = []
-      d.run do
-        u = UDPSocket.new
-        u.connect('127.0.0.1', PORT)
-        tests.each { |test|
-          u.send(test['msg'], 0)
-          expects.concat(test['expected'])
-        }
-        sleep 1
-      end
+  data('none' => {'format'    => 'none',
+                  'delimiter' => "@",
+                  'msg'       => "tcptest3@tcptest4\n",
+                  'expected'  => ['tcptest3', 'tcptest4']},
+       'json' => {'format'    => 'json',
+                  'delimiter' => "@",
+                  'msg'       =>  {'k' => 10, 'message' => 100}.to_json + "@" + {'k' => 20, 'message' => 200}.to_json + "\n",
+                  'expected'  =>  [100, 200]},
+       'regexp' => {'format'    => '/^\\[(?<time>[^\\]]*)\\] (?<message>.*)/',
+                    'delimiter' => "@",
+                    'msg'       => "[Sep 10 00:00:00] message1@[Sep 10 00:00:00] message2\n",
+                    'expected'  => ['message1', 'message2']})
+  test('test_delimiter') do |data|
+    format = data['format']
+    delimiter = data['delimiter']
+    msg = data['msg']
+    expected = data['expected']
 
-      compare_delimiter_test_result(d.emits, tests, expects)
+    d = create_driver([BASE_CONFIG, "format #{format}", "delimiter #{delimiter}"].join("\n"))
+    d.run do
+      u = UDPSocket.new
+      u.connect('127.0.0.1', PORT)
+      u.send(msg, 0)
+      sleep 0.1
     end
-  }
 
-  def compare_delimiter_test_result(emits, tests, expects)
-    assert_equal(2, emits.size)
-    emits.each_index {|i|
-      assert_equal(expects[i], emits[i][2]['message'])
-      assert(emits[i][1].is_a?(Fluent::EventTime))
+    assert_equal(2, d.emits.size)
+    d.emits.each_index {|i|
+      assert_equal(expected[i], d.emits[i][2]['message'])
+      assert(d.emits[i][1].is_a?(Fluent::EventTime))
     }
   end
 end


### PR DESCRIPTION
According to the documentation http://docs.fluentd.org/articles/in_udp
`in_udp` should have `deliimiter` option but it currently does not.

I noticed it when my code sent multi log entries in a transmittion.

I made this patch while I am not sure whether it is a documentation bug
or not; hopefully it is not - to support bulk operation.

FYI: Current `in_syslog` looks fine with multiline entries.
Maybe its parser handles well.