### PR TITLE
Use keyword arguments for `config_param` and `config_section`

### DIFF
--- a/lib/fluent/config/configure_proxy.rb
+++ b/lib/fluent/config/configure_proxy.rb
@@ -200,21 +200,13 @@ module Fluent
         end
       end
 
-      def parameter_configuration(name, *args, &block)
+      def parameter_configuration(name, type = nil, **kwargs, &block)
         name = name.to_sym
 
         opts = {}
-        args.each { |a|
-          if a.is_a?(Symbol)
-            opts[:type] = a
-          elsif a.is_a?(Hash)
-            opts.merge!(a)
-          else
-            raise ArgumentError, "#{self.name}: wrong number of arguments (#{1 + args.length} for #{block ? 2 : 3})"
-          end
-        }
+        opts[:type] = type
+        opts.merge!(kwargs)
 
-        type = opts[:type]
         if block && type
           raise ArgumentError, "#{self.name}: both of block and type cannot be specified"
         end
@@ -245,18 +237,18 @@ module Fluent
         @configured_in_section = section_name.to_sym
       end
 
-      def config_argument(name, *args, &block)
+      def config_argument(name, type = nil, **kwargs, &block)
         if @argument
           raise ArgumentError, "#{self.name}: config_argument called twice"
         end
-        name, block, opts = parameter_configuration(name, *args, &block)
+        name, block, opts = parameter_configuration(name, type, **kwargs, &block)
 
         @argument = [name, block, opts]
         name
       end
 
-      def config_param(name, *args, &block)
-        name, block, opts = parameter_configuration(name, *args, &block)
+      def config_param(name, type = nil, **kwargs, &block)
+        name, block, opts = parameter_configuration(name, type, **kwargs, &block)
 
         if @current_description
           config_set_desc(name, @current_description)

--- a/lib/fluent/config/configure_proxy.rb
+++ b/lib/fluent/config/configure_proxy.rb
@@ -37,7 +37,7 @@ module Fluent
       #   end
       # end
 
-      def initialize(name, param_name: nil, final: nil, init: nil, required: nil, multi: nil, alias: nil, type_lookup: nil)
+      def initialize(name, param_name: nil, final: nil, init: nil, required: nil, multi: nil, alias: nil, type_lookup:)
         @name = name.to_sym
         @final = final
 
@@ -108,6 +108,7 @@ module Fluent
         options[:multi] = @multi.nil? ? other.multi : self.multi
         options[:alias] = @alias.nil? ? other.alias : self.alias
         options[:final] = @final || other.final
+        options[:type_lookup] = @type_lookup
 
         merged = self.class.new(other.name, options)
 
@@ -166,6 +167,7 @@ module Fluent
         options[:multi] = @multi.nil? ? other.multi : self.multi
         options[:alias] = @alias.nil? ? other.alias : self.alias
         options[:final]  = true
+        options[:type_lookup] = @type_lookup
 
         merged = self.class.new(other.name, options)
 

--- a/lib/fluent/configurable.rb
+++ b/lib/fluent/configurable.rb
@@ -139,8 +139,8 @@ module Fluent
         configure_proxy(self.name).config_set_desc(name, desc)
       end
 
-      def config_section(name, *args, &block)
-        configure_proxy(self.name).config_section(name, *args, &block)
+      def config_section(name, **kwargs, &block)
+        configure_proxy(self.name).config_section(name, **kwargs, &block)
         attr_accessor configure_proxy(self.name).sections[name].param_name
       end
 

--- a/lib/fluent/configurable.rb
+++ b/lib/fluent/configurable.rb
@@ -126,8 +126,8 @@ module Fluent
         configure_proxy(self.name).configured_in(section_name)
       end
 
-      def config_param(name, *args, &block)
-        configure_proxy(self.name).config_param(name, *args, &block)
+      def config_param(name, type = nil, **kwargs, &block)
+        configure_proxy(self.name).config_param(name, type, **kwargs, &block)
         attr_accessor name
       end
 

--- a/test/config/test_configure_proxy.rb
+++ b/test/config/test_configure_proxy.rb
@@ -10,10 +10,10 @@ module Fluent::Config
     sub_test_case 'to generate a instance' do
       sub_test_case '#initialize' do
         test 'has default values' do
-          proxy = Fluent::Config::ConfigureProxy.new('section')
+          proxy = Fluent::Config::ConfigureProxy.new('section', type_lookup: @type_lookup)
           assert_equal(:section, proxy.name)
 
