### PR TITLE
Add 'Access-Control-Allow-Origin' to in_http plugin

### DIFF
--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -364,6 +364,7 @@ module Fluent
         code, header, body = *@callback.call(path_info, params)
         body = body.to_s
 
+        header['Access-Control-Allow-Origin'] = @origin if !@cors_allow_origins.nil? && @cors_allow_origins.include?(@origin)
         if @keep_alive
           header['Connection'] = 'Keep-Alive'
           send_response(code, header, body)


### PR DESCRIPTION
According to the document
https://en.wikipedia.org/wiki/Cross-origin_resource_sharing
The server should respond with 'Access-Control-Allow-Origin' header
in its response indicating which origin sites are allowed.