### PR TITLE
Add standard chunking format

### DIFF
--- a/lib/fluent/event.rb
+++ b/lib/fluent/event.rb
@@ -51,7 +51,6 @@ module Fluent
     end
   end
 
-
   class OneEventStream < EventStream
     def initialize(time, record)
       @time = time
@@ -175,7 +174,6 @@ module Fluent
     end
 
     def each(&block)
-      # TODO format check
       msgpack_unpacker.feed_each(@data, &block)
       nil
     end
@@ -184,5 +182,17 @@ module Fluent
       @data
     end
   end
-end
 
+  module ChunkMessagePackEventStreamer
+    include MessagePackFactory::Mixin
+    # chunk.extend(ChunkEventStreamer)
+    #  => chunk.each{|time, record| ... }
+    def each(&block)
+      open do |io|
+        msgpack_unpacker(io).each(&block)
+      end
+      nil
+    end
+    alias :msgpack_each :each
+  end
+end

--- a/lib/fluent/event.rb
+++ b/lib/fluent/event.rb
@@ -194,5 +194,9 @@ module Fluent
       nil
     end
     alias :msgpack_each :each
+
+    def to_msgpack_stream
+      read
+    end
   end
 end

--- a/lib/fluent/plugin/buffer/chunk.rb
+++ b/lib/fluent/plugin/buffer/chunk.rb
@@ -64,6 +64,11 @@ module Fluent
           raise NotImplementedError, "Implement this method in child class"
         end
 
+        # for event streams which is packed or zipped (and we want not to unpack/uncompress)
+        def concat(bulk, records)
+          raise NotImplementedError, "Implement this method in child class"
+        end
+
         def commit
           raise NotImplementedError, "Implement this method in child class"
         end

--- a/lib/fluent/plugin/buffer/chunk.rb
+++ b/lib/fluent/plugin/buffer/chunk.rb
@@ -14,9 +14,9 @@
 #    limitations under the License.
 #
 
-require 'fluent/msgpack_factory'
 require 'fluent/plugin/buffer'
 require 'fluent/unique_id'
+require 'fluent/event'
 
 require 'fileutils'
 require 'monitor'
@@ -26,8 +26,8 @@ module Fluent
     class Buffer # fluent/plugin/buffer is alread loaded
       class Chunk
         include MonitorMixin
-        include MessagePackFactory::Mixin
         include UniqueId::Mixin
+        include ChunkMessagePackEventStreamer
 
         # Chunks has 2 part:
         # * metadata: contains metadata which should be restored after resume (if possible)
@@ -111,16 +111,6 @@ module Fluent
         def write_to(io)
           open do |i|
             FileUtils.copy_stream(i, io)
-          end
-        end
-
-        def msgpack_each(&block)
-          open do |io|
-            u = msgpack_factory.unpacker(io)
-            begin
-              u.each(&block)
-            rescue EOFError
-            end
           end
         end
       end

--- a/lib/fluent/plugin/buffer/file_chunk.rb
+++ b/lib/fluent/plugin/buffer/file_chunk.rb
@@ -74,6 +74,16 @@ module Fluent
           true
         end
 
+        def concat(bulk, records)
+          raise "BUG: appending to non-staged chunk, now '#{@state}'" unless @state == :staged
+
+          bulk.force_encoding(Encoding::ASCII_8BIT)
+          @chunk.write bulk
+          @adding_bytes += bulk.bytesize
+          @adding_records += records
+          true
+        end
+
         def commit
           write_metadata # this should be at first: of course, this operation may fail
 

--- a/lib/fluent/plugin/buffer/file_chunk.rb
+++ b/lib/fluent/plugin/buffer/file_chunk.rb
@@ -16,6 +16,7 @@
 
 require 'fluent/plugin/buffer/chunk'
 require 'fluent/unique_id'
+require 'fluent/msgpack_factory'
 
 module Fluent
   module Plugin
@@ -33,6 +34,7 @@ module Fluent
         # path_suffix: path suffix string, like '.log' (or any other user specified)
 
         include SystemConfig::Mixin
+        include MessagePackFactory::Mixin
 
         FILE_PERMISSION = 0644
 

--- a/lib/fluent/plugin/buffer/memory_chunk.rb
+++ b/lib/fluent/plugin/buffer/memory_chunk.rb
@@ -22,17 +22,25 @@ module Fluent
       class MemoryChunk < Chunk
         def initialize(metadata)
           super
-          @chunk = ''.force_encoding('ASCII-8BIT')
+          @chunk = ''.force_encoding(Encoding::ASCII_8BIT)
           @chunk_bytes = 0
           @adding_bytes = 0
           @adding_records = 0
         end
 
         def append(data)
