### PR TITLE
Rename number of events

### DIFF
--- a/lib/fluent/event.rb
+++ b/lib/fluent/event.rb
@@ -21,9 +21,10 @@ module Fluent
     include Enumerable
     include MessagePackFactory::Mixin
 
-    def records
+    def size
       raise NotImplementedError, "DO NOT USE THIS CLASS directly."
     end
+    alias :length :size
 
     def repeatable?
       false
@@ -61,7 +62,7 @@ module Fluent
       OneEventStream.new(@time, @record.dup)
     end
 
-    def records
+    def size
       1
     end
 
@@ -89,7 +90,7 @@ module Fluent
       ArrayEventStream.new(entries)
     end
 
-    def records
+    def size
       @entries.size
     end
 
@@ -131,7 +132,7 @@ module Fluent
       es
     end
 
-    def records
+    def size
       @time_array.size
     end
 
@@ -160,13 +161,13 @@ module Fluent
 
   class MessagePackEventStream < EventStream
     # Keep cached_unpacker argument for existence plugins
-    def initialize(data, records = 0, cached_unpacker = nil)
+    def initialize(data, cached_unpacker = nil, size = 0)
       @data = data
-      @records = records
+      @size = size
     end
 
-    def records
-      @records
+    def size
+      @size
     end
 
     def repeatable?

--- a/lib/fluent/plugin/buffer/chunk.rb
+++ b/lib/fluent/plugin/buffer/chunk.rb
@@ -52,7 +52,7 @@ module Fluent
           @unique_id = generate_unique_id
           @metadata = metadata
 
-          @records = 0
+          @size = 0
           @created_at = Time.now
           @modified_at = Time.now
         end
@@ -77,13 +77,14 @@ module Fluent
           raise NotImplementedError, "Implement this method in child class"
         end
 
-        def size
+        def bytesize
           raise NotImplementedError, "Implement this method in child class"
         end
 
-        def records
+        def size
           raise NotImplementedError, "Implement this method in child class"
         end
+        alias :length :size
 
         def empty?
           size == 0

--- a/lib/fluent/plugin/buffer/chunk.rb
+++ b/lib/fluent/plugin/buffer/chunk.rb
@@ -36,7 +36,7 @@ module Fluent
         #             k: time slice key (optional)
         #
         #             id: unique_id of chunk (*)
-        #             r: number of records (*)
+        #             s: size (number of events in chunk) (*)
         #             c: created_at as unix time (*)
         #             m: modified_at as unix time (*)
         #              (*): fields automatically injected by chunk itself

--- a/lib/fluent/plugin/buffer/memory_chunk.rb
+++ b/lib/fluent/plugin/buffer/memory_chunk.rb
@@ -25,46 +25,46 @@ module Fluent
           @chunk = ''.force_encoding(Encoding::ASCII_8BIT)
           @chunk_bytes = 0
           @adding_bytes = 0
-          @adding_records = 0
+          @adding_size = 0
         end
 
         def append(data)
           adding = data.join.force_encoding(Encoding::ASCII_8BIT)
           @chunk << adding
           @adding_bytes += adding.bytesize
-          @adding_records += data.size
+          @adding_size += data.size
           true
         end
 
-        def concat(bulk, records)
+        def concat(bulk, bulk_size)
           bulk.force_encoding(Encoding::ASCII_8BIT)
           @chunk << bulk
           @adding_bytes += bulk.bytesize
-          @adding_records += records
+          @adding_size += bulk_size
           true
         end
 
         def commit
-          @records += @adding_records
+          @size += @adding_size
           @chunk_bytes += @adding_bytes
 
-          @adding_bytes = @adding_records = 0
+          @adding_bytes = @adding_size = 0
           @modified_at = Time.now
           true
         end
 
         def rollback
           @chunk.slice!(@chunk_bytes, @adding_bytes)
-          @adding_bytes = @adding_records = 0
+          @adding_bytes = @adding_size = 0
           true
         end
 
-        def size
+        def bytesize
           @chunk_bytes + @adding_bytes
         end
 
-        def records
-          @records + @adding_records
+        def size
+          @size + @adding_size
         end
 
         def empty?
@@ -77,7 +77,7 @@ module Fluent
 
         def purge
           @chunk = ''.force_encoding("ASCII-8BIT")
-          @chunk_bytes = @records = @adding_bytes = @adding_records = 0
+          @chunk_bytes = @size = @adding_bytes = @adding_size = 0
           true
         end
 

--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -469,7 +469,7 @@ module Fluent
         @counters_monitor.synchronize{ @emit_count += 1 }
         begin
           process(tag, es)
-          @counters_monitor.synchronize{ @emit_records += es.records }
+          @counters_monitor.synchronize{ @emit_records += es.size }
         rescue
           @counters_monitor.synchronize{ @num_errors += 1 }
           raise
@@ -562,7 +562,7 @@ module Fluent
           records += 1
         end
         meta_and_data.each_pair do |meta, es|
