### PR TITLE
Shutdown OutputThread in parallel

### DIFF
--- a/lib/fluent/output.rb
+++ b/lib/fluent/output.rb
@@ -82,13 +82,21 @@ module Fluent
       @thread = Thread.new(&method(:run))
     end
 
-    def shutdown
+    def signal
       @finish = true
       @mutex.synchronize {
         @cond.signal
       }
       Thread.pass
+    end
+
+    def shutdown
+      signal
       @thread.join
+    end
+
+    def terminated?
+      !@thread.status
     end
 
     def submit_flush
@@ -218,7 +226,20 @@ module Fluent
     end
 
     def shutdown
-      @writers.each {|writer| writer.shutdown }
+      @writers.each {|writer| writer.signal }
+      running_writers = @writers.dup
+      loop do
+        finished = []
+        running_writers.each do |writer|
+          finished << writer if writer.terminated?
+        end
+        running_writers -= finished
+        if running_writers.empty?
+          break
+        end
+        sleep(0.5)
+      end
+
       @secondary.shutdown if @secondary
       @buffer.shutdown
     end


### PR DESCRIPTION
I noticed BufferedOutput was slow when I ran 32 threads in it. BufferedOutput#shutdown stops and joins their threads sequentially. So I modified it to shutdown their threads in parallel.

As a result, it becomes several times faster in my case.