### PR TITLE
Add optional arguments to #elements to select specified child elements

### DIFF
--- a/lib/fluent/agent.rb
+++ b/lib/fluent/agent.rb
@@ -53,7 +53,7 @@ module Fluent
       super
 
       # initialize <match> and <filter> elements
-      conf.elements.select { |e| e.name == 'filter' || e.name == 'match' }.each { |e|
+      conf.elements('filter', 'match').each { |e|
         pattern = e.arg.empty? ? '**' : e.arg
         type = e['@type'] || e['type']
         if e.name == 'filter'

--- a/lib/fluent/config/element.rb
+++ b/lib/fluent/config/element.rb
@@ -34,9 +34,23 @@ module Fluent
         @unused_in = false # if this element is not used in plugins, correspoing plugin name and parent element name is set, e.g. [source, plugin class].
       end
 
-      attr_accessor :name, :arg, :elements, :unused, :v1_config, :corresponding_proxies, :unused_in
+      attr_accessor :name, :arg, :unused, :v1_config, :corresponding_proxies, :unused_in
+      attr_writer :elements
 
-      def add_element(name, arg='')
+      def elements(*names, name: nil, arg: nil)
+        raise ArgumentError, "name and names are exclusive" if name && !names.empty?
+        raise ArgumentError, "arg is available only with name" if arg && !name
+
+        if name
+          @elements.select{|e| e.name == name && (!arg || e.arg == arg) }
+        elsif !names.empty?
+          @elements.select{|e| names.include?(e.name) }
+        else
+          @elements
+        end
+      end
+
+      def add_element(name, arg = '')
         e = Element.new(name, arg, {}, [])
         e.v1_config = @v1_config
         @elements << e
@@ -63,6 +77,7 @@ module Fluent
         e
       end
 
+      # no code in fluentd uses this method
       def each_element(*names, &block)
         if names.empty?
           @elements.each(&block)

--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -163,7 +163,7 @@ module Fluent
           raise "BUG: output plugin must implement some methods. see developer documents."
         end
 
-        has_buffer_section = (conf.elements.select{|e| e.name == 'buffer' }.size > 0)
+        has_buffer_section = (conf.elements(name: 'buffer').size > 0)
 
         super
 
@@ -225,7 +225,7 @@ module Fluent
           end
 
           buffer_type = @buffer_config[:@type]
-          buffer_conf = conf.elements.select{|e| e.name == 'buffer' }.first || Fluent::Config::Element.new('buffer', '', {}, [])
+          buffer_conf = conf.elements(name: 'buffer').first || Fluent::Config::Element.new('buffer', '', {}, [])
           @buffer = Plugin.new_buffer(buffer_type, parent: self)
           @buffer.configure(buffer_conf)
 
@@ -250,7 +250,7 @@ module Fluent
           raise Fluent::ConfigError, "<secondary> section and 'retry_forever' are exclusive" if @buffer_config.retry_forever
 
           secondary_type = @secondary_config[:@type]
-          secondary_conf = conf.elements.select{|e| e.name == 'secondary' }.first
+          secondary_conf = conf.elements(name: 'secondary').first
           @secondary = Plugin.new_output(secondary_type)
           @secondary.acts_as_secondary(self)
           @secondary.configure(secondary_conf)

--- a/lib/fluent/plugin_helper/storage.rb
+++ b/lib/fluent/plugin_helper/storage.rb
@@ -95,7 +95,7 @@ module Fluent
           if @_storages[section.usage]
             raise Fluent::ConfigError, "duplicated storages configured: #{section.usage}"
           end
-          config = conf.elements.select{|e| e.name == 'storage' && e.arg == section.usage }.first
+          config = conf.elements(name: 'storage', arg: section.usage).first
           raise "storage section with argument '#{section.usage}' not found. it may be a bug." unless config
 
           storage = Plugin.new_storage(section[:@type])

--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -69,7 +69,7 @@ module Fluent
 
       # initialize <label> elements before configuring all plugins to avoid 'label not found' in input, filter and output.
       label_configs = {}
-      conf.elements.select { |e| e.name == 'label' }.each { |e|
+      conf.elements(name: 'label').each { |e|
         name = e.arg
         raise ConfigError, "Missing symbol argument on <label> directive" if name.empty?
 
@@ -90,7 +90,7 @@ module Fluent
       if @without_source
         log.info "'--without-source' is applied. Ignore <source> sections"
       else
-        conf.elements.select { |e| e.name == 'source' }.each { |e|
+        conf.elements(name: 'source').each { |e|
           type = e['@type'] || e['type']
           raise ConfigError, "Missing 'type' parameter on <source> directive" unless type
           add_source(type, e)

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -39,9 +39,7 @@ module Fluent
     end
 
     def self.create(conf)
-      systems = conf.elements.select { |e|
-        e.name == 'system'
-      }
+      systems = conf.elements(name: 'system')
       return SystemConfig.new if systems.empty?
       raise Fluent::ConfigError, "<system> is duplicated. <system> should be only one" if systems.size > 1
 

--- a/test/config/test_element.rb
+++ b/test/config/test_element.rb
@@ -1,0 +1,66 @@
+require 'helper'
+require 'fluent/config/element'
+
+class TestConfigElement < ::Test::Unit::TestCase
+  def element(name = 'ROOT', arg = '', attrs = {}, elements = [])
+    Fluent::Config::Element.new(name, arg, attrs, elements)
+  end
+
+  sub_test_case 'Most test' do
+    test 'should be written' do
+      pend 'TODO'
+    end
+  end
+
+  sub_test_case '#elements=' do
+    test 'elements can be set by others' do
+      e = element()
+      assert_equal [], e.elements
+
+      e1 = element('e1')
+      e2 = element('e2')
+      e.elements = [e1, e2]
+      assert_equal [e1, e2], e.elements
+    end
+  end
+
+  sub_test_case '#elements' do
+    setup do
+      @c1 = element('source')
+      @c2 = element('source', 'yay')
+      @c3 = element('match', 'test.**')
+      @c4 = element('label', '@mytest', {}, [ element('filter', '**'), element('match', '**') ])
+      children = [@c1, @c2, @c3, @c4]
+      @e = Fluent::Config::Element.new('ROOT', '', {}, children)
+    end
+
+    test 'returns all elements without arguments' do
+      assert_equal [@c1, @c2, @c3, @c4], @e.elements
+    end
+
+    test 'returns elements with specified names' do
+      assert_equal [@c1, @c2, @c3], @e.elements('source', 'match')
+      assert_equal [@c3, @c4], @e.elements('match', 'label')
+    end
+
+    test 'returns elements with specified name, and arg if specified' do
+      assert_equal [@c1, @c2], @e.elements(name: 'source')
+      assert_equal [@c2], @e.elements(name: 'source', arg: 'yay')
+    end
+
+    test 'keyword argument name/arg and names are exclusive' do
+      assert_raise ArgumentError do
+        @e.elements('source', name: 'match')
+      end
+      assert_raise ArgumentError do
+        @e.elements('source', 'match', name: 'label', arg: '@mytest')
+      end
+    end
+
+    test 'specifying only arg without name is invalid' do
+      assert_raise ArgumentError do
+        @e.elements(arg: '@mytest')
+      end
+    end
+  end
+end


### PR DESCRIPTION
There are too many `conf.elements.select{|e| e.name == ... }`.