-          @buffer.emit_bulk(meta, es.to_msgpack_stream(time_int: @time_as_integer), es.records)
+          @buffer.emit_bulk(meta, es.to_msgpack_stream(time_int: @time_as_integer), es.size)
         end
         @counters_monitor.synchronize{ @emit_records += records }
         meta_and_data.keys
@@ -570,14 +570,14 @@ module Fluent
 
       def handle_stream_simple(tag, es)
         meta = metadata((@chunk_key_tag ? tag : nil), nil, nil)
-        es_records = es.records
+        es_size = es.size
         es_bulk = if @custom_format
                     es.map{|time,record| format(tag, time, record) }.join
                   else
                     es.to_msgpack_stream(time_int: @time_as_integer)
                   end
-        @buffer.emit_bulk(meta, es_bulk, es_records)
-        @counters_monitor.synchronize{ @emit_records += es_records }
+        @buffer.emit_bulk(meta, es_bulk, es_size)
+        @counters_monitor.synchronize{ @emit_records += es_size }
         [meta]
       end
 

--- a/test/plugin/test_buf_file2.rb
+++ b/test/plugin/test_buf_file2.rb
@@ -18,11 +18,11 @@ class FileBufferTest < Test::Unit::TestCase
     Fluent::Plugin::Buffer::Metadata.new(timekey, tag, variables)
   end
 
-  def write_metadata(path, chunk_id, metadata, records, ctime, mtime)
+  def write_metadata(path, chunk_id, metadata, size, ctime, mtime)
     metadata = {
       timekey: metadata.timekey, tag: metadata.tag, variables: metadata.variables,
       id: chunk_id,
-      r: records,
+      s: size,
       c: ctime,
       m: mtime,
     }
@@ -361,12 +361,12 @@ class FileBufferTest < Test::Unit::TestCase
 
       m3 = metadata(timekey: event_time('2016-04-17 14:00:00 -0700').to_i)
       assert_equal @c3id, stage[m3].unique_id
-      assert_equal 4, stage[m3].records
+      assert_equal 4, stage[m3].size
       assert_equal :staged, stage[m3].state
 
       m4 = metadata(timekey: event_time('2016-04-17 14:01:00 -0700').to_i)
       assert_equal @c4id, stage[m4].unique_id
-      assert_equal 3, stage[m4].records
+      assert_equal 3, stage[m4].size
       assert_equal :staged, stage[m4].state
     end
 
@@ -385,7 +385,7 @@ class FileBufferTest < Test::Unit::TestCase
       assert_nil queue[0].metadata.variables
       assert_equal Time.parse('2016-04-17 13:58:00 -0700').localtime, queue[0].created_at
       assert_equal Time.parse('2016-04-17 13:58:22 -0700').localtime, queue[0].modified_at
-      assert_equal 4, queue[0].records
+      assert_equal 4, queue[0].size
 
       assert_equal @c2id, queue[1].unique_id
       assert_equal :queued, queue[1].state
@@ -394,7 +394,7 @@ class FileBufferTest < Test::Unit::TestCase
       assert_nil queue[1].metadata.variables
       assert_equal Time.parse('2016-04-17 13:59:00 -0700').localtime, queue[1].created_at
       assert_equal Time.parse('2016-04-17 13:59:23 -0700').localtime, queue[1].modified_at
-      assert_equal 3, queue[1].records
+      assert_equal 3, queue[1].size
     end
   end
 
@@ -477,25 +477,25 @@ class FileBufferTest < Test::Unit::TestCase
 
       assert_equal @c1id, queue[0].unique_id
       assert_equal m, queue[0].metadata
-      assert_equal 0, queue[0].records
+      assert_equal 0, queue[0].size
       assert_equal :queued, queue[0].state
       assert_equal Time.parse('2016-04-17 13:58:28 -0700'), queue[0].modified_at
 
       assert_equal @c2id, queue[1].unique_id
       assert_equal m, queue[1].metadata
-      assert_equal 0, queue[1].records
+      assert_equal 0, queue[1].size
       assert_equal :queued, queue[1].state
       assert_equal Time.parse('2016-04-17 13:59:30 -0700'), queue[1].modified_at
 
       assert_equal @c3id, queue[2].unique_id
       assert_equal m, queue[2].metadata
-      assert_equal 0, queue[2].records
+      assert_equal 0, queue[2].size
       assert_equal :queued, queue[2].state
       assert_equal Time.parse('2016-04-17 14:00:29 -0700'), queue[2].modified_at
 
       assert_equal @c4id, queue[3].unique_id
       assert_equal m, queue[3].metadata
-      assert_equal 0, queue[3].records
+      assert_equal 0, queue[3].size
       assert_equal :queued, queue[3].state
       assert_equal Time.parse('2016-04-17 14:01:22 -0700'), queue[3].modified_at
     end

--- a/test/plugin/test_buffer.rb
+++ b/test/plugin/test_buffer.rb
@@ -26,7 +26,7 @@ module FluentPluginBufferTest
       @append_count += 1
       super
     end
-    def concat(data, records)
+    def concat(data, size)
       @append_count += 1
       super
     end
