### PR TITLE
Introduce v14 test drivers

### DIFF
--- a/lib/fluent/compat/output.rb
+++ b/lib/fluent/compat/output.rb
@@ -21,6 +21,8 @@ require 'fluent/compat/call_super_mixin'
 require 'fluent/compat/output_chain'
 require 'fluent/timezone'
 
+require 'fluent/plugin_helper/compat_parameters'
+
 require 'time'
 
 module Fluent
@@ -201,21 +203,7 @@ module Fluent
 
       config_param :flush_at_shutdown, :bool, default: true
 
-      PARAMS_MAP = {
-        "buffer_type" => "@type",
-        "buffer_path" => "path",
-        "num_threads"                 => "flush_threads",
-        "flush_interval"              => "flush_interval",
-        "try_flush_interval"          => "flush_thread_interval",
-        "queued_chunk_flush_interval" => "flush_burst_interval",
-        "disable_retry_limit" => "retry_forever",
-        "retry_limit"         => "retry_max_times",
-        "max_retry_wait"      => "retry_max_interval",
-        "buffer_chunk_limit"  => "chunk_bytes_limit",
-        "buffer_queue_limit"  => "queue_length_limit",
-        "buffer_queue_full_action" => "overflow_action",
-        "flush_at_shutdown" => "flush_at_shutdown",
-      }
+      PARAMS_MAP = Fluent::PluginHelper::CompatParameters::PARAMS_MAP
 
       def configure(conf)
         bufconf = CompatOutputUtils.buffer_section(conf)
@@ -226,6 +214,7 @@ module Fluent
             "retry_type" => "exponential_backoff",
           }
           PARAMS_MAP.each do |older, newer|
+            next unless newer
             buf_params[newer] = conf[older] if conf.has_key?(older)
           end
 
@@ -330,21 +319,7 @@ module Fluent
 
       config_set_default :time_as_integer, true
 
-      PARAMS_MAP = {
-        "buffer_type" => "@type",
-        "buffer_path" => "path",
-        "num_threads"                 => "flush_threads",
-        "flush_interval"              => "flush_interval",
-        "try_flush_interval"          => "flush_thread_interval",
-        "queued_chunk_flush_interval" => "flush_burst_interval",
-        "disable_retry_limit" => "retry_forever",
-        "retry_limit"         => "retry_max_times",
-        "max_retry_wait"      => "retry_max_interval",
-        "buffer_chunk_limit"  => "chunk_bytes_limit",
-        "buffer_queue_limit"  => "queue_length_limit",
-        "buffer_queue_full_action" => "overflow_action",
-        "flush_at_shutdown" => "flush_at_shutdown",
-      }
+      PARAMS_MAP = Fluent::PluginHelper::CompatParameters::PARAMS_MAP
 
       def configure(conf)
         bufconf = CompatOutputUtils.buffer_section(conf)
@@ -355,6 +330,7 @@ module Fluent
             "retry_type" => "exponential_backoff",
           }
           PARAMS_MAP.each do |older, newer|
+            next unless newer
             buf_params[newer] = conf[older] if conf.has_key?(older)
           end
 
@@ -450,22 +426,7 @@ module Fluent
         config_set_default :@type, 'file'
       end
 
-      PARAMS_MAP = {
-        "buffer_type" => "@type",
-        "buffer_path" => "path",
-        "num_threads"                 => "flush_threads",
-        "flush_interval"              => "flush_interval",
-        "try_flush_interval"          => "flush_thread_interval",
-        "queued_chunk_flush_interval" => "flush_burst_interval",
-        "disable_retry_limit" => "retry_forever",
-        "retry_limit"         => "retry_max_times",
-        "max_retry_wait"      => "retry_max_interval",
-        "buffer_chunk_limit"  => "chunk_bytes_limit",
-        "buffer_queue_limit"  => "queue_length_limit",
-        "buffer_queue_full_action" => "overflow_action",
-        "flush_at_shutdown" => "flush_at_shutdown",
-        "time_slice_wait" => "timekey_wait",
-      }
+      PARAMS_MAP = Fluent::PluginHelper::CompatParameters::PARAMS_MAP.merge(Fluent::PluginHelper::CompatParameters::TIME_SLICED_PARAMS)
 
       def initialize
         super
@@ -488,6 +449,7 @@ module Fluent
             "retry_type" => "exponential_backoff",
           }
           PARAMS_MAP.each do |older, newer|
+            next unless newer
             buf_params[newer] = conf[older] if conf.has_key?(older)
           end
           unless buf_params.has_key?("@type")

--- a/lib/fluent/config.rb
+++ b/lib/fluent/config.rb
@@ -20,18 +20,32 @@ require 'fluent/configurable'
 
 module Fluent
   module Config
-    def self.parse(str, fname, basepath = Dir.pwd, v1_config = false)
-      if fname =~ /\.rb$/
+    def self.parse(str, fname, basepath = Dir.pwd, v1_config = nil, syntax: :v1)
+      parser = if fname =~ /\.rb$/ || syntax == :ruby
+                 :ruby
+               elsif v1_config.nil?
+                 case syntax
+                 when :v1 then :v1
+                 when :v0 then :v0
+                 else
+                   raise ArgumentError, "Unknown Fluentd configuration syntax: '#{syntax}'"
+                 end
+               elsif v1_config then :v1
+               else :v0
+               end
+      case parser
+      when :v1
+        require 'fluent/config/v1_parser'
+        V1Parser.parse(str, fname, basepath, Kernel.binding)
+      when :v0
+        # TODO: show deprecated message in v1
+        require 'fluent/config/parser'
+        Parser.parse(str, fname, basepath)
+      when :ruby
         require 'fluent/config/dsl'
         Config::DSL::Parser.parse(str, File.join(basepath, fname))
       else
-        if v1_config
-          require 'fluent/config/v1_parser'
-          V1Parser.parse(str, fname, basepath, Kernel.binding)
-        else
-          require 'fluent/config/parser'
-          Parser.parse(str, fname, basepath)
-        end
+        raise "[BUG] unknown configuration parser specification:'#{parser}'"
       end
     end
 

--- a/lib/fluent/config/section.rb
+++ b/lib/fluent/config/section.rb
@@ -144,7 +144,7 @@ module Fluent
         check_unused_section(proxy, conf, plugin_class)
 
         proxy.sections.each do |name, subproxy|
-          varname = subproxy.param_name.to_sym
+          varname = subproxy.variable_name
           elements = (conf.respond_to?(:elements) ? conf.elements : []).select{ |e| e.name == subproxy.name.to_s || e.name == subproxy.alias.to_s }
           if elements.empty? && subproxy.init? && !subproxy.multi?
             elements << Fluent::Config::Element.new(subproxy.name.to_s, '', {}, [])

--- a/lib/fluent/configurable.rb
+++ b/lib/fluent/configurable.rb
@@ -41,9 +41,9 @@ module Fluent
         next if name.to_s.start_with?('@')
         subproxy = proxy.sections[name]
         if subproxy.multi?
-          instance_variable_set("@#{subproxy.param_name}".to_sym, [])
+          instance_variable_set("@#{subproxy.variable_name}".to_sym, [])
         else
-          instance_variable_set("@#{subproxy.param_name}".to_sym, nil)
+          instance_variable_set("@#{subproxy.variable_name}".to_sym, nil)
         end
       end
     end
@@ -145,7 +145,7 @@ module Fluent
 
       def config_section(name, **kwargs, &block)
         configure_proxy(self.name).config_section(name, **kwargs, &block)
-        attr_accessor configure_proxy(self.name).sections[name].param_name
+        attr_accessor configure_proxy(self.name).sections[name].variable_name
       end
 
       def desc(description)

--- a/lib/fluent/plugin/exec_util.rb
+++ b/lib/fluent/plugin/exec_util.rb
@@ -22,106 +22,111 @@ require 'fluent/plugin'
 require 'fluent/parser'
 
 module Fluent
-  module ExecUtil
-    SUPPORTED_FORMAT = {
-      'tsv' => :tsv,
-      'json' => :json,
-      'msgpack' => :msgpack,
-    }
+  module Plugin
+    module ExecUtil
+      SUPPORTED_FORMAT = {
+        'tsv' => :tsv,
+        'json' => :json,
+        'msgpack' => :msgpack,
+      }
 
