### PR TITLE
Fix shutdown sequence to wait force_flush

### DIFF
--- a/lib/fluent/plugin/in_dummy.rb
+++ b/lib/fluent/plugin/in_dummy.rb
@@ -80,7 +80,7 @@ module Fluent::Plugin
           break unless (thread_current_running? && Time.now.to_i <= current_time)
           wait(0.1) { emit(batch_num) }
         end
-        emit(residual_num)
+        emit(residual_num) if thread_current_running?
         # wait for next second
         while thread_current_running? && Time.now.to_i <= current_time
           sleep 0.01

--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -175,6 +175,7 @@ module Fluent
 
       lifecycle_unsafe_sequence = ->(method, checker) {
         operation = case method
+                    when :before_shutdown then "preparing shutdown"
                     when :shutdown then "shutting down"
                     when :close    then "closing"
                     else
@@ -199,7 +200,8 @@ module Fluent
 
       lifecycle_safe_sequence.call(:stop, :stopped?)
 
-      lifecycle_safe_sequence.call(:before_shutdown, :before_shutdown?)
+      # before_shutdown does force_flush for output plugins: it should block, so it's unsafe operation
+      lifecycle_unsafe_sequence.call(:before_shutdown, :before_shutdown?)
 
       lifecycle_unsafe_sequence.call(:shutdown, :shutdown?)
 


### PR DESCRIPTION
These changes are to wait `#force_flush` of output plugins.

`#before_shutdown` does `#force_flush` of output plugins, but it may emit events to other plugins. We should wait completion of all plugins before proceeding `#shutdown`.

This change also includes blocker callback per kinds of plugins for each shutdown sequence steps.
This feature makes it sure to call shutdown calls of input plugins before output plugins.