@@ -262,14 +262,14 @@ class BufferTest < Test::Unit::TestCase
       assert_equal @dm3, m2
     end
 
-    test '#queued_records returns total number of records in all chunks in queue' do
+    test '#queued_records returns total number of size in all chunks in queue' do
       assert_equal 3, @p.queue.size
 
-      r0 = @p.queue[0].records
+      r0 = @p.queue[0].size
       assert_equal 1, r0
-      r1 = @p.queue[1].records
+      r1 = @p.queue[1].size
       assert_equal 1, r1
-      r2 = @p.queue[2].records
+      r2 = @p.queue[2].size
       assert_equal 1, r2
 
       assert_equal (r0+r1+r2), @p.queued_records
@@ -577,7 +577,7 @@ class BufferTest < Test::Unit::TestCase
       assert_equal [@dm0,@dm1,@dm1,m], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3,m], @p.stage.keys
       assert_equal 1, @p.stage[m].append_count
-      assert_equal 1024*1024, @p.stage[m].size
+      assert_equal 1024*1024, @p.stage[m].bytesize
       assert_equal 3, @p.queue.last.append_count # 1 -> emit (2) -> emit_step_by_step (3)
       assert @p.queue.last.rollbacked
     end
@@ -695,7 +695,7 @@ class BufferTest < Test::Unit::TestCase
       assert_equal [@dm0,@dm1,@dm1,m], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3,m], @p.stage.keys
       assert_equal 1, @p.stage[m].append_count
-      assert_equal 1024*1024, @p.stage[m].size
+      assert_equal 1024*1024, @p.stage[m].bytesize
       assert_equal 2, @p.queue.last.append_count # 1 -> emit (2) -> rollback&enqueue
       assert @p.queue.last.rollbacked
     end
@@ -866,7 +866,7 @@ class BufferTest < Test::Unit::TestCase
       m = create_metadata(Time.parse('2016-04-11 16:40:00 +0000').to_i)
 
       c1 = create_chunk(m, ["a" * 128] * 6)
-      assert_equal 6, c1.records
+      assert_equal 6, c1.size
       assert !@p.chunk_size_over?(c1)
 
       c2 = create_chunk(m, ["a" * 128] * 7)
@@ -882,7 +882,7 @@ class BufferTest < Test::Unit::TestCase
       m = create_metadata(Time.parse('2016-04-11 16:40:00 +0000').to_i)
 
       c1 = create_chunk(m, ["a" * 128] * 5)
-      assert_equal 5, c1.records
+      assert_equal 5, c1.size
       assert !@p.chunk_size_full?(c1)
 
       c2 = create_chunk(m, ["a" * 128] * 6)

--- a/test/plugin/test_buffer_chunk.rb
+++ b/test/plugin/test_buffer_chunk.rb
@@ -19,8 +19,9 @@ class BufferChunkTest < Test::Unit::TestCase
       assert chunk.respond_to?(:append)
       assert chunk.respond_to?(:commit)
       assert chunk.respond_to?(:rollback)
+      assert chunk.respond_to?(:bytesize)
       assert chunk.respond_to?(:size)
-      assert chunk.respond_to?(:records)
+      assert chunk.respond_to?(:length)
       assert chunk.respond_to?(:empty?)
       assert chunk.respond_to?(:close)
       assert chunk.respond_to?(:purge)
@@ -31,8 +32,9 @@ class BufferChunkTest < Test::Unit::TestCase
       assert_raise(NotImplementedError){ chunk.append(nil) }
       assert_raise(NotImplementedError){ chunk.commit }
       assert_raise(NotImplementedError){ chunk.rollback }
+      assert_raise(NotImplementedError){ chunk.bytesize }
       assert_raise(NotImplementedError){ chunk.size }
-      assert_raise(NotImplementedError){ chunk.records }
+      assert_raise(NotImplementedError){ chunk.length }
       assert_raise(NotImplementedError){ chunk.empty? }
       assert_raise(NotImplementedError){ chunk.close }
       assert_raise(NotImplementedError){ chunk.purge }

--- a/test/plugin/test_buffer_file_chunk.rb
+++ b/test/plugin/test_buffer_file_chunk.rb
@@ -198,7 +198,7 @@ class BufferFileChunkTest < Test::Unit::TestCase
       assert_equal Encoding::ASCII_8BIT, content.encoding
     end
 
-    test 'has #size and #records' do
+    test 'has #bytesize and #size' do
       assert @c.empty?
 
       d1 = {"f1" => 'v1', "f2" => 'v2', "f3" => 'v3'}
@@ -206,27 +206,27 @@ class BufferFileChunkTest < Test::Unit::TestCase
       data = [d1.to_json + "\n", d2.to_json + "\n"]
       @c.append(data)
 
-      assert_equal (d1.to_json + "\n" + d2.to_json + "\n").size, @c.size
-      assert_equal 2, @c.records
+      assert_equal (d1.to_json + "\n" + d2.to_json + "\n").bytesize, @c.bytesize
+      assert_equal 2, @c.size
 
       @c.commit
 
