### PR TITLE
in_tail plugin's mysterious behavior if use wildcard pattern in windows

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -146,7 +146,7 @@ module Fluent
       @paths.each { |path|
         path = date.strftime(path)
         if path.include?('*')
-          paths += Dir.glob(path).select { |p|
+          paths += Dir.glob(File.expand_path(path)).select { |p|
             if File.readable?(p)
               true
             else


### PR DESCRIPTION
`in_tail` plugin allows to write wildcard pattern in `path` option.
If we use backslash path separation and wildcard pattern simultaneously in windows, the plugin doesn't work.
If we use backslash path separation and don't use wildcard pattern in windows, the plugin works.

This PR enables to be used backslash and wildcard simultaneously in windows.

Although I did some tests in my hand manually, I was not able to write tests in code because of lack of my knowledge of ruby.