### PR TITLE
Support `overflow_action` in v14 api

### DIFF
--- a/lib/fluent/compat/output.rb
+++ b/lib/fluent/compat/output.rb
@@ -189,7 +189,7 @@ module Fluent
       desc 'The length limit of the chunk queue.'
       config_param :buffer_queue_limit, :integer, default: 256
       desc 'The action when the size of buffer queue exceeds the buffer_queue_limit.'
-      config_param :buffer_queue_full_action, :enum, list: [:exception, :block], default: :exception
+      config_param :buffer_queue_full_action, :enum, list: [:exception, :block, :drop_oldest_chunk], default: :exception
 
       config_param :flush_at_shutdown, :bool, default: true
 
@@ -204,7 +204,7 @@ module Fluent
         "max_retry_wait"      => "retry_max_interval",
         "buffer_chunk_limit"  => "chunk_bytes_limit",
         "buffer_queue_limit"  => "queue_length_limit",
-        "buffer_queue_full_action" => nil, # TODO: implement this on fluent/plugin/buffer
+        "buffer_queue_full_action" => "overflow_action",
         "flush_at_shutdown" => "flush_at_shutdown",
       }
 

--- a/lib/fluent/plugin/buffer.rb
+++ b/lib/fluent/plugin/buffer.rb
@@ -36,6 +36,8 @@ module Fluent
       DEFAULT_CHUNK_BYTES_LIMIT =   8 * 1024 * 1024 # 8MB
       DEFAULT_TOTAL_BYTES_LIMIT = 512 * 1024 * 1024 # 512MB, same with v0.12 (BufferedOutput + buf_memory: 64 x 8MB)
 
+      DEFAULT_CHUNK_FULL_THRESHOLD = 0.95
+
       configured_in :buffer
 
       # TODO: system total buffer bytes limit by SystemConfig
@@ -49,6 +51,9 @@ module Fluent
 
       # optional new limitations
       config_param :chunk_records_limit, :integer, default: nil
+
+      # if chunk size (or records) is 95% or more after #write, then that chunk will be enqueued
+      config_param :chunk_full_threshold, :float, default: DEFAULT_CHUNK_FULL_THRESHOLD
 
       Metadata = Struct.new(:timekey, :tag, :variables)
 
@@ -168,77 +173,66 @@ module Fluent
 
       # metadata MUST have consistent object_id for each variation
       # data MUST be Array of serialized events
-      def emit(metadata, data, force: false)
-        return if data.size < 1
+      # metadata_and_data MUST be a hash of { metadata => data }
+      def write(metadata_and_data, bulk: false, enqueue: false)
+        return if metadata_and_data.size < 1
         raise BufferOverflowError unless storable?
 
-        stored = false
+        staged_bytesize = 0
+        operated_chunks = []
 
-        # the case whole data can be stored in staged chunk: almost all emits will success
-        chunk = synchronize { @stage[metadata] ||= generate_chunk(metadata) }
-        original_bytesize = chunk.bytesize
-        chunk.synchronize do
-          begin
-            chunk.append(data)
-            if !chunk_size_over?(chunk) || force
-              chunk.commit
-              stored = true
-              @stage_size += (chunk.bytesize - original_bytesize)
-            else
-              chunk.rollback
+        begin
+          metadata_and_data.each do |metadata, data|
+            write_once(metadata, data, bulk: bulk) do |chunk, adding_bytesize|
+              chunk.mon_enter # add lock to prevent to be committed/rollbacked from other threads
+              operated_chunks << chunk
+              staged_bytesize += adding_bytesize
             end
+          end
+
+          return if operated_chunks.empty?
+
+          first_chunk = operated_chunks.shift
+          # Following commits for other chunks also can finish successfully if the first commit operation
+          # finishes without any exceptions.
+          # In most cases, #commit just requires very small disk spaces, so major failure reason are
+          # permission errors, disk failures and other permanent(fatal) errors.
+          begin
+            first_chunk.commit
+            enqueue_chunk(first_chunk.metadata) if enqueue || chunk_size_full?(first_chunk)
+            first_chunk.mon_exit
           rescue
-            chunk.rollback
+            operated_chunks.unshift(first_chunk)
             raise
           end
-        end
-        return if stored
 
-        # try step-by-step appending if data can't be stored into existing a chunk
-        emit_step_by_step(metadata, data)
-      end
-
-      def emit_bulk(metadata, bulk, size)
-        return if bulk.nil? || bulk.empty?
-        raise BufferOverflowError unless storable?
-
-        stored = false
-        synchronize do # critical section for buffer (stage/queue)
-          until stored
-            chunk = @stage[metadata]
-            unless chunk
-              chunk = @stage[metadata] = generate_chunk(metadata)
-            end
-
-            chunk.synchronize do # critical section for chunk (chunk append/commit/rollback)
-              begin
-                empty_chunk = chunk.empty?
-                chunk.concat(bulk, size)
-
-                if chunk_size_over?(chunk)
-                  if empty_chunk
-                    log.warn "chunk bytes limit exceeds for a bulk event stream: #{bulk.bytesize}bytes"
-                  else
-                    chunk.rollback
-                    enqueue_chunk(metadata)
-                    next
-                  end
-                end
-
-                chunk.commit
-                stored = true
-                @stage_size += bulk.bytesize
-                if chunk_size_full?(chunk)
-                  enqueue_chunk(metadata)
-                end
-              rescue
-                chunk.rollback
-                raise
-              end
+          errors = []
+          # Buffer plugin estimates there's no serious error cause: will commit for all chunks eigher way
+          operated_chunks.each do |chunk|
+            begin
+              chunk.commit
+              enqueue_chunk(chunk.metadata) if enqueue || chunk_size_full?(chunk)
+              chunk.mon_exit
+            rescue => e
+              chunk.rollback
+              chunk.mon_exit
+              errors << e
             end
           end
+
+          @stage_size += staged_bytesize
+
+          if errors.size > 0
+            log.warn "error occurs in committing chunks: only first one raised", errors: errors.map(&:class)
+            raise errors.first
+          end
+        rescue
+          operated_chunks.each do |chunk|
+            chunk.rollback rescue nil # nothing possible to do for #rollback failure
+            chunk.mon_exit rescue nil # this may raise ThreadError for chunks already committed
+          end
+          raise
         end
-        nil
       end
 
       def queued_records
@@ -358,64 +352,118 @@ module Fluent
       end
 
       def chunk_size_full?(chunk)
-        chunk.bytesize >= @chunk_bytes_limit || (@chunk_records_limit && chunk.size >= @chunk_records_limit)
+        chunk.bytesize >= @chunk_bytes_limit * @chunk_full_threshold || (@chunk_records_limit && chunk.size >= @chunk_records_limit * @chunk_full_threshold)
       end
 
-      def emit_step_by_step(metadata, data)
-        attempt_records = data.size / 3
+      class ShouldRetry < StandardError; end
 
