### PR TITLE
Remove redundant `require`

### DIFF
--- a/lib/fluent/agent.rb
+++ b/lib/fluent/agent.rb
@@ -28,7 +28,7 @@ module Fluent
   class Agent
     include Configurable
 
-    def initialize(opts = {})
+    def initialize(log:)
       super()
 
       @context = nil
@@ -37,7 +37,7 @@ module Fluent
       @started_outputs = []
       @started_filters = []
 
-      @log = Engine.log
+      @log = log
       @event_router = EventRouter.new(NoMatchMatch.new(log), self)
       @error_collector = nil
     end

--- a/lib/fluent/agent.rb
+++ b/lib/fluent/agent.rb
@@ -15,7 +15,6 @@
 #
 
 require 'fluent/configurable'
-require 'fluent/engine'
 require 'fluent/plugin'
 require 'fluent/output'
 

--- a/lib/fluent/config/configure_proxy.rb
+++ b/lib/fluent/config/configure_proxy.rb
@@ -14,8 +14,6 @@
 #    limitations under the License.
 #
 
-require 'fluent/configurable'
-
 module Fluent
   module Config
     class ConfigureProxy

--- a/lib/fluent/config/configure_proxy.rb
+++ b/lib/fluent/config/configure_proxy.rb
@@ -46,6 +46,7 @@ module Fluent
         @required = opts[:required]
         @multi = opts[:multi]
         @alias = opts[:alias]
+        @type_lookup = opts[:type_lookup]
 
         raise "init and required are exclusive" if @init && @required
 
@@ -220,7 +221,7 @@ module Fluent
 
         begin
           type = :string if type.nil?
-          block ||= Configurable.lookup_type(type)
+          block ||= @type_lookup.call(type)
         rescue ConfigError
           # override error message
           raise ArgumentError, "#{self.name}: unknown config_argument type `#{type}'"

--- a/lib/fluent/config/configure_proxy.rb
+++ b/lib/fluent/config/configure_proxy.rb
@@ -294,17 +294,19 @@ module Fluent
         @current_description = description
       end
 
-      def config_section(name, *args, &block)
+      def config_section(name, opts = {}, &block)
         unless block_given?
           raise ArgumentError, "#{self.name}: config_section requires block parameter"
         end
         name = name.to_sym
 
-        unless args.empty? || args.size == 1 && args.first.is_a?(Hash)
-          raise ArgumentError, "#{self.name}: unknown config_section arguments: #{args.inspect}"
+        unless opts.is_a?(Hash)
+          raise ArgumentError, "#{self.name}: unknown config_section arguments: #{opts.inspect}"
         end
 
-        sub_proxy = ConfigureProxy.new(name, *args)
+        opts[:type_lookup] = @type_lookup
+
+        sub_proxy = ConfigureProxy.new(name, opts)
         sub_proxy.instance_exec(&block)
 
         if sub_proxy.init?

--- a/lib/fluent/config/types.rb
+++ b/lib/fluent/config/types.rb
@@ -133,14 +133,4 @@ module Fluent
       end
     }
   end
-
-  Configurable.register_type(:string,  Config::STRING_TYPE)
-  Configurable.register_type(:enum,    Config::ENUM_TYPE)
-  Configurable.register_type(:integer, Config::INTEGER_TYPE)
-  Configurable.register_type(:float,   Config::FLOAT_TYPE)
-  Configurable.register_type(:size,    Config::SIZE_TYPE)
-  Configurable.register_type(:bool,    Config::BOOL_TYPE)
-  Configurable.register_type(:time,    Config::TIME_TYPE)
-  Configurable.register_type(:hash,    Config::HASH_TYPE)
-  Configurable.register_type(:array,   Config::ARRAY_TYPE)
 end

--- a/lib/fluent/config/types.rb
+++ b/lib/fluent/config/types.rb
@@ -17,7 +17,6 @@
 require 'json'
 
 require 'fluent/config/error'
-require 'fluent/configurable'
 
 module Fluent
   module Config

--- a/lib/fluent/configurable.rb
+++ b/lib/fluent/configurable.rb
@@ -19,6 +19,7 @@ require 'fluent/config/section'
 require 'fluent/config/error'
 require 'fluent/registry'
 require 'fluent/plugin'
+require 'fluent/config/types'
 
 module Fluent
   module Configurable
@@ -90,6 +91,20 @@ module Fluent
       CONFIG_TYPE_REGISTRY.lookup(type)
     end
 
