### PR TITLE
Fix overwriting config_section definitions:

### DIFF
--- a/lib/fluent/config/section.rb
+++ b/lib/fluent/config/section.rb
@@ -144,7 +144,7 @@ module Fluent
         check_unused_section(proxy, conf, plugin_class)
 
         proxy.sections.each do |name, subproxy|
-          varname = subproxy.param_name.to_sym
+          varname = subproxy.variable_name
           elements = (conf.respond_to?(:elements) ? conf.elements : []).select{ |e| e.name == subproxy.name.to_s || e.name == subproxy.alias.to_s }
           if elements.empty? && subproxy.init? && !subproxy.multi?
             elements << Fluent::Config::Element.new(subproxy.name.to_s, '', {}, [])

--- a/lib/fluent/configurable.rb
+++ b/lib/fluent/configurable.rb
@@ -41,9 +41,9 @@ module Fluent
         next if name.to_s.start_with?('@')
         subproxy = proxy.sections[name]
         if subproxy.multi?
-          instance_variable_set("@#{subproxy.param_name}".to_sym, [])
+          instance_variable_set("@#{subproxy.variable_name}".to_sym, [])
         else
-          instance_variable_set("@#{subproxy.param_name}".to_sym, nil)
+          instance_variable_set("@#{subproxy.variable_name}".to_sym, nil)
         end
       end
     end
@@ -145,7 +145,7 @@ module Fluent
 
       def config_section(name, **kwargs, &block)
         configure_proxy(self.name).config_section(name, **kwargs, &block)
-        attr_accessor configure_proxy(self.name).sections[name].param_name
+        attr_accessor configure_proxy(self.name).sections[name].variable_name
       end
 
       def desc(description)

--- a/test/config/test_configure_proxy.rb
+++ b/test/config/test_configure_proxy.rb
@@ -15,7 +15,8 @@ module Fluent::Config
 
           proxy = Fluent::Config::ConfigureProxy.new(:section, type_lookup: @type_lookup)
           assert_equal(:section, proxy.name)
-          assert_equal(:section, proxy.param_name)
+          assert_nil(proxy.param_name)
+          assert_equal(:section, proxy.variable_name)
           assert_nil(proxy.init)
           assert_nil(proxy.required)
           assert_false(proxy.required?)
@@ -27,6 +28,7 @@ module Fluent::Config
           proxy = Fluent::Config::ConfigureProxy.new(:section, param_name: 'sections', init: true, required: false, multi: true, type_lookup: @type_lookup)
           assert_equal(:section, proxy.name)
           assert_equal(:sections, proxy.param_name)
+          assert_equal(:sections, proxy.variable_name)
           assert_false(proxy.required)
           assert_false(proxy.required?)
           assert_true(proxy.multi)
@@ -35,6 +37,7 @@ module Fluent::Config
           proxy = Fluent::Config::ConfigureProxy.new(:section, param_name: :sections, init: false, required: true, multi: false, type_lookup: @type_lookup)
           assert_equal(:section, proxy.name)
           assert_equal(:sections, proxy.param_name)
+          assert_equal(:sections, proxy.variable_name)
           assert_true(proxy.required)
           assert_true(proxy.required?)
           assert_false(proxy.multi)
@@ -51,7 +54,8 @@ module Fluent::Config
         test 'generate a new instance which values are overwritten by the argument object' do
           proxy = p1 = Fluent::Config::ConfigureProxy.new(:section, type_lookup: @type_lookup)
           assert_equal(:section, proxy.name)
-          assert_equal(:section, proxy.param_name)
+          assert_nil(proxy.param_name)
+          assert_equal(:section, proxy.variable_name)
           assert_nil(proxy.init)
           assert_nil(proxy.required)
           assert_false(proxy.required?)
@@ -59,10 +63,11 @@ module Fluent::Config
           assert_true(proxy.multi?)
           assert_nil(proxy.configured_in_section)
 
-          p2 = Fluent::Config::ConfigureProxy.new(:section, param_name: :sections, init: false, required: true, multi: false, type_lookup: @type_lookup)
+          p2 = Fluent::Config::ConfigureProxy.new(:section, init: false, required: true, multi: false, type_lookup: @type_lookup)
           proxy = p1.merge(p2)
           assert_equal(:section, proxy.name)
-          assert_equal(:sections, proxy.param_name)
+          assert_nil(proxy.param_name)
+          assert_equal(:section, proxy.variable_name)
           assert_false(proxy.init)
           assert_false(proxy.init?)
           assert_true(proxy.required)
@@ -73,13 +78,14 @@ module Fluent::Config
         end
 
         test 'does not overwrite with argument object without any specifications of required/multi' do
-          p1 = Fluent::Config::ConfigureProxy.new(:section1, type_lookup: @type_lookup)
+          p1 = Fluent::Config::ConfigureProxy.new(:section1, param_name: :sections, type_lookup: @type_lookup)
           p1.configured_in_section = :subsection
-          p2 = Fluent::Config::ConfigureProxy.new(:section2, param_name: :sections, init: false, required: true, multi: false, type_lookup: @type_lookup)
+          p2 = Fluent::Config::ConfigureProxy.new(:section2, init: false, required: true, multi: false, type_lookup: @type_lookup)
           p3 = Fluent::Config::ConfigureProxy.new(:section3, type_lookup: @type_lookup)
           proxy = p1.merge(p2).merge(p3)
-          assert_equal(:section3, proxy.name)
-          assert_equal(:section3, proxy.param_name)
+          assert_equal(:section1, proxy.name)
+          assert_equal(:sections, proxy.param_name)
+          assert_equal(:sections, proxy.variable_name)
           assert_false(proxy.init)
           assert_false(proxy.init?)
           assert_true(proxy.required)


### PR DESCRIPTION
 * "name" and "param_name" is strongly connected with plugin's code (even in base classes)
   so these MUST be not changed by subclasses (subclass MUST use same names)
 * separate "param_name" from "name" to detect overwriting "param_name" by subclasses to raise errors
   and add "variable_name" method as internal utility
 * make it possible to change default values in finalized sections
   because it's very popular that 3rd party plugin prefer different default value for built-in predefined parameters
 * make it possible to change "init" specification of finalized sections
   because newly added/changed default values might be able to init sections