### PR TITLE
Revert "Add `@type` to secondary section"

### DIFF
--- a/fluent.conf
+++ b/fluent.conf
@@ -90,7 +90,6 @@
     host 192.168.0.11
   </server>
   <secondary>
-    @type forward
     <server>
       host 192.168.0.12
     </server>


### PR DESCRIPTION
Reverts fluent/fluentd#1031

Secondary feature requires same formatting for buffer chunks, and it means that secondary plugins should be same type with primary.
Secondary without explicit `@type` uses same type with primary implicitly, and it's right way to use secondary plugins right now, without safe chunk decoding. We should NOT show explicit `@type` specification in example.