### PR TITLE
Add --run-worker to distinguish it from running without supervisor

### DIFF
--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -60,12 +60,13 @@ op.on('-d', '--daemon PIDFILE', "daemonize fluent process") {|s|
   opts[:daemonize] = s
 }
 
-op.on('--under-supervisor', "run fluent worker under supervisor (this option is NOT for users)") { opts[:supervise] = false
-  opts[:worker_with_supervisor] = true
+op.on('--under-supervisor', "run fluent worker under supervisor (this option is NOT for users)") {
+  opts[:supervise] = false
 }
 
 op.on('--no-supervisor', "run fluent worker without supervisor") {
   opts[:supervise] = false
+  opts[:standalone_worker] = true
 }
 
 op.on('--user USER', "change user") {|s|

--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -60,12 +60,11 @@ op.on('-d', '--daemon PIDFILE', "daemonize fluent process") {|s|
   opts[:daemonize] = s
 }
 
-op.on('--run-worker', "run fluent worker under supervisor") {
-  opts[:supervise] = false
+op.on('--under-supervisor', "run fluent worker under supervisor (this option is NOT for users)") { opts[:supervise] = false
   opts[:worker_with_supervisor] = true
 }
 
-op.on('--no-supervisor', "run without fluent supervisor") {
+op.on('--no-supervisor', "run fluent worker without supervisor") {
   opts[:supervise] = false
 }
 

--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -60,6 +60,11 @@ op.on('-d', '--daemon PIDFILE', "daemonize fluent process") {|s|
   opts[:daemonize] = s
 }
 
+op.on('--run-worker', "run fluent worker under supervisor") {
+  opts[:supervise] = false
+  opts[:worker_with_supervisor] = true
+}
+
 op.on('--no-supervisor', "run without fluent supervisor") {
   opts[:supervise] = false
 }

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -311,7 +311,7 @@ module Fluent
         without_source: false,
         use_v1_config: true,
         supervise: true,
-        worker_with_supervisor: false,
+        standalone_worker: false,
         signame: nil,
         winsvcreg: nil,
       }
@@ -320,7 +320,7 @@ module Fluent
     def initialize(opt)
       @daemonize = opt[:daemonize]
       @supervise = opt[:supervise]
-      @worker_with_supervisor = opt[:worker_with_supervisor]
+      @standalone_worker= opt[:standalone_worker]
       @config_path = opt[:config_path]
       @inline_config = opt[:inline_config]
       @use_v1_config = opt[:use_v1_config]
@@ -383,7 +383,7 @@ module Fluent
       $log.info "starting fluentd-#{Fluent::VERSION} without supervision"
 
       main_process do
-        create_socket_manager unless @worker_with_supervisor
+        create_socket_manager if @standalone_worker
         change_privilege
         init_engine
         run_configure

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -453,7 +453,7 @@ module Fluent
         }
       end
 
-      fluentd_spawn_cmd << ("--run-worker")
+      fluentd_spawn_cmd << ("--under-supervisor")
       $log.info "spawn command to main: " + fluentd_spawn_cmd
 
       params = {}


### PR DESCRIPTION
This fixes https://github.com/fluent/fluentd/issues/1027

・We have to distinguish running only worker without supervisor from running worker under supervisor, because when using only worker, we have to create socket manager in worker.

・If we fix not to use socket manager when --no-supervisor, we have to fix plugin side, then the point to fix will increase. So I fixed supervisor side.