### PR TITLE
Brush up error messages when `@type` is missed

### DIFF
--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -90,7 +90,7 @@ module Fluent
       end
 
       config_section :secondary, param_name: :secondary_config, required: false, multi: false, final: true do
-        config_param :@type, :string, default: nil, alias: :type
+        config_param :@type, :string, alias: :type
         config_section :buffer, required: false, multi: false do
           # dummy to detect invalid specification for here
         end


### PR DESCRIPTION
Remove default value from `@type` of `secondary` section in
Output plugin.

Before this commit if developers forget to specify `@type`,
these error messages were printed:

```
2016-06-05 19:14:44 +0900 [error]: fluent/supervisor.rb:528:
rescue in main_process: unexpected error error="undefined method `to_sym' for nil:NilClass"
```

This change brush up error messages to

```
2016-06-05 19:15:15 +0900 [error]: fluent/supervisor.rb:516:
rescue in main_process: config error file="./fluent/fluent.conf" \
error="'@type' parameter is required, in section secondary"
```