+    {
+      string: Config::STRING_TYPE,
+      enum: Config::ENUM_TYPE,
+      integer: Config::INTEGER_TYPE,
+      float: Config::FLOAT_TYPE,
+      size: Config::SIZE_TYPE,
+      bool: Config::BOOL_TYPE,
+      time: Config::TIME_TYPE,
+      hash: Config::HASH_TYPE,
+      array: Config::ARRAY_TYPE,
+    }.each do |name, type|
+      register_type(name, type)
+    end
+
     module ClassMethods
       def configure_proxy_map
         map = {}
@@ -100,7 +115,8 @@ module Fluent
       def configure_proxy(mod_name)
         map = configure_proxy_map
         unless map[mod_name]
-          proxy = Fluent::Config::ConfigureProxy.new(mod_name, required: true, multi: false)
+          type_lookup = ->(type) { Fluent::Configurable.lookup_type(type) }
+          proxy = Fluent::Config::ConfigureProxy.new(mod_name, required: true, multi: false, type_lookup: type_lookup)
           map[mod_name] = proxy
         end
         map[mod_name]
@@ -149,7 +165,4 @@ module Fluent
       end
     end
   end
-
-  # load default types
-  require 'fluent/config/types'
 end

--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -66,7 +66,7 @@ module Fluent
       @suppress_config_dump = system_config.suppress_config_dump unless system_config.suppress_config_dump.nil?
       @without_source = system_config.without_source unless system_config.without_source.nil?
 
-      @root_agent = RootAgent.new(@system_config)
+      @root_agent = RootAgent.new(log: log, system_config: @system_config)
 
       MessagePackFactory.init
 

--- a/lib/fluent/event.rb
+++ b/lib/fluent/event.rb
@@ -14,8 +14,6 @@
 #    limitations under the License.
 #
 
-require 'fluent/engine'
-
 module Fluent
   class EventStream
     include Enumerable

--- a/lib/fluent/event.rb
+++ b/lib/fluent/event.rb
@@ -14,9 +14,12 @@
 #    limitations under the License.
 #
 
+require 'fluent/msgpack_factory'
+
 module Fluent
   class EventStream
     include Enumerable
+    include MessagePackFactory::Mixin
 
     def repeatable?
       false
@@ -27,7 +30,7 @@ module Fluent
     end
 
     def to_msgpack_stream
-      out = Fluent::Engine.msgpack_factory.packer
+      out = msgpack_packer
       each {|time,record|
         out.write([time,record])
       }
@@ -35,7 +38,7 @@ module Fluent
     end
 
     def to_msgpack_stream_forced_integer
-      out = Fluent::Engine.msgpack_factory.packer
+      out = msgpack_packer
       each {|time,record|
         out.write([time.to_i,record])
       }
@@ -151,8 +154,7 @@ module Fluent
 
     def each(&block)
       # TODO format check
-      unpacker = Fluent::Engine.msgpack_factory.unpacker
-      unpacker.feed_each(@data, &block)
+      msgpack_unpacker.feed_each(@data, &block)
       nil
     end
 

--- a/lib/fluent/filter.rb
+++ b/lib/fluent/filter.rb
@@ -16,7 +16,6 @@
 
 require 'fluent/configurable'
 require 'fluent/plugin_id'
-require 'fluent/engine'
 require 'fluent/event'
 require 'fluent/plugin' # to register itself to registry
 require 'fluent/log'

--- a/lib/fluent/label.rb
+++ b/lib/fluent/label.rb
@@ -18,8 +18,8 @@ require 'fluent/agent'
 
 module Fluent
   class Label < Agent
-    def initialize(name, opts = {})
-      super(opts)
+    def initialize(name, log:)
+      super(log: log)
 
       @context = name
       @root_agent = nil

--- a/lib/fluent/output.rb
+++ b/lib/fluent/output.rb
@@ -18,7 +18,6 @@ require 'thread'
 
 require 'fluent/configurable'
 require 'fluent/plugin_id'
-require 'fluent/engine'
 require 'fluent/log'
 require 'fluent/output_chain'
 require 'fluent/plugin'

--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -46,8 +46,8 @@ module Fluent
   class RootAgent < Agent
     ERROR_LABEL = "@ERROR".freeze # @ERROR is built-in error label
 
-    def initialize(system_config = SystemConfig.new)
-      super
+    def initialize(log:, system_config: SystemConfig.new)
+      super(log: log)
 
       @labels = {}
       @inputs = []
@@ -158,7 +158,7 @@ module Fluent
     end
 
     def add_label(name)
-      label = Label.new(name)
+      label = Label.new(name, log: log)
       label.root_agent = self
       @labels[name] = label
     end

--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -18,7 +18,6 @@ require 'delegate'
 
 require 'fluent/config/error'
 require 'fluent/agent'