-    class Parser
-      def initialize(on_message)
-        @on_message = on_message
-      end
-    end
-
-    class TextParserWrapperParser < Parser
-      def initialize(conf, on_message)
-        @parser = Plugin.new_parser(conf['format'])
-        @parser.configure(conf)
-        super(on_message)
-      end
-
-      def call(io)
-        io.each_line(&method(:each_line))
-      end
-
-      def each_line(line)
-        line.chomp!
-        @parser.parse(line) { |time, record|
-          @on_message.call(record, time)
-        }
-      end
-    end
-
-    class TSVParser < Parser
-      def initialize(keys, on_message)
-        @keys = keys
-        super(on_message)
-      end
-
-      def call(io)
-        io.each_line(&method(:each_line))
-      end
-
-      def each_line(line)
-        line.chomp!
-        vals = line.split("\t")
-
-        record = Hash[@keys.zip(vals)]
-
-        @on_message.call(record)
-      end
-    end
-
-    class JSONParser < Parser
-      def call(io)
-        y = Yajl::Parser.new
-        y.on_parse_complete = @on_message
-        y.parse(io)
-      end
-    end
-
-    class MessagePackParser < Parser
-      def call(io)
-        @u = Fluent::Engine.msgpack_factory.unpacker(io)
-        begin
-          @u.each(&@on_message)
-        rescue EOFError
+      class Parser
+        def initialize(on_message)
+          @on_message = on_message
         end
       end
-    end
 
-    class Formatter
-    end
-
-    class TSVFormatter < Formatter
-      def initialize(in_keys)
-        @in_keys = in_keys
-        super()
-      end
-
-      def call(record, out)
-        last = @in_keys.length-1
-        for i in 0..last
-          key = @in_keys[i]
-          out << record[key].to_s
-          out << "\t" if i != last
+      class TextParserWrapperParser < Parser
+        def initialize(conf, on_message)
+          @parser = Plugin.new_parser(conf['format'])
+          @parser.configure(conf)
+          super(on_message)
         end
-        out << "\n"
-      end
-    end
 
-    class JSONFormatter < Formatter
-      def call(record, out)
-        out << Yajl.dump(record) << "\n"
-      end
-    end
+        def call(io)
+          io.each_line(&method(:each_line))
+        end
 
-    class MessagePackFormatter < Formatter
-      def call(record, out)
-        record.to_msgpack(out)
+        def each_line(line)
+          line.chomp!
+          @parser.parse(line) { |time, record|
+            @on_message.call(record, time)
+          }
+        end
+      end
+
+      class TSVParser < Parser
+        def initialize(keys, on_message)
+          @keys = keys
+          super(on_message)
+        end
+
+        def call(io)
+          io.each_line(&method(:each_line))
+        end
+
+        def each_line(line)
+          line.chomp!
+          vals = line.split("\t")
+
+          record = Hash[@keys.zip(vals)]
+
+          @on_message.call(record)
+        end
+      end
+
+      class JSONParser < Parser
+        def call(io)
+          y = Yajl::Parser.new
+          y.on_parse_complete = @on_message
+          y.parse(io)
+        end
+      end
+
+      class MessagePackParser < Parser
+        def call(io)
+          @u = Fluent::Engine.msgpack_factory.unpacker(io)
+          begin
+            @u.each(&@on_message)
+          rescue EOFError
+          end
+        end
+      end
+
+      class Formatter
+      end
+
+      class TSVFormatter < Formatter
+        def initialize(in_keys)
+          @in_keys = in_keys
+          super()
+        end
+
+        def call(record, out)
+          last = @in_keys.length-1
+          for i in 0..last
+            key = @in_keys[i]
+            out << record[key].to_s
+            out << "\t" if i != last
+          end
+          out << "\n"
+        end
+      end
+
+      class JSONFormatter < Formatter
+        def call(record, out)
+          out << Yajl.dump(record) << "\n"
+        end
+      end
+
+      class MessagePackFormatter < Formatter
+        def call(record, out)
+          record.to_msgpack(out)
+        end
       end
     end
   end
+
+  # obsolete
+  ExecUtil = Fluent::Plugin::ExecUtil
 end

--- a/lib/fluent/plugin/file_util.rb
+++ b/lib/fluent/plugin/file_util.rb
@@ -15,38 +15,43 @@
 #
 
 module Fluent
-  module FileUtil
-    # Check file is writable if file exists
-    # Check directory is writable if file does not exist
-    #
-    # @param [String] path File path
-    # @return [Boolean] file is writable or not
-    def writable?(path)
-      return false if File.directory?(path)
-      return File.writable?(path) if File.exist?(path)
+  module Plugin
+    module FileUtil
+      # Check file is writable if file exists
+      # Check directory is writable if file does not exist
+      #
+      # @param [String] path File path
+      # @return [Boolean] file is writable or not
+      def writable?(path)
+        return false if File.directory?(path)
+        return File.writable?(path) if File.exist?(path)
 
-      dirname = File.dirname(path)
-      return false if !File.directory?(dirname)
-      File.writable?(dirname)
-    end
-    module_function :writable?
-
-    # Check file is writable in conjunction wtih mkdir_p(dirname(path))
-    #
-    # @param [String] path File path
-    # @return [Boolean] file writable or not
-    def writable_p?(path)
-      return false if File.directory?(path)
-      return File.writable?(path) if File.exist?(path)
-
-      dirname = File.dirname(path)
-      until File.exist?(dirname)
-        dirname = File.dirname(dirname)
+        dirname = File.dirname(path)
+        return false if !File.directory?(dirname)
+        File.writable?(dirname)
       end
+      module_function :writable?
 
-      return false if !File.directory?(dirname)
-      File.writable?(dirname)
+      # Check file is writable in conjunction wtih mkdir_p(dirname(path))
+      #
+      # @param [String] path File path
+      # @return [Boolean] file writable or not
+      def writable_p?(path)
+        return false if File.directory?(path)
+        return File.writable?(path) if File.exist?(path)
+
+        dirname = File.dirname(path)
+        until File.exist?(dirname)
+          dirname = File.dirname(dirname)
+        end
+
+        return false if !File.directory?(dirname)
+        File.writable?(dirname)
+      end
+      module_function :writable_p?
     end
-    module_function :writable_p?
   end
+
+  # obsolete
+  FileUtil = Fluent::Plugin::FileUtil
 end

--- a/lib/fluent/plugin/out_buffered_null.rb
+++ b/lib/fluent/plugin/out_buffered_null.rb
@@ -1,0 +1,59 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'fluent/plugin/output'
+
+module Fluent::Plugin
+  class BufferedNullOutput < Output
+    # This plugin is for tests of buffer plugins
+
+    Fluent::Plugin.register_output('buffered_null', self)
+
+    config_section :buffer do
+      config_set_default :chunk_keys, ['tag']
+      config_set_default :flush_at_shutdown, true
+      config_set_default :chunk_bytes_limit, 10 * 1024
+    end
+
+    attr_accessor :feed_proc, :delayed
+
+    def initialize
+      super
+      @delayed = false
+      @feed_proc = nil
+    end
+
+    def prefer_delayed_commit
+      @delayed
+    end
+
+    def write(chunk)
+      if @feed_proc
+        @feed_proc.call(chunk)
+      else
+        # ignore chunk.read
+      end
+    end
+
+    def try_write(chunk)
+      if @feed_proc
+        @feed_proc.call(chunk)
+      else
+        # ignore chunk.read
+      end
+    end
+  end
+end

--- a/lib/fluent/plugin/out_stdout.rb
+++ b/lib/fluent/plugin/out_stdout.rb
@@ -14,28 +14,26 @@
 #    limitations under the License.
 #
 
-require 'fluent/output'
+require 'fluent/plugin/output'
 
-module Fluent
+module Fluent::Plugin
   class StdoutOutput < Output
-    Plugin.register_output('stdout', self)
+    Fluent::Plugin.register_output('stdout', self)
 
     desc 'Output format.(json,hash)'
     config_param :output_type, default: 'json'
 
     def configure(conf)
       super
-      @formatter = Plugin.new_formatter(@output_type)
+      @formatter = Fluent::Plugin.new_formatter(@output_type, parent: self)
       @formatter.configure(conf)
     end
 
-    def emit(tag, es, chain)
+    def process(tag, es)
       es.each {|time,record|
         $log.write "#{Time.at(time).localtime} #{tag}: #{@formatter.format(tag, time, record).chomp}\n"
       }
       $log.flush
-
-      chain.next
     end
   end
 end

--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -400,11 +400,13 @@ module Fluent
           @buffer.after_shutdown
 
           @output_flush_threads_running = false
