### PR TITLE
add error class definition which is used but not defined yet

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -30,6 +30,9 @@ module Fluent
   class ForwardOutputResponseError < ForwardOutputError
   end
 
+  class ForwardOutputConnectionClosedError < ForwardOutputError
+  end
+
   class ForwardOutputACKTimeoutError < ForwardOutputResponseError
   end
 


### PR DESCRIPTION
This is extracted from #942.