-        synchronize do # critical section for buffer (stage/queue)
-          while data.size > 0
-            if attempt_records < MINIMUM_APPEND_ATTEMPT_RECORDS
-              attempt_records = MINIMUM_APPEND_ATTEMPT_RECORDS
+      def write_once(metadata, data, bulk: false, &block)
+        return if !bulk && (data.nil? || data.empty?)
+        return if bulk && (data.empty? || data.first.nil? || data.first.empty?)
+
+        stored = false
+        adding_bytesize = nil
+
+        chunk = synchronize { @stage[metadata] ||= generate_chunk(metadata) }
+
+        chunk.synchronize do
+          # retry this method if chunk is already queued (between getting chunk and entering critical section)
+          raise ShouldRetry unless chunk.staged?
+
+          empty_chunk = chunk.empty?
+
+          original_bytesize = chunk.bytesize
+          begin
+            if bulk
+              content, size = data
+              chunk.concat(content, size)
+            else
+              chunk.append(data)
             end
+            adding_bytesize = chunk.bytesize - original_bytesize
 
-            chunk = @stage[metadata]
-            unless chunk
-              chunk = @stage[metadata] = generate_chunk(metadata)
+            if chunk_size_over?(chunk)
+              if empty_chunk && bulk
+                log.warn "chunk bytes limit exceeds for a bulk event stream: #{bulk.bytesize}bytes"
+                stored = true
+              else
+                chunk.rollback
+              end
+            else
+              stored = true
             end
+          rescue
+            chunk.rollback
+            raise
+          end
 
-            chunk.synchronize do # critical section for chunk (chunk append/commit/rollback)
-              begin
-                empty_chunk = chunk.empty?
-                original_bytesize = chunk.bytesize
+          if stored
+            block.call(chunk, adding_bytesize)
+          elsif bulk
+            # this metadata might be enqueued already by other threads
+            # but #enqueue_chunk does nothing in such case
+            enqueue_chunk(metadata)
+            raise ShouldRetry
+          end
+        end
 
-                attempt = data.slice(0, attempt_records)
-                chunk.append(attempt)
+        unless stored
+          # try step-by-step appending if data can't be stored into existing a chunk in non-bulk mode
+          write_step_by_step(metadata, data, data.size / 3, &block)
+        end
+      rescue ShouldRetry
+        retry
+      end
 
-                if chunk_size_over?(chunk)
-                  chunk.rollback
+      def write_step_by_step(metadata, data, attempt_records, &block)
+        while data.size > 0
+          if attempt_records < MINIMUM_APPEND_ATTEMPT_RECORDS
+            attempt_records = MINIMUM_APPEND_ATTEMPT_RECORDS
+          end
 
-                  if attempt_records <= MINIMUM_APPEND_ATTEMPT_RECORDS
-                    if empty_chunk # record is too large even for empty chunk
-                      raise BufferChunkOverflowError, "minimum append butch exceeds chunk bytes limit"
-                    end
-                    # no more records for this chunk -> enqueue -> to be flushed
-                    enqueue_chunk(metadata) # `chunk` will be removed from stage
-                    attempt_records = data.size # fresh chunk may have enough space
-                  else
-                    # whole data can be processed by twice operation
-                    #  ( by using apttempt /= 2, 3 operations required for odd numbers of data)
-                    attempt_records = (attempt_records / 2) + 1
+          chunk = synchronize{ @stage[metadata] ||= generate_chunk(metadata) }
+          chunk.synchronize do # critical section for chunk (chunk append/commit/rollback)
+            raise ShouldRetry unless chunk.staged?
+            begin
+              empty_chunk = chunk.empty?
+              original_bytesize = chunk.bytesize
+
+              attempt = data.slice(0, attempt_records)
+              chunk.append(attempt)
+              adding_bytesize = (chunk.bytesize - original_bytesize)
+
+              if chunk_size_over?(chunk)
+                chunk.rollback
+
+                if attempt_records <= MINIMUM_APPEND_ATTEMPT_RECORDS
+                  if empty_chunk # record is too large even for empty chunk
+                    raise BufferChunkOverflowError, "minimum append butch exceeds chunk bytes limit"
                   end
-
-                  next
+                  # no more records for this chunk -> enqueue -> to be flushed
+                  enqueue_chunk(metadata) # `chunk` will be removed from stage
+                  attempt_records = data.size # fresh chunk may have enough space
+                else
+                  # whole data can be processed by twice operation
+                  #  ( by using apttempt /= 2, 3 operations required for odd numbers of data)
+                  attempt_records = (attempt_records / 2) + 1
                 end
 
-                chunk.commit
-                @stage_size += (chunk.bytesize - original_bytesize)
-                data.slice!(0, attempt_records)
-                # same attempt size
-                nil # discard return value of data.slice!() immediately
-              rescue
-                chunk.rollback
-                raise
+                next
               end
+
+              block.call(chunk, adding_bytesize)
+              data.slice!(0, attempt_records)
+              # same attempt size
+              nil # discard return value of data.slice!() immediately
+            rescue
+              chunk.rollback
+              raise
             end
           end
         end
-        nil
-      end # emit_step_by_step
+      rescue ShouldRetry
+        retry
+      end # write_step_by_step
     end
   end
 end

--- a/lib/fluent/plugin/buffer/chunk.rb
+++ b/lib/fluent/plugin/buffer/chunk.rb
@@ -51,12 +51,15 @@ module Fluent
           @unique_id = generate_unique_id
           @metadata = metadata
 
+          # state: staged/queued/closed
+          @state = :staged
+
           @size = 0
           @created_at = Time.now
           @modified_at = Time.now
         end
 
-        attr_reader :unique_id, :metadata, :created_at, :modified_at
+        attr_reader :unique_id, :metadata, :created_at, :modified_at, :state
 
         # data is array of formatted record string
         def append(data)
@@ -89,15 +92,28 @@ module Fluent
           size == 0
         end
 
-        ## method for post-process of enqueue (e.g., renaming file for file chunks)
-        # def enqueued!
+        def staged?
+          @state == :staged
+        end
+
+        def queued?
+          @state == :queued
+        end
+
+        def closed?
+          @state == :closed
+        end
+
+        def enqueued!
+          @state = :queued
+        end
 
         def close
-          raise NotImplementedError, "Implement this method in child class"
+          @state = :closed
         end
 
         def purge
-          raise NotImplementedError, "Implement this method in child class"
+          @state = :closed
         end
 
         def read

--- a/lib/fluent/plugin/buffer/file_chunk.rb
+++ b/lib/fluent/plugin/buffer/file_chunk.rb
@@ -38,16 +38,12 @@ module Fluent
 
         FILE_PERMISSION = 0644
 
-        attr_reader :path, :state, :permission
+        attr_reader :path, :permission
 
         def initialize(metadata, path, mode, perm: system_config.file_permission || FILE_PERMISSION)
           super(metadata)
-          # state: staged/queued/closed
-          @state = nil
           @meta = nil
-
           @permission = perm
-
           @bytesize = @size = @adding_bytes = @adding_size = 0
 
           case mode
@@ -60,7 +56,7 @@ module Fluent
         end
 
         def append(data)
-          raise "BUG: appending to non-staged chunk, now '#{@state}'" unless @state == :staged
+          raise "BUG: appending to non-staged chunk, now '#{self.state}'" unless self.staged?
 
           bytes = 0
           adding = ''.force_encoding(Encoding::ASCII_8BIT)
@@ -78,7 +74,7 @@ module Fluent
         end
 
         def concat(bulk, bulk_size)