-          @output_flush_threads.each do |state|
-            state.thread.run if state.thread.alive? # to wakeup thread and make it to stop by itself
-          end
-          @output_flush_threads.each do |state|
-            state.thread.join
+          if @output_flush_threads && !@output_flush_threads.empty?
+            @output_flush_threads.each do |state|
+              state.thread.run if state.thread.alive? # to wakeup thread and make it to stop by itself
+            end
+            @output_flush_threads.each do |state|
+              state.thread.join
+            end
           end
         end
 

--- a/lib/fluent/plugin/socket_util.rb
+++ b/lib/fluent/plugin/socket_util.rb
@@ -22,142 +22,147 @@ require 'fluent/plugin'
 require 'fluent/input'
 
 module Fluent
-  module SocketUtil
-    def create_udp_socket(host)
-      if IPAddr.new(IPSocket.getaddress(host)).ipv4?
-        UDPSocket.new
-      else
-        UDPSocket.new(Socket::AF_INET6)
-      end
-    end
-    module_function :create_udp_socket
-
-    class UdpHandler < Coolio::IO
-      def initialize(io, log, body_size_limit, callback)
-        super(io)
-        @io = io
-        @log = log
-        @body_size_limit = body_size_limit
-        @callback = callback
-      end
-
-      def on_readable
-        msg, addr = @io.recvfrom_nonblock(@body_size_limit)
-        msg.chomp!
-        @callback.call(msg, addr)
-      rescue => e
-        @log.error "unexpected error", error: e
-      end
-    end
-
-    class TcpHandler < Coolio::Socket
-      PEERADDR_FAILED = ["?", "?", "name resolusion failed", "?"]
-
-      def initialize(io, log, delimiter, callback)
-        super(io)
-        @timeout = 0
-        if io.is_a?(TCPSocket)
-          @addr = (io.peeraddr rescue PEERADDR_FAILED)
-
-          opt = [1, @timeout.to_i].pack('I!I!')  # { int l_onoff; int l_linger; }
-          io.setsockopt(Socket::SOL_SOCKET, Socket::SO_LINGER, opt)
+  module Plugin
+    module SocketUtil
+      def create_udp_socket(host)
+        if IPAddr.new(IPSocket.getaddress(host)).ipv4?
+          UDPSocket.new
+        else
+          UDPSocket.new(Socket::AF_INET6)
         end
-        @delimiter = delimiter
-        @callback = callback
-        @log = log
-        @log.trace { "accepted fluent socket object_id=#{self.object_id}" }
-        @buffer = "".force_encoding('ASCII-8BIT')
       end
+      module_function :create_udp_socket
 
-      def on_connect
-      end
-
-      def on_read(data)
-        @buffer << data
-        pos = 0
-
-        while i = @buffer.index(@delimiter, pos)
-          msg = @buffer[pos...i]
-          @callback.call(msg, @addr)
-          pos = i + @delimiter.length
+      class UdpHandler < Coolio::IO
+        def initialize(io, log, body_size_limit, callback)
+          super(io)
+          @io = io
+          @log = log
+          @body_size_limit = body_size_limit
+          @callback = callback
         end
-        @buffer.slice!(0, pos) if pos > 0
-      rescue => e
-        @log.error "unexpected error", error: e
-        close
+
+        def on_readable
+          msg, addr = @io.recvfrom_nonblock(@body_size_limit)
+          msg.chomp!
+          @callback.call(msg, addr)
+        rescue => e
+          @log.error "unexpected error", error: e
+        end
       end
 
-      def on_close
-        @log.trace { "closed fluent socket object_id=#{self.object_id}" }
-      end
-    end
+      class TcpHandler < Coolio::Socket
+        PEERADDR_FAILED = ["?", "?", "name resolusion failed", "?"]
 
-    class BaseInput < Fluent::Input
-      def initialize
-        super
-        require 'fluent/parser'
-      end
+        def initialize(io, log, delimiter, callback)
+          super(io)
+          @timeout = 0
+          if io.is_a?(TCPSocket)
+            @addr = (io.peeraddr rescue PEERADDR_FAILED)
 
-      desc 'Tag of output events.'
-      config_param :tag, :string
-      desc 'The format of the payload.'
-      config_param :format, :string
-      desc 'The port to listen to.'
-      config_param :port, :integer, default: 5150
-      desc 'The bind address to listen to.'
-      config_param :bind, :string, default: '0.0.0.0'
-      desc "The field name of the client's hostname."
-      config_param :source_host_key, :string, default: nil
-      config_param :blocking_timeout, :time, default: 0.5
-
-      def configure(conf)
-        super
-
-        @parser = Plugin.new_parser(@format)
-        @parser.configure(conf)
-      end
-
-      def start
-        super
-
-        @loop = Coolio::Loop.new
-        @handler = listen(method(:on_message))
-        @loop.attach(@handler)
-        @thread = Thread.new(&method(:run))
-      end
-
-      def shutdown
-        @loop.watchers.each { |w| w.detach }
-        @loop.stop if @loop.instance_variable_get("@running")
-        @handler.close
-        @thread.join
-
-        super
-      end
-
-      def run
-        @loop.run(@blocking_timeout)
-      rescue => e
-        log.error "unexpected error", error: e
-        log.error_backtrace
-      end
-
-      private
-
-      def on_message(msg, addr)
-        @parser.parse(msg) { |time, record|
-          unless time && record
-            log.warn "pattern not match: #{msg.inspect}"
-            return
+            opt = [1, @timeout.to_i].pack('I!I!')  # { int l_onoff; int l_linger; }
+            io.setsockopt(Socket::SOL_SOCKET, Socket::SO_LINGER, opt)
           end
+          @delimiter = delimiter
+          @callback = callback
+          @log = log
+          @log.trace { "accepted fluent socket object_id=#{self.object_id}" }
+          @buffer = "".force_encoding('ASCII-8BIT')
+        end
 
-          record[@source_host_key] = addr[3] if @source_host_key
-          router.emit(@tag, time, record)
-        }
-      rescue => e
-        log.error msg.dump, error: e, host: addr[3]
-        log.error_backtrace
+        def on_connect
+        end
+
+        def on_read(data)
+          @buffer << data
+          pos = 0
+
+          while i = @buffer.index(@delimiter, pos)
+            msg = @buffer[pos...i]
+            @callback.call(msg, @addr)
+            pos = i + @delimiter.length
+          end
+          @buffer.slice!(0, pos) if pos > 0
+        rescue => e
+          @log.error "unexpected error", error: e
+          close
+        end
+
+        def on_close
+          @log.trace { "closed fluent socket object_id=#{self.object_id}" }
+        end
+      end
+
+      class BaseInput < Fluent::Input
+        def initialize
+          super
+          require 'fluent/parser'
+        end
+
+        desc 'Tag of output events.'
+        config_param :tag, :string
+        desc 'The format of the payload.'
+        config_param :format, :string
+        desc 'The port to listen to.'
+        config_param :port, :integer, default: 5150
+        desc 'The bind address to listen to.'
+        config_param :bind, :string, default: '0.0.0.0'
+        desc "The field name of the client's hostname."
+        config_param :source_host_key, :string, default: nil
+        config_param :blocking_timeout, :time, default: 0.5
+
+        def configure(conf)
+          super
+
+          @parser = Plugin.new_parser(@format)
+          @parser.configure(conf)
+        end
+
+        def start
+          super
+
+          @loop = Coolio::Loop.new
+          @handler = listen(method(:on_message))
+          @loop.attach(@handler)
+          @thread = Thread.new(&method(:run))
+        end
+
+        def shutdown
+          @loop.watchers.each { |w| w.detach }
+          @loop.stop if @loop.instance_variable_get("@running")
+          @handler.close
+          @thread.join
+
+          super
+        end
+
+        def run
+          @loop.run(@blocking_timeout)
+        rescue => e
+          log.error "unexpected error", error: e
+          log.error_backtrace
+        end
+
+        private
+
+        def on_message(msg, addr)
+          @parser.parse(msg) { |time, record|
+            unless time && record
+              log.warn "pattern not match: #{msg.inspect}"
+              return
+            end
+
+            record[@source_host_key] = addr[3] if @source_host_key
+            router.emit(@tag, time, record)
+          }
+        rescue => e
+          log.error msg.dump, error: e, host: addr[3]
+          log.error_backtrace
+        end
       end
     end
   end
+
+  # obsolete
+  SocketUtil = Fluent::Plugin::SocketUtil
 end

--- a/lib/fluent/plugin/storage_local.rb
+++ b/lib/fluent/plugin/storage_local.rb
@@ -27,10 +27,14 @@ module Fluent
 
         @on_memory = false
         if !@path && !@_plugin_id_configured
