### PR TITLE
Propagate default value change from subclass of compat plugins

### DIFF
--- a/lib/fluent/compat/output.rb
+++ b/lib/fluent/compat/output.rb
@@ -18,6 +18,7 @@ require 'fluent/plugin'
 require 'fluent/plugin/output'
 require 'fluent/plugin/bare_output'
 require 'fluent/compat/call_super_mixin'
+require 'fluent/compat/propagate_default'
 require 'fluent/compat/output_chain'
 require 'fluent/timezone'
 require 'fluent/mixin'
@@ -212,6 +213,11 @@ module Fluent
 
       PARAMS_MAP = Fluent::PluginHelper::CompatParameters::PARAMS_MAP
 
+      def self.propagate_default_params
+        PARAMS_MAP
+      end
+      include PropagateDefault
+
       def configure(conf)
         bufconf = CompatOutputUtils.buffer_section(conf)
         config_style = (bufconf ? :v1 : :v0)
@@ -400,6 +406,11 @@ module Fluent
 
       PARAMS_MAP = Fluent::PluginHelper::CompatParameters::PARAMS_MAP
 
+      def self.propagate_default_params
+        PARAMS_MAP
+      end
+      include PropagateDefault
+
       def configure(conf)
         bufconf = CompatOutputUtils.buffer_section(conf)
         config_style = (bufconf ? :v1 : :v0)
@@ -507,7 +518,7 @@ module Fluent
 
       attr_accessor :localtime
 
-      config_section :buffer, param_name: :buffer_config do
+      config_section :buffer do
         config_set_default :@type, 'file'
       end
 
@@ -524,12 +535,16 @@ module Fluent
         end
       end
 
+      def self.propagate_default_params
+        PARAMS_MAP
+      end
+      include PropagateDefault
+
       def configure(conf)
         bufconf = CompatOutputUtils.buffer_section(conf)
         config_style = (bufconf ? :v1 : :v0)
         if config_style == :v0
           buf_params = {
-            "@type"      => "file",
             "flush_mode" => (conf['flush_interval'] ? "interval" : "lazy"),
             "retry_type" => "exponential_backoff",
           }
@@ -542,9 +557,6 @@ module Fluent
                 buf_params[newer] = conf[older]
               end
             end
-          end
-          unless buf_params.has_key?("@type")
-            buf_params["@type"] = "file"
           end
 
           if conf['timezone']
@@ -599,3 +611,4 @@ module Fluent
     end
   end
 end
+

--- a/lib/fluent/compat/propagate_default.rb
+++ b/lib/fluent/compat/propagate_default.rb
@@ -1,0 +1,64 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'fluent/configurable'
+
+module Fluent
+  module Compat
+    module PropagateDefault
+      # This mixin is to prepend to 3rd party plugins of v0.12 APIs.
+      # 3rd party plugins may override default values of some parameters, like `buffer_type`.
+      # But default values of such parameters will NOT used, but defaults of <buffer>@type</buffer>
+      # will be used in fact. It should bring troubles.
+      # This mixin defines Class method .config_param and .config_set_default (which should be used by extend)
+      # to propagate changes of default values to subsections.
+      def self.included(mod)
+        mod.extend(ClassMethods)
+      end
+
+      module ClassMethods
+        CONFIGURABLE_CLASS_METHODS = Fluent::Configurable::ClassMethods
+
+        def config_param(name, type = nil, **kwargs, &block)
+          CONFIGURABLE_CLASS_METHODS.instance_method(:config_param).bind(self).call(name, type, **kwargs, &block)
+          pparams = propagate_default_params
+          if kwargs.has_key?(:default) && pparams[name.to_s]
+            newer = pparams[name.to_s].to_sym
+            overridden_default_value = kwargs[:default]
+
+            CONFIGURABLE_CLASS_METHODS.instance_method(:config_section).bind(self).call(:buffer) do
+              config_set_default newer, overridden_default_value
+            end
+          end
+        end
+
+        def config_set_default(name, defval)
+          CONFIGURABLE_CLASS_METHODS.instance_method(:config_set_default).bind(self).call(name, defval)
+          pparams = propagate_default_params
+          if pparams[name.to_s]
+            newer = pparams[name.to_s].to_sym
+
+            CONFIGURABLE_CLASS_METHODS.instance_method(:config_section).bind(self).call(:buffer) do
+              self.config_set_default newer, defval
+              p(name: name, newer: newer, defval: defval, defaults: self.defaults)
+              p self.dump
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fluent/configurable.rb
+++ b/lib/fluent/configurable.rb
@@ -145,7 +145,10 @@ module Fluent
 
       def config_section(name, **kwargs, &block)
         configure_proxy(self.name).config_section(name, **kwargs, &block)
-        attr_accessor configure_proxy(self.name).sections[name].variable_name
+        variable_name = configure_proxy(self.name).sections[name].variable_name
+        unless self.respond_to?(variable_name)
+          attr_accessor variable_name
+        end
       end
 
       def desc(description)

--- a/test/config/test_configurable.rb
+++ b/test/config/test_configurable.rb
@@ -323,6 +323,12 @@ module ConfigurableSpec
       end
     end
 
+    class SubOwner < Owner
+      config_section :buffer do
+        config_set_default :size_of_something, 2048
+      end
+    end
+
     class FlatChild
       include Fluent::Configurable
       attr_accessor :owner
@@ -1031,6 +1037,14 @@ module Fluent::Config
         child.owner = owner
         child.configure(config_element('ROOT', '', {}, []))
         assert_equal 1024, child.size_of_something
+      end
+
+      test 'even in subclass of owner' do
+        owner = ConfigurableSpec::OverwriteDefaults::SubOwner.new
+        child = ConfigurableSpec::OverwriteDefaults::BufferChild.new
+        child.owner = owner
+        child.configure(config_element('ROOT', '', {}, []))
+        assert_equal 2048, child.size_of_something
       end
     end
 


### PR DESCRIPTION
3rd party plugins with v0.12 APIs may change default values of parameters, which is controlled by compat layers. This change should be propagated to defaults of `<buffer>` section.
This change fixes #995.