### PR TITLE
Suppress warnings

### DIFF
--- a/lib/fluent/configurable.rb
+++ b/lib/fluent/configurable.rb
@@ -68,7 +68,7 @@ module Fluent
 
       root.instance_eval{ @params.keys }.each do |param_name|
         varname = "@#{param_name}".to_sym
-        if (! root[param_name].nil?) || instance_variable_get(varname).nil?
+        if (! root[param_name].nil?) || (instance_variable_defined?(varname) && instance_variable_get(varname).nil?)
           instance_variable_set(varname, root[param_name])
         end
       end

--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -398,7 +398,7 @@ module Fluent
     extend Forwardable
     def_delegators '@logger', :enable_color?, :enable_debug, :enable_event,
       :disable_events, :tag, :tag=, :time_format, :time_format=,
-      :event, :caller_line, :puts, :write, :flush, :out, :out=,
+      :event, :caller_line, :puts, :write, :flush, :reset, :out, :out=,
       :optional_header, :optional_header=, :optional_attrs, :optional_attrs=
   end
 

--- a/lib/fluent/plugin/buffer/file_chunk.rb
+++ b/lib/fluent/plugin/buffer/file_chunk.rb
@@ -44,6 +44,7 @@ module Fluent
           super(metadata)
           # state: staged/queued/closed
           @state = nil
+          @meta = nil
 
           @permission = perm
 

--- a/lib/fluent/plugin/buffer/file_chunk.rb
+++ b/lib/fluent/plugin/buffer/file_chunk.rb
@@ -171,7 +171,7 @@ module Fluent
 
         def self.generate_queued_chunk_path(path, unique_id)
           chunk_id = Fluent::UniqueId.hex(unique_id)
-          if pos = path.index(".b#{chunk_id}.")
+          if path.index(".b#{chunk_id}.")
             path.sub(".b#{chunk_id}.", ".q#{chunk_id}.")
           else # for unexpected cases (ex: users rename files while opened by fluentd)
             path + ".q#{chunk_id}.chunk"