-          if @autosave || @persistent
+          if @persistent
             raise Fluent::ConfigError, "Plugin @id or path for <storage> required to save data"
           else
-            log.info "both of Plugin @id and path for <storage> are not specified. Using on-memory store."
+            if @autosave
+              log.warn "both of Plugin @id and path for <storage> are not specified. Using on-memory store."
+            else
+              log.info "both of Plugin @id and path for <storage> are not specified. Using on-memory store."
+            end
             @on_memory = true
           end
         elsif @path

--- a/lib/fluent/plugin/string_util.rb
+++ b/lib/fluent/plugin/string_util.rb
@@ -15,18 +15,23 @@
 #
 
 module Fluent
-  module StringUtil
-    def match_regexp(regexp, string)
-      begin
-        return regexp.match(string)
-      rescue ArgumentError => e
-        raise e unless e.message.index("invalid byte sequence in".freeze).zero?
-        $log.info "invalid byte sequence is replaced in `#{string}`"
-        string = string.scrub('?')
-        retry
+  module Plugin
+    module StringUtil
+      def match_regexp(regexp, string)
+        begin
+          return regexp.match(string)
+        rescue ArgumentError => e
+          raise e unless e.message.index("invalid byte sequence in".freeze).zero?
+          $log.info "invalid byte sequence is replaced in `#{string}`"
+          string = string.scrub('?')
+          retry
+        end
+        return true
       end
-      return true
+      module_function :match_regexp
     end
-    module_function :match_regexp
   end
+
+  # obsolete
+  StringUtil = Fluent::Plugin::StringUtil
 end

--- a/lib/fluent/plugin_helper.rb
+++ b/lib/fluent/plugin_helper.rb
@@ -21,6 +21,7 @@ require 'fluent/plugin_helper/timer'
 require 'fluent/plugin_helper/child_process'
 require 'fluent/plugin_helper/storage'
 require 'fluent/plugin_helper/retry_state'
+require 'fluent/plugin_helper/compat_parameters'
 
 module Fluent
   module PluginHelper

--- a/lib/fluent/plugin_helper/compat_parameters.rb
+++ b/lib/fluent/plugin_helper/compat_parameters.rb
@@ -1,0 +1,93 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'fluent/config/element'
+
+module Fluent
+  module PluginHelper
+    module CompatParameters
+      # This plugin helper is to bring old-fashioned buffer/other
+      # configuration parameters to v0.14 plugin API configurations.
+      # This helper is mainly to convert plugins from v0.12 API
+      # to v0.14 API safely, without breaking user deployment.
+
+      PARAMS_MAP = {
+        "buffer_type" => "@type",
+        "buffer_path" => "path",
+        "num_threads"                 => "flush_threads",
+        "flush_interval"              => "flush_interval",
+        "try_flush_interval"          => "flush_thread_interval",
+        "queued_chunk_flush_interval" => "flush_burst_interval",
+        "disable_retry_limit" => "retry_forever",
+        "retry_limit"         => "retry_max_times",
+        "max_retry_wait"      => "retry_max_interval",
+        "buffer_chunk_limit"  => "chunk_bytes_limit",
+        "buffer_queue_limit"  => "queue_length_limit",
+        "buffer_queue_full_action" => "overflow_action",
+        "flush_at_shutdown" => "flush_at_shutdown",
+      }
+
+      TIME_SLICED_PARAMS = {
+        "time_slice_format" => nil,
+        "time_slice_wait" => "timekey_wait",
+      }
+
+      def compat_parameters_default_chunk_key
+        # '', 'time' or 'tag'
+        raise NotImplementedError, "return one of '', 'time' or 'tag'"
+      end
+
+      def configure(conf)
+        if conf.elements('buffer').empty? && PARAMS_MAP.keys.any?{|k| conf.has_key?(k) } || TIME_SLICED_PARAMS.keys.any?{|k| conf.has_key?(k) }
+          # TODO: warn obsolete parameters if these are deprecated
+          attr = {}
+          PARAMS_MAP.each do |compat, current|
+            next unless current
+            attr[current] = conf[compat] if conf.has_key?(compat)
+          end
+          TIME_SLICED_PARAMS.each do |compat, current|
+            next unless current
+            attr[current] = conf[compat] if conf.has_key?(compat)
+          end
+
+          chunk_key = nil
+
+          if conf.has_key?('time_slice_format')
+            chunk_key = 'time'
+            attr['timekey_range'] = case conf['time_slice_format']
+                                    when /\%S/ then 1
+                                    when /\%M/ then 60
+                                    when /\%H/ then 3600
+                                    when /\%d/ then 86400
+                                    else
+                                      raise Fluent::ConfigError, "time_slice_format only with %Y or %m is too long"
+                                    end
+          else
+            chunk_key = compat_parameters_default_chunk_key
+            if chunk_key == 'time'
+              attr['timekey_range'] = 86400 # TimeSliceOutput.time_slice_format default value is '%Y%m%d'
+            end
+          end
+
+          e = Fluent::Config::Element.new('buffer', chunk_key, attr, [])
+          conf.elements << e
+        end
+
+        super
+      end
+    end
+  end
+end

--- a/lib/fluent/plugin_helper/event_emitter.rb
+++ b/lib/fluent/plugin_helper/event_emitter.rb
@@ -41,6 +41,14 @@ module Fluent
         @_event_emitter_used_actually
       end
 
+      def event_emitter_router(label_name)
+        if label_name
+          Engine.root_agent.find_label(label_name).event_router
+        else
+          Engine.root_agent.event_router
+        end
+      end
+
       def initialize
         super
         @_event_emitter_used_actually = false
@@ -50,13 +58,7 @@ module Fluent
       def configure(conf)
         require 'fluent/engine'
         super
-
-        if label_name = conf['@label']
-          label = Engine.root_agent.find_label(label_name)
-          @router = label.event_router
-        elsif @router.nil?
-          @router = Engine.root_agent.event_router
-        end
+        @router = event_emitter_router(conf['@label'])
       end
 
       def after_shutdown

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -51,7 +51,7 @@ module Fluent
     end
 
     def self.overwrite_system_config(hash)
-      older = $_system_config || nil
+      older = defined?($_system_config) ? $_system_config : nil
       begin
         $_system_config = SystemConfig.new(Fluent::Config::Element.new('system', '', hash, []))
         yield
@@ -111,7 +111,7 @@ module Fluent
       def system_config_override(opts={})
         require 'fluent/engine'
         if !instance_variable_defined?("@_system_config") || @_system_config.nil?
-          @_system_config = ($_system_config || Fluent::Engine.system_config).dup
+          @_system_config = (defined?($_system_config) && $_system_config ? $_system_config : Fluent::Engine.system_config).dup
         end
         opts.each_pair do |key, value|
           @_system_config.send(:"#{key.to_s}=", value)

