### PR TITLE
example: Use `@type` in example confs

### DIFF
--- a/example/filter_stdout.conf
+++ b/example/filter_stdout.conf
@@ -1,22 +1,22 @@
 <source>
-  type dummy
+  @type dummy
   tag dummy
 </source>
 
 <filter **>
-  type stdout
+  @type stdout
 </filter>
 
 <filter **>
-  type stdout
+  @type stdout
   output_type hash
 </filter>
 
 <filter **>
-  type stdout
+  @type stdout
   format ltsv
 </filter>
 
 <match **>
-  type null
+  @type null
 </match>

--- a/example/in_forward.conf
+++ b/example/in_forward.conf
@@ -1,7 +1,7 @@
 <source>
-  type forward
+  @type forward
 </source>
 
 <match test>
-  type stdout
+  @type stdout
 </match>

--- a/example/in_http.conf
+++ b/example/in_http.conf
@@ -1,5 +1,5 @@
 <source>
-  type http
+  @type http
   bind 0.0.0.0
   port 9880
   body_size_limit 32MB
@@ -10,5 +10,5 @@
 </source>
 
 <match test>
-  type stdout
+  @type stdout
 </match>

--- a/example/in_syslog.conf
+++ b/example/in_syslog.conf
@@ -1,5 +1,5 @@
 <source>
-  type syslog
+  @type syslog
   bind 0.0.0.0
   port 5140
   tag test
@@ -11,5 +11,5 @@
 </source>
 
 <match test>
-  type stdout
+  @type stdout
 </match>

--- a/example/in_tail.conf
+++ b/example/in_tail.conf
@@ -1,5 +1,5 @@
 <source>
-  type tail
+  @type tail
   format none
   path /var/log/fluentd_test.log
   pos_file /var/log/fluentd_test.pos
@@ -10,5 +10,5 @@
 </source>
 
 <match test>
-  type stdout
+  @type stdout
 </match>

--- a/example/in_tcp.conf
+++ b/example/in_tcp.conf
@@ -1,5 +1,5 @@
 <source>
-  type tcp
+  @type tcp
   format none
   bind 0.0.0.0
   port 5170
@@ -9,5 +9,5 @@
 </source>
 
 <match test>
-  type stdout
+  @type stdout
 </match>

--- a/example/in_udp.conf
+++ b/example/in_udp.conf
@@ -1,5 +1,5 @@
 <source>
-  type udp
+  @type udp
   format none
   bind 0.0.0.0
   port 5160
@@ -9,5 +9,5 @@
 </source>
 
 <match test>
-  type stdout
+  @type stdout
 </match>

--- a/example/out_copy.conf
+++ b/example/out_copy.conf
@@ -1,15 +1,15 @@
 <source>
-  type forward
+  @type forward
 </source>
 
 <match test>
-  type copy
+  @type copy
   deep_copy false
   <store>
-    type stdout
+    @type stdout
   </store>
   <store>
-    type file
+    @type file
     path /var/log/fluentd/out_file_test
     format json
     buffer_type memory

--- a/example/out_file.conf
+++ b/example/out_file.conf
@@ -1,9 +1,9 @@
 <source>
-  type forward
+  @type forward
 </source>
 
 <match test>
-  type file
+  @type file
   path /var/log/fluentd/out_file_test
   format json
   buffer_type memory

--- a/example/out_forward.conf
+++ b/example/out_forward.conf
@@ -1,10 +1,10 @@
 <source>
-  type dummy
+  @type dummy
   tag test
 </source>
 
 <match test>
-  type forward
+  @type forward
 
   <server>
     # first server

--- a/example/v0_12_filter.conf
+++ b/example/v0_12_filter.conf
@@ -9,7 +9,7 @@
 # $ echo '{"message":"hello world"}' | fluent-cat foo
 
 <source>
-  type forward
+  @type forward
   port 24224
 </source>
 
@@ -21,13 +21,13 @@
 # - {"messag22":"keep this please"} is filtered out.
 
 <filter foo>
-  type grep
+  @type grep
   regexp1  message keep this
 </filter>
 
 # Matches the events that was kept by the above filter
 <match foo>
-  type stdout
+  @type stdout
 </match>
 
 # For all events with the tag "bar", add the machine's hostname with
@@ -35,7 +35,7 @@
 # at 123.4.2.4:24224.
 
 <filter bar>
-  type record_transformer
+  @type record_transformer
   <record>
     hostname ${hostname}
   </record>
@@ -44,7 +44,7 @@
 # By the time it is getting matched here, the event has
 # the "hostname" field.
 <match bar>
-  type forward
+  @type forward
   <server>
     host 123.4.2.4
     port 24225
@@ -61,12 +61,12 @@
 # - {"last_name":"FURUHASHI"} throws an error because it has no field called "name"
 
 <filter foo.bar>
-  type grep
+  @type grep
   exclude1 hello .
 </filter>
 
 <filter foo.bar>
-  type record_transformer
+  @type record_transformer
   enable_ruby true
   <record>
     name ${name.downcase}
@@ -74,5 +74,5 @@
 </filter>
 
 <match foo.bar>
-  type stdout
+  @type stdout
 </match>


### PR DESCRIPTION
Otherwise, I've got the following warnings:

```log
2016-06-09 15:34:17 +0900 [info]: reading config file path="example/in_forward.conf"
2016-06-09 15:34:17 +0900 [info]: starting fluentd-0.14.0
2016-06-09 15:34:17 +0900 [info]: spawn command to main: /Users/hhatake/.rbenv/versions/2.3.0/bin/ruby -Eascii-8bit:ascii-8bit /Users/hhatake/Github/fluentd/vendor/bundle/ruby/2.3.0/bin/fluentd -c example/in_forward.conf --no-supervisor
2016-06-09 15:34:17 +0900 [info]: reading config file path="example/in_forward.conf"
2016-06-09 15:34:17 +0900 [info]: starting fluentd-0.14.0 without supervision
2016-06-09 15:34:17 +0900 [info]: gem 'fluentd' version '0.14.0'
2016-06-09 15:34:17 +0900 [warn]: 'type' is deprecated parameter name. use '@type' instead.
2016-06-09 15:34:17 +0900 [info]: adding match pattern="test" type="stdout"
2016-06-09 15:34:17 +0900 [warn]: 'type' is deprecated parameter name. use '@type' instead.
2016-06-09 15:34:17 +0900 [info]: adding source type="forward"
2016-06-09 15:34:17 +0900 [info]: using configuration file: <ROOT>
```