### PR TITLE
Fix missing error class and test for out_forward

### DIFF
--- a/lib/fluent/output.rb
+++ b/lib/fluent/output.rb
@@ -412,13 +412,17 @@ module Fluent
       super
     end
 
+    def format_stream(tag, es)
+      if @time_as_integer
+        es.to_msgpack_stream_forced_integer
+      else
+        es.to_msgpack_stream
+      end
+    end
+
     def emit(tag, es, chain)
       @emit_count += 1
-      if @time_as_integer
-        data = es.to_msgpack_stream_forced_integer
-      else
-        data = es.to_msgpack_stream
-      end
+      data = format_stream(tag, es)
       key = tag
       if @buffer.emit(key, data, chain)
         submit_flush

--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -30,6 +30,9 @@ module Fluent
   class ForwardOutputResponseError < ForwardOutputError
   end
 
+  class ForwardOutputConnectionClosedError < ForwardOutputError
+  end
+
   class ForwardOutputACKTimeoutError < ForwardOutputResponseError
   end
 


### PR DESCRIPTION
This change is to use BufferedOutputTestDriver in `test_out_forward`.

I added some fixes in this change. These are related with each other.
* ForwardOutput plugin will raise an error for missing ACK, but it's not defined in [the patch](https://github.com/fluent/fluentd/pull/580)
  * It was missed because 
* ObjectBufferedOutput does NOT have `#format_stream` and doing it in `#emit` directly
  * BufferedOutputTestDriver does NOT call `#emit`, and use `#format_stream` and `chunk << data` directly
* BufferedOutputTestDriver and TimeSlicedOutputTestDriver called `block.call` after chunking events
  * It's simply wrong, because `d.emit` in blocks don't work with such code
* Assigning `Engine` is already outdated