--- a/lib/fluent/test/driver/base.rb
+++ b/lib/fluent/test/driver/base.rb
@@ -1,0 +1,230 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'fluent/test/driver/test_event_router'
+
+require 'timeout'
+
+module Fluent
+  module Test
+    module Driver
+      class Base
+        def initialize(klass, opts: {}, &block)
+          if klass.is_a?(Class)
+            if block
+              # Create new class for test w/ overwritten methods
+              #   klass.dup is worse because its ancestors does NOT include original class name
+              klass = Class.new(klass)
+              klass.module_eval(&block)
+            end
+            @instance = klass.new
+          else
+            @instance = klass
+          end
+          if opts
+            @instance.system_config_override(opts)
+          end
+          @instance.log = TestLogger.new
+          @logs = @instance.log.out.logs
+
+          @run_post_conditions = []
+          @run_breaking_conditions = []
+
+          @broken = false
+
+          @event_streams = nil
+          @error_events = nil
+        end
+
+        attr_reader :instance, :logs
+
+        def configure(conf, syntax: :v1)
+          if conf.is_a?(Fluent::Config::Element)
+            @config = conf
+          else
+            @config = Config.parse(conf, "(test)", "(test_dir)", syntax: syntax)
+          end
+
+          if @instance.respond_to?(:router=)
+            @event_streams = []
+            @error_events = []
+
+            driver = self
+            mojule = Module.new do
+              define_method(:event_emitter_router) do |label_name|
+                TestEventRouter.new(driver)
+              end
+            end
+            @instance.singleton_class.module_eval do
+              prepend mojule
+            end
+          end
+
+          @instance.configure(@config)
+          self
+        end
+
+        def end_if(&block)
+          raise ArgumentError, "block is not given" unless block_given?
+          @run_post_conditions << block
+        end
+
+        def break_if(&block)
+          raise ArgumentError, "block is not given" unless block_given?
+          @run_breaking_conditions << block
+        end
+
+        def broken?
+          @broken
+        end
+
+        Emit = Struct.new(:tag, :es)
+        ErrorEvent = Struct.new(:tag, :time, :record, :error)
+
+        # via TestEventRouter
+        def emit_event_stream(tag, es)
+          @event_streams << Emit.new(tag, es)
+        end
+
+        def emit_error_event(tag, time, record, error)
+          @error_events << ErrorEvent.new(tag, time, record, error)
+        end
+
+        def events(tag: nil)
+          selected = @event_streams.select{|e| tag.nil? ? true : e.tag == tag }
+          if block_given?
+            selected.each do |e|
+              e.es.each do |time, record|
+                yield e.tag, time, record
+              end
+            end
+          else
+            list = []
+            selected.each do |e|
+              e.es.each do |time, record|
+                list << [e.tag, time, record]
+              end
+            end
+            list
+          end
+        end
+
+        def error_events(tag: nil)
+          selected = @error_events.select{|e| tag.nil? ? true : e.tag == tag }
+          if block_given?
+            selected.each do |e|
+              yield e.tag, e.time, e.record, e.error
+            end
+          else
+            selected.map{|e| [e.tag, e.time, e.record, e.error] }
+          end
+        end
+
+        def run(expect_emits: nil, expect_records: nil, timeout: nil, start: true, shutdown: true, &block)
+          instance_start if start
+
+          begin
+            run_actual(expect_emits: expect_emits, expect_records: expect_records, timeout: timeout, &block)
+          ensure
+            instance_shutdown if shutdown
+          end
+        end
+
+        def instance_start
+          unless @instance.started?
+            @instance.start
+            instance_hook_after_started
+          end
+        end
+
+        def instance_hook_after_started
+          # insert hooks for tests available after instance.start
+        end
+
+        def instance_shutdown
+          @instance.stop             unless @instance.stopped?
+          @instance.before_shutdown? unless @instance.before_shutdown?
+          @instance.shutdown         unless @instance.shutdown?
+          @instance.after_shutdown?  unless @instance.after_shutdown?
+          @instance.close     unless @instance.closed?
+          @instance.terminate unless @instance.terminated?
+        end
+
+        def run_actual(expect_emits: nil, expect_records: nil, timeout: nil, &block)
+          if @instance.respond_to?(:_threads)
+            until @instance._threads.values.all?(&:alive?)
+              sleep 0.01
+            end
+          end
+
+          if @instance.respond_to?(:event_loop_running?)
+            until @instance.event_loop_running?
+              sleep 0.01
+            end
+          end
+
+          if expect_emits
+            @run_post_conditions << ->(){ @emit_streams.size >= expect_emits }
+          end
+          if expect_records
+            @run_post_conditions << ->(){ @emit_streams.reduce(0){|a, e| a + e.es.size } >= expected_records }
+          end
+          if timeout
+            stop_at = Time.now + timeout
+            @run_breaking_conditions << ->(){ Time.now >= stop_at }
+          end
+
+          if !block_given? && @run_post_conditions.empty? && @run_breaking_conditions.empty?
+            raise ArgumentError, "no stop conditions nor block specified"
+          end
+
+          if !block_given?
+            block = ->(){ sleep(0.1) until stop? }
+          end
+
+          if timeout
+            begin
+              Timeout.timeout(timeout * 1.1) do |sec|
+                block.call
+              end
+            rescue Timeout::Error
+              @broken = true
+            end
+          else
+            block.call
+          end
+        end
+
+        def stop?
+          # Should stop running if post conditions are not registered.
+          return true unless @run_post_conditions
+
+          # Should stop running if all of the post conditions are true.
+          return true if @run_post_conditions.all? {|proc| proc.call }
+
+          # Should stop running if some of the breaking conditions is true.
+          # In this case, some post conditions may be not true.
+          if @run_breaking_conditions.any? {|proc| proc.call }
+            @broken = true
+            return true
+          end
+
+          false
+        end
+      end
+    end
+  end
+end

--- a/lib/fluent/test/driver/base.rb
+++ b/lib/fluent/test/driver/base.rb
@@ -155,10 +155,10 @@ module Fluent
         end
 
         def instance_shutdown
-          @instance.stop             unless @instance.stopped?
-          @instance.before_shutdown? unless @instance.before_shutdown?
-          @instance.shutdown         unless @instance.shutdown?
-          @instance.after_shutdown?  unless @instance.after_shutdown?
+          @instance.stop            unless @instance.stopped?
+          @instance.before_shutdown unless @instance.before_shutdown?
+          @instance.shutdown        unless @instance.shutdown?
+          @instance.after_shutdown  unless @instance.after_shutdown?
           @instance.close     unless @instance.closed?
           @instance.terminate unless @instance.terminated?
         end

--- a/lib/fluent/test/driver/event_feeder.rb
+++ b/lib/fluent/test/driver/event_feeder.rb
@@ -1,0 +1,98 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'fluent/event'
+require 'fluent/time'
+
+module Fluent
+  module Test
+    module Driver
+      module EventFeeder
+        def initialize(klass, opts: {}, &block)
+          super
+          @default_tag = nil
+          @feed_method = nil
+        end
+
+        def run(default_tag: nil, **kwargs, &block)
+          @feed_method = if @instance.respond_to?(:filter_stream)
+                           :filter_stream
+                         else
+                           :emit_events
+                         end
+          if default_tag
+            @default_tag = default_tag
+          end
+          super(**kwargs, &block)
+        end
+
+        def feed_to_plugin(tag, es)
+          @instance.__send__(@feed_method, tag, es)
+        end
+
+        # d.run do
+        #   d.feed('tag', time, {record})
+        #   d.feed('tag', [ [time, {record}], [time, {record}], ... ])
+        #   d.feed('tag', es)
+        # end
+        # d.run(default_tag: 'tag') do
+        #   d.feed({record})
+        #   d.feed(time, {record})
+        #   d.feed([ [time, {record}], [time, {record}], ... ])
+        #   d.feed(es)
+        # end
+        def feed(*args)
+          case args.size
+          when 1
+            raise ArgumentError, "tag not specified without default_tag" unless @default_tag
+            case args.first
+            when Fluent::EventStream
+              feed_to_plugin(@default_tag, args.first)
+            when Array
+              feed_to_plugin(@default_tag, ArrayEventStream.new(args.first))
+            when Hash
+              record = args.first
+              time = Fluent::EventTime.now
+              feed_to_plugin(@default_tag, OneEventStream.new(time, record))
+            else
+              raise ArgumentError, "unexpected events object (neither event(Hash), EventStream nor Array): #{args.first.class}"
+            end
+          when 2
+            if args[0].is_a?(String) && (args[1].is_a?(Array) || args[1].is_a?(Fluent::EventStream))
+              tag, es = args
+              es = ArrayEventStream.new(es) if es.is_a?(Array)
+              feed_to_plugin(tag, es)
+            elsif @default_tag && (args[0].is_a?(Fluent::EventTime) || args[0].is_a?(Integer)) && args[1].is_a?(Hash)
+              time, record = args
+              feed_to_plugin(@default_tag, OneEventStream.new(time, record))
+            else
+              raise ArgumentError, "unexpected values of argument: #{args[0].class}, #{args[1].class}"
+            end
+          when 3
+            tag, time, record = args
+            if tag.is_a?(String) && (time.is_a?(Fluent::EventTime) || time.is_a?(Integer)) && record.is_a?(Hash)
+              feed_to_plugin(tag, OneEventStream.new(time, record))
+            else
+              raise ArgumentError, "unexpected values of argument: #{tag.class}, #{time.class}, #{record.class}"
+            end
+          else
+            raise ArgumentError, "unexpected number of arguments: #{args}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fluent/test/driver/filter.rb
+++ b/lib/fluent/test/driver/filter.rb
@@ -1,0 +1,35 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'fluent/test/driver/base'
+require 'fluent/test/driver/event_feeder'
+
+require 'fluent/plugin/filter'
+
+module Fluent
+  module Test
+    module Driver
+      class Filter < Base
+        include EventFeeder
+
+        def initialize(klass, opts: {}, &block)
+          super
+          raise ArgumentError, "plugin is not an instance of Fluent::Plugin::Filter" unless @instance.is_a? Fluent::Plugin::Filter
+        end
+      end
+    end
+  end
+end

