### PR TITLE
Migrate out_exec_filter to v0.14 API

### DIFF
--- a/lib/fluent/plugin/out_exec_filter.rb
+++ b/lib/fluent/plugin/out_exec_filter.rb
@@ -367,7 +367,7 @@ module Fluent::Plugin
       if val = record.delete(@out_time_key)
         time = @time_parse_proc.call(val)
       else
-        time = Engine.now
+        time = Fluent::Engine.now
       end
 
       if val = record.delete(@out_tag_key)


### PR DESCRIPTION
I've tried to migrate `out_exec_filter` to v0.14 API.
Should we provide asynchronous buffered mode in this plugin?
