### PR TITLE
Test utility methods and additional test drivers

### DIFF
--- a/lib/fluent/test/driver/base.rb
+++ b/lib/fluent/test/driver/base.rb
@@ -14,6 +14,8 @@
 #    limitations under the License.
 #
 
+require 'fluent/config/element'
+require 'fluent/log'
 require 'fluent/test/driver/test_event_router'
 
 require 'timeout'

--- a/lib/fluent/test/driver/base_owned.rb
+++ b/lib/fluent/test/driver/base_owned.rb
@@ -1,0 +1,104 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'fluent/config'
+require 'fluent/config/element'
+require 'fluent/log'
+require 'fluent/test/driver/owner'
+
+module Fluent
+  module Test
+    module Driver
+      class BaseOwned
+        def initialize(klass, opts: {}, &block)
+          if klass.is_a?(Class)
+            if block
+              # Create new class for test w/ overwritten methods
+              #   klass.dup is worse because its ancestors does NOT include original class name
+              klass = Class.new(klass)
+              klass.module_eval(&block)
+            end
+            @instance = klass.new
+          else
+            @instance = klass
+          end
+          owner = Fluent::Test::Driver::Owner.new
+          if opts
+            owner.system_config_override(opts)
+          end
+          owner.log = TestLogger.new
+
+          @instance.owner = owner
+          if opts
+            @instance.system_config_override(opts)
+          end
+
+          @logs = owner.log.out.logs
+          @section_name = ''
+        end
+
+        attr_reader :instance, :logs
+
+        def configure(conf, syntax: :v1)
+          if conf.is_a?(Fluent::Config::Element)
+            @config = conf
+          elsif conf.is_a?(Hash)
+            @config = Fluent::Config::Element.new(@section_name, "", Hash[conf.map{|k,v| [k.to_s, v]}])
+          else
+            @config = Fluent::Config.parse(conf, @section_name, "", syntax: syntax)
+          end
+          @instance.configure(@config)
+          self
+        end
+
+        def run(start: true, shutdown: true, &block)
+          instance_start if start
+
+          begin
+            yield
+          ensure
+            instance_shutdown if shutdown
+          end
+        end
+
+        def instance_start
+          unless @instance.started?
+            @instance.start
+            instance_hook_after_started
+          end
+        end
+
+        def instance_hook_after_started
+          # insert hooks for tests available after instance.start
+        end
+
+        def instance_shutdown
+          @instance.stop            unless @instance.stopped?
+          @instance.before_shutdown unless @instance.before_shutdown?
+          @instance.shutdown        unless @instance.shutdown?
+
+          if @instance.respond_to?(:event_loop_wait_until_stop)
+            @instance.event_loop_wait_until_stop
+          end
+
+          @instance.after_shutdown  unless @instance.after_shutdown?
+          @instance.close     unless @instance.closed?
+          @instance.terminate unless @instance.terminated?
+        end
+      end
+    end
+  end
+end

--- a/lib/fluent/test/driver/base_owned.rb
+++ b/lib/fluent/test/driver/base_owned.rb
@@ -56,7 +56,7 @@ module Fluent
           if conf.is_a?(Fluent::Config::Element)
             @config = conf
           elsif conf.is_a?(Hash)
-            @config = Fluent::Config::Element.new(@section_name, "", Hash[conf.map{|k,v| [k.to_s, v]}])
+            @config = Fluent::Config::Element.new(@section_name, "", Hash[conf.map{|k,v| [k.to_s, v]}], [])
           else
             @config = Fluent::Config.parse(conf, @section_name, "", syntax: syntax)
           end

--- a/lib/fluent/test/driver/formatter.rb
+++ b/lib/fluent/test/driver/formatter.rb
@@ -1,0 +1,30 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'fluent/test/driver/base_owned'
+
+module Fluent
+  module Test
+    module Driver
+      class Formatter < BaseOwned
+        def initialize(klass, **kwargs, &block)
+          super
+          @section_name = "format"
+        end
+      end
+    end
+  end
+end

--- a/lib/fluent/test/driver/owner.rb
+++ b/lib/fluent/test/driver/owner.rb
@@ -1,0 +1,32 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'fluent/plugin/base'
+require 'fluent/plugin_id'
+require 'fluent/log'
+require 'fluent/plugin_helper'
+
+module Fluent
+  module Test
+    module Driver
+      class Owner < Fluent::Plugin::Base
+        include PluginId
+        include PluginLoggerMixin
+        include PluginHelper::Mixin
+      end
+    end
+  end
+end

--- a/lib/fluent/test/driver/parser.rb
+++ b/lib/fluent/test/driver/parser.rb
@@ -1,0 +1,30 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'fluent/test/driver/base_owned'
+
+module Fluent
+  module Test
+    module Driver
+      class Parser < BaseOwned
+        def initialize(klass, **kwargs, &block)
+          super
+          @section_name = "parse"
+        end
+      end
+    end
+  end
+end

--- a/lib/fluent/test/helpers.rb
+++ b/lib/fluent/test/helpers.rb
@@ -1,0 +1,50 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'fluent/config/element'
+require 'fluent/msgpack_factory'
+require 'fluent/time'
+
+module Fluent
+  module Test
+    module Helpers
+      def config_element(name = 'test', argument = '', params = {}, elements = [])
+        Fluent::Config::Element.new(name, argument, params, elements)
+      end
+
+      def event_time(str=nil)
+        if str
+          Fluent::EventTime.parse(str)
+        else
+          Fluent::EventTime.now
+        end
+      end
+
+      def msgpack(type)
+        case type
+        when :factory
+          Fluent::MessagePackFactory.factory
+        when :packer
+          Fluent::MessagePackFactory.packer
+        when :unpacker
+          Fluent::MessagePackFactory.unpacker
+        else
+          raise ArgumentError, "unknown msgpack object type '#{type}'"
+        end
+      end
+    end
+  end
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -42,6 +42,7 @@ require 'fileutils'
 require 'fluent/config/element'
 require 'fluent/log'
 require 'fluent/test'
+require 'fluent/test/helpers'
 require 'fluent/plugin/base'
 require 'fluent/log'
 require 'fluent/plugin_id'
@@ -67,30 +68,7 @@ unless defined?(Test::Unit::AssertionFailedError)
   end
 end
 
-def config_element(name = 'test', argument = '', params = {}, elements = [])
-  Fluent::Config::Element.new(name, argument, params, elements)
-end
-
-def event_time(str=nil)
-  if str
-    Fluent::EventTime.parse(str)
-  else
-    Fluent::EventTime.now
-  end
-end
-
-def msgpack(type)
-  case type
-  when :factory
-    Fluent::MessagePackFactory.factory
-  when :packer
-    Fluent::MessagePackFactory.packer
-  when :unpacker
-    Fluent::MessagePackFactory.unpacker
-  else
-    raise ArgumentError, "unknown msgpack object type '#{type}'"
-  end
-end
+include Fluent::Test::Helpers
 
 def unused_port(num = 1)
   ports = []


### PR DESCRIPTION
When we want to write tests of 3rd party plugins, we need some more code for:
* generating Fluent::EventTime easily
* generating Fluent::Config::Element easily (required for owned plugins - parser, formatter, storage, buffer and others)
* test drivers for owned plugins to support to
  * instantiate plugins
  * configure plugins
  * set logger, plugin id and override system configs