--- a/lib/fluent/test/driver/input.rb
+++ b/lib/fluent/test/driver/input.rb
@@ -1,0 +1,31 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'fluent/test/driver/base'
+require 'fluent/plugin/input'
+
+module Fluent
+  module Test
+    module Driver
+      class Input < Base
+        def initialize(klass, opts: {}, &block)
+          super
+          raise ArgumentError, "plugin is not an instance of Fluent::Plugin::Input" unless @instance.is_a? Fluent::Plugin::Input
+        end
+      end
+    end
+  end
+end

--- a/lib/fluent/test/driver/output.rb
+++ b/lib/fluent/test/driver/output.rb
@@ -1,0 +1,78 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'fluent/test/driver/base'
+require 'fluent/test/driver/event_feeder'
+
+require 'fluent/plugin/output'
+
+module Fluent
+  module Test
+    module Driver
+      class Output < Base
+        include EventFeeder
+
+        def initialize(klass, opts: {}, &block)
+          super
+          raise ArgumentError, "plugin is not an instance of Fluent::Plugin::Output" unless @instance.is_a? Fluent::Plugin::Output
+          @instance.in_tests = true
+          @flush_buffer_at_cleanup = nil
+          @format_hook = nil
+          @format_results = []
+        end
+
+        def run(flush: true, **kwargs, &block)
+          @flush_buffer_at_cleanup = flush
+          super(**kwargs, &block)
+        end
+
+        def run_actual(**kwargs, &block)
+          super(**kwargs, &block)
+          if @flush_buffer_at_cleanup
+            @instance.force_flush
+          end
+        end
+
+        def formatted
+          @format_results
+        end
+
+        def flush
+          @instance.force_flush
+        end
+
+        def instance_hook_after_started
+          super
+
+          # it's decided after #start whether output plugin instances use @custom_format or not.
+          if @instance.instance_eval{ @custom_format }
+            @format_hook = format_hook = ->(result){ @format_results << result }
+            m = Module.new do
+              define_method(:format) do |tag, time, record|
+                result = super(tag, time, record)
+                format_hook.call(result)
+                result
+              end
+            end
+            @instance.singleton_class.module_eval do
+              prepend m
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fluent/test/driver/test_event_router.rb
+++ b/lib/fluent/test/driver/test_event_router.rb
@@ -1,0 +1,45 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'fluent/event'
+
+module Fluent
+  module Test
+    module Driver
+      class TestEventRouter
+        def initialize(driver)
+          @driver = driver
+        end
+
+        def emit(tag, time, record)
+          @driver.emit_event_stream(tag, OneEventStream.new(time, record))
+        end
+
+        def emit_array(tag, array)
+          @driver.emit_event_stream(tag, ArrayEventStream.new(array))
+        end
+
+        def emit_stream(tag, es)
+          @driver.emit_event_stream(tag, es)
+        end
+
+        def emit_error_event(tag, time, record, error)
+          @driver.emit_error_event(tag, time, record, error)
+        end
+      end
+    end
+  end
+end

--- a/test/config/test_configure_proxy.rb
+++ b/test/config/test_configure_proxy.rb
@@ -15,7 +15,8 @@ module Fluent::Config
 
           proxy = Fluent::Config::ConfigureProxy.new(:section, type_lookup: @type_lookup)
           assert_equal(:section, proxy.name)
-          assert_equal(:section, proxy.param_name)
+          assert_nil(proxy.param_name)
+          assert_equal(:section, proxy.variable_name)
           assert_nil(proxy.init)
           assert_nil(proxy.required)
           assert_false(proxy.required?)
@@ -27,6 +28,7 @@ module Fluent::Config
           proxy = Fluent::Config::ConfigureProxy.new(:section, param_name: 'sections', init: true, required: false, multi: true, type_lookup: @type_lookup)
           assert_equal(:section, proxy.name)
           assert_equal(:sections, proxy.param_name)
+          assert_equal(:sections, proxy.variable_name)
           assert_false(proxy.required)
           assert_false(proxy.required?)
           assert_true(proxy.multi)
@@ -35,6 +37,7 @@ module Fluent::Config
           proxy = Fluent::Config::ConfigureProxy.new(:section, param_name: :sections, init: false, required: true, multi: false, type_lookup: @type_lookup)
           assert_equal(:section, proxy.name)
           assert_equal(:sections, proxy.param_name)
+          assert_equal(:sections, proxy.variable_name)
           assert_true(proxy.required)
           assert_true(proxy.required?)
           assert_false(proxy.multi)
@@ -51,7 +54,8 @@ module Fluent::Config
         test 'generate a new instance which values are overwritten by the argument object' do
           proxy = p1 = Fluent::Config::ConfigureProxy.new(:section, type_lookup: @type_lookup)
           assert_equal(:section, proxy.name)
-          assert_equal(:section, proxy.param_name)
+          assert_nil(proxy.param_name)
+          assert_equal(:section, proxy.variable_name)
           assert_nil(proxy.init)
           assert_nil(proxy.required)
           assert_false(proxy.required?)
@@ -59,10 +63,11 @@ module Fluent::Config
           assert_true(proxy.multi?)
           assert_nil(proxy.configured_in_section)
 
-          p2 = Fluent::Config::ConfigureProxy.new(:section, param_name: :sections, init: false, required: true, multi: false, type_lookup: @type_lookup)
+          p2 = Fluent::Config::ConfigureProxy.new(:section, init: false, required: true, multi: false, type_lookup: @type_lookup)
           proxy = p1.merge(p2)
           assert_equal(:section, proxy.name)
-          assert_equal(:sections, proxy.param_name)
+          assert_nil(proxy.param_name)
+          assert_equal(:section, proxy.variable_name)
           assert_false(proxy.init)
           assert_false(proxy.init?)
           assert_true(proxy.required)
@@ -73,13 +78,14 @@ module Fluent::Config
         end
 
         test 'does not overwrite with argument object without any specifications of required/multi' do
-          p1 = Fluent::Config::ConfigureProxy.new(:section1, type_lookup: @type_lookup)
+          p1 = Fluent::Config::ConfigureProxy.new(:section1, param_name: :sections, type_lookup: @type_lookup)
           p1.configured_in_section = :subsection
-          p2 = Fluent::Config::ConfigureProxy.new(:section2, param_name: :sections, init: false, required: true, multi: false, type_lookup: @type_lookup)
+          p2 = Fluent::Config::ConfigureProxy.new(:section2, init: false, required: true, multi: false, type_lookup: @type_lookup)
           p3 = Fluent::Config::ConfigureProxy.new(:section3, type_lookup: @type_lookup)
           proxy = p1.merge(p2).merge(p3)
-          assert_equal(:section3, proxy.name)
-          assert_equal(:section3, proxy.param_name)
+          assert_equal(:section1, proxy.name)
+          assert_equal(:sections, proxy.param_name)
+          assert_equal(:sections, proxy.variable_name)
           assert_false(proxy.init)
           assert_false(proxy.init?)
           assert_true(proxy.required)

--- a/test/config/test_element.rb
+++ b/test/config/test_element.rb
@@ -79,10 +79,10 @@ class TestConfigElement < ::Test::Unit::TestCase
       assert_equal('v1', e["k1"])
       assert_equal('v2', e["k2"])
       assert_equal(1, e.elements.size)
-      e.each_element('test') do |e|
-        assert_equal('test', e.name)
-        assert_equal('mydata',  e.arg)
-        assert_equal('v3', e["k3"])
+      e.each_element('test') do |el|
+        assert_equal('test', el.name)
+        assert_equal('mydata', el.arg)
+        assert_equal('v3', el["k3"])
       end
     end
 
@@ -97,10 +97,10 @@ class TestConfigElement < ::Test::Unit::TestCase
       assert_equal('v2', e["k2"])
       assert_equal('v4', e["k4"])
       assert_equal(1, e.elements.size)
-      e.each_element('test') do |e|
-        assert_equal('test', e.name)
-        assert_equal('mydata',  e.arg)
-        assert_equal('v3', e["k3"])
+      e.each_element('test') do |el|
+        assert_equal('test', el.name)
+        assert_equal('mydata', el.arg)
+        assert_equal('v3', el["k3"])
       end
       assert_equal("k3", e.unused)
     end
@@ -185,10 +185,10 @@ class TestConfigElement < ::Test::Unit::TestCase
       assert_equal('v1', e['k1'])
       assert_equal('v2', e['k2'])
       assert_equal(1, e.elements.size)