-          adding = data.join.force_encoding('ASCII-8BIT')
+          adding = data.join.force_encoding(Encoding::ASCII_8BIT)
           @chunk << adding
           @adding_bytes += adding.bytesize
           @adding_records += data.size
+          true
+        end
+
+        def concat(bulk, records)
+          bulk.force_encoding(Encoding::ASCII_8BIT)
+          @chunk << bulk
+          @adding_bytes += bulk.bytesize
+          @adding_records += records
           true
         end
 

--- a/test/plugin/test_buffer_file_chunk.rb
+++ b/test/plugin/test_buffer_file_chunk.rb
@@ -157,6 +157,37 @@ class BufferFileChunkTest < Test::Unit::TestCase
       assert_equal d4, JSON.parse(ds[3])
     end
 
+    test 'can #concat, #commit and #read it' do
+      assert @c.empty?
+
+      d1 = {"f1" => 'v1', "f2" => 'v2', "f3" => 'v3'}
+      d2 = {"f1" => 'vv1', "f2" => 'vv2', "f3" => 'vv3'}
+      data = [d1.to_json + "\n", d2.to_json + "\n"].join
+      @c.concat(data, 2)
+      @c.commit
+
+      content = @c.read
+      ds = content.split("\n").select{|d| !d.empty? }
+
+      assert_equal 2, ds.size
+      assert_equal d1, JSON.parse(ds[0])
+      assert_equal d2, JSON.parse(ds[1])
+
+      d3 = {"f1" => 'x', "f2" => 'y', "f3" => 'z'}
+      d4 = {"f1" => 'a', "f2" => 'b', "f3" => 'c'}
+      @c.concat([d3.to_json + "\n", d4.to_json + "\n"].join, 2)
+      @c.commit
+
+      content = @c.read
+      ds = content.split("\n").select{|d| !d.empty? }
+
+      assert_equal 4, ds.size
+      assert_equal d1, JSON.parse(ds[0])
+      assert_equal d2, JSON.parse(ds[1])
+      assert_equal d3, JSON.parse(ds[2])
+      assert_equal d4, JSON.parse(ds[3])
+    end
+
     test 'has its contents in binary (ascii-8bit)' do
       data1 = "aaa bbb ccc".force_encoding('utf-8')
       @c.append([data1])
@@ -229,6 +260,49 @@ class BufferFileChunkTest < Test::Unit::TestCase
       d3 = {"f1" => 'x', "f2" => 'y', "f3" => 'z'}
       d4 = {"f1" => 'a', "f2" => 'b', "f3" => 'c'}
       @c.append([d3.to_json + "\n", d4.to_json + "\n"])
+
+      assert_equal first_size + (d3.to_json + "\n" + d4.to_json + "\n").size, @c.size
+      assert_equal 4, @c.records
+
+      @c.rollback
+
+      assert_equal first_size, @c.size
+      assert_equal 2, @c.records
+
+      assert_equal (d1.to_json + "\n" + d2.to_json + "\n"), File.open(@c.path, 'rb'){|f| f.read }
+    end
+
+    test 'can #rollback to revert non-committed data from #concat' do
+      assert @c.empty?
+
+      d1 = {"f1" => 'v1', "f2" => 'v2', "f3" => 'v3'}
+      d2 = {"f1" => 'vv1', "f2" => 'vv2', "f3" => 'vv3'}
+      data = [d1.to_json + "\n", d2.to_json + "\n"].join
+      @c.concat(data, 2)
+
+      assert_equal (d1.to_json + "\n" + d2.to_json + "\n").size, @c.size
+      assert_equal 2, @c.records
+
+      @c.rollback
+
+      assert @c.empty?
+
+      assert_equal '', File.open(@c.path, 'rb'){|f| f.read }
+
+      d1 = {"f1" => 'v1', "f2" => 'v2', "f3" => 'v3'}
+      d2 = {"f1" => 'vv1', "f2" => 'vv2', "f3" => 'vv3'}
+      data = [d1.to_json + "\n", d2.to_json + "\n"]
+      @c.append(data)
+      @c.commit
+
+      assert_equal (d1.to_json + "\n" + d2.to_json + "\n").size, @c.size
+      assert_equal 2, @c.records
+
+      first_size = @c.size
+
+      d3 = {"f1" => 'x', "f2" => 'y', "f3" => 'z'}
+      d4 = {"f1" => 'a', "f2" => 'b', "f3" => 'c'}
+      @c.concat([d3.to_json + "\n", d4.to_json + "\n"].join, 2)
 
       assert_equal first_size + (d3.to_json + "\n" + d4.to_json + "\n").size, @c.size
       assert_equal 4, @c.records

--- a/test/plugin/test_buffer_memory_chunk.rb
+++ b/test/plugin/test_buffer_memory_chunk.rb
@@ -47,6 +47,37 @@ class BufferMemoryChunkTest < Test::Unit::TestCase
     assert_equal d4, JSON.parse(ds[3])
   end
 
