### PR TITLE
backport: Add simplified syntax for hash and array

### DIFF
--- a/lib/fluent/config/types.rb
+++ b/lib/fluent/config/types.rb
@@ -81,7 +81,7 @@ module Fluent
     BOOL_TYPE = Proc.new { |val, opts| Config.bool_value(val) }
     TIME_TYPE = Proc.new { |val, opts| Config.time_value(val) }
 
-    REFORMAT_VALUES = ->(type, value) {
+    REFORMAT_VALUE = ->(type, value) {
       if value.nil?
         value
       else
@@ -113,7 +113,7 @@ module Fluent
         newparam = {}
         param.each_pair do |key, value|
           new_key = opts[:symbolize_keys] ? key.to_sym : key
-          newparam[new_key] = opts[:value_type] ? REFORMAT_VALUES.call(opts[:value_type], value) : value
+          newparam[new_key] = opts[:value_type] ? REFORMAT_VALUE.call(opts[:value_type], value) : value
         end
         newparam
       end
@@ -128,7 +128,7 @@ module Fluent
         raise ConfigError, "array required but got #{val.inspect}"
       end
       if opts[:value_type]
-        param.map{|v| REFORMAT_VALUES.call(opts[:value_type], v) }
+        param.map{|v| REFORMAT_VALUE.call(opts[:value_type], v) }
       else
         param
       end

--- a/lib/fluent/config/types.rb
+++ b/lib/fluent/config/types.rb
@@ -92,6 +92,8 @@ module Fluent
         when :size then Config.size_value(value)
         when :bool then Config.bool_value(value)
         when :time then Config.time_value(value)
+        else
+          raise "unknown type in REFORMAT: #{type}"
         end
       end
     }
@@ -125,8 +127,8 @@ module Fluent
       if param.class != Array
         raise ConfigError, "array required but got #{val.inspect}"
       end
-      if opts[:type]
-        param.map{|v| REFORMAT_VALUES.call(opts[:type], v) }
+      if opts[:value_type]
+        param.map{|v| REFORMAT_VALUES.call(opts[:value_type], v) }
       else
         param
       end

--- a/lib/fluent/config/types.rb
+++ b/lib/fluent/config/types.rb
@@ -80,19 +80,56 @@ module Fluent
     SIZE_TYPE = Proc.new { |val, opts| Config.size_value(val) }
     BOOL_TYPE = Proc.new { |val, opts| Config.bool_value(val) }
     TIME_TYPE = Proc.new { |val, opts| Config.time_value(val) }
+
+    REFORMAT_VALUES = ->(type, value) {
+      if value.nil?
+        value
+      else
+        case type
+        when :string  then value.to_s
+        when :integer then value.to_i
+        when :float   then value.to_f
+        when :size then Config.size_value(value)
+        when :bool then Config.bool_value(value)
+        when :time then Config.time_value(value)
+        end
+      end
+    }
+
     HASH_TYPE = Proc.new { |val, opts|
-      param = val.is_a?(String) ? JSON.load(val) : val
+      param = if val.is_a?(String)
+                val.start_with?('{') ? JSON.load(val) : Hash[val.strip.split(/\s*,\s*/).map{|v| v.split(':', 2)}]
+              else
+                val
+              end
       if param.class != Hash
         raise ConfigError, "hash required but got #{val.inspect}"
       end
-      param
+      if opts.empty?
+        param
+      else
+        newparam = {}
+        param.each_pair do |key, value|
+          new_key = opts[:symbolize_keys] ? key.to_sym : key
+          newparam[new_key] = opts[:value_type] ? REFORMAT_VALUES.call(opts[:value_type], value) : value
+        end
+        newparam
+      end
     }
     ARRAY_TYPE = Proc.new { |val, opts|
-      param = val.is_a?(String) ? JSON.load(val) : val
+      param = if val.is_a?(String)
+                val.start_with?('[') ? JSON.load(val) : val.strip.split(/\s*,\s*/)
+              else
+                val
+              end
       if param.class != Array
         raise ConfigError, "array required but got #{val.inspect}"
       end
-      param
+      if opts[:type]
+        param.map{|v| REFORMAT_VALUES.call(opts[:type], v) }
+      else
+        param
+      end
     }
   end
 

--- a/test/config/test_types.rb
+++ b/test/config/test_types.rb
@@ -125,6 +125,11 @@ class TestConfigTypes < ::Test::Unit::TestCase
     test 'hash' do
       assert_equal({"x"=>"v","k"=>1}, Config::HASH_TYPE.call('{"x":"v","k":1}', {}))
       assert_equal({"x"=>"v","k"=>"1"}, Config::HASH_TYPE.call('x:v,k:1', {}))
+      assert_equal({"x"=>"v","k"=>"1"}, Config::HASH_TYPE.call('x:v, k:1', {}))
+      assert_equal({"x"=>"v","k"=>"1"}, Config::HASH_TYPE.call(' x:v, k:1 ', {}))
+      assert_equal({"x"=>"v","k"=>"1"}, Config::HASH_TYPE.call('x:v , k:1 ', {}))
+
+      assert_equal({"x"=>"v:v","k"=>"1"}, Config::HASH_TYPE.call('x:v:v, k:1', {}))
 
       assert_equal({x: "v", k: 1},   Config::HASH_TYPE.call('{"x":"v","k":1}', {symbolize_keys: true}))
       assert_equal({x: "v", k: "1"}, Config::HASH_TYPE.call('x:v,k:1',         {symbolize_keys: true, value_type: :string}))

--- a/test/config/test_types.rb
+++ b/test/config/test_types.rb
@@ -124,10 +124,39 @@ class TestConfigTypes < ::Test::Unit::TestCase
 
     test 'hash' do
       assert_equal({"x"=>"v","k"=>1}, Config::HASH_TYPE.call('{"x":"v","k":1}', {}))
+      assert_equal({"x"=>"v","k"=>"1"}, Config::HASH_TYPE.call('x:v,k:1', {}))
+
+      assert_equal({x: "v", k: 1},   Config::HASH_TYPE.call('{"x":"v","k":1}', {symbolize_keys: true}))
+      assert_equal({x: "v", k: "1"}, Config::HASH_TYPE.call('x:v,k:1',         {symbolize_keys: true, value_type: :string}))
+      assert_equal({x: "v", k: "1"}, Config::HASH_TYPE.call('{"x":"v","k":1}', {symbolize_keys: true, value_type: :string}))
+      assert_equal({x: 0, k: 1},     Config::HASH_TYPE.call('x:0,k:1',         {symbolize_keys: true, value_type: :integer}))
+
+      assert_equal({"x"=>1,"y"=>60,"z"=>3600}, Config::HASH_TYPE.call('{"x":"1s","y":"1m","z":"1h"}', {value_type: :time}))
+      assert_equal({"x"=>1,"y"=>60,"z"=>3600}, Config::HASH_TYPE.call('x:1s,y:1m,z:1h',               {value_type: :time}))
     end
 
     test 'array' do
       assert_equal(["1","2",1], Config::ARRAY_TYPE.call('["1","2",1]', {}))
+      assert_equal(["1","2","1"], Config::ARRAY_TYPE.call('1,2,1', {}))
+
+      assert_equal(["a","b","c"], Config::ARRAY_TYPE.call('["a","b","c"]', {}))
+      assert_equal(["a","b","c"], Config::ARRAY_TYPE.call('a,b,c', {}))
+      assert_equal(["a","b","c"], Config::ARRAY_TYPE.call('a, b, c', {}))
+      assert_equal(["a","b","c"], Config::ARRAY_TYPE.call('a , b , c', {}))
+
+      assert_equal(["a a","b,b"," c "], Config::ARRAY_TYPE.call('["a a","b,b"," c "]', {}))
+
+      assert_equal(["a a","b","c"], Config::ARRAY_TYPE.call('a a,b,c', {}))
+
+      assert_equal([1,2,1], Config::ARRAY_TYPE.call('[1,2,1]', {}))
+      assert_equal([1,2,1], Config::ARRAY_TYPE.call('["1","2","1"]', {type: :integer}))
+      assert_equal([1,2,1], Config::ARRAY_TYPE.call('1,2,1', {type: :integer}))
+
+      array_options = {
+        default: [],
+      }
+      assert_equal(["1","2"], Config::ARRAY_TYPE.call('["1","2"]', array_options))
+      assert_equal(["3"], Config::ARRAY_TYPE.call('["3"]', array_options))
     end
   end
 end

--- a/test/config/test_types.rb
+++ b/test/config/test_types.rb
@@ -149,8 +149,8 @@ class TestConfigTypes < ::Test::Unit::TestCase
       assert_equal(["a a","b","c"], Config::ARRAY_TYPE.call('a a,b,c', {}))
 
       assert_equal([1,2,1], Config::ARRAY_TYPE.call('[1,2,1]', {}))
-      assert_equal([1,2,1], Config::ARRAY_TYPE.call('["1","2","1"]', {type: :integer}))
-      assert_equal([1,2,1], Config::ARRAY_TYPE.call('1,2,1', {type: :integer}))
+      assert_equal([1,2,1], Config::ARRAY_TYPE.call('["1","2","1"]', {value_type: :integer}))
+      assert_equal([1,2,1], Config::ARRAY_TYPE.call('1,2,1', {value_type: :integer}))
 
       array_options = {
         default: [],


### PR DESCRIPTION
This backports #875 