-          raise "BUG: appending to non-staged chunk, now '#{@state}'" unless @state == :staged
+          raise "BUG: appending to non-staged chunk, now '#{self.state}'" unless self.staged?
 
           bulk.force_encoding(Encoding::ASCII_8BIT)
           @chunk.write bulk
@@ -120,8 +116,25 @@ module Fluent
           @bytesize == 0
         end
 
+        def enqueued!
+          return unless self.staged?
+
+          new_chunk_path = self.class.generate_queued_chunk_path(@path, @unique_id)
+          new_meta_path = new_chunk_path + '.meta'
+
+          write_metadata(update: false) # re-write metadata w/ finalized records
+
+          file_rename(@chunk, @path, new_chunk_path, ->(new_io){ @chunk = new_io })
+          @path = new_chunk_path
+
+          file_rename(@meta, @meta_path, new_meta_path, ->(new_io){ @meta = new_io })
+          @meta_path = new_meta_path
+
+          super
+        end
+
         def close
-          @state = :closed
+          super
           size = @chunk.size
           @chunk.close
           @meta.close if @meta # meta may be missing if chunk is queued at first
@@ -131,7 +144,7 @@ module Fluent
         end
 
         def purge
-          @state = :closed
+          super
           @chunk.close
           @meta.close if @meta
           @bytesize = @size = @adding_bytes = @adding_size = 0
@@ -146,7 +159,7 @@ module Fluent
         def open(&block)
           @chunk.seek(0, IO::SEEK_SET)
           val = yield @chunk
-          @chunk.seek(0, IO::SEEK_END) if @state == :staged
+          @chunk.seek(0, IO::SEEK_END) if self.staged?
           val
         end
 
@@ -223,23 +236,6 @@ module Fluent
           @meta.seek(0, IO::SEEK_SET)
           @meta.truncate(0)
           @meta.write(msgpack_packer.pack(data))
-        end
-
-        def enqueued!
-          return unless @state == :staged
-
-          new_chunk_path = self.class.generate_queued_chunk_path(@path, @unique_id)
-          new_meta_path = new_chunk_path + '.meta'
-
-          write_metadata(update: false) # re-write metadata w/ finalized records
-
-          file_rename(@chunk, @path, new_chunk_path, ->(new_io){ @chunk = new_io })
-          @path = new_chunk_path
-
-          file_rename(@meta, @meta_path, new_meta_path, ->(new_io){ @meta = new_io })
-          @meta_path = new_meta_path
-
-          @state = :queued
         end
 
         def file_rename(file, old_path, new_path, callback=nil)

--- a/lib/fluent/plugin/buffer/memory_chunk.rb
+++ b/lib/fluent/plugin/buffer/memory_chunk.rb
@@ -29,6 +29,8 @@ module Fluent
         end
 
         def append(data)
+          raise "BUG: appending to non-staged chunk, now '#{self.state}'" unless self.staged?
+
           adding = data.join.force_encoding(Encoding::ASCII_8BIT)
           @chunk << adding
           @adding_bytes += adding.bytesize
@@ -37,6 +39,8 @@ module Fluent
         end
 
         def concat(bulk, bulk_size)
+          raise "BUG: appending to non-staged chunk, now '#{self.state}'" unless self.staged?
+
           bulk.force_encoding(Encoding::ASCII_8BIT)
           @chunk << bulk
           @adding_bytes += bulk.bytesize
@@ -71,11 +75,8 @@ module Fluent
           @chunk.empty?
         end
 
-        def close
-          true
-        end
-
         def purge
+          super
           @chunk = ''.force_encoding("ASCII-8BIT")
           @chunk_bytes = @size = @adding_bytes = @adding_size = 0
           true

--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -493,12 +493,7 @@ module Fluent
       def emit_buffered(tag, es)
         @counters_monitor.synchronize{ @emit_count += 1 }
         begin
-          metalist = execute_chunking(tag, es)
-          if @flush_mode == :immediate
-            metalist.each do |meta|
-              @buffer.enqueue_chunk(meta)
-            end
-          end
+          execute_chunking(tag, es, enqueue: (@flush_mode == :immediate))
           if !@retry && @buffer.queued?
             submit_flush_once
           end
@@ -532,12 +527,12 @@ module Fluent
           elsif @chunk_key_time && @chunk_key_tag
             timekey_range = @buffer_config.timekey_range
             time_int = time.to_i
-            timekey = time_int - (time_int % timekey_range)
+            timekey = (time_int - (time_int % timekey_range)).to_i
             @buffer.metadata(timekey: timekey, tag: tag)
           elsif @chunk_key_time
             timekey_range = @buffer_config.timekey_range
             time_int = time.to_i
-            timekey = time_int - (time_int % timekey_range)
+            timekey = (time_int - (time_int % timekey_range)).to_i
             @buffer.metadata(timekey: timekey)
           else
             @buffer.metadata(tag: tag)
@@ -546,7 +541,7 @@ module Fluent
           timekey_range = @buffer_config.timekey_range
           timekey = if @chunk_key_time
                       time_int = time.to_i
-                      time_int - (time_int % timekey_range)
+                      (time_int - (time_int % timekey_range)).to_i
                     else
                       nil
                     end
@@ -555,17 +550,17 @@ module Fluent
         end
       end
 
-      def execute_chunking(tag, es)
+      def execute_chunking(tag, es, enqueue: false)
         if @simple_chunking
-          handle_stream_simple(tag, es)
+          handle_stream_simple(tag, es, enqueue: enqueue)
         elsif @custom_format
-          handle_stream_with_custom_format(tag, es)
+          handle_stream_with_custom_format(tag, es, enqueue: enqueue)
         else
-          handle_stream_with_standard_format(tag, es)
+          handle_stream_with_standard_format(tag, es, enqueue: enqueue)
         end
       end
 
-      def handle_stream_with_custom_format(tag, es)
+      def handle_stream_with_custom_format(tag, es, enqueue: false)
         meta_and_data = {}
         records = 0
         es.each do |time, record|
@@ -574,14 +569,12 @@ module Fluent
           meta_and_data[meta] << format(tag, time, record)
           records += 1
         end
-        meta_and_data.each_pair do |meta, data|
-          @buffer.emit(meta, data)
-        end
+        @buffer.write(meta_and_data, bulk: false, enqueue: enqueue)
         @counters_monitor.synchronize{ @emit_records += records }
-        meta_and_data.keys
+        true
       end
 
-      def handle_stream_with_standard_format(tag, es)
+      def handle_stream_with_standard_format(tag, es, enqueue: false)
         meta_and_data = {}
         records = 0
         es.each do |time, record|
@@ -590,14 +583,16 @@ module Fluent
           meta_and_data[meta].add(time, record)
           records += 1
         end
+        meta_and_data_bulk = {}
         meta_and_data.each_pair do |meta, es|
-          @buffer.emit_bulk(meta, es.to_msgpack_stream(time_int: @time_as_integer), es.size)
+          meta_and_data_bulk[meta] = [es.to_msgpack_stream(time_int: @time_as_integer), es.size]
         end
+        @buffer.write(meta_and_data_bulk, bulk: true, enqueue: enqueue)
         @counters_monitor.synchronize{ @emit_records += records }
-        meta_and_data.keys
+        true
       end
 
-      def handle_stream_simple(tag, es)
+      def handle_stream_simple(tag, es, enqueue: false)
         meta = metadata((@chunk_key_tag ? tag : nil), nil, nil)
         records = es.size
         if @custom_format