-      assert_equal (d1.to_json + "\n" + d2.to_json + "\n").size, @c.size
-      assert_equal 2, @c.records
+      assert_equal (d1.to_json + "\n" + d2.to_json + "\n").bytesize, @c.bytesize
+      assert_equal 2, @c.size
 
-      first_size = @c.size
+      first_bytesize = @c.bytesize
 
       d3 = {"f1" => 'x', "f2" => 'y', "f3" => 'z'}
       d4 = {"f1" => 'a', "f2" => 'b', "f3" => 'c'}
       @c.append([d3.to_json + "\n", d4.to_json + "\n"])
 
-      assert_equal first_size + (d3.to_json + "\n" + d4.to_json + "\n").size, @c.size
-      assert_equal 4, @c.records
+      assert_equal first_bytesize + (d3.to_json + "\n" + d4.to_json + "\n").bytesize, @c.bytesize
+      assert_equal 4, @c.size
 
       @c.commit
 
-      assert_equal first_size + (d3.to_json + "\n" + d4.to_json + "\n").size, @c.size
-      assert_equal 4, @c.records
+      assert_equal first_bytesize + (d3.to_json + "\n" + d4.to_json + "\n").bytesize, @c.bytesize
+      assert_equal 4, @c.size
     end
 
     test 'can #rollback to revert non-committed data' do
@@ -237,8 +237,8 @@ class BufferFileChunkTest < Test::Unit::TestCase
       data = [d1.to_json + "\n", d2.to_json + "\n"]
       @c.append(data)
 
-      assert_equal (d1.to_json + "\n" + d2.to_json + "\n").size, @c.size
-      assert_equal 2, @c.records
+      assert_equal (d1.to_json + "\n" + d2.to_json + "\n").bytesize, @c.bytesize
+      assert_equal 2, @c.size
 
       @c.rollback
 
@@ -252,22 +252,22 @@ class BufferFileChunkTest < Test::Unit::TestCase
       @c.append(data)
       @c.commit
 
-      assert_equal (d1.to_json + "\n" + d2.to_json + "\n").size, @c.size
-      assert_equal 2, @c.records
+      assert_equal (d1.to_json + "\n" + d2.to_json + "\n").bytesize, @c.bytesize
+      assert_equal 2, @c.size
 
-      first_size = @c.size
+      first_bytesize = @c.bytesize
 
       d3 = {"f1" => 'x', "f2" => 'y', "f3" => 'z'}
       d4 = {"f1" => 'a', "f2" => 'b', "f3" => 'c'}
       @c.append([d3.to_json + "\n", d4.to_json + "\n"])
 
-      assert_equal first_size + (d3.to_json + "\n" + d4.to_json + "\n").size, @c.size
-      assert_equal 4, @c.records
+      assert_equal first_bytesize + (d3.to_json + "\n" + d4.to_json + "\n").bytesize, @c.bytesize
+      assert_equal 4, @c.size
 
       @c.rollback
 
-      assert_equal first_size, @c.size
-      assert_equal 2, @c.records
+      assert_equal first_bytesize, @c.bytesize
+      assert_equal 2, @c.size
 
       assert_equal (d1.to_json + "\n" + d2.to_json + "\n"), File.open(@c.path, 'rb'){|f| f.read }
     end
@@ -280,8 +280,8 @@ class BufferFileChunkTest < Test::Unit::TestCase
       data = [d1.to_json + "\n", d2.to_json + "\n"].join
       @c.concat(data, 2)
 
-      assert_equal (d1.to_json + "\n" + d2.to_json + "\n").size, @c.size
-      assert_equal 2, @c.records
+      assert_equal (d1.to_json + "\n" + d2.to_json + "\n").bytesize, @c.bytesize
+      assert_equal 2, @c.size
 
       @c.rollback
 
@@ -295,22 +295,22 @@ class BufferFileChunkTest < Test::Unit::TestCase
       @c.append(data)
       @c.commit
 
-      assert_equal (d1.to_json + "\n" + d2.to_json + "\n").size, @c.size
-      assert_equal 2, @c.records
+      assert_equal (d1.to_json + "\n" + d2.to_json + "\n").bytesize, @c.bytesize
+      assert_equal 2, @c.size
 
-      first_size = @c.size
+      first_bytesize = @c.bytesize
 
       d3 = {"f1" => 'x', "f2" => 'y', "f3" => 'z'}
       d4 = {"f1" => 'a', "f2" => 'b', "f3" => 'c'}
       @c.concat([d3.to_json + "\n", d4.to_json + "\n"].join, 2)
 
-      assert_equal first_size + (d3.to_json + "\n" + d4.to_json + "\n").size, @c.size
-      assert_equal 4, @c.records
+      assert_equal first_bytesize + (d3.to_json + "\n" + d4.to_json + "\n").bytesize, @c.bytesize
+      assert_equal 4, @c.size
 
       @c.rollback
 
-      assert_equal first_size, @c.size
-      assert_equal 2, @c.records
+      assert_equal first_bytesize, @c.bytesize
+      assert_equal 2, @c.size
 
       assert_equal (d1.to_json + "\n" + d2.to_json + "\n"), File.open(@c.path, 'rb'){|f| f.read }
     end
