### PR TITLE
appveyor: Follow Devkit installation path change

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,13 +23,13 @@ branches:
 environment:
   matrix:
     - ruby_version: "22-x64"
-      devkit: C:\Ruby21-x64\DevKit
+      devkit: C:\Ruby23-x64\DevKit
     - ruby_version: "22"
-      devkit: C:\Ruby21\DevKit
+      devkit: C:\Ruby23\DevKit
     - ruby_version: "21-x64"
-      devkit: C:\Ruby21-x64\DevKit
+      devkit: C:\Ruby23-x64\DevKit
     - ruby_version: "21"
-      devkit: C:\Ruby21\DevKit
+      devkit: C:\Ruby23\DevKit
 matrix:
   allow_failures:
     - ruby_version: "21"


### PR DESCRIPTION
Recently, AppVeyor deployed Ruby 2.3 in worker VMs, it causes DevKit installation path change.

ref: https://github.com/appveyor/ci/issues/747#issuecomment-209222264