### PR TITLE
Migrate in syslog to v0.14 API

### DIFF
--- a/lib/fluent/plugin/in_syslog.rb
+++ b/lib/fluent/plugin/in_syslog.rb
@@ -25,7 +25,7 @@ module Fluent::Plugin
   class SyslogInput < Input
     Fluent::Plugin.register_input('syslog', self)
 
-    helpers :thread, :parser, :event_loop
+    helpers :parser, :event_loop
 
     SYSLOG_REGEXP = /^\<([0-9]+)\>(.*)/
 

--- a/lib/fluent/plugin/in_syslog.rb
+++ b/lib/fluent/plugin/in_syslog.rb
@@ -17,13 +17,13 @@
 require 'cool.io'
 require 'yajl'
 
-require 'fluent/input'
+require 'fluent/plugin/input'
 require 'fluent/config/error'
-require 'fluent/parser'
+require 'fluent/plugin/parser'
 
-module Fluent
+module Fluent::Plugin
   class SyslogInput < Input
-    Plugin.register_input('syslog', self)
+    Fluent::Plugin.register_input('syslog', self)
 
     SYSLOG_REGEXP = /^\<([0-9]+)\>(.*)/
 
@@ -99,11 +99,11 @@ module Fluent
       @use_default = false
 
       if conf.has_key?('format')
-        @parser = Plugin.new_parser(conf['format'])
+        @parser = Fluent::Plugin.new_parser(conf['format'])
         @parser.configure(conf)
       else
         conf['with_priority'] = true
-        @parser = TextParser::SyslogParser.new
+        @parser = Fluent::Plugin::SyslogParser.new
         @parser.configure(conf)
         @use_default = true
       end

--- a/lib/fluent/plugin/in_syslog.rb
+++ b/lib/fluent/plugin/in_syslog.rb
@@ -25,6 +25,8 @@ module Fluent::Plugin
   class SyslogInput < Input
     Fluent::Plugin.register_input('syslog', self)
 
+    helpers :thread
+
     SYSLOG_REGEXP = /^\<([0-9]+)\>(.*)/
 
     FACILITY_MAP = {
@@ -122,14 +124,13 @@ module Fluent::Plugin
       @handler = listen(callback)
       @loop.attach(@handler)
 
-      @thread = Thread.new(&method(:run))
+      thread_create(:syslog_input, &method(:run))
     end
 
     def shutdown
       @loop.watchers.each {|w| w.detach }
       @loop.stop
       @handler.close
-      @thread.join
 
       super
     end

--- a/lib/fluent/plugin/in_syslog.rb
+++ b/lib/fluent/plugin/in_syslog.rb
@@ -25,7 +25,7 @@ module Fluent::Plugin
   class SyslogInput < Input
     Fluent::Plugin.register_input('syslog', self)
 
-    helpers :thread
+    helpers :thread, :parser
 
     SYSLOG_REGEXP = /^\<([0-9]+)\>(.*)/
 
@@ -101,12 +101,10 @@ module Fluent::Plugin
       @use_default = false
 
       if conf.has_key?('format')
-        @parser = Fluent::Plugin.new_parser(conf['format'])
-        @parser.configure(conf)
+        @parser = parser_create(usage: 'syslog_input', type: conf['format'], conf: conf)
       else
         conf['with_priority'] = true
-        @parser = Fluent::Plugin::SyslogParser.new
-        @parser.configure(conf)
+        @parser = parser_create(usage: 'syslog_input', type: 'syslog', conf: conf)
         @use_default = true
       end
     end

--- a/test/plugin/test_in_syslog.rb
+++ b/test/plugin/test_in_syslog.rb
@@ -1,5 +1,5 @@
 require_relative '../helper'
-require 'fluent/test'
+require 'fluent/test/driver/input'
 require 'fluent/plugin/in_syslog'
 
 class SyslogInputTest < Test::Unit::TestCase
@@ -34,7 +34,7 @@ class SyslogInputTest < Test::Unit::TestCase
   ]
 
   def create_driver(conf=CONFIG)
-    Fluent::Test::InputTestDriver.new(Fluent::SyslogInput).configure(conf)
+    Fluent::Test::Driver::Input.new(Fluent::Plugin::SyslogInput).configure(conf)
   end
 
   def test_configure
@@ -69,9 +69,9 @@ class SyslogInputTest < Test::Unit::TestCase
         sleep 1
       end
 
-      emits = d.emits
-      emits.each_index {|i|
-        assert_equal_event_time(tests[i]['expected'], emits[i][1])
+      events = d.events
+      events.each_index {|i|
+        assert_equal_event_time(tests[i]['expected'], events[i][1])
       }
     }
   end
@@ -89,7 +89,7 @@ class SyslogInputTest < Test::Unit::TestCase
       sleep 1
     end
 
-    compare_test_result(d.emits, tests)
+    compare_test_result(d.events, tests)
   end
 
   def test_msg_size_with_tcp
@@ -105,7 +105,7 @@ class SyslogInputTest < Test::Unit::TestCase
       sleep 1
     end
 
-    compare_test_result(d.emits, tests)
+    compare_test_result(d.events, tests)
   end
 
   def test_msg_size_with_same_tcp_connection
@@ -121,7 +121,7 @@ class SyslogInputTest < Test::Unit::TestCase
       sleep 1
     end
 
-    compare_test_result(d.emits, tests)
+    compare_test_result(d.events, tests)
   end
 
   def test_msg_size_with_json_format
@@ -141,11 +141,11 @@ class SyslogInputTest < Test::Unit::TestCase
       sleep 1
     end
 
-    compare_test_result(d.emits, tests)
+    compare_test_result(d.events, tests)
   end
 
   def test_msg_size_with_include_source_host
-    d = create_driver([CONFIG, 'include_source_host'].join("\n"))
+    d = create_driver([CONFIG, 'include_source_host true'].join("\n"))
     tests = create_test_case
 
     host = nil
@@ -159,7 +159,7 @@ class SyslogInputTest < Test::Unit::TestCase
       sleep 1
     end
 
-    compare_test_result(d.emits, tests, host)
+    compare_test_result(d.events, tests, host)
   end
 
   def create_test_case
@@ -170,11 +170,11 @@ class SyslogInputTest < Test::Unit::TestCase
     ]
   end
 
-  def compare_test_result(emits, tests, host = nil)
-    emits.each_index { |i|
-      assert_equal('syslog.kern.info', emits[0][0]) # <6> means kern.info
-      assert_equal(tests[i]['expected'], emits[i][2]['message'])
-      assert_equal(host, emits[i][2]['source_host']) if host
+  def compare_test_result(events, tests, host = nil)
+    events.each_index { |i|
+      assert_equal('syslog.kern.info', events[i][0]) # <6> means kern.info
+      assert_equal(tests[i]['expected'], events[i][2]['message'])
+      assert_equal(host, events[i][2]['source_host']) if host
     }
   end
 end


### PR DESCRIPTION
- [x] Use v0.14 Input API
- [x] Use plugin helpers
  - [x] ~~thread~~
  - [x] parser
  - [x] event_loop
- [x] ~~Use udp and tcp plugin helpers after available~~ This PR should not contain this change.