@@ -329,7 +329,7 @@ class BufferFileChunkTest < Test::Unit::TestCase
       content = @c.read
 
       unique_id = @c.unique_id
-      records = @c.records
+      size = @c.size
       created_at = @c.created_at
       modified_at = @c.modified_at
 
@@ -340,7 +340,7 @@ class BufferFileChunkTest < Test::Unit::TestCase
       stored_meta = {
         timekey: nil, tag: nil, variables: nil,
         id: unique_id,
-        r: records,
+        s: size,
         c: @c.created_at.to_i,
         m: @c.modified_at.to_i,
       }
@@ -362,8 +362,8 @@ class BufferFileChunkTest < Test::Unit::TestCase
       @c.purge
 
       assert @c.empty?
+      assert_equal 0, @c.bytesize
       assert_equal 0, @c.size
-      assert_equal 0, @c.records
 
       assert !File.exist?(@c.path)
       assert !File.exist?(@c.path + '.meta')
@@ -415,7 +415,7 @@ class BufferFileChunkTest < Test::Unit::TestCase
       expected = {
         timekey: nil, tag: nil, variables: nil,
         id: @c.unique_id,
-        r: @c.records,
+        s: @c.size,
         c: @c.created_at.to_i,
         m: @c.modified_at.to_i,
       }
@@ -433,7 +433,7 @@ class BufferFileChunkTest < Test::Unit::TestCase
       expected = {
         timekey: nil, tag: nil, variables: nil,
         id: @c.unique_id,
-        r: @c.records,
+        s: @c.size,
         c: @c.created_at.to_i,
         m: dummy_now.to_i,
       }
@@ -444,7 +444,7 @@ class BufferFileChunkTest < Test::Unit::TestCase
       expected = {
         timekey: nil, tag: nil, variables: nil,
         id: @c.unique_id,
-        r: @c.records,
+        s: @c.size,
         c: @c.created_at.to_i,
         m: @c.modified_at.to_i,
       }
@@ -453,7 +453,7 @@ class BufferFileChunkTest < Test::Unit::TestCase
       content = @c.read
 
       unique_id = @c.unique_id
-      records = @c.records
+      size = @c.size
       created_at = @c.created_at
       modified_at = @c.modified_at
 
@@ -464,7 +464,7 @@ class BufferFileChunkTest < Test::Unit::TestCase
       stored_meta = {
         timekey: nil, tag: nil, variables: nil,
         id: unique_id,
-        r: records,
+        s: size,
         c: @c.created_at.to_i,
         m: @c.modified_at.to_i,
       }
@@ -491,7 +491,7 @@ class BufferFileChunkTest < Test::Unit::TestCase
       @metadata = {
         timekey: nil, tag: 'testing', variables: {k: "x"},
         id: @chunk_id,
-        r: 4,
+        s: 4,
         c: Time.parse('2016-04-07 17:44:00 +0900').to_i,
         m: Time.parse('2016-04-07 17:44:13 +0900').to_i,
       }
@@ -519,7 +519,7 @@ class BufferFileChunkTest < Test::Unit::TestCase
       assert_equal 'testing', @c.metadata.tag
       assert_equal({k: "x"}, @c.metadata.variables)
 
-      assert_equal 4, @c.records
+      assert_equal 4, @c.size
       assert_equal Time.parse('2016-04-07 17:44:00 +0900'), @c.created_at
       assert_equal Time.parse('2016-04-07 17:44:13 +0900'), @c.modified_at
 
@@ -548,7 +548,7 @@ class BufferFileChunkTest < Test::Unit::TestCase
       assert_equal 'testing', @c.metadata.tag
       assert_equal({k: "x"}, @c.metadata.variables)
 
-      assert_equal 4, @c.records
+      assert_equal 4, @c.size
       assert_equal Time.parse('2016-04-07 17:44:00 +0900'), @c.created_at
       assert_equal Time.parse('2016-04-07 17:44:13 +0900'), @c.modified_at
 
@@ -564,7 +564,7 @@ class BufferFileChunkTest < Test::Unit::TestCase
       metadata = {
         timekey: nil, tag: 'testing', variables: {k: "x"},
         id: @chunk_id,
-        r: 4,
+        s: 4,
         c: Time.parse('2016-04-07 17:44:00 +0900').to_i,
         m: Time.parse('2016-04-07 17:44:13 +0900').to_i,
       }
@@ -575,7 +575,7 @@ class BufferFileChunkTest < Test::Unit::TestCase
       metadata = {
         timekey: nil, tag: 'testing', variables: {k: "x"},
         id: @chunk_id,
-        r: 5,
+        s: 5,
         c: Time.parse('2016-04-07 17:44:00 +0900').to_i,
         m: Time.parse('2016-04-07 17:44:38 +0900').to_i,
       }
@@ -601,7 +601,7 @@ class BufferFileChunkTest < Test::Unit::TestCase
 
       assert f.binmode?
       assert f.sync
