### PR TITLE
Logger dumps error with classname

### DIFF
--- a/lib/fluent/agent.rb
+++ b/lib/fluent/agent.rb
@@ -84,7 +84,7 @@ module Fluent
             log.info "shutting down filter#{@context.nil? ? '' : " in #{@context}"}", type: Plugin.lookup_type_from_class(f.class), plugin_id: f.plugin_id
             f.shutdown
           rescue => e
-            log.warn "unexpected error while shutting down filter plugins", plugin: f.class, plugin_id: f.plugin_id, error_class: e.class, error: e
+            log.warn "unexpected error while shutting down filter plugins", plugin: f.class, plugin_id: f.plugin_id, error: e
             log.warn_backtrace
           end
         end
@@ -98,7 +98,7 @@ module Fluent
             log.info "shutting down output#{@context.nil? ? '' : " in #{@context}"}", type: Plugin.lookup_type_from_class(o.class), plugin_id: o.plugin_id
             o.shutdown
           rescue => e
-            log.warn "unexpected error while shutting down output plugins", plugin: o.class, plugin_id: o.plugin_id, error_class: e.class, error: e
+            log.warn "unexpected error while shutting down output plugins", plugin: o.class, plugin_id: o.plugin_id, error: e
             log.warn_backtrace
           end
         end
@@ -118,7 +118,7 @@ module Fluent
             flush_recursive(o.outputs)
           end
         rescue => e
-          log.debug "error while force flushing", error_class: e.class, error: e
+          log.debug "error while force flushing", error: e
           log.debug_backtrace
         end
       }

--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -166,7 +166,7 @@ module Fluent
           begin
             @event_router.emit(tag, time, record)
           rescue => e
-            $log.error "failed to emit fluentd's log event", tag: tag, event: record, error_class: e.class, error: e
+            $log.error "failed to emit fluentd's log event", tag: tag, event: record, error: e
           end
         }
       end
@@ -195,7 +195,7 @@ module Fluent
         end
 
       rescue => e
-        $log.error "unexpected error", error_class: e.class, error: e
+        $log.error "unexpected error", error: e
         $log.error_backtrace
       ensure
         $log.info "shutting down fluentd"