+  test 'can #concat, #commit and #read it' do
+    assert @c.empty?
+
+    d1 = {"f1" => 'v1', "f2" => 'v2', "f3" => 'v3'}
+    d2 = {"f1" => 'vv1', "f2" => 'vv2', "f3" => 'vv3'}
+    data = [d1.to_json + "\n", d2.to_json + "\n"].join
+    @c.concat(data, 2)
+    @c.commit
+
+    content = @c.read
+    ds = content.split("\n").select{|d| !d.empty? }
+
+    assert_equal 2, ds.size
+    assert_equal d1, JSON.parse(ds[0])
+    assert_equal d2, JSON.parse(ds[1])
+
+    d3 = {"f1" => 'x', "f2" => 'y', "f3" => 'z'}
+    d4 = {"f1" => 'a', "f2" => 'b', "f3" => 'c'}
+    @c.concat([d3.to_json + "\n", d4.to_json + "\n"].join, 2)
+    @c.commit
+
+    content = @c.read
+    ds = content.split("\n").select{|d| !d.empty? }
+
+    assert_equal 4, ds.size
+    assert_equal d1, JSON.parse(ds[0])
+    assert_equal d2, JSON.parse(ds[1])
+    assert_equal d3, JSON.parse(ds[2])
+    assert_equal d4, JSON.parse(ds[3])
+  end
+
   test 'has its contents in binary (ascii-8bit)' do
     data1 = "aaa bbb ccc".force_encoding('utf-8')
     @c.append([data1])
@@ -119,6 +150,47 @@ class BufferMemoryChunkTest < Test::Unit::TestCase
     d3 = {"f1" => 'x', "f2" => 'y', "f3" => 'z'}
     d4 = {"f1" => 'a', "f2" => 'b', "f3" => 'c'}
     @c.append([d3.to_json + "\n", d4.to_json + "\n"])
+
+    assert_equal first_size + (d3.to_json + "\n" + d4.to_json + "\n").size, @c.size
+    assert_equal 4, @c.records
+
+    @c.rollback
+
+    assert_equal first_size, @c.size
+    assert_equal 2, @c.records
+  end
+
+  test 'can #rollback to revert non-committed data from #concat' do
+    assert @c.empty?
+
+    d1 = {"f1" => 'v1', "f2" => 'v2', "f3" => 'v3'}
+    d2 = {"f1" => 'vv1', "f2" => 'vv2', "f3" => 'vv3'}
+    data = [d1.to_json + "\n", d2.to_json + "\n"].join
+    @c.concat(data, 2)
+
+    assert_equal (d1.to_json + "\n" + d2.to_json + "\n").size, @c.size
+    assert_equal 2, @c.records
+
+    @c.rollback
+
+    assert @c.empty?
+
+    assert @c.empty?
+
+    d1 = {"f1" => 'v1', "f2" => 'v2', "f3" => 'v3'}
+    d2 = {"f1" => 'vv1', "f2" => 'vv2', "f3" => 'vv3'}
+    data = [d1.to_json + "\n", d2.to_json + "\n"]
+    @c.append(data)
+    @c.commit
+
+    assert_equal (d1.to_json + "\n" + d2.to_json + "\n").size, @c.size
+    assert_equal 2, @c.records
+
+    first_size = @c.size
+
+    d3 = {"f1" => 'x', "f2" => 'y', "f3" => 'z'}
+    d4 = {"f1" => 'a', "f2" => 'b', "f3" => 'c'}
+    @c.concat([d3.to_json + "\n", d4.to_json + "\n"].join, 2)
 
     assert_equal first_size + (d3.to_json + "\n" + d4.to_json + "\n").size, @c.size
     assert_equal 4, @c.records

--- a/test/plugin/test_output.rb
+++ b/test/plugin/test_output.rb
@@ -1,6 +1,7 @@
 require_relative '../helper'
 require 'fluent/plugin/output'
 require 'fluent/plugin/buffer'
+require 'fluent/event'
 
 require 'json'
 require 'time'
@@ -288,7 +289,7 @@ class OutputTest < Test::Unit::TestCase
       i.start
 
       t = event_time()
-      i.emit('tag', [ [t, {"key" => "value1"}], [t, {"key" => "value2"}] ])
+      i.emit('tag', Fluent::ArrayEventStream.new([ [t, {"key" => "value1"}], [t, {"key" => "value2"}] ]))
 
       assert process_called
 
@@ -303,7 +304,7 @@ class OutputTest < Test::Unit::TestCase
       i.start
 
       t = event_time()