--- a/lib/fluent/plugin/in_forward.rb
+++ b/lib/fluent/plugin/in_forward.rb
@@ -242,7 +242,7 @@ module Fluent
         @log.trace {
           begin
             remote_port, remote_addr = *Socket.unpack_sockaddr_in(@_io.getpeername)
-          rescue => e
+          rescue
             remote_port = nil
             remote_addr = nil
           end

--- a/lib/fluent/plugin/in_forward.rb
+++ b/lib/fluent/plugin/in_forward.rb
@@ -229,7 +229,7 @@ module Fluent
         super(io)
 
         if io.is_a?(TCPSocket) # for unix domain socket support in the future
-          proto, port, host, addr = ( io.peeraddr rescue PEERADDR_FAILED )
+          _proto, port, host, addr = ( io.peeraddr rescue PEERADDR_FAILED )
           @source = "host: #{host}, addr: #{addr}, port: #{port}"
 
           opt = [1, linger_timeout].pack('I!I!')  # { int l_onoff; int l_linger; }

--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -45,6 +45,8 @@ module Fluent
       super
       require 'fluent/plugin/socket_util'
       @nodes = []  #=> [Node]
+      @loop = nil
+      @thread = nil
     end
 
     desc 'The timeout time when sending event logs.'

--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -440,7 +440,6 @@ module Fluent
     end
 
     def on_heartbeat(sockaddr, msg)
-      port, host = Socket.unpack_sockaddr_in(sockaddr)
       if node = @nodes.find {|n| n.sockaddr == sockaddr }
         #log.trace "heartbeat from '#{node.name}'", :host=>node.host, :port=>node.port
         if node.heartbeat

--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -102,9 +102,9 @@ module Fluent
         log.warn "'host' option in forward output is obsoleted. Use '<server> host xxx </server>' instead."
         port = conf['port']
         port = port ? port.to_i : LISTEN_PORT
-        e = conf.add_element('server')
-        e['host'] = host
-        e['port'] = port.to_s
+        element = conf.add_element('server')
+        element['host'] = host
+        element['port'] = port.to_s
       end
 
       recover_sample_size = @recover_wait / @heartbeat_interval

--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -47,6 +47,7 @@ module Fluent
       @nodes = []  #=> [Node]
       @loop = nil
       @thread = nil
+      @finished = false
     end
 
     desc 'The timeout time when sending event logs.'

--- a/lib/fluent/plugin/owned_by_mixin.rb
+++ b/lib/fluent/plugin/owned_by_mixin.rb
@@ -27,11 +27,15 @@ module Fluent
       end
 
       def owner
-        @_owner
+        if instance_variable_defined?("@_owner")
+          @_owner
+        end
       end
 
       def log
-        @log
+        if instance_variable_defined?("@log")
+          @log
+        end
       end
     end
   end

--- a/lib/fluent/plugin/socket_util.rb
+++ b/lib/fluent/plugin/socket_util.rb
@@ -55,6 +55,7 @@ module Fluent
 
       def initialize(io, log, delimiter, callback)
         super(io)
+        @timeout = 0
         if io.is_a?(TCPSocket)
           @addr = (io.peeraddr rescue PEERADDR_FAILED)
 

--- a/lib/fluent/plugin_helper.rb
+++ b/lib/fluent/plugin_helper.rb
@@ -32,7 +32,7 @@ module Fluent
 
     def helpers(*snake_case_symbols)
       helper_modules = snake_case_symbols.map{|name| Fluent::PluginHelper.const_get(name.to_s.split('_').map(&:capitalize).join) }
-      include *helper_modules
+      include(*helper_modules)
     end
   end
 end

--- a/lib/fluent/plugin_id.rb
+++ b/lib/fluent/plugin_id.rb
@@ -47,11 +47,17 @@ module Fluent
     end
 
     def plugin_id_configured?
-      @_id_configured
+      if instance_variable_defined?("@_id_configured")
+        @_id_configured
+      end
     end
 
     def plugin_id
-      @id ? @id : "object:#{object_id.to_s(16)}"
+      if instance_variable_defined?("@id")
+        @id || "object:#{object_id.to_s(16)}"
+      else
+        "object:#{object_id.to_s(16)}"
+      end
     end
   end
 end

--- a/lib/fluent/process.rb
+++ b/lib/fluent/process.rb
@@ -116,7 +116,7 @@ module Fluent
     end
 
     def process_parent(ipr, opw, pid, delegate_object)
-      child_uri = read_header(ipr)
+      # child_uri = read_header(ipr)
 
       # read event stream from the pipe and forward to Engine.emit_stream
       forward_thread = Thread.new(ipr, pid, &method(:input_forward_main))

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -103,15 +103,16 @@ module Fluent
     module Mixin
       def system_config
         require 'fluent/engine'
-        unless $_system_config
+        unless defined?($_system_config)
           $_system_config = nil
         end
-        @_system_config || $_system_config || Fluent::Engine.system_config
+        (instance_variable_defined?("@_system_config") && @_system_config) ||
+          $_system_config || Fluent::Engine.system_config
       end
 
       def system_config_override(opts={})
         require 'fluent/engine'
-        unless @_system_config
+        if !instance_variable_defined?("@_system_config") || @_system_config.nil?
           @_system_config = ($_system_config || Fluent::Engine.system_config).dup
         end
         opts.each_pair do |key, value|

--- a/test/config/test_system_config.rb
+++ b/test/config/test_system_config.rb
@@ -21,6 +21,8 @@ module Fluent::Config
       @suppress_repeated_stacktrace = nil
       @without_source = nil
       @emit_error_log_interval = nil
+      @file_permission = nil
+      @dir_permission = nil
     end
   end
 

--- a/test/plugin/test_buf_file.rb
+++ b/test/plugin/test_buf_file.rb
@@ -678,7 +678,7 @@ module FluentFileBufferTest
 
         chunk = buf.new_chunk('key1')
         assert chunk
-        assert File.exists?(chunk.path)
+        assert File.exist?(chunk.path)
         assert chunk.path =~ /\A#{prefix}[-_.a-zA-Z0-9\%]+\.b[0-9a-f]+#{suffix}\Z/, "path from new_chunk must be a 'b' buffer chunk"
         chunk.close
 

--- a/test/plugin/test_buffer.rb
+++ b/test/plugin/test_buffer.rb
@@ -234,7 +234,7 @@ class BufferTest < Test::Unit::TestCase
 
     test '#new_metadata creates metadata instance without inserting metadata_list' do
       assert_equal [@dm2,@dm3,@dm0,@dm1], @p.metadata_list
-      m = @p.new_metadata(timekey: Time.parse('2016-04-11 16:40:00 +0000').to_i)
+      _m = @p.new_metadata(timekey: Time.parse('2016-04-11 16:40:00 +0000').to_i)
       assert_equal [@dm2,@dm3,@dm0,@dm1], @p.metadata_list
     end
 
@@ -242,7 +242,7 @@ class BufferTest < Test::Unit::TestCase
       assert_equal [@dm2,@dm3,@dm0,@dm1], @p.metadata_list
 
       m = @p.new_metadata(timekey: Time.parse('2016-04-11 16:40:00 +0000').to_i)
-      mx = @p.add_metadata(m)
+      _mx = @p.add_metadata(m)
       assert_equal [@dm2,@dm3,@dm0,@dm1,m], @p.metadata_list
       assert_equal m.object_id, m.object_id
 
@@ -278,7 +278,7 @@ class BufferTest < Test::Unit::TestCase
     test '#queued? returns queue has any chunks or not without arguments' do
       assert @p.queued?
 
-      @p.queue.reject!{|c| true }
+      @p.queue.reject!{|_c| true }
       assert !@p.queued?
     end
 

--- a/test/plugin/test_buffer.rb
+++ b/test/plugin/test_buffer.rb
@@ -570,8 +570,6 @@ class BufferTest < Test::Unit::TestCase
       assert_equal [@dm2,@dm3,m], @p.stage.keys
       assert_equal 1, @p.stage[m].append_count
 
-      prev_stage_size = @p.stage_size
-
       @p.emit(m, [row])
 
       assert_equal [@dm0,@dm1,@dm1,m], @p.queue.map(&:metadata)

--- a/test/plugin/test_buffer_file_chunk.rb
+++ b/test/plugin/test_buffer_file_chunk.rb
@@ -341,8 +341,8 @@ class BufferFileChunkTest < Test::Unit::TestCase
         timekey: nil, tag: nil, variables: nil,
         id: unique_id,
         s: size,
-        c: @c.created_at.to_i,
-        m: @c.modified_at.to_i,
+        c: created_at.to_i,
+        m: modified_at.to_i,
       }
 
       assert_equal stored_meta, read_metadata_file(@c.path + '.meta')