@@ -613,9 +608,9 @@ module Fluent
           es_size = es.size
           es_bulk = es.to_msgpack_stream(time_int: @time_as_integer)
         end
-        @buffer.emit_bulk(meta, es_bulk, es_size)
+        @buffer.write({meta => [es_bulk, es_size]}, bulk: true, enqueue: enqueue)
         @counters_monitor.synchronize{ @emit_records += records }
-        [meta]
+        true
       end
 
       def commit_write(chunk_id, delayed: @delayed_commit, secondary: false)

--- a/test/plugin/test_buffer.rb
+++ b/test/plugin/test_buffer.rb
@@ -13,21 +13,26 @@ module FluentPluginBufferTest
     include Fluent::PluginId
     include Fluent::PluginLoggerMixin
   end
+  class DummyMemoryChunkError < StandardError; end
   class DummyMemoryChunk < Fluent::Plugin::Buffer::MemoryChunk
     attr_reader :append_count, :rollbacked, :closed, :purged
+    attr_accessor :failing
     def initialize(metadata)
       super
       @append_count = 0
       @rollbacked = false
       @closed = false
       @purged = false
+      @failing = false
     end
     def append(data)
       @append_count += 1
+      raise DummyMemoryChunkError if @failing
       super
     end
     def concat(data, size)
       @append_count += 1
+      raise DummyMemoryChunkError if @failing
       super
     end
     def rollback
@@ -495,30 +500,30 @@ class BufferTest < Test::Unit::TestCase
       assert{ qchunks.all?{ |c| c.purged } }
     end
 
-    test '#emit returns immediately if argument data is empty array' do
+    test '#write returns immediately if argument data is empty array' do
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3], @p.stage.keys
 
       m = @p.metadata(timekey: Time.parse('2016-04-11 16:40:00 +0000').to_i)
 
-      @p.emit(m, [])
+      @p.write({m => []})
 
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3], @p.stage.keys
     end
 
-    test '#emit raises BufferOverflowError if buffer is not storable' do
+    test '#write raises BufferOverflowError if buffer is not storable' do
       @p.stage_size = 256 * 1024 * 1024
       @p.queue_size = 256 * 1024 * 1024
 
       m = @p.metadata(timekey: Time.parse('2016-04-11 16:40:00 +0000').to_i)
 
       assert_raise Fluent::Plugin::Buffer::BufferOverflowError do
-        @p.emit(m, ["x" * 256])
+        @p.write({m => ["x" * 256]})
       end
     end
 
-    test '#emit stores data into an existing chunk with metadata specified' do
+    test '#write stores data into an existing chunk with metadata specified' do
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3], @p.stage.keys
 
@@ -527,7 +532,7 @@ class BufferTest < Test::Unit::TestCase
 
       assert_equal 1, @p.stage[@dm3].append_count
 
-      @p.emit(@dm3, ["x" * 256, "y" * 256, "z" * 256])
+      @p.write({@dm3 => ["x" * 256, "y" * 256, "z" * 256]})
 
       assert_equal 2, @p.stage[@dm3].append_count
       assert_equal (dm3data + ("x" * 256) + ("y" * 256) + ("z" * 256)), @p.stage[@dm3].read
@@ -537,7 +542,7 @@ class BufferTest < Test::Unit::TestCase
       assert_equal [@dm2,@dm3], @p.stage.keys
     end
 
-    test '#emit creates new chunk and store data into it if there are no chunks for specified metadata' do
+    test '#write creates new chunk and store data into it if there are no chunks for specified metadata' do
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3], @p.stage.keys
 
@@ -545,7 +550,7 @@ class BufferTest < Test::Unit::TestCase
 
       m = @p.metadata(timekey: Time.parse('2016-04-11 16:40:00 +0000').to_i)
 
-      @p.emit(m, ["x" * 256, "y" * 256, "z" * 256])
+      @p.write({m => ["x" * 256, "y" * 256, "z" * 256]})
 
       assert_equal 1, @p.stage[m].append_count
       assert_equal ("x" * 256 + "y" * 256 + "z" * 256), @p.stage[m].read
@@ -555,8 +560,9 @@ class BufferTest < Test::Unit::TestCase
       assert_equal [@dm2,@dm3,m], @p.stage.keys
     end
 
-    test '#emit tries to enqueue and store data into a new chunk if existing chunk is full' do
+    test '#write tries to enqueue and store data into a new chunk if existing chunk is full' do
       assert_equal 8 * 1024 * 1024, @p.chunk_bytes_limit
+      assert_equal 0.95, @p.chunk_full_threshold
 
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3], @p.stage.keys
@@ -564,30 +570,31 @@ class BufferTest < Test::Unit::TestCase
       m = @p.metadata(timekey: Time.parse('2016-04-11 16:40:00 +0000').to_i)
 
       row = "x" * 1024 * 1024
-      @p.emit(m, [row] * 8)
+      small_row = "x" * 1024 * 512
+      @p.write({m => [row] * 7 + [small_row]})
 
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3,m], @p.stage.keys
       assert_equal 1, @p.stage[m].append_count
 
-      @p.emit(m, [row])
+      @p.write({m => [row]})
 
       assert_equal [@dm0,@dm1,@dm1,m], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3,m], @p.stage.keys
       assert_equal 1, @p.stage[m].append_count
       assert_equal 1024*1024, @p.stage[m].bytesize
-      assert_equal 3, @p.queue.last.append_count # 1 -> emit (2) -> emit_step_by_step (3)
+      assert_equal 3, @p.queue.last.append_count # 1 -> write (2) -> write_step_by_step (3)
       assert @p.queue.last.rollbacked
     end
 
-    test '#emit rollbacks if commit raises errors' do
+    test '#write rollbacks if commit raises errors' do
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3], @p.stage.keys
 
       m = @p.metadata(timekey: Time.parse('2016-04-11 16:40:00 +0000').to_i)
 
       row = "x" * 1024
-      @p.emit(m, [row] * 8)
+      @p.write({m => [row] * 8})
 
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3,m], @p.stage.keys
@@ -602,7 +609,7 @@ class BufferTest < Test::Unit::TestCase
       end
 
       assert_raise "yay" do
-        @p.emit(m, [row])
+        @p.write({m => [row]})
       end
 
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
@@ -613,30 +620,31 @@ class BufferTest < Test::Unit::TestCase
       assert_equal row * 8, target_chunk.read
     end
 
-    test '#emit_bulk returns immediately if argument data is nil or empty string' do
+    test '#write w/ bulk returns immediately if argument data is nil or empty string' do
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3], @p.stage.keys
 
       m = @p.metadata(timekey: Time.parse('2016-04-11 16:40:00 +0000').to_i)
 
-      @p.emit_bulk(m, '', 0)
+      @p.write({}, bulk: true)
+      @p.write({m => ['', 0]}, bulk: true)
 
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3], @p.stage.keys
     end
 
-    test '#emit_bulk raises BufferOverflowError if buffer is not storable' do
+    test '#write w/ bulk raises BufferOverflowError if buffer is not storable' do
       @p.stage_size = 256 * 1024 * 1024
       @p.queue_size = 256 * 1024 * 1024
 
       m = @p.metadata(timekey: Time.parse('2016-04-11 16:40:00 +0000').to_i)
 
       assert_raise Fluent::Plugin::Buffer::BufferOverflowError do