-          proxy = Fluent::Config::ConfigureProxy.new(:section)
+          proxy = Fluent::Config::ConfigureProxy.new(:section, type_lookup: @type_lookup)
           assert_equal(:section, proxy.name)
           assert_equal(:section, proxy.param_name)
           assert_nil(proxy.init)
@@ -24,7 +24,7 @@ module Fluent::Config
         end
 
         test 'can specify param_name/required/multi with optional arguments' do
-          proxy = Fluent::Config::ConfigureProxy.new(:section, param_name: 'sections', init: true, required: false, multi: true)
+          proxy = Fluent::Config::ConfigureProxy.new(:section, param_name: 'sections', init: true, required: false, multi: true, type_lookup: @type_lookup)
           assert_equal(:section, proxy.name)
           assert_equal(:sections, proxy.param_name)
           assert_false(proxy.required)
@@ -32,7 +32,7 @@ module Fluent::Config
           assert_true(proxy.multi)
           assert_true(proxy.multi?)
 
-          proxy = Fluent::Config::ConfigureProxy.new(:section, param_name: :sections, init: false, required: true, multi: false)
+          proxy = Fluent::Config::ConfigureProxy.new(:section, param_name: :sections, init: false, required: true, multi: false, type_lookup: @type_lookup)
           assert_equal(:section, proxy.name)
           assert_equal(:sections, proxy.param_name)
           assert_true(proxy.required)
@@ -42,14 +42,14 @@ module Fluent::Config
         end
         test 'raise error if both of init and required are true' do
           assert_raise "init and required are exclusive" do
-            Fluent::Config::ConfigureProxy.new(:section, init: true, required: true)
+            Fluent::Config::ConfigureProxy.new(:section, init: true, required: true, type_lookup: @type_lookup)
           end
         end
       end
 
       sub_test_case '#merge' do
         test 'generate a new instance which values are overwritten by the argument object' do
-          proxy = p1 = Fluent::Config::ConfigureProxy.new(:section)
+          proxy = p1 = Fluent::Config::ConfigureProxy.new(:section, type_lookup: @type_lookup)
           assert_equal(:section, proxy.name)
           assert_equal(:section, proxy.param_name)
           assert_nil(proxy.init)
@@ -59,7 +59,7 @@ module Fluent::Config
           assert_true(proxy.multi?)
           assert_nil(proxy.configured_in_section)
 
-          p2 = Fluent::Config::ConfigureProxy.new(:section, param_name: :sections, init: false, required: true, multi: false)
+          p2 = Fluent::Config::ConfigureProxy.new(:section, param_name: :sections, init: false, required: true, multi: false, type_lookup: @type_lookup)
           proxy = p1.merge(p2)
           assert_equal(:section, proxy.name)
           assert_equal(:sections, proxy.param_name)
@@ -73,10 +73,10 @@ module Fluent::Config
         end
 
         test 'does not overwrite with argument object without any specifications of required/multi' do
-          p1 = Fluent::Config::ConfigureProxy.new(:section1)
+          p1 = Fluent::Config::ConfigureProxy.new(:section1, type_lookup: @type_lookup)
           p1.configured_in_section = :subsection
-          p2 = Fluent::Config::ConfigureProxy.new(:section2, param_name: :sections, init: false, required: true, multi: false)
-          p3 = Fluent::Config::ConfigureProxy.new(:section3)
+          p2 = Fluent::Config::ConfigureProxy.new(:section2, param_name: :sections, init: false, required: true, multi: false, type_lookup: @type_lookup)
+          p3 = Fluent::Config::ConfigureProxy.new(:section3, type_lookup: @type_lookup)
           proxy = p1.merge(p2).merge(p3)
           assert_equal(:section3, proxy.name)
           assert_equal(:section3, proxy.param_name)
@@ -126,13 +126,13 @@ module Fluent::Config
 
       sub_test_case '#configured_in' do
         test 'sets a section name which have configuration parameters of target plugin in owners configuration' do
-          proxy = Fluent::Config::ConfigureProxy.new(:section)
+          proxy = Fluent::Config::ConfigureProxy.new(:section, type_lookup: @type_lookup)
           proxy.configured_in(:mysection)
           assert_equal :mysection, proxy.configured_in_section
         end
 
         test 'do not permit to be called twice' do
-          proxy = Fluent::Config::ConfigureProxy.new(:section)
+          proxy = Fluent::Config::ConfigureProxy.new(:section, type_lookup: @type_lookup)
           proxy.configured_in(:mysection)
           assert_raise(ArgumentError) { proxy.configured_in(:myothersection) }
         end


### PR DESCRIPTION
I've changed internal API related to `config_param` and `config_section`.