### PR TITLE
[#360] Add include support for Ruby DSL

### DIFF
--- a/lib/fluent/config/dsl.rb
+++ b/lib/fluent/config/dsl.rb
@@ -106,7 +106,7 @@ module Fluent
           if args.first =~ /\.rb$/
             path = File.expand_path(args.first)
             data = File.read(path)
-            self.instance_eval(data, @proxy.include_basepath)
+            self.instance_eval(data, path)
           else
             ss = StringScanner.new('')
             Config::V1Parser.new(ss, @proxy.include_basepath, '', nil).eval_include(@attrs, @elements, args.first)

--- a/lib/fluent/config/dsl.rb
+++ b/lib/fluent/config/dsl.rb
@@ -35,12 +35,17 @@ module Fluent
       end
 
       class Proxy
-        def initialize(name, arg)
+        def initialize(name, arg, include_basepath = Dir.pwd)
           @element = Element.new(name, arg, self)
+          @include_basepath = include_basepath
         end
 
         def element
           @element
+        end
+
+        def include_basepath
+          @include_basepath
         end
 
         def eval(source, source_path)
@@ -94,6 +99,18 @@ module Fluent
           end
 
           self
+        end
+
+        def include(*args)
+          ::Kernel.raise ::ArgumentError, "#{name} block requires arguments for include path" if args.nil? || args.size != 1
+          if args.first =~ /\.rb$/
+            path = File.expand_path(args.first)
+            data = File.read(path)
+            self.instance_eval(data, @proxy.include_basepath)
+          else
+            ss = StringScanner.new('')
+            Config::V1Parser.new(ss, @proxy.include_basepath, '', nil).eval_include(@attrs, @elements, args.first)
+          end
         end
 
         def source(&block)

--- a/lib/fluent/config/v1_parser.rb
+++ b/lib/fluent/config/v1_parser.rb
@@ -148,14 +148,15 @@ module Fluent
 
       def eval_include(attrs, elems, uri)
         u = URI.parse(uri)
-        if u.scheme == 'file' || u.path == uri  # file path
+        if u.scheme == 'file' || (!u.scheme.nil? && u.scheme.length == 1) || u.path == uri # file path
+          # When the Windows absolute path then u.scheme.length == 1
+          # e.g. C:
           path = u.path
           if path[0] != ?/
             pattern = File.expand_path("#{@include_basepath}/#{path}")
           else
             pattern = path
           end
-
           Dir.glob(pattern).sort.each { |entry|
             basepath = File.dirname(entry)
             fname = File.basename(entry)

--- a/test/config/test_dsl.rb
+++ b/test/config/test_dsl.rb
@@ -2,6 +2,66 @@ require_relative '../helper'
 require 'fluent/config/element'
 require "fluent/config/dsl"
 
+TMP_DIR = File.dirname(__FILE__) + "/tmp/config_dsl#{ENV['TEST_ENV_NUMBER']}"
+def write_config(path, data)
+  FileUtils.mkdir_p(File.dirname(path))
+  File.open(path, "w") {|f| f.write data }
+end
+
+def prepare_config1
+  write_config "#{TMP_DIR}/config_test_1.conf", %[
+  k1 root_config
+  include dir/config_test_2.conf  #
+  @include #{TMP_DIR}/config_test_4.conf
+  include file://#{TMP_DIR}/config_test_5.conf
+  @include config.d/*.conf
+]
+  write_config "#{TMP_DIR}/dir/config_test_2.conf", %[
+  k2 relative_path_include
+  @include ../config_test_3.conf
+]
+  write_config "#{TMP_DIR}/config_test_3.conf", %[
+  k3 relative_include_in_included_file
+]
+  write_config "#{TMP_DIR}/config_test_4.conf", %[
+  k4 absolute_path_include
+]
+  write_config "#{TMP_DIR}/config_test_5.conf", %[
+  k5 uri_include
+]
+  write_config "#{TMP_DIR}/config.d/config_test_6.conf", %[
+  k6 wildcard_include_1
+  <elem1 name>
+    include normal_parameter
+  </elem1>
+]
+  write_config "#{TMP_DIR}/config.d/config_test_7.conf", %[
+  k7 wildcard_include_2
+]
+  write_config "#{TMP_DIR}/config.d/config_test_8.conf", %[
+  <elem2 name>
+    @include ../dir/config_test_9.conf
+  </elem2>
+]
+  write_config "#{TMP_DIR}/dir/config_test_9.conf", %[
+  k9 embeded
+  <elem3 name>
+    nested nested_value
+    include hoge
+  </elem3>
+]
+  write_config "#{TMP_DIR}/config.d/00_config_test_8.conf", %[
+  k8 wildcard_include_3
+  <elem4 name>
+    include normal_parameter
+  </elem4>
+]
+end
+
+def prepare_config2
+  write_config "#{TMP_DIR}/config_test_1.rb", DSL_CONFIG_EXAMPLE
+end
+
 DSL_CONFIG_EXAMPLE = %q[
 worker {
   hostname = "myhostname"
@@ -57,6 +117,14 @@ source {
 }
 ]
 
+DSL_CONFIG_EXAMPLE_FOR_INCLUDE_CONF = %q[
+include "#{TMP_DIR}/config_test_1.conf"
+]
+
+DSL_CONFIG_EXAMPLE_FOR_INCLUDE_RB = %q[
+include "#{TMP_DIR}/config_test_1.rb"
+]
+
 DSL_CONFIG_RETURNS_NON_ELEMENT = %q[
 worker {
 }
@@ -73,6 +141,9 @@ match('aa','bb'){
 ]
 DSL_CONFIG_WRONG_SYNTAX3 = %q[
 match('aa','bb')
+]
+DSL_CONFIG_WRONG_SYNTAX4 = %q[
+include
 ]
 
 module Fluent::Config
@@ -158,6 +229,112 @@ module Fluent::Config
       end
     end
 
+    sub_test_case 'with include conf' do
+      def setup
+        prepare_config1
+        @root = Fluent::Config::DSL::Parser.parse(DSL_CONFIG_EXAMPLE_FOR_INCLUDE_CONF, 'dsl_config_for_include.conf')
+      end
+      test 'include config' do
+        assert_equal('root_config', @root['k1'])
+        assert_equal('relative_path_include', @root['k2'])
+        assert_equal('relative_include_in_included_file', @root['k3'])
+        assert_equal('absolute_path_include', @root['k4'])
+        assert_equal('uri_include', @root['k5'])
+        assert_equal('wildcard_include_1', @root['k6'])
+        assert_equal('wildcard_include_2', @root['k7'])
+        assert_equal('wildcard_include_3', @root['k8'])
+        assert_equal([
+            'k1',
+            'k2',
+            'k3',
+            'k4',
+            'k5',
+            'k8', # Because of the file name this comes first.
+            'k6',
+            'k7',
+          ], @root.keys)
+
+        elem1 = @root.elements.find { |e| e.name == 'elem1' }
+        assert(elem1)
+        assert_equal('name', elem1.arg)
+        assert_equal('normal_parameter', elem1['include'])
+
+        elem2 = @root.elements.find { |e| e.name == 'elem2' }
+        assert(elem2)
+        assert_equal('name', elem2.arg)
+        assert_equal('embeded', elem2['k9'])
+        assert_not_include(elem2, 'include')
+
+        elem3 = elem2.elements.find { |e| e.name == 'elem3' }
+        assert(elem3)
+        assert_equal('nested_value', elem3['nested'])
+        assert_equal('hoge', elem3['include'])
+      end
+
+      # TODO: Add uri based include spec
+    end
+
+    sub_test_case 'with include rb' do
+      def setup
+        prepare_config2
+        @root = Fluent::Config::DSL::Parser.parse(DSL_CONFIG_EXAMPLE_FOR_INCLUDE_RB, 'dsl_config_for_include.rb')
+      end
+      sub_test_case '.parse' do
+        test 'makes root element' do
+          assert_equal('ROOT', @root.name)
+          assert_predicate(@root.arg, :empty?)
+          assert_equal(0, @root.keys.size)
+        end
+
+        test 'makes worker element for worker tag' do
+          assert_equal(1, @root.elements.size)
+
+          worker = @root.elements.first
+          assert_equal('worker', worker.name)
+          assert_predicate(worker.arg, :empty?)
+          assert_equal(0, worker.keys.size)
+          assert_equal(10, worker.elements.size)
+        end
+
+        test 'makes subsections for blocks, with variable substitution' do
+          ele4 = @root.elements.first.elements[4]
+
+          assert_equal('source', ele4.name)
+          assert_predicate(ele4.arg, :empty?)
+          assert_equal(2, ele4.keys.size)
+          assert_equal('tail', ele4['type'])
+          assert_equal("/var/log/httpd/access.part4.log", ele4['path'])
+        end
+
+        test 'makes user-defined sections with blocks' do
+          filter0 = @root.elements.first.elements[4].elements.first
+
+          assert_equal('filter', filter0.name)
+          assert_equal('bar.**', filter0.arg)
+          assert_equal('hoge', filter0['type'])
+          assert_equal('moge', filter0['val1'])
+          assert_equal(JSON.dump(['foo', 'bar', 'baz']), filter0['val2'])
+          assert_equal('10', filter0['val3'])
+          assert_equal('hoge', filter0['id'])
+
+          assert_equal(2, filter0.elements.size)
+          assert_equal('subsection', filter0.elements[0].name)
+          assert_equal('bar', filter0.elements[0]['foo'])
+          assert_equal('subsection', filter0.elements[1].name)
+          assert_equal('baz', filter0.elements[1]['foo'])
+        end
+
+        test 'makes values with user-assigned variable substitutions' do
+          match0 = @root.elements.first.elements[4].elements.last
+
+          assert_equal('match', match0.name)
+          assert_equal('{foo,bar}.**', match0.arg)
+          assert_equal('file', match0['type'])
+          assert_equal('/var/log/httpd/access.myhostname.4.log', match0['path'])
+        end
+      end
+    end
+
     sub_test_case 'with configuration that returns non element on top' do
       sub_test_case '.parse' do
         test 'does not crash' do
@@ -170,8 +347,9 @@ module Fluent::Config
       sub_test_case '.parse' do
         test 'raises ArgumentError correctly' do
           assert_raise(ArgumentError) { Fluent::Config::DSL::Parser.parse(DSL_CONFIG_WRONG_SYNTAX1, 'dsl_config_wrong_syntax1') }
-          assert_raise(ArgumentError) { Fluent::Config::DSL::Parser.parse(DSL_CONFIG_WRONG_SYNTAX2, 'dsl_config_wrong_syntax1') }
-          assert_raise(ArgumentError) { Fluent::Config::DSL::Parser.parse(DSL_CONFIG_WRONG_SYNTAX3, 'dsl_config_wrong_syntax1') }
+          assert_raise(ArgumentError) { Fluent::Config::DSL::Parser.parse(DSL_CONFIG_WRONG_SYNTAX2, 'dsl_config_wrong_syntax2') }
+          assert_raise(ArgumentError) { Fluent::Config::DSL::Parser.parse(DSL_CONFIG_WRONG_SYNTAX3, 'dsl_config_wrong_syntax3') }
+          assert_raise(ArgumentError) { Fluent::Config::DSL::Parser.parse(DSL_CONFIG_WRONG_SYNTAX4, 'dsl_config_wrong_syntax4') }
         end
       end
     end


### PR DESCRIPTION
This PR add include support for Ruby DSL.
And Fix bug parser include at the Windows.
Like this conditions
- First conf include absolute path
- Second(child) conf include relative path

Because `URI.parse` return `u.scheme = c`.
When Windows absolute path is `C:/projects/fluentd/test/tmp/config`.
Then used `open-uri` and basepath change `/`.

But after merge this PR.
There is a bug.
When It has some drives In the Windows.
Like a C: and D:
And upper case.
I think it is rare case.
If you need fix this bug.
Please make issue.