### PR TITLE
Add support for drop_oldest_chunk when buffer queue is full

### DIFF
--- a/test/test_buffer.rb
+++ b/test/test_buffer.rb
@@ -589,6 +589,24 @@ module FluentBufferTest
         assert db.emit('key', data, chain)
       end
 
+      def test_emit_with_drop_oldest_chunk
+        db = dummy_buffer(:drop_oldest_chunk)
+      
+        assert !db.emit('key', data, chain)
+        assert db.emit('key', data, chain)
+        
+        # oldest (and only) chunk in queue is dropped before newer data is enqueued 
+        assert db.emit('key', data, chain)
+        
+        assert db.queue.size == 1
+
+        assert !pop_chunk(db)
+        assert db.queue.size == 0
+
+        # queue is now empty so can emit data again
+        assert db.emit('key', data, chain)
+      end
+
       def pop_chunk(db)
         out = DummyOutput.new
         c1 = DummyChunk.new('k1', 1)


### PR DESCRIPTION
- Drop oldest chunk from queue without writing to output when buffer
queue is full
- Add test