### PR TITLE
fix bug not to use primary plugin type in default

### DIFF
--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -196,8 +196,6 @@ module Fluent
       end
 
       def configure(conf)
-        primary_type = conf['@type']
-
         unless implement?(:synchronous) || implement?(:buffered) || implement?(:delayed_commit)
           raise "BUG: output plugin must implement some methods. see developer documents."
         end
@@ -290,7 +288,7 @@ module Fluent
 
           secondary_type = @secondary_config[:@type]
           unless secondary_type
-            secondary_type = primary_type
+            secondary_type = conf['@type'] # primary plugin type
           end
           secondary_conf = conf.elements(name: 'secondary').first
           @secondary = Plugin.new_output(secondary_type)

--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -196,6 +196,8 @@ module Fluent
       end
 
       def configure(conf)
+        primary_type = conf['@type']
+
         unless implement?(:synchronous) || implement?(:buffered) || implement?(:delayed_commit)
           raise "BUG: output plugin must implement some methods. see developer documents."
         end
@@ -287,6 +289,9 @@ module Fluent
           raise Fluent::ConfigError, "<secondary> section and 'retry_forever' are exclusive" if @buffer_config.retry_forever
 
           secondary_type = @secondary_config[:@type]
+          unless secondary_type
+            secondary_type = primary_type
+          end
           secondary_conf = conf.elements(name: 'secondary').first
           @secondary = Plugin.new_output(secondary_type)
           @secondary.acts_as_secondary(self)

--- a/test/plugin/test_output_as_buffered_secondary.rb
+++ b/test/plugin/test_output_as_buffered_secondary.rb
@@ -134,6 +134,19 @@ class BufferedOutputSecondaryTest < Test::Unit::TestCase
       end
     end
 
+    test 'uses same plugin type with primary if @type is missing in secondary' do
+      bufconf = config_element('buffer','tag',{'flush_interval' => 1, 'retry_type' => :periodic, 'retry_wait' => 3, 'retry_timeout' => 30, 'retry_randomize' => false})
+      secconf = config_element('secondary','',{})
+      priconf = config_element('ROOT', '', {'@type' => 'output_secondary_test'}, [bufconf, secconf])
+      i = create_output()
+      assert_nothing_raised do
+        i.configure(priconf)
+      end
+      logs = i.log.out.logs
+      assert{ logs.empty? }
+      assert{ i.secondary.is_a? FluentPluginOutputAsBufferedSecondaryTest::DummyFullFeatureOutput }
+    end
+
     test 'warns if secondary plugin is different type from primary one' do
       priconf = config_element('buffer','tag',{'flush_interval' => 1, 'retry_type' => :periodic, 'retry_wait' => 3, 'retry_timeout' => 30, 'retry_randomize' => false})
       secconf = config_element('secondary','',{'@type' => 'output_secondary_test2'})


### PR DESCRIPTION
If secondary type is not specified explicitly.
It's the same behavior with v0.12.