-      assert_equal data.size, f.size
+      assert_equal data.bytesize, f.size
 
       io = nil
       @c.file_rename(f, testing_file1, testing_file2, ->(new_io){ io = new_io })
@@ -614,7 +614,7 @@ class BufferFileChunkTest < Test::Unit::TestCase
       assert_equal Encoding::ASCII_8BIT, io.external_encoding
       assert io.sync
       assert io.binmode?
-      assert_equal data.size, io.size
+      assert_equal data.bytesize, io.size
 
       assert_equal pos, io.pos
 
@@ -644,7 +644,7 @@ class BufferFileChunkTest < Test::Unit::TestCase
       @metadata = {
         timekey: @dummy_timekey, tag: 'testing', variables: {k: "x"},
         id: @chunk_id,
-        r: 4,
+        s: 4,
         c: Time.parse('2016-04-07 17:44:00 +0900').to_i,
         m: Time.parse('2016-04-07 17:44:13 +0900').to_i,
       }
@@ -671,8 +671,8 @@ class BufferFileChunkTest < Test::Unit::TestCase
       assert_equal gen_metadata(timekey: @dummy_timekey, tag: 'testing', variables: {k: "x"}), @c.metadata
       assert_equal Time.at(@metadata[:c]), @c.created_at
       assert_equal Time.at(@metadata[:m]), @c.modified_at
-      assert_equal @metadata[:r], @c.records
-      assert_equal @d.size, @c.size
+      assert_equal @metadata[:s], @c.size
+      assert_equal @d.bytesize, @c.bytesize
       assert_equal @d, @c.read
 
       assert_raise "BUG: appending to non-staged chunk, now 'queued'" do
@@ -713,8 +713,8 @@ class BufferFileChunkTest < Test::Unit::TestCase
       assert_equal :queued, @c.state
       assert_equal @chunk_id, @c.unique_id
       assert_equal gen_metadata, @c.metadata
-      assert_equal @d.size, @c.size
-      assert_equal 0, @c.records
+      assert_equal @d.bytesize, @c.bytesize
+      assert_equal 0, @c.size
       assert_equal @d, @c.read
 
       assert_raise "BUG: appending to non-staged chunk, now 'queued'" do
@@ -755,8 +755,8 @@ class BufferFileChunkTest < Test::Unit::TestCase
       assert_equal :queued, @c.state
       assert_equal @chunk_id, @c.unique_id
       assert_equal gen_metadata, @c.metadata
-      assert_equal @d.size, @c.size
-      assert_equal 0, @c.records
+      assert_equal @d.bytesize, @c.bytesize
+      assert_equal 0, @c.size
       assert_equal @d, @c.read
 
       assert_raise "BUG: appending to non-staged chunk, now 'queued'" do

--- a/test/plugin/test_buffer_memory_chunk.rb
+++ b/test/plugin/test_buffer_memory_chunk.rb
@@ -13,7 +13,7 @@ class BufferMemoryChunkTest < Test::Unit::TestCase
     assert_equal '', @c.instance_eval{ @chunk }
     assert_equal 0, @c.instance_eval{ @chunk_bytes }
     assert_equal 0, @c.instance_eval{ @adding_bytes }
-    assert_equal 0, @c.instance_eval{ @adding_records }
+    assert_equal 0, @c.instance_eval{ @adding_size }
   end
 
   test 'can #append, #commit and #read it' do
@@ -88,7 +88,7 @@ class BufferMemoryChunkTest < Test::Unit::TestCase
     assert_equal Encoding::ASCII_8BIT, content.encoding
   end
 
-  test 'has #size and #records' do
+  test 'has #bytesize and #size' do
     assert @c.empty?
 
     d1 = {"f1" => 'v1', "f2" => 'v2', "f3" => 'v3'}
@@ -96,27 +96,27 @@ class BufferMemoryChunkTest < Test::Unit::TestCase
     data = [d1.to_json + "\n", d2.to_json + "\n"]
     @c.append(data)
 
-    assert_equal (d1.to_json + "\n" + d2.to_json + "\n").size, @c.size
-    assert_equal 2, @c.records
+    assert_equal (d1.to_json + "\n" + d2.to_json + "\n").bytesize, @c.bytesize
+    assert_equal 2, @c.size
 
     @c.commit
 
-    assert_equal (d1.to_json + "\n" + d2.to_json + "\n").size, @c.size
-    assert_equal 2, @c.records
+    assert_equal (d1.to_json + "\n" + d2.to_json + "\n").bytesize, @c.bytesize
+    assert_equal 2, @c.size
 
-    first_size = @c.size
+    first_bytesize = @c.bytesize
 
     d3 = {"f1" => 'x', "f2" => 'y', "f3" => 'z'}
     d4 = {"f1" => 'a', "f2" => 'b', "f3" => 'c'}
     @c.append([d3.to_json + "\n", d4.to_json + "\n"])
 
-    assert_equal first_size + (d3.to_json + "\n" + d4.to_json + "\n").size, @c.size
-    assert_equal 4, @c.records
+    assert_equal first_bytesize + (d3.to_json + "\n" + d4.to_json + "\n").bytesize, @c.bytesize
+    assert_equal 4, @c.size
 
     @c.commit
 
