### PR TITLE
Add `config_section` option `init` to initialize section objects

### DIFF
--- a/lib/fluent/config/section.rb
+++ b/lib/fluent/config/section.rb
@@ -141,6 +141,10 @@ module Fluent
         proxy.sections.each do |name, subproxy|
           varname = subproxy.param_name.to_sym
           elements = (conf.respond_to?(:elements) ? conf.elements : []).select{ |e| e.name == subproxy.name.to_s || e.name == subproxy.alias.to_s }
+          if elements.empty? && subproxy.init? && !subproxy.multi?
+            elements << Fluent::Config::Element.new(subproxy.name.to_s, '', {}, [])
+          end
+
           # set subproxy for secret option
           elements.each { |element|
             element.corresponding_proxies << subproxy

--- a/test/config/test_configurable.rb
+++ b/test/config/test_configurable.rb
@@ -89,6 +89,16 @@ module ConfigurableSpec
     end
   end
 
+  class Init0
+    include Fluent::Configurable
+    config_section :sec1, init: true, multi: false do
+      config_param :name, :string, default: 'sec1'
+    end
+    config_section :sec2, init: true, multi: true do
+      config_param :name, :string, default: 'sec1'
+    end
+  end
+
   class Example0
     include Fluent::Configurable
 
@@ -640,6 +650,15 @@ module Fluent::Config
           assert_raise(Fluent::ConfigError) { checker.call(complete.reject{|k,v| k == "floatvalue"  }) }
           assert_raise(Fluent::ConfigError) { checker.call(complete.reject{|k,v| k == "hashvalue"   }) }
           assert_raise(Fluent::ConfigError) { checker.call(complete.reject{|k,v| k == "arrayvalue"  }) }
+        end
+
+        test 'generates section with default values for init:true sections' do
+          conf = config_element('ROOT', '', {}, [])
+          init0 = ConfigurableSpec::Init0.new
+          assert_nothing_raised { init0.configure(conf) }
+          assert init0.sec1
+          assert_equal "sec1", init0.sec1.name
+          assert_equal [], init0.sec2
         end
 
         test 'accepts configuration values as string representation' do


### PR DESCRIPTION
 if not specified: fixes #850