### PR TITLE
Add `@type` to secondary section

### DIFF
--- a/fluent.conf
+++ b/fluent.conf
@@ -90,6 +90,7 @@
     host 192.168.0.11
   </server>
   <secondary>
+    @type forward
     <server>
       host 192.168.0.12
     </server>


### PR DESCRIPTION
Without `@type` developers can not getting started
as web site says.

http://docs.fluentd.org/articles/install-by-gem