-require 'fluent/engine'
 require 'fluent/label'
 require 'fluent/plugin'
 require 'fluent/system_config'

--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -21,6 +21,7 @@ require 'fluent/agent'
 require 'fluent/label'
 require 'fluent/plugin'
 require 'fluent/system_config'
+require 'fluent/time'
 
 module Fluent
   #
@@ -218,7 +219,7 @@ module Fluent
       end
 
       def handle_emits_error(tag, es, e)
-        now = Engine.now
+        now = EventTime.now
         if @suppress_emit_error_log_interval.zero? || now > @next_emit_error_log_time
           log.warn "emit transaction failed in @ERROR:", error: e, tag: tag
           log.warn_backtrace

--- a/test/config/test_configure_proxy.rb
+++ b/test/config/test_configure_proxy.rb
@@ -3,6 +3,10 @@ require 'fluent/config/configure_proxy'
 
 module Fluent::Config
   class TestConfigureProxy < ::Test::Unit::TestCase
+    setup do
+      @type_lookup = ->(type) { Fluent::Configurable.lookup_type(type) }
+    end
+
     sub_test_case 'to generate a instance' do
       sub_test_case '#initialize' do
         test 'has default values' do
@@ -134,67 +138,67 @@ module Fluent::Config
       end
 
       sub_test_case '#config_param / #config_set_default / #config_argument' do
+        setup do
+          @proxy = Fluent::Config::ConfigureProxy.new(:section, type_lookup: @type_lookup)
+        end
+
         test 'does not permit config_set_default for param w/ :default option' do
-          proxy = Fluent::Config::ConfigureProxy.new(:section)
-          proxy.config_param(:name, :string, default: "name1")
-          assert_raise(ArgumentError) { proxy.config_set_default(:name, "name2") }
+          @proxy.config_param(:name, :string, default: "name1")
+          assert_raise(ArgumentError) { @proxy.config_set_default(:name, "name2") }
         end
 
         test 'does not permit default value specification twice' do
-          proxy = Fluent::Config::ConfigureProxy.new(:section)
-          proxy.config_param(:name, :string)
-          proxy.config_set_default(:name, "name1")
-          assert_raise(ArgumentError) { proxy.config_set_default(:name, "name2") }
+          @proxy.config_param(:name, :string)
+          @proxy.config_set_default(:name, "name1")
+          assert_raise(ArgumentError) { @proxy.config_set_default(:name, "name2") }
         end
 
         test 'does not permit default value specification twice, even on config_argument' do
-          proxy = Fluent::Config::ConfigureProxy.new(:section)
-          proxy.config_param(:name, :string)
-          proxy.config_set_default(:name, "name1")
+          @proxy.config_param(:name, :string)
+          @proxy.config_set_default(:name, "name1")
 
-          proxy.config_argument(:name)
-          assert_raise(ArgumentError) { proxy.config_argument(:name, default: "name2") }
+          @proxy.config_argument(:name)
+          assert_raise(ArgumentError) { @proxy.config_argument(:name, default: "name2") }
         end
       end
 
       sub_test_case '#config_param without default values cause error if section is configured as init:true' do
+        setup do
+          @proxy = Fluent::Config::ConfigureProxy.new(:section, type_lookup: @type_lookup)
+        end
+
         test 'with simple config_param with default value' do
-          proxy = Fluent::Config::ConfigureProxy.new(:section)
           assert_nothing_raised do
-            proxy.config_section :subsection, init: true do
+            @proxy.config_section :subsection, init: true do
               config_param :param1, :integer, default: 1
             end
           end
         end
         test 'with simple config_param without default value' do
-          proxy = Fluent::Config::ConfigureProxy.new(:section)
           assert_raise ArgumentError do
-            proxy.config_section :subsection, init: true do
+            @proxy.config_section :subsection, init: true do
               config_param :param1, :integer
             end
           end
         end
         test 'with config_param with config_set_default' do
-          proxy = Fluent::Config::ConfigureProxy.new(:section)
           assert_nothing_raised do
-            proxy.config_section :subsection, init: true do
+            @proxy.config_section :subsection, init: true do
               config_param :param1, :integer
               config_set_default :param1, 1
             end
           end
         end
         test 'with config_argument' do
-          proxy = Fluent::Config::ConfigureProxy.new(:section)
           assert_raise ArgumentError do
-            proxy.config_section :subsection, init: true do
+            @proxy.config_section :subsection, init: true do
               config_argument :param0, :string
             end
           end
         end
         test 'with config_argument with default value' do