-      i.emit('tag', [ [t, {"key" => "value1"}], [t, {"key" => "value2"}] ])
+      i.emit('tag', Fluent::ArrayEventStream.new([ [t, {"key" => "value1"}], [t, {"key" => "value2"}] ]))
 
       assert_equal 2, format_called_times
 
@@ -325,7 +326,7 @@ class OutputTest < Test::Unit::TestCase
       assert !i.prefer_buffered_processing
 
       t = event_time()
-      i.emit('tag', [ [t, {"key" => "value1"}], [t, {"key" => "value2"}] ])
+      i.emit('tag', Fluent::ArrayEventStream.new([ [t, {"key" => "value1"}], [t, {"key" => "value2"}] ]))
 
       waiting(4){ Thread.pass until process_called }
 
@@ -350,7 +351,7 @@ class OutputTest < Test::Unit::TestCase
       assert i.prefer_buffered_processing
 
       t = event_time()
-      i.emit('tag', [ [t, {"key" => "value1"}], [t, {"key" => "value2"}] ])
+      i.emit('tag', Fluent::ArrayEventStream.new([ [t, {"key" => "value1"}], [t, {"key" => "value2"}] ]))
 
       assert !process_called
       assert_equal 2, format_called_times
@@ -367,7 +368,7 @@ class OutputTest < Test::Unit::TestCase
       i.start
 
       t = event_time()
-      i.emit('tag', [ [t, {"key" => "value1"}], [t, {"key" => "value2"}] ])
+      i.emit('tag', Fluent::ArrayEventStream.new([ [t, {"key" => "value1"}], [t, {"key" => "value2"}] ]))
       i.force_flush
 
       waiting(4){ Thread.pass until write_called }
@@ -386,7 +387,7 @@ class OutputTest < Test::Unit::TestCase
       i.start
 
       t = event_time()
-      i.emit('tag', [ [t, {"key" => "value1"}], [t, {"key" => "value2"}] ])
+      i.emit('tag', Fluent::ArrayEventStream.new([ [t, {"key" => "value1"}], [t, {"key" => "value2"}] ]))
       i.force_flush
 
       waiting(4){ Thread.pass until try_write_called }
@@ -410,7 +411,7 @@ class OutputTest < Test::Unit::TestCase
       assert !i.prefer_delayed_commit
 
       t = event_time()
-      i.emit('tag', [ [t, {"key" => "value1"}], [t, {"key" => "value2"}] ])
+      i.emit('tag', Fluent::ArrayEventStream.new([ [t, {"key" => "value1"}], [t, {"key" => "value2"}] ]))
       i.force_flush
 
       waiting(4){ Thread.pass until write_called || try_write_called }
@@ -435,7 +436,7 @@ class OutputTest < Test::Unit::TestCase
       assert i.prefer_delayed_commit
 
       t = event_time()
-      i.emit('tag', [ [t, {"key" => "value1"}], [t, {"key" => "value2"}] ])
+      i.emit('tag', Fluent::ArrayEventStream.new([ [t, {"key" => "value1"}], [t, {"key" => "value2"}] ]))
       i.force_flush
 
       waiting(4){ Thread.pass until write_called || try_write_called }
@@ -471,7 +472,7 @@ class OutputTest < Test::Unit::TestCase
       @i.start
 
       t = event_time()
-      es = [ [t, {"key" => "value1"}], [t, {"key" => "value2"}] ]
+      es = Fluent::ArrayEventStream.new([ [t, {"key" => "value1"}], [t, {"key" => "value2"}] ])
       5.times do
         @i.emit('tag', es)
       end

--- a/test/plugin/test_output_as_buffered_retries.rb
+++ b/test/plugin/test_output_as_buffered_retries.rb
@@ -1,6 +1,7 @@
 require_relative '../helper'
 require 'fluent/plugin/output'
 require 'fluent/plugin/buffer'
+require 'fluent/event'
 
 require 'json'
 require 'time'
@@ -71,11 +72,11 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
     end
   end
   def dummy_event_stream
-    [
+    Fluent::ArrayEventStream.new([
       [ event_time('2016-04-13 18:33:00'), {"name" => "moris", "age" => 36, "message" => "data1"} ],
       [ event_time('2016-04-13 18:33:13'), {"name" => "moris", "age" => 36, "message" => "data2"} ],
       [ event_time('2016-04-13 18:33:32'), {"name" => "moris", "age" => 36, "message" => "data3"} ],
-    ]
+    ])
   end
   def get_log_time(msg, logs)
     log_time = nil

--- a/test/plugin/test_output_as_buffered_secondary.rb
+++ b/test/plugin/test_output_as_buffered_secondary.rb
@@ -1,6 +1,7 @@
 require_relative '../helper'
 require 'fluent/plugin/output'
 require 'fluent/plugin/buffer'
+require 'fluent/event'
 
 require 'json'
 require 'time'