-    assert_equal first_size + (d3.to_json + "\n" + d4.to_json + "\n").size, @c.size
-    assert_equal 4, @c.records
+    assert_equal first_bytesize + (d3.to_json + "\n" + d4.to_json + "\n").bytesize, @c.bytesize
+    assert_equal 4, @c.size
   end
 
   test 'can #rollback to revert non-committed data' do
@@ -127,8 +127,8 @@ class BufferMemoryChunkTest < Test::Unit::TestCase
     data = [d1.to_json + "\n", d2.to_json + "\n"]
     @c.append(data)
 
-    assert_equal (d1.to_json + "\n" + d2.to_json + "\n").size, @c.size
-    assert_equal 2, @c.records
+    assert_equal (d1.to_json + "\n" + d2.to_json + "\n").bytesize, @c.bytesize
+    assert_equal 2, @c.size
 
     @c.rollback
 
@@ -142,22 +142,22 @@ class BufferMemoryChunkTest < Test::Unit::TestCase
     @c.append(data)
     @c.commit
 
-    assert_equal (d1.to_json + "\n" + d2.to_json + "\n").size, @c.size
-    assert_equal 2, @c.records
+    assert_equal (d1.to_json + "\n" + d2.to_json + "\n").bytesize, @c.bytesize
+    assert_equal 2, @c.size
 
-    first_size = @c.size
+    first_bytesize = @c.bytesize
 
     d3 = {"f1" => 'x', "f2" => 'y', "f3" => 'z'}
     d4 = {"f1" => 'a', "f2" => 'b', "f3" => 'c'}
     @c.append([d3.to_json + "\n", d4.to_json + "\n"])
 
-    assert_equal first_size + (d3.to_json + "\n" + d4.to_json + "\n").size, @c.size
-    assert_equal 4, @c.records
+    assert_equal first_bytesize + (d3.to_json + "\n" + d4.to_json + "\n").bytesize, @c.bytesize
+    assert_equal 4, @c.size
 
     @c.rollback
 
-    assert_equal first_size, @c.size
-    assert_equal 2, @c.records
+    assert_equal first_bytesize, @c.bytesize
+    assert_equal 2, @c.size
   end
 
   test 'can #rollback to revert non-committed data from #concat' do
@@ -168,8 +168,8 @@ class BufferMemoryChunkTest < Test::Unit::TestCase
     data = [d1.to_json + "\n", d2.to_json + "\n"].join
     @c.concat(data, 2)
 
-    assert_equal (d1.to_json + "\n" + d2.to_json + "\n").size, @c.size
-    assert_equal 2, @c.records
+    assert_equal (d1.to_json + "\n" + d2.to_json + "\n").bytesize, @c.bytesize
+    assert_equal 2, @c.size
 
     @c.rollback
 
@@ -183,22 +183,22 @@ class BufferMemoryChunkTest < Test::Unit::TestCase
     @c.append(data)
     @c.commit
 
-    assert_equal (d1.to_json + "\n" + d2.to_json + "\n").size, @c.size
-    assert_equal 2, @c.records
+    assert_equal (d1.to_json + "\n" + d2.to_json + "\n").bytesize, @c.bytesize
+    assert_equal 2, @c.size
 
-    first_size = @c.size
+    first_bytesize = @c.bytesize
 
     d3 = {"f1" => 'x', "f2" => 'y', "f3" => 'z'}
     d4 = {"f1" => 'a', "f2" => 'b', "f3" => 'c'}
     @c.concat([d3.to_json + "\n", d4.to_json + "\n"].join, 2)
 
-    assert_equal first_size + (d3.to_json + "\n" + d4.to_json + "\n").size, @c.size
-    assert_equal 4, @c.records
+    assert_equal first_bytesize + (d3.to_json + "\n" + d4.to_json + "\n").bytesize, @c.bytesize
+    assert_equal 4, @c.size
 
     @c.rollback
 
-    assert_equal first_size, @c.size
-    assert_equal 2, @c.records
+    assert_equal first_bytesize, @c.bytesize
+    assert_equal 2, @c.size
   end
 
   test 'does nothing for #close' do
@@ -233,8 +233,8 @@ class BufferMemoryChunkTest < Test::Unit::TestCase
     @c.purge
 
     assert @c.empty?
+    assert_equal 0, @c.bytesize
     assert_equal 0, @c.size
-    assert_equal 0, @c.records
     assert_equal '', @c.read
   end
 

--- a/test/plugin/test_output_as_buffered.rb
+++ b/test/plugin/test_output_as_buffered.rb
@@ -157,7 +157,7 @@ class BufferedOutputTest < Test::Unit::TestCase
       assert{ @i.buffer.queue.size == 0 && ary.size == 0 }
 
       staged_chunk = @i.buffer.stage[@i.buffer.stage.keys.first]
-      assert{ staged_chunk.records != 0 }
+      assert{ staged_chunk.size != 0 }
 
       @i.emit("test.tag", Fluent::ArrayEventStream.new([ [t, r] ]))
 