-        @p.emit_bulk(m, "x" * 256, 1)
+        @p.write({m => ["x" * 256, 1]}, bulk: true)
       end
     end
 
-    test '#emit_bulk stores data into an existing chunk with metadata specified' do
+    test '#write w/ bulk stores data into an existing chunk with metadata specified' do
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3], @p.stage.keys
 
@@ -645,7 +653,7 @@ class BufferTest < Test::Unit::TestCase
 
       assert_equal 1, @p.stage[@dm3].append_count
 
-      @p.emit_bulk(@dm3, ("x"*256 + "y"*256 + "z"*256), 3)
+      @p.write({@dm3 => [("x"*256 + "y"*256 + "z"*256), 3]}, bulk: true)
 
       assert_equal 2, @p.stage[@dm3].append_count
       assert_equal (dm3data + ("x" * 256) + ("y" * 256) + ("z" * 256)), @p.stage[@dm3].read
@@ -655,7 +663,7 @@ class BufferTest < Test::Unit::TestCase
       assert_equal [@dm2,@dm3], @p.stage.keys
     end
 
-    test '#emit_bulk creates new chunk and store data into it if there are not chunks for specified metadata' do
+    test '#write w/ bulk creates new chunk and store data into it if there are not chunks for specified metadata' do
       assert_equal 8 * 1024 * 1024, @p.chunk_bytes_limit
 
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
@@ -665,14 +673,14 @@ class BufferTest < Test::Unit::TestCase
 
       row = "x" * 1024 * 1024
       row_half = "x" * 1024 * 512
-      @p.emit_bulk(m, row*7 + row_half, 8)
+      @p.write({m => [row*7 + row_half, 8]}, bulk: true)
 
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3,m], @p.stage.keys
       assert_equal 1, @p.stage[m].append_count
     end
 
-    test '#emit_bulk tries to enqueue and store data into a new chunk if existing chunk does not have space for bulk' do
+    test '#write w/ bulk tries to enqueue and store data into a new chunk if existing chunk does not have space for bulk' do
       assert_equal 8 * 1024 * 1024, @p.chunk_bytes_limit
 
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
@@ -682,23 +690,23 @@ class BufferTest < Test::Unit::TestCase
 
       row = "x" * 1024 * 1024
       row_half = "x" * 1024 * 512
-      @p.emit_bulk(m, row*7 + row_half, 8)
+      @p.write({m => [row*7 + row_half, 8]}, bulk: true)
 
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3,m], @p.stage.keys
       assert_equal 1, @p.stage[m].append_count
 
-      @p.emit_bulk(m, row, 1)
+      @p.write({m => [row, 1]}, bulk: true)
 
       assert_equal [@dm0,@dm1,@dm1,m], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3,m], @p.stage.keys
       assert_equal 1, @p.stage[m].append_count
       assert_equal 1024*1024, @p.stage[m].bytesize
-      assert_equal 2, @p.queue.last.append_count # 1 -> emit (2) -> rollback&enqueue
+      assert_equal 2, @p.queue.last.append_count # 1 -> write (2) -> rollback&enqueue
       assert @p.queue.last.rollbacked
     end
 
-    test '#emit_bulk enqueues chunk if it is already full after adding bulk data' do
+    test '#write w/ bulk enqueues chunk if it is already full after adding bulk data' do
       assert_equal 8 * 1024 * 1024, @p.chunk_bytes_limit
 
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
@@ -707,14 +715,14 @@ class BufferTest < Test::Unit::TestCase
       m = @p.metadata(timekey: Time.parse('2016-04-11 16:40:00 +0000').to_i)
 
       row = "x" * 1024 * 1024
-      @p.emit_bulk(m, row * 8, 8)
+      @p.write({m => [row * 8, 8]}, bulk: true)
 
       assert_equal [@dm0,@dm1,@dm1,m], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3], @p.stage.keys
       assert_equal 1, @p.queue.last.append_count
     end
 
-    test '#emit_bulk rollbacks if commit raises errors' do
+    test '#write w/ bulk rollbacks if commit raises errors' do
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3], @p.stage.keys
 
@@ -722,7 +730,7 @@ class BufferTest < Test::Unit::TestCase
 
       row = "x" * 1024
       row_half = "x" * 512
-      @p.emit_bulk(m, row * 7 + row_half, 8)
+      @p.write({m => [row * 7 + row_half, 8]}, bulk: true)
 
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3,m], @p.stage.keys
@@ -737,7 +745,7 @@ class BufferTest < Test::Unit::TestCase
       end
 
       assert_raise "yay" do
-        @p.emit_bulk(m, row, 1)
+        @p.write({m => [row, 1]}, bulk: true)
       end
 
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
@@ -746,6 +754,52 @@ class BufferTest < Test::Unit::TestCase
       assert_equal 2, target_chunk.append_count
       assert target_chunk.rollbacked
       assert_equal row * 7 + row_half, target_chunk.read
+    end
+
+    test '#write writes many metadata and data pairs at once' do
+      assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
+      assert_equal [@dm2,@dm3], @p.stage.keys
+
+      row = "x" * 1024
+      @p.write({ @dm0 => [row, row, row], @dm1 => [row, row] }, bulk: false)
+
+      assert_equal [@dm2,@dm3,@dm0,@dm1], @p.stage.keys
+    end
+
+    test '#write does not commit on any chunks if any append operation on chunk fails' do
+      assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
+      assert_equal [@dm2,@dm3], @p.stage.keys
+
+      row = "x" * 1024
+      @p.write({ @dm0 => [row, row, row], @dm1 => [row, row] }, bulk: false)
+
+      assert_equal [@dm2,@dm3,@dm0,@dm1], @p.stage.keys
+
+      dm2_size = @p.stage[@dm2].size
+      assert !@p.stage[@dm2].rollbacked
+      dm3_size = @p.stage[@dm3].size
+      assert !@p.stage[@dm3].rollbacked
+
+      assert{ @p.stage[@dm0].size == 3 }
+      assert !@p.stage[@dm0].rollbacked
+      assert{ @p.stage[@dm1].size == 2 }
+      assert !@p.stage[@dm1].rollbacked
+
+      @p.stage[@dm1].failing = true
+
+      assert_raise(FluentPluginBufferTest::DummyMemoryChunkError) do
+        @p.write({ @dm2 => [row], @dm3 => [row], @dm0 => [row, row, row], @dm1 => [row, row] }, bulk: false)
+      end
+
+      assert{ @p.stage[@dm2].size == dm2_size }
+      assert @p.stage[@dm2].rollbacked
+      assert{ @p.stage[@dm3].size == dm3_size }
+      assert @p.stage[@dm3].rollbacked
+
+      assert{ @p.stage[@dm0].size == 3 }
+      assert @p.stage[@dm0].rollbacked
+      assert{ @p.stage[@dm1].size == 2 }
+      assert @p.stage[@dm1].rollbacked
     end
   end
 
@@ -789,7 +843,7 @@ class BufferTest < Test::Unit::TestCase
       assert @p.storable?
 
       dm3 = @p.metadata(timekey: @dm3.timekey)