@@ -465,8 +465,8 @@ class BufferFileChunkTest < Test::Unit::TestCase
         timekey: nil, tag: nil, variables: nil,
         id: unique_id,
         s: size,
-        c: @c.created_at.to_i,
-        m: @c.modified_at.to_i,
+        c: created_at.to_i,
+        m: modified_at.to_i,
       }
 
       assert_equal stored_meta, read_metadata_file(@c.path + '.meta')

--- a/test/plugin/test_filter.rb
+++ b/test/plugin/test_filter.rb
@@ -218,8 +218,6 @@ class FilterPluginTest < Test::Unit::TestCase
       assert @p.router
 
       @p.router = DummyRouter.new([])
-      data = {'message' => 'mydata'}
-      dummy_error = EOFError.new("dummy eof")
 
       test_es = [
         [event_time('2016-04-19 13:01:00 -0700'), {"num" => "1", "message" => "Hello filters!"}],

--- a/test/plugin/test_in_forward.rb
+++ b/test/plugin/test_in_forward.rb
@@ -59,7 +59,7 @@ class ForwardInputTest < Test::Unit::TestCase
     d.expect_emit "tag2", time, {"a"=>2}
 
     d.run do
-      d.expected_emits.each {|tag,time,record|
+      d.expected_emits.each {|tag, _time, record|
         send_data Fluent::Engine.msgpack_factory.packer.write([tag, 0, record]).to_s
       }
     end
@@ -74,8 +74,8 @@ class ForwardInputTest < Test::Unit::TestCase
     d.expect_emit "tag2", time, {"a"=>2}
 
     d.run do
-      d.expected_emits.each {|tag,time,record|
-        send_data Fluent::Engine.msgpack_factory.packer.write([tag, time, record]).to_s
+      d.expected_emits.each {|tag, _time, record|
+        send_data Fluent::Engine.msgpack_factory.packer.write([tag, _time, record]).to_s
       }
     end
   end
@@ -89,8 +89,8 @@ class ForwardInputTest < Test::Unit::TestCase
     d.expect_emit "tag2", time, {"a"=>2}
 
     d.run do
-      d.expected_emits.each {|tag,time,record|
-        send_data Fluent::Engine.msgpack_factory.packer.write([tag, time, record]).to_s
+      d.expected_emits.each {|tag, _time, record|
+        send_data Fluent::Engine.msgpack_factory.packer.write([tag, _time, record]).to_s
       }
     end
   end
@@ -104,13 +104,13 @@ class ForwardInputTest < Test::Unit::TestCase
     d.expect_emit "tag2", time, {"a" => 2}
 
     d.run do
-      entries = d.expected_emits.map { |tag, time, record| [tag, time, record] }
+      entries = d.expected_emits.map {|tag, _time, record| [tag, _time, record] }
       # These entries are skipped
       entries << ['tag1', true, {'a' => 3}] << ['tag2', time, 'invalid record']
 
-      entries.each { |tag, time, record|
+      entries.each {|tag, _time, record|
         # Without ack, logs are sometimes not saved to logs during test.
-        send_data Fluent::Engine.msgpack_factory.packer.write([tag, time, record]).to_s, true
+        send_data Fluent::Engine.msgpack_factory.packer.write([tag, _time, record]).to_s, true
       }
     end
 
@@ -127,7 +127,7 @@ class ForwardInputTest < Test::Unit::TestCase
 
     d.run do
       entries = []
-      d.expected_emits.each {|tag,time,record|
+      d.expected_emits.each {|tag, _time,record|
         entries << [time, record]
       }
       send_data Fluent::Engine.msgpack_factory.packer.write(["tag1", entries]).to_s
@@ -144,8 +144,8 @@ class ForwardInputTest < Test::Unit::TestCase
 
     d.run do
       entries = []
-      d.expected_emits.each {|tag,time,record|
-        entries << [time, record]
+      d.expected_emits.each {|_tag, _time, record|
+        entries << [_time, record]
       }
       send_data Fluent::Engine.msgpack_factory.packer.write(["tag1", entries]).to_s
     end
@@ -160,7 +160,7 @@ class ForwardInputTest < Test::Unit::TestCase
     d.expect_emit "tag1", time, {"a" => 2}
 
     d.run do
-      entries = d.expected_emits.map { |tag, time, record| [time, record] }
+      entries = d.expected_emits.map {|_tag, _time, record| [_time, record] }
       # These entries are skipped
       entries << ['invalid time', {'a' => 3}] << [time, 'invalid record']
 
@@ -180,8 +180,8 @@ class ForwardInputTest < Test::Unit::TestCase
 
     d.run do
       entries = ''
-      d.expected_emits.each {|tag,time,record|
-        Fluent::Engine.msgpack_factory.packer(entries).write([time, record]).flush
+      d.expected_emits.each {|_tag, _time, record|
+        Fluent::Engine.msgpack_factory.packer(entries).write([_time, record]).flush
       }
       send_data Fluent::Engine.msgpack_factory.packer.write(["tag1", entries]).to_s
     end
@@ -197,8 +197,8 @@ class ForwardInputTest < Test::Unit::TestCase
 
     d.run do
       entries = ''
-      d.expected_emits.each {|tag,time,record|
-        Fluent::Engine.msgpack_factory.packer(entries).write([time, record]).flush
+      d.expected_emits.each {|_tag, _time, record|
+        Fluent::Engine.msgpack_factory.packer(entries).write([_time, record]).flush
       }
       send_data Fluent::Engine.msgpack_factory.packer.write(["tag1", entries]).to_s
     end
@@ -213,13 +213,13 @@ class ForwardInputTest < Test::Unit::TestCase
     d.expect_emit "tag1", time, {"a" => 2}
 
     d.run do
-      entries = d.expected_emits.map { |tag ,time, record| [time, record] }
+      entries = d.expected_emits.map {|_tag , _time, record| [_time, record] }
       # These entries are skipped
       entries << ['invalid time', {'a' => 3}] << [time, 'invalid record']
 
       packed_entries = ''
-      entries.each { |time, record|
-        Fluent::Engine.msgpack_factory.packer(packed_entries).write([time, record]).flush
+      entries.each {|_time, record|
+        Fluent::Engine.msgpack_factory.packer(packed_entries).write([_time, record]).flush
       }
       send_data Fluent::Engine.msgpack_factory.packer.write(["tag1", packed_entries]).to_s
     end
@@ -236,8 +236,8 @@ class ForwardInputTest < Test::Unit::TestCase
     d.expect_emit "tag2", time, {"a"=>2}
 
     d.run do
-      d.expected_emits.each {|tag,time,record|
-        send_data [tag, time, record].to_json
+      d.expected_emits.each {|tag, _time, record|
+        send_data [tag, _time, record].to_json
       }
     end
   end
@@ -266,7 +266,7 @@ class ForwardInputTest < Test::Unit::TestCase
     emits = d.emits
     assert_equal 16, emits.size
     assert emits.map(&:first).all?{|t| t == "test.tag" }
-    assert_equal (0...16).to_a, emits.map{|tag, t, record| t - time }
+    assert_equal (0...16).to_a, emits.map{|_tag, t, _record| t - time }
 
     # check log
     assert d.instance.log.logs.select{|line|
@@ -363,10 +363,10 @@ class ForwardInputTest < Test::Unit::TestCase
     expected_acks = []
 
     d.run do
-      events.each {|tag,time,record|
+      events.each {|tag, _time, record|
         op = { 'chunk' => Base64.encode64(record.object_id.to_s) }
         expected_acks << op['chunk']
-        send_data [tag, time, record, op].to_msgpack, true
+        send_data [tag, _time, record, op].to_msgpack, true
       }
     end
 
@@ -390,7 +390,7 @@ class ForwardInputTest < Test::Unit::TestCase
 
     d.run do
       entries = []
-      events.each {|tag,time,record|
+      events.each {|_tag, _time, record|
         entries << [time, record]
       }
       op = { 'chunk' => Base64.encode64(entries.object_id.to_s) }
@@ -417,8 +417,8 @@ class ForwardInputTest < Test::Unit::TestCase
 
     d.run do
       entries = ''
-      events.each {|tag,time,record|
-        [time, record].to_msgpack(entries)
+      events.each {|_tag, _time, record|
+        [_time, record].to_msgpack(entries)
       }
       op = { 'chunk' => Base64.encode64(entries.object_id.to_s) }
       expected_acks << op['chunk']
@@ -443,10 +443,10 @@ class ForwardInputTest < Test::Unit::TestCase
     expected_acks = []
 
     d.run do
-      events.each {|tag,time,record|
+      events.each {|tag, _time, record|
         op = { 'chunk' => Base64.encode64(record.object_id.to_s) }
         expected_acks << op['chunk']
-        send_data [tag, time, record, op].to_json, true
+        send_data [tag, _time, record, op].to_json, true
       }
     end
 
@@ -467,8 +467,8 @@ class ForwardInputTest < Test::Unit::TestCase
     d.expected_emits_length = events.length
 
     d.run do
-      events.each {|tag,time,record|
-        send_data [tag, time, record].to_msgpack, true
+      events.each {|tag, _time, record|
+        send_data [tag, _time, record].to_msgpack, true
       }
     end
 
@@ -489,8 +489,8 @@ class ForwardInputTest < Test::Unit::TestCase
 
     d.run do
       entries = []
-      events.each {|tag,time,record|
-        entries << [time, record]
+      events.each {|_tag, _time, record|
+        entries << [_time, record]
       }
       send_data ["tag1", entries].to_msgpack, true
     end
@@ -512,8 +512,8 @@ class ForwardInputTest < Test::Unit::TestCase
 
     d.run do
       entries = ''
-      events.each {|tag,time,record|
-        [time, record].to_msgpack(entries)
+      events.each {|_tag, _time, record|
+        [_time, record].to_msgpack(entries)
       }
       send_data ["tag1", entries].to_msgpack, true
     end
@@ -534,8 +534,8 @@ class ForwardInputTest < Test::Unit::TestCase
     d.expected_emits_length = events.length
 
     d.run do
-      events.each {|tag,time,record|
-        send_data [tag, time, record].to_json, true
+      events.each {|tag, _time, record|
+        send_data [tag, _time, record].to_json, true
       }
     end
 

--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -390,7 +390,7 @@ class ForwardOutputTest < Test::Unit::TestCase
         if do_respond
           def write(data)
             @sock.write data
-          rescue => e
+          rescue
             @sock.close_write
             @sock.close
           end

--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -411,7 +411,7 @@ class ForwardOutputTest < Test::Unit::TestCase
 
       define_method(:start) do
         @thread = Thread.new do
-          Socket.tcp_server_loop(@host, @port) do |sock, client_addrinfo|
+          Socket.tcp_server_loop(@bind, @port) do |sock, client_addrinfo|
             begin
               handler = handler_class.new(sock, @log, method(:on_message))
               loop do

--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -385,6 +385,7 @@ class ForwardOutputTest < Test::Unit::TestCase
           @log = log
           @chunk_counter = 0
           @on_message = on_message
+          @source = nil
         end
 
         if do_respond

--- a/test/plugin/test_output.rb
+++ b/test/plugin/test_output.rb
@@ -89,7 +89,7 @@ class OutputTest < Test::Unit::TestCase
         yield
       end
     rescue Timeout::Error
-      STDERR.print *(@i.log.out.logs)
+      STDERR.print(*@i.log.out.logs)
       raise
     end
   end

--- a/test/plugin/test_output.rb
+++ b/test/plugin/test_output.rb
@@ -14,11 +14,20 @@ module FluentPluginOutputTest
     end
   end
   class DummySyncOutput < DummyBareOutput
+    def initialize
+      super
+      @process = nil
+    end
     def process(tag, es)
       @process ? @process.call(tag, es) : nil
     end
   end
   class DummyAsyncOutput < DummyBareOutput
+    def initialize
+      super
+      @format = nil
+      @write = nil
+    end
     def format(tag, time, record)
       @format ? @format.call(tag, time, record) : [tag, time, record].to_json
     end
@@ -27,11 +36,20 @@ module FluentPluginOutputTest
     end
   end
   class DummyAsyncStandardOutput < DummyBareOutput
+    def initialize
+      super
+      @write = nil
+    end
     def write(chunk)
       @write ? @write.call(chunk) : nil
     end
   end
   class DummyDelayedOutput < DummyBareOutput
+    def initialize
+      super
+      @format = nil
+      @try_write = nil
+    end
     def format(tag, time, record)
       @format ? @format.call(tag, time, record) : [tag, time, record].to_json
     end
@@ -40,11 +58,24 @@ module FluentPluginOutputTest
     end
   end
   class DummyDelayedStandardOutput < DummyBareOutput
+    def initialize
+      super
+      @try_write = nil
+    end
     def try_write(chunk)
       @try_write ? @try_write.call(chunk) : nil
     end
   end
   class DummyFullFeatureOutput < DummyBareOutput
+    def initialize
+      super
+      @prefer_buffered_processing = nil
+      @prefer_delayed_commit = nil
+      @process = nil
+      @format = nil
+      @write = nil
+      @try_write = nil
+    end
     def prefer_buffered_processing
       @prefer_buffered_processing ? @prefer_buffered_processing.call : false
     end

--- a/test/plugin/test_output_as_buffered.rb
+++ b/test/plugin/test_output_as_buffered.rb
@@ -15,11 +15,20 @@ module FluentPluginOutputAsBufferedTest
     end
   end
   class DummySyncOutput < DummyBareOutput
+    def initialize
+      super
+      @process = nil
+    end
     def process(tag, es)
       @process ? @process.call(tag, es) : nil
     end
   end
   class DummyAsyncOutput < DummyBareOutput
+    def initialize
+      super
+      @format = nil
+      @write = nil
+    end
     def format(tag, time, record)
       @format ? @format.call(tag, time, record) : [tag, time, record].to_json
     end
@@ -28,6 +37,12 @@ module FluentPluginOutputAsBufferedTest
     end
   end
   class DummyDelayedOutput < DummyBareOutput
+    def initialize
+      super
+      @format = nil
+      @try_write = nil
+      @shutdown_hook = nil
+    end
     def format(tag, time, record)
       @format ? @format.call(tag, time, record) : [tag, time, record].to_json
     end
@@ -42,6 +57,15 @@ module FluentPluginOutputAsBufferedTest
     end
   end
   class DummyFullFeatureOutput < DummyBareOutput
+    def initialize
+      super
+      @prefer_buffered_processing = nil
+      @prefer_delayed_commit = nil
+      @process = nil
+      @format = nil
+      @write = nil
+      @try_write = nil
+    end
     def prefer_buffered_processing
       @prefer_buffered_processing ? @prefer_buffered_processing.call : false
     end

--- a/test/plugin/test_output_as_buffered.rb
+++ b/test/plugin/test_output_as_buffered.rb
@@ -252,7 +252,6 @@ class BufferedOutputTest < Test::Unit::TestCase
       (0...10).each do |i|
         r["key#{i}"] = "value #{i}"
       end
-      event_size = [tag, t, r].to_json.size # 195
 
       3.times do |i|
         rand_records = rand(1..5)
@@ -261,7 +260,7 @@ class BufferedOutputTest < Test::Unit::TestCase
 
         @i.interrupt_flushes
 
-        @i.emit("test.tag", es)
+        @i.emit(tag, es)
 
         assert{ @i.buffer.stage.size == 1 }
 
@@ -359,13 +358,12 @@ class BufferedOutputTest < Test::Unit::TestCase
       (0...10).each do |i|
         r["key#{i}"] = "value #{i}"
       end
-      event_size = [tag, t, r].to_json.size # 195
 
       3.times do |i|
         rand_records = rand(1..5)
         es = Fluent::ArrayEventStream.new([ [t, r] ] * rand_records)
         assert_equal rand_records, es.size
-        @i.emit("test.tag", es)
+        @i.emit(tag, es)
 
         assert{ @i.buffer.stage.size == 0 && (@i.buffer.queue.size == 1 || @i.buffer.dequeued.size == 1 || ary.size > 0) }
 

--- a/test/plugin/test_output_as_buffered.rb
+++ b/test/plugin/test_output_as_buffered.rb
@@ -84,7 +84,7 @@ class BufferedOutputTest < Test::Unit::TestCase
         yield
       end
     rescue Timeout::Error
-      STDERR.print *(@i.log.out.logs)
+      STDERR.print(*@i.log.out.logs)
       raise
     end
   end

--- a/test/plugin/test_output_as_buffered_retries.rb
+++ b/test/plugin/test_output_as_buffered_retries.rb
@@ -353,7 +353,7 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
       prev_write_count = @i.write_count
       prev_num_errors = @i.num_errors
 
-      first_failure = @i.retry.start
+      _first_failure = @i.retry.start
 
       chunks = @i.buffer.queue.dup
 
@@ -569,7 +569,7 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
       prev_write_count = @i.write_count
       prev_num_errors = @i.num_errors
 
-      first_failure = @i.retry.start
+      _first_failure = @i.retry.start
 
       chunks = @i.buffer.queue.dup
 

--- a/test/plugin/test_output_as_buffered_retries.rb
+++ b/test/plugin/test_output_as_buffered_retries.rb
@@ -67,7 +67,7 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
         yield
       end
     rescue Timeout::Error
-      STDERR.print *(@i.log.out.logs)
+      STDERR.print(*@i.log.out.logs)
       raise
     end
   end

--- a/test/plugin/test_output_as_buffered_retries.rb
+++ b/test/plugin/test_output_as_buffered_retries.rb
@@ -15,11 +15,24 @@ module FluentPluginOutputAsBufferedRetryTest
     end
   end
   class DummySyncOutput < DummyBareOutput
+    def initialize
+      super
+      @process = nil
+    end
     def process(tag, es)
       @process ? @process.call(tag, es) : nil
     end
   end
   class DummyFullFeatureOutput < DummyBareOutput
+    def initialize
+      super
+      @prefer_buffered_processing = nil
+      @prefer_delayed_commit = nil
+      @process = nil
+      @format = nil
+      @write = nil
+      @try_write = nil
+    end
     def prefer_buffered_processing
       @prefer_buffered_processing ? @prefer_buffered_processing.call : false
     end
@@ -87,6 +100,10 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
     log_time
   end
 
+  setup do
+    @i = create_output
+  end
+
   teardown do
     if @i
       @i.stop unless @i.stopped?
@@ -107,7 +124,6 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
         'flush_burst_interval' => 0.1,
         'retry_randomize' => false,
       }
-      @i = create_output()
       @i.configure(config_element('ROOT','',{},[config_element('buffer',chunk_key,hash)]))
       @i.register(:prefer_buffered_processing){ true }
       @i.start
@@ -139,7 +155,6 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
         'retry_randomize' => false,
         'retry_max_interval' => 60 * 60,
       }
-      @i = create_output()
       @i.configure(config_element('ROOT','',{},[config_element('buffer',chunk_key,hash)]))
       @i.register(:prefer_buffered_processing){ true }
       @i.register(:format){|tag,time,record| [tag,time.to_i,record].to_json + "\n" }
@@ -179,7 +194,6 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
         'retry_randomize' => false,
         'retry_max_interval' => 60,
       }
-      @i = create_output()
       @i.configure(config_element('ROOT','',{},[config_element('buffer',chunk_key,hash)]))
       @i.register(:prefer_buffered_processing){ true }
       @i.register(:format){|tag,time,record| [tag,time.to_i,record].to_json + "\n" }
@@ -232,7 +246,6 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
         'retry_randomize' => false,
         'retry_timeout' => 3600,
       }
-      @i = create_output()
       @i.configure(config_element('ROOT','',{},[config_element('buffer',chunk_key,hash)]))
       @i.register(:prefer_buffered_processing){ true }
       @i.register(:format){|tag,time,record| [tag,time.to_i,record].to_json + "\n" }
@@ -320,7 +333,6 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
         'retry_randomize' => false,
         'retry_max_times' => 10,
       }
-      @i = create_output()
       @i.configure(config_element('ROOT','',{},[config_element('buffer',chunk_key,hash)]))
       @i.register(:prefer_buffered_processing){ true }
       @i.register(:format){|tag,time,record| [tag,time.to_i,record].to_json + "\n" }
@@ -399,7 +411,6 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
         'retry_wait' => 3,
         'retry_randomize' => false,
       }
-      @i = create_output()
       @i.configure(config_element('ROOT','',{},[config_element('buffer',chunk_key,hash)]))
       @i.register(:prefer_buffered_processing){ true }
       @i.register(:format){|tag,time,record| [tag,time.to_i,record].to_json + "\n" }
@@ -443,7 +454,6 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
         'retry_randomize' => false,
         'retry_timeout' => 120,
       }
-      @i = create_output()
       @i.configure(config_element('ROOT','',{},[config_element('buffer',chunk_key,hash)]))
       @i.register(:prefer_buffered_processing){ true }
       @i.register(:format){|tag,time,record| [tag,time.to_i,record].to_json + "\n" }
@@ -536,7 +546,6 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
         'retry_randomize' => false,
         'retry_max_times' => 10,
       }
-      @i = create_output()
       @i.configure(config_element('ROOT','',{},[config_element('buffer',chunk_key,hash)]))
       @i.register(:prefer_buffered_processing){ true }
       @i.register(:format){|tag,time,record| [tag,time.to_i,record].to_json + "\n" }
@@ -632,7 +641,6 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
         'retry_timeout' => 3600,
         'retry_max_times' => 10,
       }
-      @i = create_output()
       @i.configure(config_element('ROOT','',{},[config_element('buffer',chunk_key,hash)]))
       @i.register(:prefer_buffered_processing){ true }
       @i.register(:format){|tag,time,record| [tag,time.to_i,record].to_json + "\n" }
@@ -701,7 +709,6 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
         'retry_timeout' => 360,
         'retry_max_times' => 10,
       }
-      @i = create_output()
       @i.configure(config_element('ROOT','',{},[config_element('buffer',chunk_key,hash)]))
       @i.register(:prefer_buffered_processing){ true }
       @i.register(:format){|tag,time,record| [tag,time.to_i,record].to_json + "\n" }
@@ -766,7 +773,6 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
         'retry_randomize' => false,
         'retry_max_interval' => 60 * 60,
       }
-      @i = create_output()
       @i.configure(config_element('ROOT','',{},[config_element('buffer',chunk_key,hash)]))
       @i.register(:prefer_buffered_processing){ true }
       @i.register(:prefer_delayed_commit){ true }

--- a/test/plugin/test_output_as_buffered_secondary.rb
+++ b/test/plugin/test_output_as_buffered_secondary.rb
@@ -67,7 +67,7 @@ class BufferedOutputSecondaryTest < Test::Unit::TestCase
         yield
       end
     rescue Timeout::Error
-      STDERR.print *(@i.log.out.logs)
+      STDERR.print(*@i.log.out.logs)
       raise
     end
   end

--- a/test/plugin/test_output_as_buffered_secondary.rb
+++ b/test/plugin/test_output_as_buffered_secondary.rb
@@ -15,11 +15,24 @@ module FluentPluginOutputAsBufferedSecondaryTest
     end
   end
   class DummySyncOutput < DummyBareOutput
+    def initialize
+      super
+      @process = nil
+    end
     def process(tag, es)
       @process ? @process.call(tag, es) : nil
     end
   end
   class DummyFullFeatureOutput < DummyBareOutput
+    def initialize
+      super
+      @prefer_buffered_processing = nil
+      @prefer_delayed_commit = nil
+      @process = nil
+      @format = nil
+      @write = nil
+      @try_write = nil
+    end
     def prefer_buffered_processing
       @prefer_buffered_processing ? @prefer_buffered_processing.call : false
     end
@@ -77,6 +90,10 @@ class BufferedOutputSecondaryTest < Test::Unit::TestCase
       [ event_time('2016-04-13 18:33:13'), {"name" => "moris", "age" => 36, "message" => "data2"} ],
       [ event_time('2016-04-13 18:33:32'), {"name" => "moris", "age" => 36, "message" => "data3"} ],
     ])
+  end
+
+  setup do
+    @i = create_output
   end
 
   teardown do
@@ -169,7 +186,6 @@ class BufferedOutputSecondaryTest < Test::Unit::TestCase
       written = []
       priconf = config_element('buffer','tag',{'flush_interval' => 1, 'retry_type' => :periodic, 'retry_wait' => 3, 'retry_timeout' => 60, 'retry_randomize' => false})
       secconf = config_element('secondary','',{'@type' => 'output_secondary_test2'})
-      @i = create_output()
       @i.configure(config_element('ROOT','',{},[priconf,secconf]))
       @i.register(:prefer_buffered_processing){ true }
       @i.register(:prefer_delayed_commit){ false }
@@ -232,7 +248,6 @@ class BufferedOutputSecondaryTest < Test::Unit::TestCase
       written = []
       priconf = config_element('buffer','tag',{'flush_interval' => 1, 'retry_type' => :periodic, 'retry_wait' => 3, 'retry_timeout' => 60, 'retry_randomize' => false})
       secconf = config_element('secondary','',{'@type' => 'output_secondary_test2'})
-      @i = create_output()
       @i.configure(config_element('ROOT','',{},[priconf,secconf]))
       @i.register(:prefer_buffered_processing){ true }
       @i.register(:prefer_delayed_commit){ true }
@@ -296,7 +311,6 @@ class BufferedOutputSecondaryTest < Test::Unit::TestCase
       chunks = []
       priconf = config_element('buffer','tag',{'flush_interval' => 1, 'retry_type' => :periodic, 'retry_wait' => 3, 'retry_timeout' => 60, 'retry_randomize' => false})
       secconf = config_element('secondary','',{'@type' => 'output_secondary_test2'})
-      @i = create_output()
       @i.configure(config_element('ROOT','',{},[priconf,secconf]))
       @i.register(:prefer_buffered_processing){ true }
       @i.register(:prefer_delayed_commit){ true }
@@ -371,7 +385,6 @@ class BufferedOutputSecondaryTest < Test::Unit::TestCase
       chunks = []
       priconf = config_element('buffer','tag',{'flush_interval' => 1, 'retry_type' => :periodic, 'retry_wait' => 3, 'retry_timeout' => 60, 'retry_randomize' => false})
       secconf = config_element('secondary','',{'@type' => 'output_secondary_test2'})
-      @i = create_output()
       @i.configure(config_element('ROOT','',{},[priconf,secconf]))
       @i.register(:prefer_buffered_processing){ true }
       @i.register(:prefer_delayed_commit){ false }
@@ -446,7 +459,6 @@ class BufferedOutputSecondaryTest < Test::Unit::TestCase
       chunks = []
       priconf = config_element('buffer','tag',{'flush_interval' => 1, 'retry_type' => :periodic, 'retry_wait' => 3, 'retry_timeout' => 60, 'delayed_commit_timeout' => 2, 'retry_randomize' => false})
       secconf = config_element('secondary','',{'@type' => 'output_secondary_test2'})
-      @i = create_output()
       @i.configure(config_element('ROOT','',{},[priconf,secconf]))
       @i.register(:prefer_buffered_processing){ true }
       @i.register(:prefer_delayed_commit){ false }
@@ -530,7 +542,6 @@ class BufferedOutputSecondaryTest < Test::Unit::TestCase
     test 'retry_wait for secondary is same with one for primary' do
       priconf = config_element('buffer','tag',{'flush_interval' => 1, 'retry_type' => :periodic, 'retry_wait' => 3, 'retry_timeout' => 60, 'retry_randomize' => false})
       secconf = config_element('secondary','',{'@type' => 'output_secondary_test2'})
-      @i = create_output()
       @i.configure(config_element('ROOT','',{},[priconf,secconf]))
       @i.register(:prefer_buffered_processing){ true }
       @i.register(:prefer_delayed_commit){ false }
@@ -599,7 +610,6 @@ class BufferedOutputSecondaryTest < Test::Unit::TestCase
       written = []
       priconf = config_element('buffer','tag',{'flush_interval' => 1, 'retry_type' => :expbackoff, 'retry_wait' => 1, 'retry_timeout' => 60, 'retry_randomize' => false})
       secconf = config_element('secondary','',{'@type' => 'output_secondary_test2'})
-      @i = create_output()
       @i.configure(config_element('ROOT','',{},[priconf,secconf]))
       @i.register(:prefer_buffered_processing){ true }
       @i.register(:prefer_delayed_commit){ false }
@@ -668,7 +678,6 @@ class BufferedOutputSecondaryTest < Test::Unit::TestCase
     test 'exponential backoff interval will be initialized when switched to secondary' do
       priconf = config_element('buffer','tag',{'flush_interval' => 1, 'retry_type' => :expbackoff, 'retry_wait' => 1, 'retry_timeout' => 60, 'retry_randomize' => false})
       secconf = config_element('secondary','',{'@type' => 'output_secondary_test2'})
-      @i = create_output()
       @i.configure(config_element('ROOT','',{},[priconf,secconf]))
       @i.register(:prefer_buffered_processing){ true }
       @i.register(:prefer_delayed_commit){ false }

--- a/test/plugin/test_output_as_standard.rb
+++ b/test/plugin/test_output_as_standard.rb
@@ -50,7 +50,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
         yield
       end
     rescue Timeout::Error
-      STDERR.print *(@i.log.out.logs)
+      STDERR.print(*@i.log.out.logs)
       raise
     end
   end

--- a/test/plugin/test_output_as_standard.rb
+++ b/test/plugin/test_output_as_standard.rb
@@ -65,6 +65,10 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
     es
   end
 
+  setup do
+    @i = nil
+  end
+
   teardown do
     if @i
       @i.stop unless @i.stopped?

--- a/test/plugin_helper/test_retry_state.rb
+++ b/test/plugin_helper/test_retry_state.rb
@@ -7,6 +7,7 @@ require 'time'
 class Fluent::PluginHelper::RetryState::RetryStateMachine
   def override_current_time(time)
     (class << self; self; end).module_eval do
+      alias_method(:current_time_orig, :current_time)
       define_method(:current_time){ time }
     end
   end

--- a/test/plugin_helper/test_storage.rb
+++ b/test/plugin_helper/test_storage.rb
@@ -281,7 +281,7 @@ class StorageHelperTest < Test::Unit::TestCase
     d.configure(conf)
     d.start
 
-    s = d.storage_create(usage: 'mydata')
+    d.storage_create(usage: 'mydata')
     assert_equal 0, d._timers.size
   end
 
@@ -293,7 +293,7 @@ class StorageHelperTest < Test::Unit::TestCase
     d.configure(conf)
     d.start
 
-    s = d.storage_create(usage: 'mydata')
+    d.storage_create(usage: 'mydata')
     assert_equal 1, d._timers.size
   end
 

--- a/test/plugin_helper/test_thread.rb
+++ b/test/plugin_helper/test_thread.rb
@@ -77,13 +77,13 @@ class ThreadTest < Test::Unit::TestCase
   test 'can wait until all threads start' do
     d1 = Dummy.new.configure(config_element()).start
     ary = []
-    t1 = d1.thread_create(:t1) do
+    d1.thread_create(:t1) do
       ary << 1
     end
-    t2 = d1.thread_create(:t2) do
+    d1.thread_create(:t2) do
       ary << 2
     end
-    t3 = d1.thread_create(:t3) do
+    d1.thread_create(:t3) do
       ary << 3
     end
     Timeout.timeout(10) do


### PR DESCRIPTION
In previous version about 2500 lines of warnings.
In this version about 1200 lines of warnings.

Remained warinigs:

* From ServerEngine about 400 lines
  * See https://github.com/fluent/serverengine/pull/47
* `Encoding.default_external`, `Encoding.default_internal` about 800 lines
* Some other warnings about 50 lines