-          proxy = Fluent::Config::ConfigureProxy.new(:section)
           assert_nothing_raised do
-            proxy.config_section :subsection, init: true do
+            @proxy.config_section :subsection, init: true do
               config_argument :param0, :string, default: ''
             end
           end
@@ -203,7 +207,7 @@ module Fluent::Config
 
       sub_test_case '#config_set_desc' do
         setup do
-          @proxy = Fluent::Config::ConfigureProxy.new(:section)
+          @proxy = Fluent::Config::ConfigureProxy.new(:section, type_lookup: @type_lookup)
         end
 
         test 'does not permit description specification twice w/ :desc option' do
@@ -220,7 +224,7 @@ module Fluent::Config
 
       sub_test_case '#desc' do
         setup do
-          @proxy = Fluent::Config::ConfigureProxy.new(:section)
+          @proxy = Fluent::Config::ConfigureProxy.new(:section, type_lookup: @type_lookup)
         end
 
         test 'permit to specify description twice' do
@@ -240,7 +244,7 @@ module Fluent::Config
 
       sub_test_case '#dump' do
         setup do
-          @proxy = Fluent::Config::ConfigureProxy.new(:section)
+          @proxy = Fluent::Config::ConfigureProxy.new(:section, type_lookup: @type_lookup)
         end
 
         test 'empty proxy' do

--- a/test/config/test_configure_proxy.rb
+++ b/test/config/test_configure_proxy.rb
@@ -92,7 +92,8 @@ module Fluent::Config
 
       sub_test_case '#overwrite_defaults' do
         test 'overwrites only defaults with others defaults' do
-          p1 = Fluent::Config::ConfigureProxy.new(:mychild)
+          type_lookup = ->(type) { Fluent::Configurable.lookup_type(type) }
+          p1 = Fluent::Config::ConfigureProxy.new(:mychild, type_lookup: type_lookup)
           p1.configured_in_section = :child
           p1.config_param(:k1a, :string)
           p1.config_param(:k1b, :string)
@@ -102,7 +103,7 @@ module Fluent::Config
             config_param :k3, :time, default: 30
           end
 
-          p0 = Fluent::Config::ConfigureProxy.new(:myparent)
+          p0 = Fluent::Config::ConfigureProxy.new(:myparent, type_lookup: type_lookup)
           p0.config_section(:child) do
             config_set_default :k1a, "v1a"
             config_param :k1b, :string, default: "v1b"

--- a/test/test_root_agent.rb
+++ b/test/test_root_agent.rb
@@ -8,7 +8,7 @@ class RootAgentTest < ::Test::Unit::TestCase
   include FluentTest
 
   def test_initialize
-    ra = RootAgent.new
+    ra = RootAgent.new(log: $log)
     assert_equal 0, ra.instance_variable_get(:@suppress_emit_error_log_interval)
     assert_nil ra.instance_variable_get(:@next_emit_error_log_time)
   end
@@ -19,7 +19,7 @@ class RootAgentTest < ::Test::Unit::TestCase
     )
   def test_initialize_with_opt(data)
     opt, expected = data
-    ra = RootAgent.new(SystemConfig.new(opt))
+    ra = RootAgent.new(log: $log, system_config: SystemConfig.new(opt))
     expected.each { |k, v|
       assert_equal v, ra.instance_variable_get(k)
     }
@@ -27,7 +27,7 @@ class RootAgentTest < ::Test::Unit::TestCase
 
   sub_test_case 'configure' do
     setup do
-      @ra = RootAgent.new
+      @ra = RootAgent.new(log: $log)
       stub(Engine).root_agent { @ra }
     end
 
@@ -104,7 +104,7 @@ EOC
 
   sub_test_case 'start/shutdown' do
     setup do
-      @ra = RootAgent.new
+      @ra = RootAgent.new(log: $log)
       @ra.configure(Config.parse(<<-EOC, "(test)", "(test_dir)", true))
 <source>
   @type test_in


### PR DESCRIPTION
This change suppresses following warnings(about 130 lines warnings):

lib/fluent/config/configure_proxy.rb:17: warning: loading in progress, circular require considered harmful
lib/fluent/config/types.rb:20: warning: loading in progress, circular require considered harmful
lib/fluent/event.rb:17: warning: loading in progress, circular require considered harmful
lib/fluent/filter.rb:19: warning: loading in progress, circular require considered harmful
lib/fluent/agent.rb:18: warning: loading in progress, circular require considered harmful
lib/fluent/output.rb:21: warning: loading in progress, circular require considered harmful
lib/fluent/root_agent.rb:21: warning: loading in progress, circular require considered harmful