--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -292,7 +292,7 @@ module Fluent
       }
 
       map.each_pair {|k,v|
-        if k == "error".freeze
+        if k == "error".freeze && v.is_a?(Exception) && !map.has_key?("error_class")
           message << " error_class=#{v.class.to_s} error=#{v.to_s.inspect}"
         else
           message << " #{k}=#{v.inspect}"

--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -293,7 +293,7 @@ module Fluent
 
       map.each_pair {|k,v|
         if k == "error".freeze
-          message << " error=#{v.class}[#{v.message}]"
+          message << " error_class=#{v.class.to_s} error=#{v.to_s.inspect}"
         else
           message << " #{k}=#{v.inspect}"
         end

--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -292,7 +292,11 @@ module Fluent
       }
 
       map.each_pair {|k,v|
-        message << " #{k}=#{v.inspect}"
+        if k == "error".freeze
+          message << " error=#{v.class}[#{v.message}]"
+        else
+          message << " #{k}=#{v.inspect}"
+        end
       }
 
       unless @threads_exclude_events.include?(Thread.current)

--- a/lib/fluent/output.rb
+++ b/lib/fluent/output.rb
@@ -329,20 +329,20 @@ module Fluent
         end
 
         if @disable_retry_limit || error_count < @retry_limit
-          $log.warn "temporarily failed to flush the buffer.", next_retry: Time.at(@next_retry_time), error_class: e.class.to_s, error: e.to_s, plugin_id: plugin_id
+          $log.warn "temporarily failed to flush the buffer.", next_retry: Time.at(@next_retry_time), error: e, plugin_id: plugin_id
           $log.warn_backtrace e.backtrace
 
         elsif @secondary
           if error_count == @retry_limit
-            $log.warn "failed to flush the buffer.", error_class: e.class.to_s, error: e.to_s, plugin_id: plugin_id
+            $log.warn "failed to flush the buffer.", error: e, plugin_id: plugin_id
             $log.warn "retry count exceededs limit. falling back to secondary output."
             $log.warn_backtrace e.backtrace
             retry  # retry immediately
           elsif error_count <= @retry_limit + @secondary_limit
-            $log.warn "failed to flush the buffer, next retry will be with secondary output.", next_retry: Time.at(@next_retry_time), error_class: e.class.to_s, error: e.to_s, plugin_id: plugin_id
+            $log.warn "failed to flush the buffer, next retry will be with secondary output.", next_retry: Time.at(@next_retry_time), error: e, plugin_id: plugin_id
             $log.warn_backtrace e.backtrace
           else
-            $log.warn "failed to flush the buffer.", error_class: e.class, error: e.to_s, plugin_id: plugin_id
+            $log.warn "failed to flush the buffer.", error: e, plugin_id: plugin_id
             $log.warn "secondary retry count exceededs limit."
             $log.warn_backtrace e.backtrace
             write_abort
@@ -350,7 +350,7 @@ module Fluent
           end
 
         else
-          $log.warn "failed to flush the buffer.", error_class: e.class.to_s, error: e.to_s, plugin_id: plugin_id
+          $log.warn "failed to flush the buffer.", error: e, plugin_id: plugin_id
           $log.warn "retry count exceededs limit."
           $log.warn_backtrace e.backtrace
           write_abort
@@ -373,7 +373,7 @@ module Fluent
       begin
         @buffer.before_shutdown(self)
       rescue
-        $log.warn "before_shutdown failed", error: $!.to_s
+        $log.warn "before_shutdown failed", error: $!
         $log.warn_backtrace
       end
     end
@@ -395,7 +395,7 @@ module Fluent
       begin
         @buffer.clear!
       rescue
-        $log.error "unexpected error while aborting", error: $!.to_s
+        $log.error "unexpected error while aborting", error: $!
         $log.error_backtrace
       end
     end

--- a/lib/fluent/plugin/filter_grep.rb
+++ b/lib/fluent/plugin/filter_grep.rb
@@ -70,7 +70,7 @@ module Fluent
           result = record
         end
       rescue => e
-        log.warn "failed to grep events", error_class: e.class, error: e.message
+        log.warn "failed to grep events", error: e
         log.warn_backtrace
       end
       result

--- a/lib/fluent/plugin/filter_record_transformer.rb
+++ b/lib/fluent/plugin/filter_record_transformer.rb
@@ -107,7 +107,7 @@ module Fluent
       end
       new_es
     rescue => e
-      log.warn "failed to reform records", error_class: e.class, error: e.message
+      log.warn "failed to reform records", error: e
       log.warn_backtrace
       log.debug "map:#{@map} record:#{last_record} placeholder_values:#{placeholder_values}"
     end
@@ -121,7 +121,7 @@ module Fluent
         value_str
       end
     rescue => e
-      log.warn "failed to parse #{value_str} as json. Assuming #{value_str} is a string", error_class: e.class, error: e.message
+      log.warn "failed to parse #{value_str} as json. Assuming #{value_str} is a string", error: e
       value_str # emit as string
     end
 
@@ -307,7 +307,7 @@ module Fluent
           placeholders['hostname'],
         )
       rescue => e
-        log.warn "failed to expand `#{str}`", error_class: e.class, error: e.message
+        log.warn "failed to expand `#{str}`", error: e
         log.warn_backtrace
         nil
       end

--- a/lib/fluent/plugin/in_exec.rb
+++ b/lib/fluent/plugin/in_exec.rb
@@ -149,7 +149,7 @@ module Fluent
           Process.waitpid(io.pid)
           sleep @run_interval
         rescue
-          log.error "exec failed to run or shutdown child process", error: $!.to_s, error_class: $!.class.to_s
+          log.error "exec failed to run or shutdown child process", error: $!
           log.warn_backtrace $!.backtrace
         end
       end
@@ -176,7 +176,7 @@ module Fluent
 
       router.emit(tag, time, record)
     rescue => e
-      log.error "exec failed to emit", error: e.to_s, error_class: e.class.to_s, tag: tag, record: Yajl.dump(record)
+      log.error "exec failed to emit", error: e, tag: tag, record: Yajl.dump(record)
     end
   end
 end

--- a/lib/fluent/plugin/in_forward.rb
+++ b/lib/fluent/plugin/in_forward.rb
@@ -106,7 +106,7 @@ module Fluent
     def run
       @loop.run(@blocking_timeout)
     rescue => e
-      log.error "unexpected error", error: e, error_class: e.class
+      log.error "unexpected error", error: e
       log.error_backtrace
     end
 

--- a/lib/fluent/plugin/in_object_space.rb
+++ b/lib/fluent/plugin/in_object_space.rb
@@ -115,7 +115,7 @@ module Fluent
 
       router.emit(@tag, now, record)
     rescue => e
-      log.error "object space failed to emit", error: e.to_s, error_class: e.class.to_s, tag: @tag, record: Yajl.dump(record)
+      log.error "object space failed to emit", error: e, tag: @tag, record: Yajl.dump(record)
     end
   end
 end

--- a/lib/fluent/plugin/in_syslog.rb
+++ b/lib/fluent/plugin/in_syslog.rb
@@ -200,7 +200,7 @@ module Fluent
 
       router.emit(tag, time, record)
     rescue => e