@@ -165,7 +165,7 @@ class BufferedOutputTest < Test::Unit::TestCase
 
       waiting(10) do
         Thread.pass until @i.buffer.queue.size == 0 && @i.buffer.dequeued.size == 0
-        Thread.pass until staged_chunk.records == 0
+        Thread.pass until staged_chunk.size == 0
       end
 
       assert_equal 1, ary.size
@@ -257,7 +257,7 @@ class BufferedOutputTest < Test::Unit::TestCase
       3.times do |i|
         rand_records = rand(1..5)
         es = Fluent::ArrayEventStream.new([ [t, r] ] * rand_records)
-        assert_equal rand_records, es.records
+        assert_equal rand_records, es.size
 
         @i.interrupt_flushes
 
@@ -266,13 +266,13 @@ class BufferedOutputTest < Test::Unit::TestCase
         assert{ @i.buffer.stage.size == 1 }
 
         staged_chunk = @i.instance_eval{ @buffer.stage[@buffer.stage.keys.first] }
-        assert{ staged_chunk.records != 0 }
+        assert{ staged_chunk.size != 0 }
 
         @i.enqueue_thread_wait
 
         waiting(10) do
           Thread.pass until @i.buffer.queue.size == 0 && @i.buffer.dequeued.size == 0
-          Thread.pass until staged_chunk.records == 0
+          Thread.pass until staged_chunk.size == 0
         end
 
         assert_equal rand_records, ary.size
@@ -364,7 +364,7 @@ class BufferedOutputTest < Test::Unit::TestCase
       3.times do |i|
         rand_records = rand(1..5)
         es = Fluent::ArrayEventStream.new([ [t, r] ] * rand_records)
-        assert_equal rand_records, es.records
+        assert_equal rand_records, es.size
         @i.emit("test.tag", es)
 
         assert{ @i.buffer.stage.size == 0 && (@i.buffer.queue.size == 1 || @i.buffer.dequeued.size == 1 || ary.size > 0) }

--- a/test/plugin/test_output_as_standard.rb
+++ b/test/plugin/test_output_as_standard.rb
@@ -86,7 +86,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
       es = test_event_stream
 
       buffer_mock = flexmock(@i.buffer)
-      buffer_mock.should_receive(:emit_bulk).once.with(m, es.to_msgpack_stream, es.records)
+      buffer_mock.should_receive(:emit_bulk).once.with(m, es.to_msgpack_stream, es.size)
 
       @i.execute_chunking("mytag.test", es)
     end
@@ -100,7 +100,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
       es = test_event_stream
 
       buffer_mock = flexmock(@i.buffer)
-      buffer_mock.should_receive(:emit_bulk).once.with(m, es.to_msgpack_stream(time_int: true), es.records)
+      buffer_mock.should_receive(:emit_bulk).once.with(m, es.to_msgpack_stream(time_int: true), es.size)
 
       @i.execute_chunking("mytag.test", es)
     end
@@ -116,7 +116,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
       es = test_event_stream
 
       buffer_mock = flexmock(@i.buffer)
-      buffer_mock.should_receive(:emit_bulk).once.with(m, es.to_msgpack_stream, es.records)
+      buffer_mock.should_receive(:emit_bulk).once.with(m, es.to_msgpack_stream, es.size)
 
       @i.execute_chunking("mytag.test", es)
     end
@@ -130,7 +130,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
       es = test_event_stream
 
       buffer_mock = flexmock(@i.buffer)
-      buffer_mock.should_receive(:emit_bulk).once.with(m, es.to_msgpack_stream(time_int: true), es.records)
+      buffer_mock.should_receive(:emit_bulk).once.with(m, es.to_msgpack_stream(time_int: true), es.size)
 
       @i.execute_chunking("mytag.test", es)
     end
@@ -261,7 +261,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
       es = test_event_stream
 
       buffer_mock = flexmock(@i.buffer)
-      buffer_mock.should_receive(:emit_bulk).once.with(m, es.map{|t,r| [t,r].to_json }.join, es.records)
+      buffer_mock.should_receive(:emit_bulk).once.with(m, es.map{|t,r| [t,r].to_json }.join, es.size)
 
       @i.execute_chunking("mytag.test", es)
     end
@@ -278,7 +278,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
       es = test_event_stream
 
       buffer_mock = flexmock(@i.buffer)
-      buffer_mock.should_receive(:emit_bulk).once.with(m, es.map{|t,r| [t,r].to_json }.join, es.records)
+      buffer_mock.should_receive(:emit_bulk).once.with(m, es.map{|t,r| [t,r].to_json }.join, es.size)
 
       @i.execute_chunking("mytag.test", es)
     end


### PR DESCRIPTION
in EventStream and Chunk.

But I leave a parameter name of `chunk_records_limit` because I think it's understandable for users, and `queued_records` and some other names of implementation / internal APIs.

In v0.12, `Chunk#size` means bytes of chunk content. So I'll add a mixin to extend chunks to return bytes of chunk content by `#size`, and apply it to chunks on compatibility layers.