-      @p.emit(dm3, ["c" * 128])
+      @p.write({dm3 => ["c" * 128]})
 
       assert_equal 10240, (@p.stage_size + @p.queue_size)
       assert !@p.storable?
@@ -817,18 +871,19 @@ class BufferTest < Test::Unit::TestCase
       c2 = create_chunk(m, ["a" * 128] * 8)
       assert @p.chunk_size_full?(c2)
 
-      c3 = create_chunk(m, ["a" * 128] * 7 + ["a" * 127])
+      assert_equal 0.95, @p.chunk_full_threshold
+      c3 = create_chunk(m, ["a" * 128] * 6 + ["a" * 64])
       assert !@p.chunk_size_full?(c3)
     end
 
-    test '#emit raises BufferChunkOverflowError if incoming data is bigger than chunk bytes limit' do
+    test '#write raises BufferChunkOverflowError if incoming data is bigger than chunk bytes limit' do
       assert_equal [@dm0,@dm0,@dm0,@dm0,@dm0,@dm1,@dm1,@dm1,@dm1], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3], @p.stage.keys
 
       m = create_metadata(Time.parse('2016-04-11 16:40:00 +0000').to_i)
 
       assert_raise Fluent::Plugin::Buffer::BufferChunkOverflowError do
-        @p.emit(m, ["a" * 128] * 9)
+        @p.write({m => ["a" * 128] * 9})
       end
     end
   end

--- a/test/plugin/test_output_as_buffered.rb
+++ b/test/plugin/test_output_as_buffered.rb
@@ -129,6 +129,7 @@ class BufferedOutputTest < Test::Unit::TestCase
     setup do
       hash = {
         'flush_mode' => 'none',
+        'flush_burst_interval' => 0.01,
         'flush_threads' => 2,
         'chunk_bytes_limit' => 1024,
       }
@@ -231,6 +232,7 @@ class BufferedOutputTest < Test::Unit::TestCase
         'flush_mode' => 'fast',
         'flush_interval' => 1,
         'flush_threads' => 1,
+        'flush_burst_interval' => 0.01,
         'chunk_bytes_limit' => 1024,
       }
       @i = create_output(:buffered)
@@ -340,6 +342,7 @@ class BufferedOutputTest < Test::Unit::TestCase
       hash = {
         'flush_mode' => 'immediate',
         'flush_threads' => 1,
+        'flush_burst_interval' => 0.01,
         'chunk_bytes_limit' => 1024,
       }
       @i = create_output(:buffered)
@@ -434,6 +437,7 @@ class BufferedOutputTest < Test::Unit::TestCase
         'timekey_range' => 30, # per 30seconds
         'timekey_wait' => 5, # 5 second delay for flush
         'flush_threads' => 1,
+        'flush_burst_interval' => 0.01,
       }
       @i = create_output(:buffered)
       @i.configure(config_element('ROOT','',{},[config_element('buffer',chunk_key,hash)]))

--- a/test/plugin/test_output_as_buffered.rb
+++ b/test/plugin/test_output_as_buffered.rb
@@ -152,12 +152,12 @@ class BufferedOutputTest < Test::Unit::TestCase
       t = event_time()
       es = Fluent::ArrayEventStream.new([ [t, {"key" => "value1"}], [t, {"key" => "value2"}] ])
 
-      5.times do
+      4.times do
         @i.emit_events('tag.test', es)
       end
 
-      assert_equal 10, ary.size
-      5.times do |i|
+      assert_equal 8, ary.size
+      4.times do |i|
         assert_equal ["tag.test", t, {"key" => "value1"}], ary[i*2]
         assert_equal ["tag.test", t, {"key" => "value2"}], ary[i*2+1]
       end
@@ -175,7 +175,7 @@ class BufferedOutputTest < Test::Unit::TestCase
       end
       event_size = [tag, t, r].to_json.size # 195
 
-      (1024 / event_size).times do |i|
+      (1024 * 0.9 / event_size).to_i.times do |i|
         @i.emit_events("test.tag", Fluent::ArrayEventStream.new([ [t, r] ]))
       end
       assert{ @i.buffer.queue.size == 0 && ary.size == 0 }
@@ -208,7 +208,7 @@ class BufferedOutputTest < Test::Unit::TestCase
       end
       event_size = [tag, t, r].to_json.size # 195
 
-      (1024 / event_size).times do |i|
+      (1024 * 0.9 / event_size).to_i.times do |i|
         @i.emit_events("test.tag", Fluent::ArrayEventStream.new([ [t, r] ]))
       end
       assert{ @i.buffer.queue.size == 0 && ary.size == 0 }
@@ -221,7 +221,7 @@ class BufferedOutputTest < Test::Unit::TestCase
       waiting(10) do
         Thread.pass until ary.size == 1
       end
-      assert_equal [tag,t,r].to_json * (1024 / event_size), ary.first
+      assert_equal [tag,t,r].to_json * (1024 * 0.9 / event_size), ary.first
     end
   end
 
@@ -252,12 +252,12 @@ class BufferedOutputTest < Test::Unit::TestCase
       t = event_time()
       es = Fluent::ArrayEventStream.new([ [t, {"key" => "value1"}], [t, {"key" => "value2"}] ])
 
-      5.times do
+      4.times do
         @i.emit_events('tag.test', es)
       end
 
-      assert_equal 10, ary.size
-      5.times do |i|
+      assert_equal 8, ary.size
+      4.times do |i|
         assert_equal ["tag.test", t, {"key" => "value1"}], ary[i*2]
         assert_equal ["tag.test", t, {"key" => "value2"}], ary[i*2+1]
       end
@@ -278,14 +278,17 @@ class BufferedOutputTest < Test::Unit::TestCase
       end
 
       3.times do |i|
-        rand_records = rand(1..5)
+        rand_records = rand(1..4)
         es = Fluent::ArrayEventStream.new([ [t, r] ] * rand_records)
         assert_equal rand_records, es.size
 
         @i.interrupt_flushes
 
+        assert{ @i.buffer.queue.size == 0 }
+
         @i.emit_events("test.tag", es)
 
+        assert{ @i.buffer.queue.size == 0 }
         assert{ @i.buffer.stage.size == 1 }
 
         staged_chunk = @i.instance_eval{ @buffer.stage[@buffer.stage.keys.first] }
@@ -315,7 +318,7 @@ class BufferedOutputTest < Test::Unit::TestCase
       end
       event_size = [tag, t, r].to_json.size # 195
 
-      (1024 / event_size).times do |i|
+      (1024 * 0.9 / event_size).to_i.times do |i|
         @i.emit_events("test.tag", Fluent::ArrayEventStream.new([ [t, r] ]))
       end
       assert{ @i.buffer.queue.size == 0 && ary.size == 0 }
@@ -328,7 +331,7 @@ class BufferedOutputTest < Test::Unit::TestCase
       waiting(10) do
         Thread.pass until ary.size == 1
       end
-      assert_equal [tag,t,r].to_json * (1024 / event_size), ary.first
+      assert_equal [tag,t,r].to_json * (1024 * 0.9 / event_size), ary.first
     end
   end
 
@@ -358,12 +361,12 @@ class BufferedOutputTest < Test::Unit::TestCase
       t = event_time()
       es = Fluent::ArrayEventStream.new([ [t, {"key" => "value1"}], [t, {"key" => "value2"}] ])
 
