### PR TITLE
Fix string scrub dependency

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -27,7 +27,9 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("sigdump", ["~> 0.2.2"])
   gem.add_runtime_dependency("tzinfo", [">= 1.0.0"])
   gem.add_runtime_dependency("tzinfo-data", [">= 1.0.0"])
-  gem.add_runtime_dependency("string-scrub", [">= 0.0.3", "<= 0.0.5"])
+  unless "".respond_to?(:scrub)
+    gem.add_runtime_dependency("string-scrub", [">= 0.1.1"])
+  end
 
   gem.add_development_dependency("rake", [">= 0.9.2"])
   gem.add_development_dependency("flexmock", ["~> 1.3.3"])

--- a/lib/fluent/plugin/string_util.rb
+++ b/lib/fluent/plugin/string_util.rb
@@ -14,6 +14,8 @@
 #    limitations under the License.
 #
 
+require "string-scrub" unless "".respond_to?(:scrub)
+
 module Fluent
   module StringUtil
     def match_regexp(regexp, string)


### PR DESCRIPTION
We don't need to install string-scrub gem Ruby 2.1 or later.
Because `String#scrub` has been added since Ruby 2.1.

We need explicit `require "string-scrub"` to use `String#scrub` with Ruby 2.0 and Ruby1.9.3.