### PR TITLE
Fix lifecycle control

### DIFF
--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -46,6 +46,8 @@ module Fluent
       @system_config = SystemConfig.new
     end
 
+    MAINLOOP_SLEEP_INTERVAL = 0.3
+
     MATCH_CACHE_SIZE = 1024
     LOG_EMIT_INTERVAL = 0.1
 
@@ -177,18 +179,7 @@ module Fluent
           @log_emit_thread = Thread.new(&method(:log_event_loop))
         end
 
-        unless @engine_stopped
-          # for empty loop
-          @default_loop = Coolio::Loop.default
-          @default_loop.attach Coolio::TimerWatcher.new(1, true)
-          # TODO attach async watch for thread pool
-          @default_loop.run
-        end
-
-        if @engine_stopped and @default_loop
-          @default_loop.stop
-          @default_loop = nil
-        end
+        sleep MAINLOOP_SLEEP_INTERVAL until @engine_stopped
 
       rescue Exception => e
         $log.error "unexpected error", error: e
@@ -206,10 +197,6 @@ module Fluent
 
     def stop
       @engine_stopped = true
-      if @default_loop
-        @default_loop.stop
-        @default_loop = nil
-      end
       nil
     end
 

--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -190,16 +190,17 @@ module Fluent
           @default_loop = nil
         end
 
-      rescue => e
+      rescue Exception => e
         $log.error "unexpected error", error: e
         $log.error_backtrace
-      ensure
-        $log.info "shutting down fluentd"
-        shutdown
-        if @log_emit_thread
-          @log_event_loop_stop = true
-          @log_emit_thread.join
-        end
+        raise
+      end
+
+      $log.info "shutting down fluentd"
+      shutdown
+      if @log_emit_thread
+        @log_event_loop_stop = true
+        @log_emit_thread.join
       end
     end
 

--- a/lib/fluent/plugin/in_debug_agent.rb
+++ b/lib/fluent/plugin/in_debug_agent.rb
@@ -42,6 +42,8 @@ module Fluent
     end
 
     def start
+      super
+
       if @unix_path
         require 'drb/unix'
         uri = "drbunix:#{@unix_path}"
@@ -55,6 +57,8 @@ module Fluent
 
     def shutdown
       @server.stop_service if @server
+
+      super
     end
   end
 end

--- a/lib/fluent/plugin/in_dummy.rb
+++ b/lib/fluent/plugin/in_dummy.rb
@@ -64,6 +64,7 @@ module Fluent
     def shutdown
       @running = false
       @thread.join
+      super
     end
 
     def run

--- a/lib/fluent/plugin/in_exec.rb
+++ b/lib/fluent/plugin/in_exec.rb
@@ -103,6 +103,8 @@ module Fluent
     end
 
     def start
+      super
+
       if @run_interval
         @finished = false
         @thread = Thread.new(&method(:run_periodic))
@@ -134,6 +136,8 @@ module Fluent
         end
         @thread.join
       end
+
+      super
     end
 
     def run

--- a/lib/fluent/plugin/in_forward.rb
+++ b/lib/fluent/plugin/in_forward.rb
@@ -55,6 +55,8 @@ module Fluent
     end
 
     def start
+      super
+
       @loop = Coolio::Loop.new
 
       socket_manager_path = ENV['SERVERENGINE_SOCKETMANAGER_PATH']
@@ -89,6 +91,8 @@ module Fluent
       @usock.close
       @thread.join
       @lsock.close
+
+      super
     end
 
     def listen(client)

--- a/lib/fluent/plugin/in_gc_stat.rb
+++ b/lib/fluent/plugin/in_gc_stat.rb
@@ -50,6 +50,8 @@ module Fluent
     end
 
     def start
+      super
+
       @loop = Coolio::Loop.new
       @timer = TimerWatcher.new(@emit_interval, true, log, &method(:on_timer))
       @loop.attach(@timer)
@@ -60,6 +62,8 @@ module Fluent
       @loop.watchers.each {|w| w.detach }
       @loop.stop
       @thread.join