-      5.times do
+      4.times do
         @i.emit_events('tag.test', es)
       end
 
-      assert_equal 10, ary.size
-      5.times do |i|
+      assert_equal 8, ary.size
+      4.times do |i|
         assert_equal ["tag.test", t, {"key" => "value1"}], ary[i*2]
         assert_equal ["tag.test", t, {"key" => "value2"}], ary[i*2+1]
       end

--- a/test/plugin/test_output_as_buffered_overflow.rb
+++ b/test/plugin/test_output_as_buffered_overflow.rb
@@ -1,0 +1,242 @@
+require_relative '../helper'
+require 'fluent/plugin/output'
+require 'fluent/plugin/buffer'
+require 'fluent/event'
+
+require 'json'
+require 'time'
+require 'timeout'
+require 'timecop'
+
+module FluentPluginOutputAsBufferedOverflowTest
+  class DummyBareOutput < Fluent::Plugin::Output
+    def register(name, &block)
+      instance_variable_set("@#{name}", block)
+    end
+  end
+  class DummyAsyncOutput < DummyBareOutput
+    def format(tag, time, record)
+      @format ? @format.call(tag, time, record) : [tag, time, record].to_json
+    end
+    def write(chunk)
+      @write ? @write.call(chunk) : nil
+    end
+  end
+end
+
+class BufferedOutputOverflowTest < Test::Unit::TestCase
+  def create_output
+    FluentPluginOutputAsBufferedOverflowTest::DummyAsyncOutput.new
+  end
+  def create_metadata(timekey: nil, tag: nil, variables: nil)
+    Fluent::Plugin::Buffer::Metadata.new(timekey, tag, variables)
+  end
+  def waiting(seconds)
+    begin
+      Timeout.timeout(seconds) do
+        yield
+      end
+    rescue Timeout::Error
+      STDERR.print *(@i.log.out.logs)
+      raise
+    end
+  end
+
+  teardown do
+    if @i
+      @i.stop unless @i.stopped?
+      @i.before_shutdown unless @i.before_shutdown?
+      @i.shutdown unless @i.shutdown?
+      @i.after_shutdown unless @i.after_shutdown?
+      @i.close unless @i.closed?
+      @i.terminate unless @i.terminated?
+    end
+    Timecop.return
+  end
+
+  sub_test_case 'buffered output with default configuration (throws exception for buffer overflow)' do
+    setup do
+      hash = {
+        'flush_mode' => 'none',
+        'flush_burst_interval' => 0.01,
+        'chunk_bytes_limit' => 1024,
+        'total_bytes_limit' => 4096,
+      }
+      @i = create_output()
+      @i.configure(config_element('ROOT','',{},[config_element('buffer','tag',hash)]))
+      @i.start
+    end
+
+    test '#emit_events raises error when buffer is full' do
+      @i.register(:format){|tag, time, record| "x" * 128 } # 128bytes per record (x4 -> 512bytes)
+
+      es = Fluent::ArrayEventStream.new([
+        [event_time(), {"message" => "test"}],
+        [event_time(), {"message" => "test"}],
+        [event_time(), {"message" => "test"}],
+        [event_time(), {"message" => "test"}],
+      ])
+
+      8.times do |i|
+        @i.emit_events("tag#{i}", es)
+      end
+
+      assert !@i.buffer.storable?
+
+      assert_raise(Fluent::Plugin::Buffer::BufferOverflowError) do
+        @i.emit_events("tag9", es)
+      end
+      logs = @i.log.out.logs
+      assert{ logs.any?{|line| line.include?("failed to write data into buffer by buffer overflow") } }
+    end
+  end
+
+  sub_test_case 'buffered output configured with "overflow_action block"' do
+    setup do
+      hash = {
+        'flush_mode' => 'none',
+        'flush_burst_interval' => 0.01,
+        'chunk_bytes_limit' => 1024,
+        'total_bytes_limit' => 4096,
+        'overflow_action' => "block",
+      }
+      @i = create_output()
+      @i.configure(config_element('ROOT','',{'log_level' => 'debug'},[config_element('buffer','tag',hash)]))
+      @i.start
+    end
+
+    test '#emit_events blocks until any queues are flushed' do
+      failing = true
+      flushed_chunks = []
+      @i.register(:format){|tag, time, record| "x" * 128 } # 128bytes per record (x4 -> 512bytes)
+      @i.register(:write) do |chunk|
+        if failing
+          raise "blocking"
+        end
+        flushed_chunks << chunk
+      end
+
+      es = Fluent::ArrayEventStream.new([
+        [event_time(), {"message" => "test"}],
+        [event_time(), {"message" => "test"}],
+        [event_time(), {"message" => "test"}],
+        [event_time(), {"message" => "test"}],
+        [event_time(), {"message" => "test"}],
+        [event_time(), {"message" => "test"}],
+        [event_time(), {"message" => "test"}],
+        [event_time(), {"message" => "test"}],
+      ])
+
+      4.times do |i|
+        @i.emit_events("tag#{i}", es)
+      end
+
+      assert !@i.buffer.storable?
+
+      thread = Thread.new do
+        sleep 3
+        failing = false
+      end
+
+      assert_nothing_raised do
+        @i.emit_events("tag9", es)
+      end
+
+      assert !failing
+      assert{ flushed_chunks.size > 0 }
+
+      logs = @i.log.out.logs
+      assert{ logs.any?{|line| line.include?("failed to write data into buffer by buffer overflow") } }
+      assert{ logs.any?{|line| line.include?("buffer.write is now blocking") } }
+      assert{ logs.any?{|line| line.include?("retrying buffer.write after blocked operation") } }
+    end
+  end
+
+  sub_test_case 'buffered output configured with "overflow_action drop_oldest_chunk"' do
+    setup do
+      hash = {
+        'flush_mode' => 'none',
+        'flush_burst_interval' => 0.01,
+        'chunk_bytes_limit' => 1024,
+        'total_bytes_limit' => 4096,
+        'overflow_action' => "drop_oldest_chunk",
+      }
+      @i = create_output()
+      @i.configure(config_element('ROOT','',{'log_level' => 'debug'},[config_element('buffer','tag',hash)]))
+      @i.start
+    end
+
+    test '#emit_events will success by dropping oldest chunk' do
+      failing = true
+      flushed_chunks = []
+      @i.register(:format){|tag, time, record| "x" * 128 } # 128bytes per record (x4 -> 512bytes)
+      @i.register(:write) do |chunk|
+        if failing
+          raise "blocking"
+        end
+        flushed_chunks << chunk
+      end
+
+      es = Fluent::ArrayEventStream.new([
+        [event_time(), {"message" => "test"}],
+        [event_time(), {"message" => "test"}],
+        [event_time(), {"message" => "test"}],
+        [event_time(), {"message" => "test"}],
+        [event_time(), {"message" => "test"}],
+        [event_time(), {"message" => "test"}],
+        [event_time(), {"message" => "test"}],
+        [event_time(), {"message" => "test"}],
+      ])
+
+      4.times do |i|
+        @i.emit_events("tag#{i}", es)
+      end
+
+      assert !@i.buffer.storable?
+
+      assert{ @i.buffer.queue[0].metadata.tag == "tag0" }
+      assert{ @i.buffer.queue[1].metadata.tag == "tag1" }
+
+      assert_nothing_raised do
+        @i.emit_events("tag9", es)
+      end
+
+      assert failing
+      assert{ flushed_chunks.size == 0 }
+
+      assert{ @i.buffer.queue[0].metadata.tag == "tag1" }
+
+      logs = @i.log.out.logs
+      assert{ logs.any?{|line| line.include?("failed to write data into buffer by buffer overflow") } }
+      assert{ logs.any?{|line| line.include?("dropping oldest chunk to make space after buffer overflow") } }
+    end
+
+    test '#emit_events raises OverflowError if all buffer spaces are used by staged chunks' do
+      @i.register(:format){|tag, time, record| "x" * 128 } # 128bytes per record (x4 -> 512bytes)
+
+      es = Fluent::ArrayEventStream.new([
+        [event_time(), {"message" => "test"}],
+        [event_time(), {"message" => "test"}],
+        [event_time(), {"message" => "test"}],
+        [event_time(), {"message" => "test"}],
+      ])
+
+      8.times do |i|
+        @i.emit_events("tag#{i}", es)
+      end
+
+      assert !@i.buffer.storable?
+
+      assert{ @i.buffer.queue.size == 0 }
+      assert{ @i.buffer.stage.size == 8 }
+
+      assert_raise Fluent::Plugin::Buffer::BufferOverflowError do
+        @i.emit_events("tag9", es)
+      end
+
+      logs = @i.log.out.logs
+      assert{ logs.any?{|line| line.include?("failed to write data into buffer by buffer overflow") } }
+      assert{ logs.any?{|line| line.include?("no queued chunks to be dropped for drop_oldest_chunk") } }
+    end
+  end
+end