-      e.each_element('test') do |e|
-        assert_equal('test', e.name)
-        assert_equal('ext',  e.arg)
-        assert_equal('v3', e["k3"])
+      e.each_element('test') do |el|
+        assert_equal('test', el.name)
+        assert_equal('ext', el.arg)
+        assert_equal('v3', el["k3"])
       end
     end
   end

--- a/test/plugin/test_in_dummy.rb
+++ b/test/plugin/test_in_dummy.rb
@@ -1,5 +1,5 @@
 require_relative '../helper'
-require 'fluent/test'
+require 'fluent/test/driver/input'
 require 'fluent/plugin/in_dummy'
 
 class DummyTest < Test::Unit::TestCase
@@ -8,7 +8,7 @@ class DummyTest < Test::Unit::TestCase
   end
 
   def create_driver(conf)
-    Fluent::Test::InputTestDriver.new(Fluent::DummyInput).configure(conf)
+    Fluent::Test::Driver::Input.new(Fluent::Plugin::DummyInput).configure(conf)
   end
 
   sub_test_case 'configure' do
@@ -71,11 +71,9 @@ class DummyTest < Test::Unit::TestCase
 
     test 'simple' do
       d = create_driver(config)
-      d.run {
-        # d.run sleeps 0.5 sec
-      }
-      emits = d.emits
-      emits.each do |tag, time, record|
+      d.run(timeout: 0.5)
+
+      d.events.each do |tag, time, record|
         assert_equal("dummy", tag)
         assert_equal({"foo"=>"bar"}, record)
         assert(time.is_a?(Fluent::EventTime))
@@ -84,11 +82,9 @@ class DummyTest < Test::Unit::TestCase
 
     test 'with auto_increment_key' do
       d = create_driver(config + %[auto_increment_key id])
-      d.run {
-        # d.run sleeps 0.5 sec
-      }
-      emits = d.emits
-      emits.each_with_index do |(tag, _time, record), i|
+      d.run(timeout: 0.5)
+
+      d.events.each_with_index do |(tag, _time, record), i|
         assert_equal("dummy", tag)
         assert_equal({"foo"=>"bar", "id"=>i}, record)
       end

--- a/test/plugin/test_out_buffered_null.rb
+++ b/test/plugin/test_out_buffered_null.rb
@@ -1,0 +1,79 @@
+require_relative '../helper'
+require 'fluent/test/driver/output'
+require 'fluent/plugin/out_buffered_null'
+
+class BufferedNullOutputTestCase < Test::Unit::TestCase
+  sub_test_case 'BufferedNullOutput' do
+    test 'default chunk limit size is 100' do
+      d = Fluent::Test::Driver::Output.new(Fluent::Plugin::BufferedNullOutput).configure('')
+      assert_equal 10 * 1024, d.instance.buffer_config.chunk_bytes_limit
+      assert d.instance.buffer_config.flush_at_shutdown
+      assert_equal ['tag'], d.instance.buffer_config.chunk_keys
+      assert d.instance.chunk_key_tag
+      assert !d.instance.chunk_key_time
+      assert_equal [], d.instance.chunk_keys
+    end
+
+    test 'writes standard formattted chunks' do
+      d = Fluent::Test::Driver::Output.new(Fluent::Plugin::BufferedNullOutput).configure('')
+      t = event_time("2016-05-23 00:22:13 -0800")
+      d.run(default_tag: 'test', flush: true) do
+        d.feed(t, {"message" => "null null null"})
+        d.feed(t, {"message" => "null null"})
+        d.feed(t, {"message" => "null"})
+      end
+
+      assert_equal 3, d.instance.emit_count
+      assert_equal 3, d.instance.emit_records
+    end
+
+    test 'check for chunk passed to #write' do
+      d = Fluent::Test::Driver::Output.new(Fluent::Plugin::BufferedNullOutput).configure('')
+      data = []
+      d.instance.feed_proc = ->(chunk){ data << [chunk.unique_id, chunk.metadata.tag, chunk.read] }
+
+      t = event_time("2016-05-23 00:22:13 -0800")
+      d.run(default_tag: 'test', flush: true) do
+        d.feed(t, {"message" => "null null null"})
+        d.feed(t, {"message" => "null null"})
+        d.feed(t, {"message" => "null"})
+      end
+
+      assert_equal 1, data.size
+      chunk_id, tag, binary = data.first
+      events = []
+      Fluent::MessagePackFactory.unpacker.feed_each(binary){|obj| events << obj }
+      assert_equal 'test', tag
+      assert_equal [ [t, {"message" => "null null null"}], [t, {"message" => "null null"}], [t, {"message" => "null"}] ], events
+    end
+
+    test 'check for chunk passed to #try_write' do
+      d = Fluent::Test::Driver::Output.new(Fluent::Plugin::BufferedNullOutput).configure('')
+      data = []
+      d.instance.feed_proc = ->(chunk){ data << [chunk.unique_id, chunk.metadata.tag, chunk.read] }
+      d.instance.delayed = true
+
+      t = event_time("2016-05-23 00:22:13 -0800")
+      d.run(default_tag: 'test', flush: true, shutdown: false) do
+        d.feed(t, {"message" => "null null null"})
+        d.feed(t, {"message" => "null null"})
+        d.feed(t, {"message" => "null"})
+      end
+
+      assert_equal 1, data.size
+      chunk_id, tag, binary = data.first
+      events = []
+      Fluent::MessagePackFactory.unpacker.feed_each(binary){|obj| events << obj }
+      assert_equal 'test', tag
+      assert_equal [ [t, {"message" => "null null null"}], [t, {"message" => "null null"}], [t, {"message" => "null"}] ], events
+
+      assert_equal [chunk_id], d.instance.buffer.dequeued.keys
+
+      d.instance.commit_write(chunk_id)
+
+      assert_equal [], d.instance.buffer.dequeued.keys
+
+      d.instance_shutdown
+    end
+  end
+end

--- a/test/plugin/test_out_exec.rb
+++ b/test/plugin/test_out_exec.rb
@@ -1,5 +1,5 @@
 require_relative '../helper'
-require 'fluent/test'
+require 'fluent/test/driver/output'
 require 'fluent/plugin/out_exec'
 require 'fileutils'
 
@@ -32,7 +32,7 @@ class ExecOutputTest < Test::Unit::TestCase
 
   def create_driver(conf = TSV_CONFIG)
     config = CONFIG + conf
-    Fluent::Test::TimeSlicedOutputTestDriver.new(Fluent::ExecOutput).configure(config, true)
+    Fluent::Test::Driver::Output.new(Fluent::Plugin::ExecOutput).configure(config)
   end
 
   def create_test_case
@@ -51,42 +51,60 @@ class ExecOutputTest < Test::Unit::TestCase
     assert_equal true, d.instance.localtime
   end
 
+  def test_configure_with_compat_buffer_parameters
+    conf = TSV_CONFIG + %[
+      buffer_type memory
+      time_slice_format %Y%m%d%H
+      num_threads 5
+      buffer_chunk_limit 50m
+      buffer_queue_limit 128
+      flush_at_shutdown yes
+    ]
+    d = create_driver(conf)
+    assert_equal 3600, d.instance.buffer_config.timekey_range
+    assert_equal 5, d.instance.buffer_config.flush_threads
+    assert_equal 50*1024*1024, d.instance.buffer.chunk_bytes_limit
+    assert_equal 128, d.instance.buffer.queue_length_limit
+    assert d.instance.buffer_config.flush_at_shutdown
+  end
+
   def test_format
     d = create_driver
     time, tests = create_test_case
 
-    tests.each { |test|
-      d.emit(test, time)
-    }
+    d.run(default_tag: 'test') do
+      d.feed(time, tests[0])
+      d.feed(time, tests[1])
+    end
 
-    d.expect_format %[2011-01-02 13:14:15\ttest\tv1\n]
-    d.expect_format %[2011-01-02 13:14:15\ttest\tv2\n]
-
-    d.run
+    assert_equal %[2011-01-02 13:14:15\ttest\tv1\n], d.formatted[0]
+    assert_equal %[2011-01-02 13:14:15\ttest\tv2\n], d.formatted[1]
   end
 
   def test_format_json
     d = create_driver("format json")
     time, tests = create_test_case
 
-    tests.each { |test|
-      d.emit(test, time)
-      d.expect_format Yajl.dump(test) + "\n"
-    }
+    d.run(default_tag: 'test') do
+      d.feed(time, tests[0])
+      d.feed(time, tests[1])
+    end
 
