### PR TITLE
Suppress encoding related warnings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,7 @@ Rake::TestTask.new(:base_test) do |t|
   t.test_files = Dir["test/**/test_*.rb"].sort
   t.verbose = false
   t.warning = false
+  t.ruby_opts = ["-Eascii-8bit:ascii-8bit"]
 end
 
 task :parallel_test do

--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -57,10 +57,6 @@ module Fluent
       @system_config = system_config
 
       BasicSocket.do_not_reverse_lookup = true
-      if defined?(Encoding)
-        Encoding.default_internal = 'ASCII-8BIT' if Encoding.respond_to?(:default_internal)
-        Encoding.default_external = 'ASCII-8BIT' if Encoding.respond_to?(:default_external)
-      end
 
       suppress_interval(system_config.emit_error_log_interval) unless system_config.emit_error_log_interval.nil?
       @suppress_config_dump = system_config.suppress_config_dump unless system_config.suppress_config_dump.nil?

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -421,12 +421,14 @@ module Fluent
       $log.info "starting fluentd-#{Fluent::VERSION}"
 
       if Fluent.windows?
-        fluentd_spawn_cmd = ServerEngine.ruby_bin_path + ' "' + $0.gsub('"', '""') + '" '
+        fluentd_spawn_cmd = ServerEngine.ruby_bin_path + " -Eascii-8bit:ascii-8bit "
+        fluentd_spawn_cmd << ' "' + $0.gsub('"', '""') + '" '
         $fluentdargv.each{|a|
           fluentd_spawn_cmd << ('"' + a.gsub('"', '""') + '" ')
         }
       else
-        fluentd_spawn_cmd = $0.shellescape + ' '
+        fluentd_spawn_cmd = ServerEngine.ruby_bin_path + " -Eascii-8bit:ascii-8bit "
+        fluentd_spawn_cmd << $0.shellescape + ' '
         $fluentdargv.each{|a|
           fluentd_spawn_cmd << (a.shellescape + " ")
         }


### PR DESCRIPTION
This change suppresses warning messages about 800 lines on CI.

```
lib/fluent/engine.rb:61: warning: setting Encoding.default_internal
lib/fluent/engine.rb:62: warning: setting Encoding.default_external
(about 400 times repeat)
lib/fluent/engine.rb:61: warning: setting Encoding.default_internal
lib/fluent/engine.rb:62: warning: setting Encoding.default_external
```