+
+      super
     end
 
     def run

--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -112,7 +112,6 @@ module Fluent
       detach_multi_process do
         super
         @km = KeepaliveManager.new(@keepalive_timeout)
-        #@lsock = Coolio::TCPServer.new(@bind, @port, Handler, @km, method(:on_request), @body_size_limit)
         @lsock = Coolio::TCPServer.new(lsock, nil, Handler, @km, method(:on_request),
                                        @body_size_limit, @format, log,
                                        @cors_allow_origins)
@@ -131,6 +130,8 @@ module Fluent
       @loop.stop
       @lsock.close
       @thread.join
+
+      super
     end
 
     def run

--- a/lib/fluent/plugin/in_monitor_agent.rb
+++ b/lib/fluent/plugin/in_monitor_agent.rb
@@ -235,6 +235,8 @@ module Fluent
     end
 
     def start
+      super
+
       log.debug "listening monitoring http server on http://#{@bind}:#{@port}/api/plugins"
       @srv = WEBrick::HTTPServer.new({
           BindAddress: @bind,
@@ -290,6 +292,8 @@ module Fluent
         @thread_for_emit.join
         @thread_for_emit = nil
       end
+
+      super
     end
 
     MONITOR_INFO = {

--- a/lib/fluent/plugin/in_object_space.rb
+++ b/lib/fluent/plugin/in_object_space.rb
@@ -52,6 +52,8 @@ module Fluent
     end
 
     def start
+      super
+
       @loop = Coolio::Loop.new
       @timer = TimerWatcher.new(@emit_interval, true, log, &method(:on_timer))
       @loop.attach(@timer)
@@ -62,6 +64,8 @@ module Fluent
       @loop.watchers.each {|w| w.detach }
       @loop.stop
       @thread.join
+
+      super
     end
 
     def run

--- a/lib/fluent/plugin/in_stream.rb
+++ b/lib/fluent/plugin/in_stream.rb
@@ -35,6 +35,8 @@ module Fluent
     end
 
     def start
+      super
+
       @loop = Coolio::Loop.new
       @lsock = listen
       @loop.attach(@lsock)
@@ -46,6 +48,8 @@ module Fluent
       @loop.stop
       @lsock.close
       @thread.join
+
+      super
     end
 
     #def listen

--- a/lib/fluent/plugin/in_syslog.rb
+++ b/lib/fluent/plugin/in_syslog.rb
@@ -110,6 +110,8 @@ module Fluent
     end
 
     def start
+      super
+
       callback = if @use_default
                    method(:receive_data)
                  else
@@ -128,6 +130,8 @@ module Fluent
       @loop.stop
       @handler.close
       @thread.join
+
+      super
     end
 
     def run

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -118,6 +118,8 @@ module Fluent
     end
 
     def start
+      super
+
       if @pos_file
         @pf_file = File.open(@pos_file, File::RDWR|File::CREAT|File::BINARY, @file_perm)
         @pf_file.sync = true
@@ -139,6 +141,8 @@ module Fluent
       @loop.stop rescue nil # when all watchers are detached, `stop` raises RuntimeError. We can ignore this exception.
       @thread.join
       @pf_file.close if @pf_file
+
+      super
     end
 
     def expand_paths

--- a/lib/fluent/plugin/out_copy.rb
+++ b/lib/fluent/plugin/out_copy.rb
@@ -51,15 +51,19 @@ module Fluent
     end
 
     def start
-      @outputs.each {|o|
-        o.start
-      }
+      super
+
+      @outputs.each do |o|
+        o.start unless o.started?
+      end
     end
 
     def shutdown
-      @outputs.each {|o|
-        o.shutdown
-      }
+      @outputs.each do |o|
+        o.shutdown unless o.shutdown?
+      end
+
+      super
     end
 
     def emit(tag, es, chain)

--- a/lib/fluent/plugin/out_exec_filter.rb
+++ b/lib/fluent/plugin/out_exec_filter.rb
@@ -220,21 +220,22 @@ module Fluent
     end
 
     def before_shutdown
-      super
       log.debug "out_exec_filter#before_shutdown called"
       @children.each {|c|
         c.finished = true
       }
       sleep 0.5  # TODO wait time before killing child process
+
+      super
     end
 
     def shutdown
-      super
-
       @children.reject! {|c|
         c.shutdown
         true
       }
+
+      super
     end
 
     def format_stream(tag, es)

--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -193,6 +193,8 @@ module Fluent
       end
       @thread.join if @thread
       @usock.close if @usock
+
+      super
     end
 
     def run

--- a/lib/fluent/plugin/out_null.rb
+++ b/lib/fluent/plugin/out_null.rb
@@ -20,20 +20,6 @@ module Fluent
   class NullOutput < Output
     Plugin.register_output('null', self)
 
-    def initialize
-      super
-    end
-
-    def configure(conf)
-      super
-    end
-
-    def start
-    end
-
-    def shutdown
-    end
-
     def emit(tag, es, chain)
       chain.next
     end

--- a/lib/fluent/plugin/out_roundrobin.rb
+++ b/lib/fluent/plugin/out_roundrobin.rb
@@ -57,17 +57,21 @@ module Fluent
     end
 
     def start
+      super
+
       rebuild_weight_array
 
-      @outputs.each {|o|
-        o.start
-      }
+      @outputs.each do |o|
+        o.start unless o.started?
+      end
     end
 
     def shutdown
-      @outputs.each {|o|
-        o.shutdown
-      }
+      @outputs.each do |o|
+        o.shutdown unless o.shutdown?
+      end
+
+      super
     end
 
     def emit(tag, es, chain)

--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -360,13 +360,13 @@ module Fluent
       end
 
       def stop
-        super
         @secondary.stop if @secondary
         @buffer.stop if @buffering && @buffer
+
+        super
       end
 
       def before_shutdown
-        super
         @secondary.before_shutdown if @secondary
 
         if @buffering && @buffer
@@ -375,16 +375,18 @@ module Fluent
           end
           @buffer.before_shutdown
         end
+
+        super
       end
 
       def shutdown
-        super
         @secondary.shutdown if @secondary
         @buffer.shutdown if @buffering && @buffer
+
+        super
       end
 
       def after_shutdown
-        super
         try_rollback_all if @buffering && !@as_secondary # rollback regardless with @delayed_commit, because secondary may do it
         @secondary.after_shutdown if @secondary
 
@@ -399,18 +401,22 @@ module Fluent
             state.thread.join
           end
         end
+
+        super
       end
 
       def close
-        super
         @buffer.close if @buffering && @buffer
         @secondary.close if @secondary
+
+        super
       end
 
       def terminate
-        super
         @buffer.terminate if @buffering && @buffer
         @secondary.terminate if @secondary
+
+        super
       end
 
       def support_in_v12_style?(feature)

--- a/lib/fluent/plugin/socket_util.rb
+++ b/lib/fluent/plugin/socket_util.rb
@@ -118,6 +118,8 @@ module Fluent
       end
 
       def start
+        super
+
         @loop = Coolio::Loop.new
         @handler = listen(method(:on_message))
         @loop.attach(@handler)
@@ -129,6 +131,8 @@ module Fluent
         @loop.stop if @loop.instance_variable_get("@running")
         @handler.close
         @thread.join
+
+        super
       end
 
       def run

--- a/lib/fluent/plugin_helper/thread.rb
+++ b/lib/fluent/plugin_helper/thread.rb
@@ -59,13 +59,13 @@ module Fluent
           begin
             yield
             thread_exit = true
-          rescue => e
+          rescue Exception => e
             log.warn "thread exited by unexpected error", plugin: self.class, title: title, error: e
             thread_exit = true
             raise
           ensure
             unless thread_exit
-              log.warn "thread doesn't exit correctly (killed or other reason)", plugin: self.class, title: title
+              log.warn "thread doesn't exit correctly (killed or other reason)", plugin: self.class, title: title, error: $!
             end
             @_threads_mutex.synchronize do
               @_threads.delete(::Thread.current.object_id)

--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -132,7 +132,7 @@ module Fluent
 
     def start
       lifecycle(desc: true) do |i| # instance
-        i.start
+        i.start unless i.started?
       end
     end
 
@@ -157,19 +157,19 @@ module Fluent
     end
 
     def shutdown # Fluentd's shutdown sequence is stop, before_shutdown, shutdown, after_shutdown, close, terminate for plugins
-      lifecycle_safe_sequence = ->(method) {
+      lifecycle_safe_sequence = ->(method, checker) {
         lifecycle do |instance, kind|
           begin
             log.debug "calling #{method} on #{kind} plugin", type: Plugin.lookup_type_from_class(instance.class), plugin_id: instance.plugin_id
-            instance.send(method)
-          rescue => e
+            instance.send(method) unless instance.send(checker)
+          rescue Exception => e
             log.warn "unexpected error while calling #{method} on #{kind} plugin", pluguin: instance.class, plugin_id: instance.plugin_id, error: e
             log.warn_backtrace
           end
         end
       }
 
-      lifecycle_unsafe_sequence = ->(method) {
+      lifecycle_unsafe_sequence = ->(method, checker) {
         operation = case method
                     when :shutdown then "shutting down"
                     when :close    then "closing"
@@ -182,9 +182,9 @@ module Fluent
             Thread.current.abort_on_exception = true
             begin
               log.info "#{operation} #{kind} plugin", type: Plugin.lookup_type_from_class(instance.class), plugin_id: instance.plugin_id
-              instance.send(method)
-            rescue => e
-              log.warn "unexpected error while #{operation} #{kind} plugin", plugin: instance.class, plugin_id: instance.plugin_id, error: e
+              instance.send(method) unless instance.send(checker)
+            rescue Exception => e
+              log.warn "unexpected error while #{operation} on #{kind} plugin", plugin: instance.class, plugin_id: instance.plugin_id, error: e
               log.warn_backtrace
             end
           end
@@ -193,17 +193,17 @@ module Fluent
         operation_threads.each{|t| t.join }
       }
 
-      lifecycle_safe_sequence.call(:stop)
+      lifecycle_safe_sequence.call(:stop, :stopped?)
 
-      lifecycle_safe_sequence.call(:before_shutdown)
+      lifecycle_safe_sequence.call(:before_shutdown, :before_shutdown?)
 
-      lifecycle_unsafe_sequence.call(:shutdown)
+      lifecycle_unsafe_sequence.call(:shutdown, :shutdown?)
 
-      lifecycle_safe_sequence.call(:after_shutdown)
+      lifecycle_safe_sequence.call(:after_shutdown, :after_shutdown?)
 
-      lifecycle_unsafe_sequence.call(:close)
+      lifecycle_unsafe_sequence.call(:close, :closed?)
 
-      lifecycle_safe_sequence.call(:terminate)
+      lifecycle_safe_sequence.call(:terminate, :terminated?)
     end
 
     def suppress_interval(interval_time)

--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -157,6 +157,10 @@ module Fluent
     end
 
     def shutdown # Fluentd's shutdown sequence is stop, before_shutdown, shutdown, after_shutdown, close, terminate for plugins
+      # Thesee method callers does `rescue Exception` to call methods of shutdown sequence as far as possible
+      # if plugin methods does something like infinite recursive call, `exit`, unregistering signal handlers or others.
+      # Plugins should be separated and be in sandbox to protect data in each plugins/buffers.
+
       lifecycle_safe_sequence = ->(method, checker) {
         lifecycle do |instance, kind|
           begin


### PR DESCRIPTION
This change includes some changes and bug fixes about lifecycle of process and plugins.
* plugins should call `super` in `start` and `shutdown`
* plugins sometimes raise non-standard errors: these should be rescued and logged
* ServerEngine sends SIGTERM to stop worker process, but it wasn't rescued
  * `shutdown` was called in `ensure` clause, and it invokes shutdown sequence *unexpectedly*

This change also includes removing `default_loop` from Engine. It wasn't used in anywhere, so I simplified main loop by removing it.