-    d.run
+    assert_equal Yajl.dump(tests[0]) + "\n", d.formatted[0]
+    assert_equal Yajl.dump(tests[1]) + "\n", d.formatted[1]
   end
 
   def test_format_msgpack
     d = create_driver("format msgpack")
     time, tests = create_test_case
 
-    tests.each { |test|
-      d.emit(test, time)
-      d.expect_format test.to_msgpack
-    }
+    d.run(default_tag: 'test') do
+      d.feed(time, tests[0])
+      d.feed(time, tests[1])
+    end
 
-    d.run
+    assert_equal tests[0].to_msgpack, d.formatted[0]
+    assert_equal tests[1].to_msgpack, d.formatted[1]
   end
 
   def test_format_time
@@ -98,30 +116,33 @@ class ExecOutputTest < Test::Unit::TestCase
     ]
     d = create_driver(config)
 
-    time = Fluent::EventTime::from_time(Time.parse("2011-01-02 13:14:15.123"))
+    time = event_time("2011-01-02 13:14:15.123")
     tests = [{"k1"=>"v1","kx"=>"vx"}, {"k1"=>"v2","kx"=>"vx"}]
 
-    tests.each { |test|
-      d.emit(test, time)
-    }
+    d.run(default_tag: 'test') do
+      d.feed(time, tests[0])
+      d.feed(time, tests[1])
+    end
 
-    d.expect_format %[2011-01-02 13:14:15.123\ttest\tv1\n]
-    d.expect_format %[2011-01-02 13:14:15.123\ttest\tv2\n]
-
-    d.run
+    assert_equal %[2011-01-02 13:14:15.123\ttest\tv1\n], d.formatted[0]
+    assert_equal %[2011-01-02 13:14:15.123\ttest\tv2\n], d.formatted[1]
   end
 
   def test_write
     d = create_driver
     time, tests = create_test_case
 
-    tests.each { |test|
-      d.emit(test, time)
-    }
-
-    d.run
+    d.run(default_tag: 'test', flush: true) do
+      d.feed(time, tests[0])
+      d.feed(time, tests[1])
+    end
 
     expect_path = "#{TMP_DIR}/out"
+
+    waiting(10, plugin: d.instance) do
+      sleep(0.1) until File.exist?(expect_path)
+    end
+
     assert_equal true, File.exist?(expect_path)
 
     data = File.read(expect_path)

--- a/test/plugin_helper/test_compat_parameters.rb
+++ b/test/plugin_helper/test_compat_parameters.rb
@@ -1,0 +1,175 @@
+require_relative '../helper'
+require 'fluent/plugin_helper/compat_parameters'
+require 'fluent/plugin/base'
+
+class CompatParameterTest < Test::Unit::TestCase
+  setup do
+    Fluent::Test.setup
+    @i = nil
+  end
+
+  teardown do
+    if @i
+      @i.stop unless @i.stopped?
+      @i.before_shutdown unless @i.before_shutdown?
+      @i.shutdown unless @i.shutdown?
+      @i.after_shutdown unless @i.after_shutdown?
+      @i.close unless @i.closed?
+      @i.terminate unless @i.terminated?
+    end
+  end
+
+  class Dummy0 < Fluent::Plugin::Output
+    helpers :compat_parameters
+    def compat_parameters_default_chunk_key
+      ''
+    end
+    def write(chunk)
+      # dummy
+    end
+  end
+  class Dummy1 < Fluent::Plugin::Output
+    helpers :compat_parameters
+    def compat_parameters_default_chunk_key
+      'time'
+    end
+    def write(chunk)
+      # dummy
+    end
+  end
+  class Dummy2 < Fluent::Plugin::Output
+    helpers :compat_parameters
+    # for test to assume default key time by 'time_slice_format'
+    def write(chunk)
+      # dummy
+    end
+  end
+  class Dummy3 < Fluent::Plugin::Output
+    helpers :compat_parameters
+    def compat_parameters_default_chunk_key
+      'tag'
+    end
+    def write(chunk)
+      # dummy
+    end
+  end
+
+  sub_test_case 'plugins which does not have default chunk key' do
+    setup do
+      @p = Dummy0
+    end
+
+    test 'plugin helper converts parameters into plugin configuration parameters' do
+      hash = {
+        'num_threads' => 8,
+        'flush_interval' => '10s',
+        'buffer_chunk_limit' => '8m',
+        'buffer_queue_limit' => '1024',
+        'flush_at_shutdown' => 'yes',
+      }
+      conf = config_element('ROOT', '', hash)
+      @i = @p.new
+      @i.configure(conf)
+
+      assert_equal 'memory', @i.buffer_config[:@type]
+      assert_equal [], @i.buffer_config.chunk_keys
+      assert_equal 8, @i.buffer_config.flush_threads
+      assert_equal 10, @i.buffer_config.flush_interval
+      assert @i.buffer_config.flush_at_shutdown
+
+      assert_equal 8*1024*1024, @i.buffer.chunk_bytes_limit
+      assert_equal 1024, @i.buffer.queue_length_limit
+    end
+  end
+
+  sub_test_case 'plugins which has default chunk key: time' do
+    setup do
+      @p = Dummy1
+    end
+
+    test 'plugin helper converts parameters into plugin configuration parameters' do
+      hash = {
+        'buffer_type' => 'file',
+        'buffer_path' => '/tmp/mybuffer',
+        'disable_retry_limit' => 'yes',
+        'max_retry_wait' => '1h',
+        'buffer_queue_full_action' => 'block',
+      }
+      conf = config_element('ROOT', '', hash)
+      @i = @p.new
+      @i.configure(conf)
+
+      assert_equal 'file', @i.buffer_config[:@type]
+      assert_equal 24*60*60, @i.buffer_config.timekey_range
+      assert @i.buffer_config.retry_forever
+      assert_equal 60*60, @i.buffer_config.retry_max_interval
+      assert_equal :block, @i.buffer_config.overflow_action
+
+      assert !@i.chunk_key_tag
+      assert_equal [], @i.chunk_keys
+
+      assert_equal '/tmp/mybuffer/buffer.*.log', @i.buffer.path
+    end
+  end
+
+  sub_test_case 'plugins which does not have default chunk key' do
+    setup do
+      @p = Dummy2
+    end
+
+    test 'plugin helper converts parameters into plugin configuration parameters' do
+      hash = {
+        'buffer_type' => 'file',
+        'buffer_path' => '/tmp/mybuffer',
+        'time_slice_format' => '%Y%m%d%H',
+        'time_slice_wait' => '10',
+        'retry_limit' => '1024',
+        'buffer_queue_full_action' => 'drop_oldest_chunk',
+      }
+      conf = config_element('ROOT', '', hash)
+      @i = @p.new
+      @i.configure(conf)
+
+      assert_equal 'file', @i.buffer_config[:@type]
+      assert_equal 60*60, @i.buffer_config.timekey_range
+      assert_equal 10, @i.buffer_config.timekey_wait
+      assert_equal 1024, @i.buffer_config.retry_max_times
+      assert_equal :drop_oldest_chunk, @i.buffer_config.overflow_action
+
+      assert @i.chunk_key_time
+      assert !@i.chunk_key_tag
+      assert_equal [], @i.chunk_keys
+
+      assert_equal '/tmp/mybuffer/buffer.*.log', @i.buffer.path
+    end
+  end
+
+  sub_test_case 'plugins which has default chunk key: tag' do
+    setup do
+      @p = Dummy3
+    end
+
+    test 'plugin helper converts parameters into plugin configuration parameters' do
+      hash = {
+        'buffer_type' => 'memory',
+        'num_threads' => '10',
+        'flush_interval' => '10s',
+        'try_flush_interval' => '0.1',
+        'queued_chunk_flush_interval' => '0.5',
+      }
+      conf = config_element('ROOT', '', hash)
+      @i = @p.new
+      @i.configure(conf)
+
+      assert_equal 'memory', @i.buffer_config[:@type]
+      assert_equal 10, @i.buffer_config.flush_threads
+      assert_equal 10, @i.buffer_config.flush_interval
+      assert_equal 0.1, @i.buffer_config.flush_thread_interval
+      assert_equal 0.5, @i.buffer_config.flush_burst_interval
+
+      assert !@i.chunk_key_time
+      assert @i.chunk_key_tag
+      assert_equal [], @i.chunk_keys
+    end
+  end
+end


### PR DESCRIPTION
This change introduces plugin test drivers for v0.14 plugin APIs, and includes some port of plugins for Input, Output (non-buffered and buffered [tag, time]).
Some fixes which were found via implementation of plugins/test drivers are also included.

This change depends on #981, #969 .