### PR TITLE
Add "encoding" parameter to in_tail plugin

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -66,7 +66,7 @@ module Fluent
       begin
         Encoding.find(encoding_name)
       rescue ArgumentError => e
-        raise ConfigError.new(e.message)
+        raise ConfigError, e.message
       end
     end
 

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -511,7 +511,7 @@ class TailInputTest < Test::Unit::TestCase
         f.puts "s test"
       }
 
-      sleep 3
+      sleep 4
       emits = d.emits
       assert(emits.length == 1)
       assert_equal(Encoding::ASCII_8BIT, emits[0][2]['message1'].encoding)


### PR DESCRIPTION
Currently, ``in_tail`` plugin emits strings with ASCII-8BIT encoding, which is resulted from IO#readpartial. This behavior entails inconvenience when filtering records. For example:

- [What do we write regex at filter-grep in Japanease? / Fluentd Google Group](https://groups.google.com/forum/#!topic/fluentd/0AxzJu2SMS4)

This PR adds ``encoding`` parameter to in_tail plugin, leaving ASCII-8BIT as default for compatibility.