### PR TITLE
Fix string-scrub dependency on ruby > 2

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("sigdump", ["~> 0.2.2"])
   gem.add_runtime_dependency("tzinfo", [">= 1.0.0"])
   gem.add_runtime_dependency("tzinfo-data", [">= 1.0.0"])
-  gem.add_runtime_dependency("string-scrub", [">= 0.0.3"])
+  gem.add_runtime_dependency("string-scrub", [">= 0.0.3", "<= 0.0.5"])
 
   gem.add_development_dependency("rake", [">= 0.9.2"])
   gem.add_development_dependency("flexmock", ["~> 1.3.3"])


### PR DESCRIPTION
string-scrub 0.1.0 dropped today, and the strict
ruby version constraint stops fluent from being
installed on a modern ruby.