### PR TITLE
Fix logger on Fluent::StringUtil to use $log.

### DIFF
--- a/lib/fluent/plugin/string_util.rb
+++ b/lib/fluent/plugin/string_util.rb
@@ -21,7 +21,7 @@ module Fluent
         return regexp.match(string)
       rescue ArgumentError => e
         raise e unless e.message.index("invalid byte sequence in".freeze).zero?
-        log.info "invalid byte sequence is replaced in `#{string}`"
+        $log.info "invalid byte sequence is replaced in `#{string}`"
         string = string.scrub('?')
         retry
       end

--- a/test/plugin/test_string_util.rb
+++ b/test/plugin/test_string_util.rb
@@ -1,0 +1,26 @@
+require_relative '../helper'
+require 'fluent/plugin/string_util'
+
+class StringUtilTest < Test::Unit::TestCase
+  def setup
+    @null_value_pattern = Regexp.new("^(-|null|NULL)$")
+  end
+
+  sub_test_case 'valid string' do
+    test 'null string' do
+      assert_equal Fluent::StringUtil.match_regexp(@null_value_pattern, "null").to_s, "null"
+      assert_equal Fluent::StringUtil.match_regexp(@null_value_pattern, "NULL").to_s, "NULL"
+      assert_equal Fluent::StringUtil.match_regexp(@null_value_pattern, "-").to_s, "-"
+    end
+
+    test 'normal string' do
+      assert_equal Fluent::StringUtil.match_regexp(@null_value_pattern, "fluentd"), nil
+    end
+  end
+
+  sub_test_case 'invalid string' do
+    test 'normal string' do
+      assert_equal Fluent::StringUtil.match_regexp(@null_value_pattern, "\xff"), nil
+    end
+  end
+end


### PR DESCRIPTION
Hello.

fix bug. related #657

> I found that log is not defined in Fluent::StringUtil.match_regexp. So this rescue block will raise NameError every time. 