### PR TITLE
Warn too many staged chunks at configure

### DIFF
--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -37,6 +37,8 @@ module Fluent
       CHUNK_KEY_PATTERN = /^[-_.@a-zA-Z0-9]+$/
       CHUNK_KEY_PLACEHOLDER_PATTERN = /\$\{[-_.@a-zA-Z0-9]+\}/
 
+      CHUNKING_FIELD_WARN_NUM = 4
+
       config_param :time_as_integer, :bool, default: false
 
       # `<buffer>` and `<secondary>` sections are available only when '#format' and '#write' are implemented
@@ -251,6 +253,10 @@ module Fluent
             Fluent::Timezone.validate!(@buffer_config.timekey_zone)
             @buffer_config.timekey_zone = '+0000' if @buffer_config.timekey_use_utc
             @output_time_formatter_cache = {}
+          end
+
+          if (@chunk_key_tag ? 1 : 0) + @chunk_keys.size >= CHUNKING_FIELD_WARN_NUM
+            log.warn "many chunk keys specified, and it may cause too many chunks on your system."
           end
 
           # no chunk keys or only tags (chunking can be done without iterating event stream)

--- a/lib/fluent/test.rb
+++ b/lib/fluent/test.rb
@@ -16,6 +16,7 @@
 
 require 'test/unit'
 require 'fluent/env' # for Fluent.windows?
+require 'fluent/test/log'
 require 'fluent/test/base'
 require 'fluent/test/input_test'
 require 'fluent/test/output_test'
@@ -29,3 +30,22 @@ dl_opts[:log_level] = ServerEngine::DaemonLogger::INFO
 logdev = Fluent::Test::DummyLogDevice.new
 logger = ServerEngine::DaemonLogger.new(logdev, dl_opts)
 $log ||= Fluent::Log.new(logger)
+
+module Fluent
+  module Test
+    def self.setup
+      Fluent.__send__(:remove_const, :Engine)
+      engine = Fluent.const_set(:Engine, EngineClass.new).init(SystemConfig.new)
+
+      engine.define_singleton_method(:now=) {|n|
+        @now = n
+      }
+      engine.define_singleton_method(:now) {
+        @now ||= super()
+      }
+
+      nil
+    end
+  end
+end
+

--- a/lib/fluent/test/base.rb
+++ b/lib/fluent/test/base.rb
@@ -14,27 +14,14 @@
 #    limitations under the License.
 #
 
+require 'fluent/config'
 require 'fluent/engine'
 require 'fluent/system_config'
-require 'fluent/config'
+require 'fluent/test/log'
 require 'serverengine'
 
 module Fluent
   module Test
-    def self.setup
-      Fluent.__send__(:remove_const, :Engine)
-      engine = Fluent.const_set(:Engine, EngineClass.new).init(SystemConfig.new)
-
-      engine.define_singleton_method(:now=) {|n|
-        @now = n
-      }
-      engine.define_singleton_method(:now) {
-        @now ||= super()
-      }
-
-      nil
-    end
-
     class TestDriver
       include ::Test::Unit::Assertions
 
@@ -82,57 +69,6 @@ module Fluent
         ensure
           @instance.shutdown
         end
-      end
-    end
-
-    class DummyLogDevice
-      attr_reader :logs
-
-      def initialize
-        @logs = []
-      end
-
-      def reset
-        @logs = []
-      end
-
-      def tty?
-        false
-      end
-
-      def puts(*args)
-        args.each{ |arg| write(arg + "\n") }
-      end
-
-      def write(message)
-        @logs.push message
-      end
-
-      def flush
-        true
-      end
-
-      def close
-        true
-      end
-    end
-
-    class TestLogger < Fluent::PluginLogger
-      def initialize
-        @logdev = DummyLogDevice.new
-        dl_opts = {}
-        dl_opts[:log_level] = ServerEngine::DaemonLogger::INFO
-        logger = ServerEngine::DaemonLogger.new(@logdev, dl_opts)
-        log = Fluent::Log.new(logger)
-        super(log)
-      end
-
-      def reset
-        @logdev.reset
-      end
-
-      def logs
-        @logdev.logs
       end
     end
   end

--- a/lib/fluent/test/log.rb
+++ b/lib/fluent/test/log.rb
@@ -1,0 +1,73 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'serverengine'
+require 'fluent/log'
+
+module Fluent
+  module Test
+    class DummyLogDevice
+      attr_reader :logs
+
+      def initialize
+        @logs = []
+      end
+
+      def reset
+        @logs = []
+      end
+
+      def tty?
+        false
+      end
+
+      def puts(*args)
+        args.each{ |arg| write(arg + "\n") }
+      end
+
+      def write(message)
+        @logs.push message
+      end
+
+      def flush
+        true
+      end
+
+      def close
+        true
+      end
+    end
+
+    class TestLogger < Fluent::PluginLogger
+      def initialize
+        @logdev = DummyLogDevice.new
+        dl_opts = {}
+        dl_opts[:log_level] = ServerEngine::DaemonLogger::INFO
+        logger = ServerEngine::DaemonLogger.new(@logdev, dl_opts)
+        log = Fluent::Log.new(logger)
+        super(log)
+      end
+
+      def reset
+        @logdev.reset
+      end
+
+      def logs
+        @logdev.logs
+      end
+    end
+  end
+end


### PR DESCRIPTION
Output plugin with many chunk keys will generate too many staged chunks.
It doesn't cause crashes directly, but make performance worse and may cause any problems with file buffers.