### PR TITLE
Add support for emit_config to in_monitor_agent

### DIFF
--- a/lib/fluent/plugin/in_monitor_agent.rb
+++ b/lib/fluent/plugin/in_monitor_agent.rb
@@ -32,6 +32,7 @@ module Fluent
     config_param :port, :integer, default: 24220
     config_param :tag, :string, default: nil
     config_param :emit_interval, :time, default: 60
+    config_param :emit_config, :bool, default: false
 
     class MonitorServlet < WEBrick::HTTPServlet::AbstractServlet
       def initialize(server, agent)
@@ -253,7 +254,7 @@ module Fluent
         log.debug "tag parameter is specified. Emit plugins info to '#{@tag}'"
 
         @loop = Coolio::Loop.new
-        opts = {with_config: false}
+        opts = {with_config: @emit_config}
         timer = TimerWatcher.new(@emit_interval, log) {
           es = MultiEventStream.new
           now = Engine.now


### PR DESCRIPTION
We want to monitor the health of our output plugins. To do so, we want to compare the current buffer_queue_length with the configured buffer_queue_limit. With the current implementation, in_monitor_agent only emits the first. Adding support for the second.

I could not find any tests for this plugin.