@@ -71,11 +72,11 @@ class BufferedOutputSecondaryTest < Test::Unit::TestCase
     end
   end
   def dummy_event_stream
-    [
+    Fluent::ArrayEventStream.new([
       [ event_time('2016-04-13 18:33:00'), {"name" => "moris", "age" => 36, "message" => "data1"} ],
       [ event_time('2016-04-13 18:33:13'), {"name" => "moris", "age" => 36, "message" => "data2"} ],
       [ event_time('2016-04-13 18:33:32'), {"name" => "moris", "age" => 36, "message" => "data3"} ],
-    ]
+    ])
   end
 
   teardown do

--- a/test/plugin/test_output_as_standard.rb
+++ b/test/plugin/test_output_as_standard.rb
@@ -31,7 +31,7 @@ module FluentPluginStandardBufferedOutputTest
   end
 end
 
-class OutputTest < Test::Unit::TestCase
+class StandardBufferedOutputTest < Test::Unit::TestCase
   def create_output(type=:full)
     case type
     when :bare     then FluentPluginStandardBufferedOutputTest::DummyBareOutput.new

--- a/test/plugin/test_output_as_standard.rb
+++ b/test/plugin/test_output_as_standard.rb
@@ -1,0 +1,346 @@
+require_relative '../helper'
+require 'fluent/plugin/output'
+require 'fluent/plugin/buffer'
+require 'fluent/msgpack_factory'
+require 'fluent/event'
+
+require 'json'
+require 'time'
+require 'timeout'
+
+require 'flexmock/test_unit'
+
+module FluentPluginStandardBufferedOutputTest
+  class DummyBareOutput < Fluent::Plugin::Output
+    def register(name, &block)
+      instance_variable_set("@#{name}", block)
+    end
+  end
+  class DummyAsyncOutput < DummyBareOutput
+    def format(tag, time, record)
+      @format ? @format.call(tag, time, record) : [tag, time, record].to_json
+    end
+    def write(chunk)
+      @write ? @write.call(chunk) : nil
+    end
+  end
+  class DummyAsyncStandardOutput < DummyBareOutput
+    def write(chunk)
+      @write ? @write.call(chunk) : nil
+    end
+  end
+end
+
+class OutputTest < Test::Unit::TestCase
+  def create_output(type=:full)
+    case type
+    when :bare     then FluentPluginStandardBufferedOutputTest::DummyBareOutput.new
+    when :buffered then FluentPluginStandardBufferedOutputTest::DummyAsyncOutput.new
+    when :standard then FluentPluginStandardBufferedOutputTest::DummyAsyncStandardOutput.new
+    else
+      raise ArgumentError, "unknown type: #{type}"
+    end
+  end
+  def create_metadata(timekey: nil, tag: nil, variables: nil)
+    Fluent::Plugin::Buffer::Metadata.new(timekey, tag, variables)
+  end
+  def waiting(seconds)
+    begin
+      Timeout.timeout(seconds) do
+        yield
+      end
+    rescue Timeout::Error
+      STDERR.print *(@i.log.out.logs)
+      raise
+    end
+  end
+  def test_event_stream
+    es = Fluent::MultiEventStream.new
+    es.add(event_time('2016-04-21 17:19:00 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+    es.add(event_time('2016-04-21 17:19:13 -0700'), {"key" => "my value", "name" => "moris2", "message" => "hello!"})
+    es.add(event_time('2016-04-21 17:19:25 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+    es.add(event_time('2016-04-21 17:20:01 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+    es.add(event_time('2016-04-21 17:20:13 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+    es.add(event_time('2016-04-21 17:21:32 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+    es
+  end
+
+  teardown do
+    if @i
+      @i.stop unless @i.stopped?
+      @i.before_shutdown unless @i.before_shutdown?
+      @i.shutdown unless @i.shutdown?
+      @i.after_shutdown unless @i.after_shutdown?
+      @i.close unless @i.closed?
+      @i.terminate unless @i.terminated?
+    end
+  end
+
+  sub_test_case 'standard buffered without any chunk keys' do
+    test '#execute_chunking calls @buffer.emit_bulk just once with predefined msgpack format' do
+      @i = create_output(:standard)
+      @i.configure(config_element())
+      @i.start
+
+      m = create_metadata()
+      es = test_event_stream
+
+      buffer_mock = flexmock(@i.buffer)
+      buffer_mock.should_receive(:emit_bulk).once.with(m, es.to_msgpack_stream, es.records)
+
+      @i.execute_chunking("mytag.test", es)
+    end
+
+    test '#execute_chunking calls @buffer.emit_bulk just once with predefined msgpack format, but time will be int if time_as_integer specified' do
+      @i = create_output(:standard)
+      @i.configure(config_element('ROOT','',{"time_as_integer"=>"true"}))
+      @i.start
+
+      m = create_metadata()
+      es = test_event_stream
+
+      buffer_mock = flexmock(@i.buffer)
+      buffer_mock.should_receive(:emit_bulk).once.with(m, es.to_msgpack_stream(time_int: true), es.records)
+
+      @i.execute_chunking("mytag.test", es)
+    end
+  end
+
+  sub_test_case 'standard buffered with tag chunk key' do
+    test '#execute_chunking calls @buffer.emit_bulk just once with predefined msgpack format' do
+      @i = create_output(:standard)
+      @i.configure(config_element('ROOT','',{},[config_element('buffer','tag')]))
+      @i.start
+
+      m = create_metadata(tag: "mytag.test")
+      es = test_event_stream
+
+      buffer_mock = flexmock(@i.buffer)
+      buffer_mock.should_receive(:emit_bulk).once.with(m, es.to_msgpack_stream, es.records)
+
+      @i.execute_chunking("mytag.test", es)
+    end
+
+    test '#execute_chunking calls @buffer.emit_bulk just once with predefined msgpack format, but time will be int if time_as_integer specified' do
+      @i = create_output(:standard)
+      @i.configure(config_element('ROOT','',{"time_as_integer"=>"true"},[config_element('buffer','tag')]))
+      @i.start
+
+      m = create_metadata(tag: "mytag.test")
+      es = test_event_stream
+
+      buffer_mock = flexmock(@i.buffer)
+      buffer_mock.should_receive(:emit_bulk).once.with(m, es.to_msgpack_stream(time_int: true), es.records)
+
+      @i.execute_chunking("mytag.test", es)
+    end
+  end
+
+  sub_test_case 'standard buffered with time chunk key' do
+    test '#execute_chunking calls @buffer.emit_bulk in times of # of time ranges with predefined msgpack format' do
+      @i = create_output(:standard)
+      @i.configure(config_element('ROOT','',{},[config_element('buffer','time',{"timekey_range" => "60"})]))
+      @i.start
+
+      m1 = create_metadata(timekey: Time.parse('2016-04-21 17:19:00 -0700').to_i)
+      m2 = create_metadata(timekey: Time.parse('2016-04-21 17:20:00 -0700').to_i)
+      m3 = create_metadata(timekey: Time.parse('2016-04-21 17:21:00 -0700').to_i)
+
+      es1 = Fluent::MultiEventStream.new
+      es1.add(event_time('2016-04-21 17:19:00 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+      es1.add(event_time('2016-04-21 17:19:13 -0700'), {"key" => "my value", "name" => "moris2", "message" => "hello!"})
+      es1.add(event_time('2016-04-21 17:19:25 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+
+      es2 = Fluent::MultiEventStream.new
+      es2.add(event_time('2016-04-21 17:20:01 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+      es2.add(event_time('2016-04-21 17:20:13 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+
+      es3 = Fluent::MultiEventStream.new
+      es3.add(event_time('2016-04-21 17:21:32 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+
+      buffer_mock = flexmock(@i.buffer)
+      buffer_mock.should_receive(:emit_bulk).with(m1, es1.to_msgpack_stream, 3).once
+      buffer_mock.should_receive(:emit_bulk).with(m2, es2.to_msgpack_stream, 2).once
+      buffer_mock.should_receive(:emit_bulk).with(m3, es3.to_msgpack_stream, 1).once
+
+      es = test_event_stream
+      @i.execute_chunking("mytag.test", es)
+    end
+
+    test '#execute_chunking calls @buffer.emit_bulk in times of # of time ranges with predefined msgpack format, but time will be int if time_as_integer specified' do
+      @i = create_output(:standard)
+      @i.configure(config_element('ROOT','',{"time_as_integer" => "true"},[config_element('buffer','time',{"timekey_range" => "60"})]))
+      @i.start
+
+      m1 = create_metadata(timekey: Time.parse('2016-04-21 17:19:00 -0700').to_i)
+      m2 = create_metadata(timekey: Time.parse('2016-04-21 17:20:00 -0700').to_i)
+      m3 = create_metadata(timekey: Time.parse('2016-04-21 17:21:00 -0700').to_i)
+
+      es1 = Fluent::MultiEventStream.new
+      es1.add(event_time('2016-04-21 17:19:00 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+      es1.add(event_time('2016-04-21 17:19:13 -0700'), {"key" => "my value", "name" => "moris2", "message" => "hello!"})
+      es1.add(event_time('2016-04-21 17:19:25 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+
+      es2 = Fluent::MultiEventStream.new
+      es2.add(event_time('2016-04-21 17:20:01 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+      es2.add(event_time('2016-04-21 17:20:13 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+
+      es3 = Fluent::MultiEventStream.new
+      es3.add(event_time('2016-04-21 17:21:32 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+
+      buffer_mock = flexmock(@i.buffer)
+      buffer_mock.should_receive(:emit_bulk).with(m1, es1.to_msgpack_stream(time_int: true), 3).once
+      buffer_mock.should_receive(:emit_bulk).with(m2, es2.to_msgpack_stream(time_int: true), 2).once
+      buffer_mock.should_receive(:emit_bulk).with(m3, es3.to_msgpack_stream(time_int: true), 1).once
+
+      es = test_event_stream
+      @i.execute_chunking("mytag.test", es)
+    end
+  end
+
+  sub_test_case 'standard buffered with variable chunk keys' do
+    test '#execute_chunking calls @buffer.emit_bulk in times of # of variable variations with predefined msgpack format' do
+      @i = create_output(:standard)
+      @i.configure(config_element('ROOT','',{},[config_element('buffer','key,name')]))
+      @i.start
+
+      m1 = create_metadata(variables: {key: "my value", name: "moris1"})
+      es1 = Fluent::MultiEventStream.new
+      es1.add(event_time('2016-04-21 17:19:00 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+      es1.add(event_time('2016-04-21 17:19:25 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+      es1.add(event_time('2016-04-21 17:20:01 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+      es1.add(event_time('2016-04-21 17:20:13 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+      es1.add(event_time('2016-04-21 17:21:32 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+
+      m2 = create_metadata(variables: {key: "my value", name: "moris2"})
+      es2 = Fluent::MultiEventStream.new
+      es2.add(event_time('2016-04-21 17:19:13 -0700'), {"key" => "my value", "name" => "moris2", "message" => "hello!"})
+
+      buffer_mock = flexmock(@i.buffer)
+      buffer_mock.should_receive(:emit_bulk).with(m1, es1.to_msgpack_stream, 5).once
+      buffer_mock.should_receive(:emit_bulk).with(m2, es2.to_msgpack_stream, 1).once
+
+      es = test_event_stream
+      @i.execute_chunking("mytag.test", es)
+    end
+
+    test '#execute_chunking calls @buffer.emit_bulk in times of # of variable variations with predefined msgpack format, but time will be int if time_as_integer specified' do
+      @i = create_output(:standard)
+      @i.configure(config_element('ROOT','',{"time_as_integer" => "true"},[config_element('buffer','key,name')]))
+      @i.start
+
+      m1 = create_metadata(variables: {key: "my value", name: "moris1"})
+      es1 = Fluent::MultiEventStream.new
+      es1.add(event_time('2016-04-21 17:19:00 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+      es1.add(event_time('2016-04-21 17:19:25 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+      es1.add(event_time('2016-04-21 17:20:01 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+      es1.add(event_time('2016-04-21 17:20:13 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+      es1.add(event_time('2016-04-21 17:21:32 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+
+      m2 = create_metadata(variables: {key: "my value", name: "moris2"})
+      es2 = Fluent::MultiEventStream.new
+      es2.add(event_time('2016-04-21 17:19:13 -0700'), {"key" => "my value", "name" => "moris2", "message" => "hello!"})
+
+      buffer_mock = flexmock(@i.buffer)
+      buffer_mock.should_receive(:emit_bulk).with(m1, es1.to_msgpack_stream(time_int: true), 5).once
+      buffer_mock.should_receive(:emit_bulk).with(m2, es2.to_msgpack_stream(time_int: true), 1).once
+
+      es = test_event_stream
+      @i.execute_chunking("mytag.test", es)
+    end
+  end
+
+  sub_test_case 'custom format buffered without any chunk keys' do
+    test '#execute_chunking calls @buffer.emit_bulk just once with customized format' do
+      @i = create_output(:buffered)
+      @i.register(:format){|tag, time, record| [time, record].to_json }
+      @i.configure(config_element())
+      @i.start
+
+      m = create_metadata()
+      es = test_event_stream
+
+      buffer_mock = flexmock(@i.buffer)
+      buffer_mock.should_receive(:emit_bulk).once.with(m, es.map{|t,r| [t,r].to_json }.join, es.records)
+
+      @i.execute_chunking("mytag.test", es)
+    end
+  end
+
+  sub_test_case 'custom format buffered with tag chunk key' do
+    test '#execute_chunking calls @buffer.emit_bulk just once with customized format' do
+      @i = create_output(:buffered)
+      @i.register(:format){|tag, time, record| [time, record].to_json }
+      @i.configure(config_element('ROOT','',{},[config_element('buffer','tag')]))
+      @i.start
+
+      m = create_metadata(tag: "mytag.test")
+      es = test_event_stream
+
+      buffer_mock = flexmock(@i.buffer)
+      buffer_mock.should_receive(:emit_bulk).once.with(m, es.map{|t,r| [t,r].to_json }.join, es.records)
+
+      @i.execute_chunking("mytag.test", es)
+    end
+  end
+  sub_test_case 'custom format buffered with time chunk key' do
+    test '#execute_chunking calls @buffer.emit in times of # of time ranges with customized format' do
+      @i = create_output(:buffered)
+      @i.register(:format){|tag, time, record| [time, record].to_json }
+      @i.configure(config_element('ROOT','',{},[config_element('buffer','time',{"timekey_range" => "60"})]))
+      @i.start
+
+      m1 = create_metadata(timekey: Time.parse('2016-04-21 17:19:00 -0700').to_i)
+      m2 = create_metadata(timekey: Time.parse('2016-04-21 17:20:00 -0700').to_i)
+      m3 = create_metadata(timekey: Time.parse('2016-04-21 17:21:00 -0700').to_i)
+
+      es1 = Fluent::MultiEventStream.new
+      es1.add(event_time('2016-04-21 17:19:00 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+      es1.add(event_time('2016-04-21 17:19:13 -0700'), {"key" => "my value", "name" => "moris2", "message" => "hello!"})
+      es1.add(event_time('2016-04-21 17:19:25 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+
+      es2 = Fluent::MultiEventStream.new
+      es2.add(event_time('2016-04-21 17:20:01 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+      es2.add(event_time('2016-04-21 17:20:13 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+
+      es3 = Fluent::MultiEventStream.new
+      es3.add(event_time('2016-04-21 17:21:32 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+
+      buffer_mock = flexmock(@i.buffer)
+      buffer_mock.should_receive(:emit).with(m1, es1.map{|t,r| [t,r].to_json }).once
+      buffer_mock.should_receive(:emit).with(m2, es2.map{|t,r| [t,r].to_json }).once
+      buffer_mock.should_receive(:emit).with(m3, es3.map{|t,r| [t,r].to_json }).once
+
+      es = test_event_stream
+      @i.execute_chunking("mytag.test", es)
+    end
+  end
+
+  sub_test_case 'custom format buffered with variable chunk keys' do
+    test '#execute_chunking calls @buffer.emit in times of # of variable variations with customized format' do
+      @i = create_output(:buffered)
+      @i.register(:format){|tag, time, record| [time, record].to_json }
+      @i.configure(config_element('ROOT','',{},[config_element('buffer','key,name')]))
+      @i.start
+
+      m1 = create_metadata(variables: {key: "my value", name: "moris1"})
+      es1 = Fluent::MultiEventStream.new
+      es1.add(event_time('2016-04-21 17:19:00 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+      es1.add(event_time('2016-04-21 17:19:25 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+      es1.add(event_time('2016-04-21 17:20:01 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+      es1.add(event_time('2016-04-21 17:20:13 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+      es1.add(event_time('2016-04-21 17:21:32 -0700'), {"key" => "my value", "name" => "moris1", "message" => "hello!"})
+
+      m2 = create_metadata(variables: {key: "my value", name: "moris2"})
+      es2 = Fluent::MultiEventStream.new
+      es2.add(event_time('2016-04-21 17:19:13 -0700'), {"key" => "my value", "name" => "moris2", "message" => "hello!"})
+
+      buffer_mock = flexmock(@i.buffer)
+      buffer_mock.should_receive(:emit).with(m1, es1.map{|t,r| [t,r].to_json }).once
+      buffer_mock.should_receive(:emit).with(m2, es2.map{|t,r| [t,r].to_json }).once
+
+      es = test_event_stream
+      @i.execute_chunking("mytag.test", es)
+    end
+  end
+end

--- a/test/test_event.rb
+++ b/test/test_event.rb
@@ -7,7 +7,7 @@ module EventTest
     include Fluent
 
     def setup
-      @time = Engine.now
+      @time = event_time()
       @record = {'k' => 'v', 'n' => 1}
       @es = OneEventStream.new(@time, @record)
     end
@@ -33,6 +33,14 @@ module EventTest
       stream = @es.to_msgpack_stream
       Fluent::Engine.msgpack_factory.unpacker.feed_each(stream) { |time, record|
         assert_equal @time, time
+        assert_equal @record, record
+      }
+    end
+
+    test 'to_msgpack_stream with time_int argument' do
+      stream = @es.to_msgpack_stream(time_int: true)
+      Fluent::Engine.msgpack_factory.unpacker.feed_each(stream) { |time, record|
+        assert_equal @time.to_i, time
         assert_equal @record, record
       }
     end


### PR DESCRIPTION
This change is to add formatting for buffer chunks. Output without explicit `#format` definition will use this standard format to write event streams to buffer chunks, and actually, it's same with `EventStream.to_msgpack_stream`.
At the same time, this change moves a method to iterate events from chunks to `event.rb` as mixin. It's about event streams, not chunk itself.