--- a/test/plugin/test_output_as_standard.rb
+++ b/test/plugin/test_output_as_standard.rb
@@ -113,7 +113,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
   sub_test_case 'standard buffered with tag chunk key' do
     test '#execute_chunking calls @buffer.write(bulk: true) just once with predefined msgpack format' do
       @i = create_output(:standard)
-      @i.configure(config_element('ROOT','',{},[config_element('buffer','tag')]))
+      @i.configure(config_element('ROOT','',{},[config_element('buffer','tag',{'flush_burst_interval' => 0.01})]))
       @i.start
 
       m = create_metadata(tag: "mytag.test")
@@ -127,7 +127,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
 
     test '#execute_chunking calls @buffer.write(bulk: true) just once with predefined msgpack format, but time will be int if time_as_integer specified' do
       @i = create_output(:standard)
-      @i.configure(config_element('ROOT','',{"time_as_integer"=>"true"},[config_element('buffer','tag')]))
+      @i.configure(config_element('ROOT','',{"time_as_integer"=>"true"},[config_element('buffer','tag',{'flush_burst_interval' => 0.01})]))
       @i.start
 
       m = create_metadata(tag: "mytag.test")
@@ -143,7 +143,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
   sub_test_case 'standard buffered with time chunk key' do
     test '#execute_chunking calls @buffer.write(bulk: true) with predefined msgpack format' do
       @i = create_output(:standard)
-      @i.configure(config_element('ROOT','',{},[config_element('buffer','time',{"timekey_range" => "60"})]))
+      @i.configure(config_element('ROOT','',{},[config_element('buffer','time',{"timekey_range" => "60",'flush_burst_interval' => 0.01})]))
       @i.start
 
       m1 = create_metadata(timekey: Time.parse('2016-04-21 17:19:00 -0700').to_i)
@@ -175,7 +175,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
 
     test '#execute_chunking calls @buffer.write(bulk: true) with predefined msgpack format, but time will be int if time_as_integer specified' do
       @i = create_output(:standard)
-      @i.configure(config_element('ROOT','',{"time_as_integer" => "true"},[config_element('buffer','time',{"timekey_range" => "60"})]))
+      @i.configure(config_element('ROOT','',{"time_as_integer" => "true"},[config_element('buffer','time',{"timekey_range" => "60",'flush_burst_interval' => 0.01})]))
       @i.start
 
       m1 = create_metadata(timekey: Time.parse('2016-04-21 17:19:00 -0700').to_i)
@@ -209,7 +209,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
   sub_test_case 'standard buffered with variable chunk keys' do
     test '#execute_chunking calls @buffer.write(bulk: true) with predefined msgpack format' do
       @i = create_output(:standard)
-      @i.configure(config_element('ROOT','',{},[config_element('buffer','key,name')]))
+      @i.configure(config_element('ROOT','',{},[config_element('buffer','key,name',{'flush_burst_interval' => 0.01})]))
       @i.start
 
       m1 = create_metadata(variables: {key: "my value", name: "moris1"})
@@ -236,7 +236,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
 
     test '#execute_chunking calls @buffer.write(bulk: true) in times of # of variable variations with predefined msgpack format, but time will be int if time_as_integer specified' do
       @i = create_output(:standard)
-      @i.configure(config_element('ROOT','',{"time_as_integer" => "true"},[config_element('buffer','key,name')]))
+      @i.configure(config_element('ROOT','',{"time_as_integer" => "true"},[config_element('buffer','key,name',{'flush_burst_interval' => 0.01})]))
       @i.start
 
       m1 = create_metadata(variables: {key: "my value", name: "moris1"})
@@ -283,7 +283,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
     test '#execute_chunking calls @buffer.write(bulk: true) just once with customized format' do
       @i = create_output(:buffered)
       @i.register(:format){|tag, time, record| [time, record].to_json }
-      @i.configure(config_element('ROOT','',{},[config_element('buffer','tag')]))
+      @i.configure(config_element('ROOT','',{},[config_element('buffer','tag',{'flush_burst_interval' => 0.01})]))
       @i.start
 
       m = create_metadata(tag: "mytag.test")
@@ -299,7 +299,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
     test '#execute_chunking calls @buffer.write with customized format' do
       @i = create_output(:buffered)
       @i.register(:format){|tag, time, record| [time, record].to_json }
-      @i.configure(config_element('ROOT','',{},[config_element('buffer','time',{"timekey_range" => "60"})]))
+      @i.configure(config_element('ROOT','',{},[config_element('buffer','time',{"timekey_range" => "60",'flush_burst_interval' => 0.01})]))
       @i.start
 
       m1 = create_metadata(timekey: Time.parse('2016-04-21 17:19:00 -0700').to_i)
@@ -334,7 +334,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
     test '#execute_chunking calls @buffer.write in times of # of variable variations with customized format' do
       @i = create_output(:buffered)
       @i.register(:format){|tag, time, record| [time, record].to_json }
-      @i.configure(config_element('ROOT','',{},[config_element('buffer','key,name')]))
+      @i.configure(config_element('ROOT','',{},[config_element('buffer','key,name',{'flush_burst_interval' => 0.01})]))
       @i.start
 
       m1 = create_metadata(variables: {key: "my value", name: "moris1"})


### PR DESCRIPTION
I found that implementing `buffer_queue_full_action` in v0.14 requires change of internal API of Buffer.
This pull-request does:
* merge `Buffer#emit` and `Buffer#emit_bulk` to `Buffer#write`
* fix `Buffer#write` to get a set of metadata and its data (as a hash) to control commit/rollback as a transaction

This change is based on #912 