-      log.error "syslog failed to emit", error: e.to_s, error_class: e.class.to_s, tag: tag, record: Yajl.dump(record)
+      log.error "syslog failed to emit", error: e, tag: tag, record: Yajl.dump(record)
     end
   end
 end

--- a/lib/fluent/plugin/out_exec_filter.rb
+++ b/lib/fluent/plugin/out_exec_filter.rb
@@ -383,7 +383,7 @@ module Fluent
       router.emit(tag, time, record)
     rescue
       if @suppress_error_log_interval == 0 || Time.now.to_i > @next_log_time
-        log.error "exec_filter failed to emit", error: $!.to_s, error_class: $!.class.to_s, record: Yajl.dump(record)
+        log.error "exec_filter failed to emit", error: $!, record: Yajl.dump(record)
         log.warn_backtrace $!.backtrace
         @next_log_time = Time.now.to_i + @suppress_error_log_interval
       end

--- a/lib/fluent/plugin/socket_util.rb
+++ b/lib/fluent/plugin/socket_util.rb
@@ -46,7 +46,7 @@ module Fluent
         msg.chomp!
         @callback.call(msg, addr)
       rescue => e
-        @log.error "unexpected error", error: e, error_class: e.class
+        @log.error "unexpected error", error: e
       end
     end
 
@@ -82,7 +82,7 @@ module Fluent
         end
         @buffer.slice!(0, pos) if pos > 0
       rescue => e
-        @log.error "unexpected error", error: e, error_class: e.class
+        @log.error "unexpected error", error: e
         close
       end
 
@@ -133,7 +133,7 @@ module Fluent
       def run
         @loop.run(@blocking_timeout)
       rescue => e
-        log.error "unexpected error", error: e, error_class: e.class
+        log.error "unexpected error", error: e
         log.error_backtrace
       end
 
@@ -150,7 +150,7 @@ module Fluent
           router.emit(@tag, time, record)
         }
       rescue => e
-        log.error msg.dump, error: e, error_class: e.class, host: addr[3]
+        log.error msg.dump, error: e, host: addr[3]
         log.error_backtrace
       end
     end

--- a/lib/fluent/plugin/storage_local.rb
+++ b/lib/fluent/plugin/storage_local.rb
@@ -49,7 +49,7 @@ module Fluent
               data = Yajl::Parser.parse(open(@path, 'r:utf-8'){ |io| io.read })
               raise Fluent::ConfigError, "Invalid contents (not object) in plugin storage file: '#{@path}'" unless data.is_a?(Hash)
             rescue => e
-              log.error "failed to read data from plugin storage file", path: @path, error_class: e.class, error: e
+              log.error "failed to read data from plugin storage file", path: @path, error: e
               raise Fluent::ConfigError, "Unexpected error: failed to read data from plugin storage file: '#{@path}'"
             end
           else
@@ -71,7 +71,7 @@ module Fluent
           end
           @store = json
         rescue => e
-          log.error "failed to load data for plugin storage from file", path: @path, error_class: e.class, error: e
+          log.error "failed to load data for plugin storage from file", path: @path, error: e
         end
       end
 
@@ -83,7 +83,7 @@ module Fluent
           open(tmp_path, 'w:utf-8', @mode){ |io| io.write json_string }
           File.rename(tmp_path, @path)
         rescue => e
-          log.error "failed to save data for plugin storage to file", path: @path, tmp: tmp_path, error_class: e.class, error: e
+          log.error "failed to save data for plugin storage to file", path: @path, tmp: tmp_path, error: e
         end
       end
 

--- a/lib/fluent/plugin_helper/child_process.rb
+++ b/lib/fluent/plugin_helper/child_process.rb
@@ -272,10 +272,10 @@ module Fluent
             if e.message == 'stream closed'
               log.debug "Process I/O stream closed", title: title, pid: pid, command: command, arguments: arguments
             else
-              log.error "Unexpected I/O error for child process", title: title, pid: pid, command: command, arguments: arguments, error_class: e.class, error: e
+              log.error "Unexpected I/O error for child process", title: title, pid: pid, command: command, arguments: arguments, error: e
             end
           rescue => e
-            log.warn "Unexpected error while processing I/O for child process", title: title, pid: pid, command: command, error_class: e.class, error: e
+            log.warn "Unexpected error while processing I/O for child process", title: title, pid: pid, command: command, error: e
           end
           process_info = @_child_process_mutex.synchronize do
             process_info = @_child_process_processes[pid]

--- a/lib/fluent/plugin_helper/storage.rb
+++ b/lib/fluent/plugin_helper/storage.rb
@@ -62,7 +62,7 @@ module Fluent
             begin
               s.storage.save
             rescue => e
