### PR TITLE
backport Fix broken fluent-debug command(#891) to v0.12

### DIFF
--- a/lib/fluent/command/debug.rb
+++ b/lib/fluent/command/debug.rb
@@ -62,9 +62,12 @@ end
 
 require 'fluent/log'
 require 'fluent/engine'
+require 'fluent/system_config'
+
+include Fluent::SystemConfig::Mixin
 
 $log = Fluent::Log.new(STDERR, Fluent::Log::LEVEL_TRACE)
-Fluent::Engine.init
+Fluent::Engine.init(system_config)
 
 DRb::DRbObject.class_eval do
   undef_method :methods


### PR DESCRIPTION
This PR is back porting following PR:

```
Merge pull request #891 from cosmo0920/fix-broken-fluent-debug-command
fluent-debug: Fix broken fluent-debug command
```