### PR TITLE
Fix `DEFAULT_PLUGIN_PATH`

### DIFF
--- a/lib/fluent/registry.rb
+++ b/lib/fluent/registry.rb
@@ -18,7 +18,7 @@ require 'fluent/config/error'
 
 module Fluent
   class Registry
-    DEFAULT_PLUGIN_PATH = File.expand_path('plugin', __FILE__)
+    DEFAULT_PLUGIN_PATH = File.expand_path('../plugin', __FILE__)
 
     def initialize(kind, search_prefix)
       @kind = kind


### PR DESCRIPTION
Before this commit `DEFAULT_PLUGIN_PATH` pointed
`lib/fluent/registry.rb/plugin`.
I feel this is not intended and change to point
`lib/fluent/plugin`.