-              log.error "plugin storage failed to save its data", usage: usage, type: type, error_class: e.class, error: e
+              log.error "plugin storage failed to save its data", usage: usage, type: type, error: e
             end
           end
         end
@@ -115,7 +115,7 @@ module Fluent
           begin
             s.storage.save if s.storage.save_at_shutdown
           rescue => e
-            log.error "unexpected error while saving data of plugin storages", usage: usage, storage: s.storage, error_class: e.class, error: e
+            log.error "unexpected error while saving data of plugin storages", usage: usage, storage: s.storage, error: e
           end
         end
 
@@ -127,7 +127,7 @@ module Fluent
           begin
             s.storage.close
           rescue => e
-            log.error "unexpected error while closing plugin storages", usage: usage, storage: s.storage, error_class: e.class, error: e
+            log.error "unexpected error while closing plugin storages", usage: usage, storage: s.storage, error: e
           end
           s.running = false
         end
@@ -140,7 +140,7 @@ module Fluent
           begin
             s.storage.terminate
           rescue => e
-            log.error "unexpected error while terminating plugin storages", usage: usage, storage: s.storage, error_class: e.class, error: e
+            log.error "unexpected error while terminating plugin storages", usage: usage, storage: s.storage, error: e
           end
         end
         @_storages = {}

--- a/lib/fluent/plugin_helper/thread.rb
+++ b/lib/fluent/plugin_helper/thread.rb
@@ -60,7 +60,7 @@ module Fluent
             yield
             thread_exit = true
           rescue => e
-            log.warn "thread exited by unexpected error", plugin: self.class, title: title, error_class: e.class, error: e
+            log.warn "thread exited by unexpected error", plugin: self.class, title: title, error: e
             thread_exit = true
             raise
           ensure

--- a/lib/fluent/plugin_helper/timer.rb
+++ b/lib/fluent/plugin_helper/timer.rb
@@ -74,7 +74,7 @@ module Fluent
         def on_timer
           @callback.call if @checker.call
         rescue => e
-          @log.error "Unexpected error raised. Stopping the timer.", title: @title, error: e, error_class: e.class
+          @log.error "Unexpected error raised. Stopping the timer.", title: @title, error: e
           @log.error_backtrace
           self.detach
           @log.error "Timer detached.", title: @title

--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -126,7 +126,7 @@ module Fluent
             log.info "shutting down input", type: Plugin.lookup_type_from_class(i.class), plugin_id: i.plugin_id
             i.shutdown
           rescue => e
-            log.warn "unexpected error while shutting down input plugin", plugin: i.class, plugin_id: i.plugin_id, error_class: e.class, error: e
+            log.warn "unexpected error while shutting down input plugin", plugin: i.class, plugin_id: i.plugin_id, error: e
             log.warn_backtrace
           end
         end
@@ -173,7 +173,7 @@ module Fluent
     end
 
     def emit_error_event(tag, time, record, error)
-      error_info = {error_class: error.class, error: error.to_s, tag: tag, time: time}
+      error_info = {error: error, tag: tag, time: time}
       if @error_collector
         # A record is not included in the logs because <@ERROR> handles it. This warn is for the notification
         log.warn "send an error event to @ERROR:", error_info
@@ -185,7 +185,7 @@ module Fluent
     end
 
     def handle_emits_error(tag, es, error)
-      error_info = {error_class: error.class, error: error.to_s, tag: tag}
+      error_info = {error: error, tag: tag}
       if @error_collector
         log.warn "send an error event stream to @ERROR:", error_info
         @error_collector.emit_stream(tag, es)
@@ -214,14 +214,14 @@ module Fluent
       end
 
       def emit_error_event(tag, time, record, error)
-        error_info = {error_class: error.class, error: error.to_s, tag: tag, time: time, record: record}
+        error_info = {error: error, tag: tag, time: time, record: record}
         log.warn "dump an error event in @ERROR:", error_info
       end
 
       def handle_emits_error(tag, es, e)
         now = Engine.now
         if @suppress_emit_error_log_interval.zero? || now > @next_emit_error_log_time
-          log.warn "emit transaction failed in @ERROR:", error_class: e.class, error: e, tag: tag
+          log.warn "emit transaction failed in @ERROR:", error: e, tag: tag
           log.warn_backtrace
           @next_emit_error_log_time = now + @suppress_emit_error_log_interval
         end


### PR DESCRIPTION
In these days, many plugin authors (and core developers) writes logging code like below many times.
```ruby
log.error "my message", error_class: e.class, error: e.to_s, other: attributes
```
Fairly speaking, this is waste of time and key typing.

Fluentd will log errors like below with this change by just specifying `error: e`:
```ruby
log.error "my message", error: e
# [error]: my message error=MyErrorClass[message of e]
```
