### PR TITLE
Split events emitted at once to multi chunks

### DIFF
--- a/lib/fluent/compat/output.rb
+++ b/lib/fluent/compat/output.rb
@@ -314,7 +314,7 @@ module Fluent
           # on-the-fly key assignment can be done, and it's not configurable if Plugin#emit does it dynamically
           meta = @buffer.metadata(variables: (key && !key.empty? ? {key: key} : nil))
           write_guard do
-            @buffer.write({meta => [data, size]}, bulk: true, enqueue: enqueue)
+            @buffer.write({meta => data}, format: ->(data){ data }, size: ->(){ size }, enqueue: enqueue)
           end
           @counters_monitor.synchronize{ @emit_records += size }
           return [meta]
@@ -325,17 +325,16 @@ module Fluent
           size = es.size
           bulk = format_stream(tag, es)
           write_guard do
-            @buffer.write({meta => [bulk, size]}, bulk: true, enqueue: enqueue)
+            @buffer.write({meta => bulk}, format: ->(data){ data }, size: ->(){ size }, enqueue: enqueue)
           end
           @counters_monitor.synchronize{ @emit_records += size }
           return [meta]
         end
 
         meta = metadata(nil, nil, nil)
-        es_size = 0
-        es_bulk = es.map{|time,record| es_size += 1; format(tag, time, record) }.join
+        data = es.map{|time,record| format(tag, time, record) }
         write_guard do
-          @buffer.write({meta => [es_bulk, es_size]}, bulk: true, enqueue: enqueue)
+          @buffer.write({meta => data}, enqueue: enqueue)
         end
         @counters_monitor.synchronize{ @emit_records += es_size }
         [meta]

--- a/lib/fluent/compat/output.rb
+++ b/lib/fluent/compat/output.rb
@@ -314,7 +314,7 @@ module Fluent
           # on-the-fly key assignment can be done, and it's not configurable if Plugin#emit does it dynamically
           meta = @buffer.metadata(variables: (key && !key.empty? ? {key: key} : nil))
           write_guard do
-            @buffer.write({meta => data}, format: ->(data){ data }, size: ->(){ size }, enqueue: enqueue)
+            @buffer.write({meta => data}, format: ->(_data){ _data }, size: ->(){ size }, enqueue: enqueue)
           end
           @counters_monitor.synchronize{ @emit_records += size }
           return [meta]
@@ -325,7 +325,7 @@ module Fluent
           size = es.size
           bulk = format_stream(tag, es)
           write_guard do
-            @buffer.write({meta => bulk}, format: ->(data){ data }, size: ->(){ size }, enqueue: enqueue)
+            @buffer.write({meta => bulk}, format: ->(_data){ _data }, size: ->(){ size }, enqueue: enqueue)
           end
           @counters_monitor.synchronize{ @emit_records += size }
           return [meta]

--- a/lib/fluent/event.rb
+++ b/lib/fluent/event.rb
@@ -44,6 +44,11 @@ module Fluent
       false
     end
 
+    # for test
+    def ==(other)
+      self.to_msgpack_stream == other.to_msgpack_stream
+    end
+
     def slice(index, num)
       raise NotImplementedError, "DO NOT USE THIS CLASS directly."
     end

--- a/lib/fluent/event.rb
+++ b/lib/fluent/event.rb
@@ -44,11 +44,6 @@ module Fluent
       false
     end
 
-    # for test
-    def ==(other)
-      self.to_msgpack_stream == other.to_msgpack_stream
-    end
-
     def slice(index, num)
       raise NotImplementedError, "DO NOT USE THIS CLASS directly."
     end

--- a/lib/fluent/plugin/buffer.rb
+++ b/lib/fluent/plugin/buffer.rb
@@ -488,9 +488,7 @@ module Fluent
         if splits_count > data.size
           splits_count = data.size
         end
-        slice_size = if splits_count > data.size
-                       data.size
-                     elsif data.size % splits_count == 0
+        slice_size = if data.size % splits_count == 0
                        data.size / splits_count
                      else
                        data.size / (splits_count - 1)

--- a/lib/fluent/plugin/buffer.rb
+++ b/lib/fluent/plugin/buffer.rb
@@ -470,6 +470,11 @@ module Fluent
 
         unless stored
           # try step-by-step appending if data can't be stored into existing a chunk in non-bulk mode
+          #
+          # 1/10 size of original event stream (splits_count == 10) seems enough small
+          # to try emitting events into existing chunk.
+          # it does not matter to split event stream into very small splits, because chunks have less
+          # overhead to write data many times (even about file buffer chunks).
           write_step_by_step(metadata, data, format, 10, &block)
         end
       rescue ShouldRetry

--- a/lib/fluent/plugin/buffer/chunk.rb
+++ b/lib/fluent/plugin/buffer/chunk.rb
@@ -51,8 +51,8 @@ module Fluent
           @unique_id = generate_unique_id
           @metadata = metadata
 
-          # state: staged/queued/closed
-          @state = :staged
+          # state: unstaged/staged/queued/closed
+          @state = :unstaged
 
           @size = 0
           @created_at = Time.now
@@ -96,6 +96,14 @@ module Fluent
           size == 0
         end
 
+        def writable?
+          @state == :staged || @state == :unstaged
+        end
+
+        def unstaged?
+          @state == :unstaged
+        end
+
         def staged?
           @state == :staged
         end
@@ -108,16 +116,29 @@ module Fluent
           @state == :closed
         end
 
+        def staged!
+          @state = :staged
+          self
+        end
+
+        def unstaged!
+          @state = :unstaged
+          self
+        end
+
         def enqueued!
           @state = :queued
+          self
         end
 
         def close
           @state = :closed
+          self
         end
 
         def purge
           @state = :closed
+          self
         end
 
         def read

--- a/lib/fluent/plugin/buffer/file_chunk.rb
+++ b/lib/fluent/plugin/buffer/file_chunk.rb
@@ -56,7 +56,7 @@ module Fluent
         end
 
         def concat(bulk, bulk_size)
-          raise "BUG: appending to non-staged chunk, now '#{self.state}'" unless self.staged?
+          raise "BUG: appending to unwritable chunk, now '#{self.state}'" unless self.writable?
 
           bulk.force_encoding(Encoding::ASCII_8BIT)
           @chunk.write bulk
@@ -249,7 +249,7 @@ module Fluent
           @meta.sync = true
           @meta.binmode
 
-          @state = :staged
+          @state = :unstaged
           @bytesize = 0
           @commit_position = @chunk.pos # must be 0
           @adding_bytes = 0

--- a/lib/fluent/plugin/buffer/file_chunk.rb
+++ b/lib/fluent/plugin/buffer/file_chunk.rb
@@ -56,7 +56,7 @@ module Fluent
         end
 
         def concat(bulk, bulk_size)
-          raise "BUG: appending to unwritable chunk, now '#{self.state}'" unless self.writable?
+          raise "BUG: concatenating to unwritable chunk, now '#{self.state}'" unless self.writable?
 
           bulk.force_encoding(Encoding::ASCII_8BIT)
           @chunk.write bulk

--- a/lib/fluent/plugin/buffer/memory_chunk.rb
+++ b/lib/fluent/plugin/buffer/memory_chunk.rb
@@ -29,7 +29,7 @@ module Fluent
         end
 
         def concat(bulk, bulk_size)
-          raise "BUG: appending to unwritable chunk, now '#{self.state}'" unless self.writable?
+          raise "BUG: concatenating to unwritable chunk, now '#{self.state}'" unless self.writable?
 
           bulk.force_encoding(Encoding::ASCII_8BIT)
           @chunk << bulk

--- a/lib/fluent/plugin/buffer/memory_chunk.rb
+++ b/lib/fluent/plugin/buffer/memory_chunk.rb
@@ -29,7 +29,7 @@ module Fluent
         end
 
         def concat(bulk, bulk_size)
-          raise "BUG: appending to non-staged chunk, now '#{self.state}'" unless self.staged?
+          raise "BUG: appending to unwritable chunk, now '#{self.state}'" unless self.writable?
 
           bulk.force_encoding(Encoding::ASCII_8BIT)
           @chunk << bulk

--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -627,6 +627,9 @@ module Fluent
         end
       end
 
+      FORMAT_MSGPACK_STREAM = ->(e){ e.to_msgpack_stream }
+      FORMAT_MSGPACK_STREAM_TIME_INT = ->(e){ e.to_msgpack_stream(time_int: true) }
+
       # metadata_and_data is a Hash of:
       #  (standard format) metadata => event stream
       #  (custom format)   metadata => array of formatted event
@@ -653,7 +656,7 @@ module Fluent
       end
 
       def handle_stream_with_standard_format(tag, es, enqueue: false)
-        format_proc = ->(es){ es.to_msgpack_stream(time_int: @time_as_integer) }
+        format_proc = @time_as_integer ? FORMAT_MSGPACK_STREAM_TIME_INT : FORMAT_MSGPACK_STREAM
         meta_and_data = {}
         records = 0
         es.each do |time, record|
@@ -681,7 +684,7 @@ module Fluent
             records += 1
           end
         else
-          format_proc = ->(es){ es.to_msgpack_stream(time_int: @time_as_integer) }
+          format_proc = @time_as_integer ? FORMAT_MSGPACK_STREAM_TIME_INT : FORMAT_MSGPACK_STREAM
           data = es
         end
         write_guard do

--- a/lib/fluent/test/output_test.rb
+++ b/lib/fluent/test/output_test.rb
@@ -84,9 +84,9 @@ module Fluent
           end
 
           chunk = if @instance.instance_eval{ @chunk_key_tag }
-                    @instance.buffer.generate_chunk(@instance.metadata(@tag, nil, nil))
+                    @instance.buffer.generate_chunk(@instance.metadata(@tag, nil, nil)).staged!
                   else
-                    @instance.buffer.generate_chunk(@instance.metadata(nil, nil, nil))
+                    @instance.buffer.generate_chunk(@instance.metadata(nil, nil, nil)).staged!
                   end
           chunk.concat(buffer, es.size)
 
@@ -140,7 +140,7 @@ module Fluent
           end
 
           lines.keys.each do |meta|
-            chunk = @instance.buffer.generate_chunk(meta)
+            chunk = @instance.buffer.generate_chunk(meta).staged!
             chunk.append(lines[meta])
             begin
               result.push(@instance.write(chunk))

--- a/test/plugin/test_buf_file.rb
+++ b/test/plugin/test_buf_file.rb
@@ -181,7 +181,7 @@ class FileBufferTest < Test::Unit::TestCase
       assert c1.is_a? Fluent::Plugin::Buffer::FileChunk
       assert_equal m1, c1.metadata
       assert c1.empty?
-      assert_equal :staged, c1.state
+      assert_equal :unstaged, c1.state
       assert_equal Fluent::Plugin::Buffer::FileChunk::FILE_PERMISSION, c1.permission
       assert_equal @bufpath.gsub('.*.', ".b#{Fluent::UniqueId.hex(c1.unique_id)}."), c1.path
       assert{ File.stat(c1.path).mode.to_s(8).end_with?('644') }
@@ -191,7 +191,7 @@ class FileBufferTest < Test::Unit::TestCase
       assert c2.is_a? Fluent::Plugin::Buffer::FileChunk
       assert_equal m2, c2.metadata
       assert c2.empty?
-      assert_equal :staged, c2.state
+      assert_equal :unstaged, c2.state
       assert_equal Fluent::Plugin::Buffer::FileChunk::FILE_PERMISSION, c2.permission
       assert_equal @bufpath.gsub('.*.', ".b#{Fluent::UniqueId.hex(c2.unique_id)}."), c2.path
       assert{ File.stat(c2.path).mode.to_s(8).end_with?('644') }
@@ -221,7 +221,7 @@ class FileBufferTest < Test::Unit::TestCase
       assert c.is_a? Fluent::Plugin::Buffer::FileChunk
       assert_equal m, c.metadata
       assert c.empty?
-      assert_equal :staged, c.state
+      assert_equal :unstaged, c.state
       assert_equal 0600, c.permission
       assert_equal bufpath.gsub('.*.', ".b#{Fluent::UniqueId.hex(c.unique_id)}."), c.path
       assert{ File.stat(c.path).mode.to_s(8).end_with?('600') }

--- a/test/plugin/test_buffer.rb
+++ b/test/plugin/test_buffer.rb
@@ -1,6 +1,7 @@
 require_relative '../helper'
 require 'fluent/plugin/buffer'
 require 'fluent/plugin/buffer/memory_chunk'
+require 'fluent/event'
 require 'flexmock/test_unit'
 
 require 'fluent/log'
@@ -53,19 +54,25 @@ module FluentPluginBufferTest
       c.commit
       c
     end
+    def create_chunk_es(metadata, es)
+      c = FluentPluginBufferTest::DummyMemoryChunk.new(metadata)
+      c.concat(es.to_msgpack_stream, es.size)
+      c.commit
+      c
+    end
     def resume
       dm0 = create_metadata(Time.parse('2016-04-11 16:00:00 +0000').to_i, nil, nil)
       dm1 = create_metadata(Time.parse('2016-04-11 16:10:00 +0000').to_i, nil, nil)
       dm2 = create_metadata(Time.parse('2016-04-11 16:20:00 +0000').to_i, nil, nil)
       dm3 = create_metadata(Time.parse('2016-04-11 16:30:00 +0000').to_i, nil, nil)
       staged = {
-        dm2 => create_chunk(dm2, ["b" * 100]),
-        dm3 => create_chunk(dm3, ["c" * 100]),
+        dm2 => create_chunk(dm2, ["b" * 100]).staged!,
+        dm3 => create_chunk(dm3, ["c" * 100]).staged!,
       }
       queued = [
-        create_chunk(dm0, ["0" * 100]),
-        create_chunk(dm1, ["a" * 100]),
-        create_chunk(dm1, ["a" * 3]),
+        create_chunk(dm0, ["0" * 100]).enqueued!,
+        create_chunk(dm1, ["a" * 100]).enqueued!,
+        create_chunk(dm1, ["a" * 3]).enqueued!,
       ]
       return staged, queued
     end
@@ -93,6 +100,13 @@ class BufferTest < Test::Unit::TestCase
   def create_chunk(metadata, data)
     c = FluentPluginBufferTest::DummyMemoryChunk.new(metadata)
     c.append(data)
+    c.commit
+    c
+  end
+
+  def create_chunk_es(metadata, es)
+    c = FluentPluginBufferTest::DummyMemoryChunk.new(metadata)
+    c.concat(es.to_msgpack_stream, es.size)
     c.commit
     c
   end
@@ -507,6 +521,18 @@ class BufferTest < Test::Unit::TestCase
       assert_equal [@dm2,@dm3], @p.stage.keys
     end
 
+    test '#write returns immediately if argument data is empty event stream' do
+      assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
+      assert_equal [@dm2,@dm3], @p.stage.keys
+
+      m = @p.metadata(timekey: Time.parse('2016-04-11 16:40:00 +0000').to_i)
+
+      @p.write({m => Fluent::ArrayEventStream.new([])})
+
+      assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
+      assert_equal [@dm2,@dm3], @p.stage.keys
+    end
+
     test '#write raises BufferOverflowError if buffer is not storable' do
       @p.stage_size = 256 * 1024 * 1024
       @p.queue_size = 256 * 1024 * 1024
@@ -615,31 +641,20 @@ class BufferTest < Test::Unit::TestCase
       assert_equal row * 8, target_chunk.read
     end
 
-    test '#write w/ bulk returns immediately if argument data is nil or empty string' do
-      assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
-      assert_equal [@dm2,@dm3], @p.stage.keys
-
-      m = @p.metadata(timekey: Time.parse('2016-04-11 16:40:00 +0000').to_i)
-
-      @p.write({}, bulk: true)
-      @p.write({m => ['', 0]}, bulk: true)
-
-      assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
-      assert_equal [@dm2,@dm3], @p.stage.keys
-    end
-
-    test '#write w/ bulk raises BufferOverflowError if buffer is not storable' do
+    test '#write w/ format raises BufferOverflowError if buffer is not storable' do
       @p.stage_size = 256 * 1024 * 1024
       @p.queue_size = 256 * 1024 * 1024
 
       m = @p.metadata(timekey: Time.parse('2016-04-11 16:40:00 +0000').to_i)
 
+      es = Fluent::ArrayEventStream.new([ [event_time('2016-04-11 16:40:01 +0000'), {"message" => "xxxxxxxxxxxxxx"} ] ])
+
       assert_raise Fluent::Plugin::Buffer::BufferOverflowError do
-        @p.write({m => ["x" * 256, 1]}, bulk: true)
+        @p.write({m => es}, format: ->(e){e.to_msgpack_stream})
       end
     end
 
-    test '#write w/ bulk stores data into an existing chunk with metadata specified' do
+    test '#write w/ format stores data into an existing chunk with metadata specified' do
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3], @p.stage.keys
 
@@ -648,17 +663,25 @@ class BufferTest < Test::Unit::TestCase
 
       assert_equal 1, @p.stage[@dm3].append_count
 
-      @p.write({@dm3 => [("x"*256 + "y"*256 + "z"*256), 3]}, bulk: true)
+      es = Fluent::ArrayEventStream.new(
+        [
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "x" * 128}],
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "y" * 128}],
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "z" * 128}],
+        ]
+      )
+
+      @p.write({@dm3 => es}, format: ->(e){e.to_msgpack_stream})
 
       assert_equal 2, @p.stage[@dm3].append_count
-      assert_equal (dm3data + ("x" * 256) + ("y" * 256) + ("z" * 256)), @p.stage[@dm3].read
-      assert_equal (prev_stage_size + 768), @p.stage_size
+      assert_equal (dm3data + es.to_msgpack_stream), @p.stage[@dm3].read
+      assert_equal (prev_stage_size + es.to_msgpack_stream.bytesize), @p.stage_size
 
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3], @p.stage.keys
     end
 
-    test '#write w/ bulk creates new chunk and store data into it if there are not chunks for specified metadata' do
+    test '#write w/ format creates new chunk and store data into it if there are not chunks for specified metadata' do
       assert_equal 8 * 1024 * 1024, @p.chunk_limit_size
 
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
@@ -666,16 +689,26 @@ class BufferTest < Test::Unit::TestCase
 
       m = @p.metadata(timekey: Time.parse('2016-04-11 16:40:00 +0000').to_i)
 
-      row = "x" * 1024 * 1024
-      row_half = "x" * 1024 * 512
-      @p.write({m => [row*7 + row_half, 8]}, bulk: true)
+      es = Fluent::ArrayEventStream.new(
+        [
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "x" * 1024 * 1024}],
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "x" * 1024 * 1024}],
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "x" * 1024 * 1024}],
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "x" * 1024 * 1024}],
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "x" * 1024 * 1024}],
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "x" * 1024 * 1024}],
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "x" * 1024 * 1024}],
+          [event_time('2016-04-11 16:40:03 +0000'), {"message" => "z" * 1024 * 512}],
+        ]
+      )
+      @p.write({m => es}, format: ->(e){e.to_msgpack_stream})
 
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3,m], @p.stage.keys
       assert_equal 1, @p.stage[m].append_count
     end
 
-    test '#write w/ bulk tries to enqueue and store data into a new chunk if existing chunk does not have space for bulk' do
+    test '#write w/ format tries to enqueue and store data into a new chunk if existing chunk does not have enough space' do
       assert_equal 8 * 1024 * 1024, @p.chunk_limit_size
 
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
@@ -683,49 +716,80 @@ class BufferTest < Test::Unit::TestCase
 
       m = @p.metadata(timekey: Time.parse('2016-04-11 16:40:00 +0000').to_i)
 
-      row = "x" * 1024 * 1024
-      row_half = "x" * 1024 * 512
-      @p.write({m => [row*7 + row_half, 8]}, bulk: true)
+      es = Fluent::ArrayEventStream.new(
+        [
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "x" * 1024 * 1024}],
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "x" * 1024 * 1024}],
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "x" * 1024 * 1024}],
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "x" * 1024 * 1024}],
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "x" * 1024 * 1024}],
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "x" * 1024 * 1024}],
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "x" * 1024 * 1024}],
+          [event_time('2016-04-11 16:40:03 +0000'), {"message" => "z" * 1024 * 512}],
+        ]
+      )
+      @p.write({m => es}, format: ->(e){e.to_msgpack_stream})
 
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3,m], @p.stage.keys
       assert_equal 1, @p.stage[m].append_count
 
-      @p.write({m => [row, 1]}, bulk: true)
+      es2 = Fluent::OneEventStream.new(event_time('2016-04-11 16:40:03 +0000'), {"message" => "z" * 1024 * 1024})
+      @p.write({m => es2}, format: ->(e){e.to_msgpack_stream})
 
       assert_equal [@dm0,@dm1,@dm1,m], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3,m], @p.stage.keys
       assert_equal 1, @p.stage[m].append_count
-      assert_equal 1024*1024, @p.stage[m].bytesize
+      assert_equal es2.to_msgpack_stream.bytesize, @p.stage[m].bytesize
       assert_equal 2, @p.queue.last.append_count # 1 -> write (2) -> rollback&enqueue
       assert @p.queue.last.rollbacked
     end
 
-    test '#write w/ bulk enqueues chunk if it is already full after adding bulk data' do
+    test '#write w/ format enqueues chunk if it is already full after adding data' do
       assert_equal 8 * 1024 * 1024, @p.chunk_limit_size
 
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3], @p.stage.keys
 
       m = @p.metadata(timekey: Time.parse('2016-04-11 16:40:00 +0000').to_i)
-
-      row = "x" * 1024 * 1024
-      @p.write({m => [row * 8, 8]}, bulk: true)
+      es = Fluent::ArrayEventStream.new(
+        [
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "x" * (1024 * 1024 - 25)}], # 1024 * 1024 bytes as msgpack stream
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "x" * (1024 * 1024 - 25)}],
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "x" * (1024 * 1024 - 25)}],
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "x" * (1024 * 1024 - 25)}],
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "x" * (1024 * 1024 - 25)}],
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "x" * (1024 * 1024 - 25)}],
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "x" * (1024 * 1024 - 25)}],
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "x" * (1024 * 1024 - 25)}],
+        ]
+      )
+      @p.write({m => es}, format: ->(e){e.to_msgpack_stream})
 
       assert_equal [@dm0,@dm1,@dm1,m], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3], @p.stage.keys
       assert_equal 1, @p.queue.last.append_count
     end
 
-    test '#write w/ bulk rollbacks if commit raises errors' do
+    test '#write w/ format rollbacks if commit raises errors' do
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3], @p.stage.keys
 
       m = @p.metadata(timekey: Time.parse('2016-04-11 16:40:00 +0000').to_i)
 
-      row = "x" * 1024
-      row_half = "x" * 512
-      @p.write({m => [row * 7 + row_half, 8]}, bulk: true)
+      es = Fluent::ArrayEventStream.new(
+        [
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "x" * 1024 * 1024}],
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "x" * 1024 * 1024}],
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "x" * 1024 * 1024}],
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "x" * 1024 * 1024}],
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "x" * 1024 * 1024}],
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "x" * 1024 * 1024}],
+          [event_time('2016-04-11 16:40:01 +0000'), {"message" => "x" * 1024 * 1024}],
+          [event_time('2016-04-11 16:40:03 +0000'), {"message" => "z" * 1024 * 512}],
+        ]
+      )
+      @p.write({m => es}, format: ->(e){e.to_msgpack_stream})
 
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3,m], @p.stage.keys
@@ -739,8 +803,13 @@ class BufferTest < Test::Unit::TestCase
         define_method(:commit){ raise "yay" }
       end
 
+      es2 = Fluent::ArrayEventStream.new(
+        [
+          [event_time('2016-04-11 16:40:04 +0000'), {"message" => "z" * 1024 * 128}],
+        ]
+      )
       assert_raise "yay" do
-        @p.write({m => [row, 1]}, bulk: true)
+        @p.write({m => es2}, format: ->(e){e.to_msgpack_stream})
       end
 
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
@@ -748,7 +817,7 @@ class BufferTest < Test::Unit::TestCase
 
       assert_equal 2, target_chunk.append_count
       assert target_chunk.rollbacked
-      assert_equal row * 7 + row_half, target_chunk.read
+      assert_equal es.to_msgpack_stream, target_chunk.read
     end
 
     test '#write writes many metadata and data pairs at once' do
@@ -756,7 +825,7 @@ class BufferTest < Test::Unit::TestCase
       assert_equal [@dm2,@dm3], @p.stage.keys
 
       row = "x" * 1024
-      @p.write({ @dm0 => [row, row, row], @dm1 => [row, row] }, bulk: false)
+      @p.write({ @dm0 => [row, row, row], @dm1 => [row, row] })
 
       assert_equal [@dm2,@dm3,@dm0,@dm1], @p.stage.keys
     end
@@ -766,7 +835,7 @@ class BufferTest < Test::Unit::TestCase
       assert_equal [@dm2,@dm3], @p.stage.keys
 
       row = "x" * 1024
-      @p.write({ @dm0 => [row, row, row], @dm1 => [row, row] }, bulk: false)
+      @p.write({ @dm0 => [row, row, row], @dm1 => [row, row] })
 
       assert_equal [@dm2,@dm3,@dm0,@dm1], @p.stage.keys
 
@@ -783,7 +852,7 @@ class BufferTest < Test::Unit::TestCase
       @p.stage[@dm1].failing = true
 
       assert_raise(FluentPluginBufferTest::DummyMemoryChunkError) do
-        @p.write({ @dm2 => [row], @dm3 => [row], @dm0 => [row, row, row], @dm1 => [row, row] }, bulk: false)
+        @p.write({ @dm2 => [row], @dm3 => [row], @dm0 => [row, row, row], @dm1 => [row, row] })
       end
 
       assert{ @p.stage[@dm2].size == dm2_size }
@@ -798,6 +867,172 @@ class BufferTest < Test::Unit::TestCase
     end
   end
 
+  sub_test_case 'standard format with configuration for test with lower chunk limit size' do
+    setup do
+      @p = create_buffer({"chunk_limit_size" => 1_280_000})
+      @format = ->(e){e.to_msgpack_stream}
+      @dm0 = dm0 = create_metadata(Time.parse('2016-04-11 16:00:00 +0000').to_i, nil, nil)
+      # 1 record is 128bytes in msgpack stream
+      @es0 = es0 = Fluent::ArrayEventStream.new([ [event_time('2016-04-11 16:00:01 +0000'), {"message" => "x" * (128 - 22)}] ] * 5000)
+      (class << @p; self; end).module_eval do
+        define_method(:resume) {
+          staged = {
+            dm0 => create_chunk_es(dm0, es0).staged!,
+          }
+          queued = []
+          return staged, queued
+        }
+      end
+      @p.start
+    end
+
+    test '#write appends event stream into staged chunk' do
+      assert_equal [@dm0], @p.stage.keys
+      assert_equal [], @p.queue.map(&:metadata)
+
+      assert_equal 1_280_000, @p.chunk_limit_size
+
+      es = Fluent::ArrayEventStream.new([ [event_time('2016-04-11 16:00:02 +0000'), {"message" => "x" * (128 - 22)}] ] * 1000)
+      @p.write({@dm0 => es}, format: @format)
+
+      assert_equal [@dm0], @p.stage.keys
+      assert_equal [], @p.queue.map(&:metadata)
+
+      assert_equal (@es0.to_msgpack_stream + es.to_msgpack_stream), @p.stage[@dm0].read
+    end
+
+    test '#write writes event stream into a new chunk with enqueueing existing chunk if event stream is larger than available space of existing chunk' do
+      assert_equal [@dm0], @p.stage.keys
+      assert_equal [], @p.queue.map(&:metadata)
+
+      assert_equal 1_280_000, @p.chunk_limit_size
+
+      es = Fluent::ArrayEventStream.new([ [event_time('2016-04-11 16:00:02 +0000'), {"message" => "x" * (128 - 22)}] ] * 8000)
+      @p.write({@dm0 => es}, format: @format)
+
+      assert_equal [@dm0], @p.stage.keys
+      assert_equal [@dm0], @p.queue.map(&:metadata)
+
+      assert_equal (es.to_msgpack_stream), @p.stage[@dm0].read
+    end
+
+    test '#write writes event stream into many chunks excluding staged chunk if event stream is larger than chunk limit size' do
+      assert_equal [@dm0], @p.stage.keys
+      assert_equal [], @p.queue.map(&:metadata)
+
+      assert_equal 1_280_000, @p.chunk_limit_size
+
+      es = Fluent::ArrayEventStream.new([ [event_time('2016-04-11 16:00:02 +0000'), {"message" => "x" * (128 - 22)}] ] * 45000)
+      @p.write({@dm0 => es}, format: @format)
+
+      assert_equal [@dm0], @p.stage.keys
+      assert_equal 5400, @p.stage[@dm0].size
+      assert_equal [@dm0,@dm0,@dm0,@dm0,@dm0], @p.queue.map(&:metadata)
+      assert_equal [5000, 9900, 9900, 9900, 9900], @p.queue.map(&:size) # splits: 45000 / 100 => 450 * ...
+      # 9900 * 4 + 5400 == 45000
+    end
+
+    test '#write raises BufferChunkOverflowError if a record is biggar than chunk limit size' do
+      assert_equal [@dm0], @p.stage.keys
+      assert_equal [], @p.queue.map(&:metadata)
+
+      assert_equal 1_280_000, @p.chunk_limit_size
+
+      es = Fluent::ArrayEventStream.new([ [event_time('2016-04-11 16:00:02 +0000'), {"message" => "x" * 1_280_000}] ])
+      assert_raise Fluent::Plugin::Buffer::BufferChunkOverflowError do
+        @p.write({@dm0 => es}, format: @format)
+      end
+    end
+  end
+
+  sub_test_case 'custom format with configuration for test with lower chunk limit size' do
+    setup do
+      @p = create_buffer({"chunk_limit_size" => 1_280_000})
+      @dm0 = dm0 = create_metadata(Time.parse('2016-04-11 16:00:00 +0000').to_i, nil, nil)
+      @row = "x" * 128
+      @data0 = data0 = [@row] * 5000
+      (class << @p; self; end).module_eval do
+        define_method(:resume) {
+          staged = {
+            dm0 => create_chunk(dm0, data0).staged!,
+          }
+          queued = []
+          return staged, queued
+        }
+      end
+      @p.start
+    end
+
+    test '#write appends event stream into staged chunk' do
+      assert_equal [@dm0], @p.stage.keys
+      assert_equal [], @p.queue.map(&:metadata)
+
+      assert_equal 1_280_000, @p.chunk_limit_size
+
+      data = [@row] * 1000
+      @p.write({@dm0 => data})
+
+      assert_equal [@dm0], @p.stage.keys
+      assert_equal [], @p.queue.map(&:metadata)
+
+      assert_equal (@row * 6000), @p.stage[@dm0].read
+    end
+
+    test '#write writes event stream into a new chunk with enqueueing existing chunk if event stream is larger than available space of existing chunk' do
+      assert_equal [@dm0], @p.stage.keys
+      assert_equal [], @p.queue.map(&:metadata)
+
+      staged_chunk_object_id = @p.stage[@dm0].object_id
+
+      assert_equal 1_280_000, @p.chunk_limit_size
+
+      data = [@row] * 8000
+      @p.write({@dm0 => data})
+
+      assert_equal [@dm0], @p.queue.map(&:metadata)
+      assert_equal [staged_chunk_object_id], @p.queue.map(&:object_id)
+      assert_equal [@dm0], @p.stage.keys
+
+      assert_equal [9800], @p.queue.map(&:size)
+      assert_equal 3200, @p.stage[@dm0].size
+      # 9800 + 3200 == 5000 + 8000
+    end
+
+    test '#write writes event stream into many chunks including staging chunk if event stream is larger than chunk limit size' do
+      assert_equal [@dm0], @p.stage.keys
+      assert_equal [], @p.queue.map(&:metadata)
+
+      staged_chunk_object_id = @p.stage[@dm0].object_id
+
+      assert_equal 1_280_000, @p.chunk_limit_size
+
+      assert_equal 5000, @p.stage[@dm0].size
+
+      data = [@row] * 45000
+      @p.write({@dm0 => data})
+
+      assert_equal staged_chunk_object_id, @p.queue.first.object_id
+
+      assert_equal [@dm0], @p.stage.keys
+      assert_equal 900, @p.stage[@dm0].size
+      assert_equal [@dm0,@dm0,@dm0,@dm0,@dm0], @p.queue.map(&:metadata)
+      assert_equal [9500, 9900, 9900, 9900, 9900], @p.queue.map(&:size) # splits: 45000 / 100 => 450 * ...
+      ##### 900 + 9500 + 9900 * 4 == 5000 + 45000
+    end
+
+    test '#write raises BufferChunkOverflowError if a record is biggar than chunk limit size' do
+      assert_equal [@dm0], @p.stage.keys
+      assert_equal [], @p.queue.map(&:metadata)
+
+      assert_equal 1_280_000, @p.chunk_limit_size
+
+      es = ["x" * 1_280_000 + "x" * 300]
+      assert_raise Fluent::Plugin::Buffer::BufferChunkOverflowError do
+        @p.write({@dm0 => es})
+      end
+    end
+  end
+
   sub_test_case 'with configuration for test with lower limits' do
     setup do
       @p = create_buffer({"chunk_limit_size" => 1024, "total_limit_size" => 10240})
@@ -808,19 +1043,19 @@ class BufferTest < Test::Unit::TestCase
       (class << @p; self; end).module_eval do
         define_method(:resume) {
           staged = {
-            dm2 => create_chunk(dm2, ["b" * 128] * 7),
-            dm3 => create_chunk(dm3, ["c" * 128] * 5),
+            dm2 => create_chunk(dm2, ["b" * 128] * 7).staged!,
+            dm3 => create_chunk(dm3, ["c" * 128] * 5).staged!,
           }
           queued = [
-            create_chunk(dm0, ["0" * 128] * 8),
-            create_chunk(dm0, ["0" * 128] * 8),
-            create_chunk(dm0, ["0" * 128] * 8),
-            create_chunk(dm0, ["0" * 128] * 8),
-            create_chunk(dm0, ["0" * 128] * 8),
-            create_chunk(dm1, ["a" * 128] * 8),
-            create_chunk(dm1, ["a" * 128] * 8),
-            create_chunk(dm1, ["a" * 128] * 8), # 8
-            create_chunk(dm1, ["a" * 128] * 3),
+            create_chunk(dm0, ["0" * 128] * 8).enqueued!,
+            create_chunk(dm0, ["0" * 128] * 8).enqueued!,
+            create_chunk(dm0, ["0" * 128] * 8).enqueued!,
+            create_chunk(dm0, ["0" * 128] * 8).enqueued!,
+            create_chunk(dm0, ["0" * 128] * 8).enqueued!,
+            create_chunk(dm1, ["a" * 128] * 8).enqueued!,
+            create_chunk(dm1, ["a" * 128] * 8).enqueued!,
+            create_chunk(dm1, ["a" * 128] * 8).enqueued!, # 8th queued chunk
+            create_chunk(dm1, ["a" * 128] * 3).enqueued!,
           ]
           return staged, queued
         }
@@ -870,17 +1105,6 @@ class BufferTest < Test::Unit::TestCase
       c3 = create_chunk(m, ["a" * 128] * 6 + ["a" * 64])
       assert !@p.chunk_size_full?(c3)
     end
-
-    test '#write raises BufferChunkOverflowError if incoming data is bigger than chunk bytes limit' do
-      assert_equal [@dm0,@dm0,@dm0,@dm0,@dm0,@dm1,@dm1,@dm1,@dm1], @p.queue.map(&:metadata)
-      assert_equal [@dm2,@dm3], @p.stage.keys
-
-      m = create_metadata(Time.parse('2016-04-11 16:40:00 +0000').to_i)
-
-      assert_raise Fluent::Plugin::Buffer::BufferChunkOverflowError do
-        @p.write({m => ["a" * 128] * 9})
-      end
-    end
   end
 
   sub_test_case 'with configuration includes chunk_records_limit' do
@@ -893,14 +1117,14 @@ class BufferTest < Test::Unit::TestCase
       (class << @p; self; end).module_eval do
         define_method(:resume) {
           staged = {
-            dm2 => create_chunk(dm2, ["b" * 128] * 1),
-            dm3 => create_chunk(dm3, ["c" * 128] * 2),
+            dm2 => create_chunk(dm2, ["b" * 128] * 1).staged!,
+            dm3 => create_chunk(dm3, ["c" * 128] * 2).staged!,
           }
           queued = [
-            create_chunk(dm0, ["0" * 128] * 6),
-            create_chunk(dm1, ["a" * 128] * 6),
-            create_chunk(dm1, ["a" * 128] * 6),
-            create_chunk(dm1, ["a" * 128] * 3),
+            create_chunk(dm0, ["0" * 128] * 6).enqueued!,
+            create_chunk(dm1, ["a" * 128] * 6).enqueued!,
+            create_chunk(dm1, ["a" * 128] * 6).enqueued!,
+            create_chunk(dm1, ["a" * 128] * 3).enqueued!,
           ]
           return staged, queued
         }
@@ -951,14 +1175,14 @@ class BufferTest < Test::Unit::TestCase
       (class << @p; self; end).module_eval do
         define_method(:resume) {
           staged = {
-            dm2 => create_chunk(dm2, ["b" * 128] * 1),
-            dm3 => create_chunk(dm3, ["c" * 128] * 2),
+            dm2 => create_chunk(dm2, ["b" * 128] * 1).staged!,
+            dm3 => create_chunk(dm3, ["c" * 128] * 2).staged!,
           }
           queued = [
-            create_chunk(dm0, ["0" * 128] * 6),
-            create_chunk(dm1, ["a" * 128] * 6),
-            create_chunk(dm1, ["a" * 128] * 6),
-            create_chunk(dm1, ["a" * 128] * 3),
+            create_chunk(dm0, ["0" * 128] * 6).enqueued!,
+            create_chunk(dm1, ["a" * 128] * 6).enqueued!,
+            create_chunk(dm1, ["a" * 128] * 6).enqueued!,
+            create_chunk(dm1, ["a" * 128] * 3).enqueued!,
           ]
           return staged, queued
         }

--- a/test/plugin/test_buffer_file_chunk.rb
+++ b/test/plugin/test_buffer_file_chunk.rb
@@ -122,7 +122,7 @@ class BufferFileChunkTest < Test::Unit::TestCase
       assert File.exist?(gen_chunk_path('b', @c.unique_id) + '.meta')
       assert{ File.stat(gen_chunk_path('b', @c.unique_id) + '.meta').mode.to_s(8).end_with?(@klass.const_get('FILE_PERMISSION').to_s(8)) }
 
-      assert_equal :staged, @c.state
+      assert_equal :unstaged, @c.state
       assert @c.empty?
     end
 

--- a/test/plugin/test_output_as_standard.rb
+++ b/test/plugin/test_output_as_standard.rb
@@ -90,7 +90,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
       es = test_event_stream
 
       buffer_mock = flexmock(@i.buffer)
-      buffer_mock.should_receive(:write).once.with({m => [es.to_msgpack_stream, es.size]}, bulk: true, enqueue: false)
+      buffer_mock.should_receive(:write).once.with({m => es}, format: Fluent::Plugin::Output::FORMAT_MSGPACK_STREAM, enqueue: false)
 
       @i.execute_chunking("mytag.test", es)
     end
@@ -104,7 +104,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
       es = test_event_stream
 
       buffer_mock = flexmock(@i.buffer)
-      buffer_mock.should_receive(:write).once.with({m => [es.to_msgpack_stream(time_int: true), es.size]}, bulk: true, enqueue: false)
+      buffer_mock.should_receive(:write).once.with({m => es}, format: Fluent::Plugin::Output::FORMAT_MSGPACK_STREAM_TIME_INT, enqueue: false)
 
       @i.execute_chunking("mytag.test", es)
     end
@@ -120,7 +120,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
       es = test_event_stream
 
       buffer_mock = flexmock(@i.buffer)
-      buffer_mock.should_receive(:write).once.with({m => [es.to_msgpack_stream, es.size]}, bulk: true, enqueue: false)
+      buffer_mock.should_receive(:write).once.with({m => es}, format: Fluent::Plugin::Output::FORMAT_MSGPACK_STREAM, enqueue: false)
 
       @i.execute_chunking("mytag.test", es)
     end
@@ -134,7 +134,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
       es = test_event_stream
 
       buffer_mock = flexmock(@i.buffer)
-      buffer_mock.should_receive(:write).once.with({m => [es.to_msgpack_stream(time_int: true), es.size]}, bulk: true, enqueue: false)
+      buffer_mock.should_receive(:write).once.with({m => es}, format: Fluent::Plugin::Output::FORMAT_MSGPACK_STREAM_TIME_INT, enqueue: false)
 
       @i.execute_chunking("mytag.test", es)
     end
@@ -164,10 +164,10 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
 
       buffer_mock = flexmock(@i.buffer)
       buffer_mock.should_receive(:write).once.with({
-          m1 => [es1.to_msgpack_stream, 3],
-          m2 => [es2.to_msgpack_stream, 2],
-          m3 => [es3.to_msgpack_stream, 1],
-        }, bulk: true, enqueue: false)
+          m1 => es1,
+          m2 => es2,
+          m3 => es3,
+        }, format: Fluent::Plugin::Output::FORMAT_MSGPACK_STREAM, enqueue: false)
 
       es = test_event_stream
       @i.execute_chunking("mytag.test", es)
@@ -196,10 +196,10 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
 
       buffer_mock = flexmock(@i.buffer)
       buffer_mock.should_receive(:write).with({
-          m1 => [es1.to_msgpack_stream(time_int: true), 3],
-          m2 => [es2.to_msgpack_stream(time_int: true), 2],
-          m3 => [es3.to_msgpack_stream(time_int: true), 1],
-        }, bulk: true, enqueue: false)
+          m1 => es1,
+          m2 => es2,
+          m3 => es3,
+        }, format: Fluent::Plugin::Output::FORMAT_MSGPACK_STREAM_TIME_INT, enqueue: false)
 
       es = test_event_stream
       @i.execute_chunking("mytag.test", es)
@@ -226,9 +226,9 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
 
       buffer_mock = flexmock(@i.buffer)
       buffer_mock.should_receive(:write).with({
-          m1 => [es1.to_msgpack_stream, 5],
-          m2 => [es2.to_msgpack_stream, 1],
-        }, bulk: true, enqueue: false).once
+          m1 => es1,
+          m2 => es2,
+        }, format: Fluent::Plugin::Output::FORMAT_MSGPACK_STREAM, enqueue: false).once
 
       es = test_event_stream
       @i.execute_chunking("mytag.test", es)
@@ -253,9 +253,9 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
 
       buffer_mock = flexmock(@i.buffer)
       buffer_mock.should_receive(:write).with({
-          m1 => [es1.to_msgpack_stream(time_int: true), 5],
-          m2 => [es2.to_msgpack_stream(time_int: true), 1],
-        }, bulk: true, enqueue: false).once
+          m1 => es1,
+          m2 => es2,
+        }, format: Fluent::Plugin::Output::FORMAT_MSGPACK_STREAM_TIME_INT, enqueue: false).once
 
       es = test_event_stream
       @i.execute_chunking("mytag.test", es)
@@ -273,7 +273,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
       es = test_event_stream
 
       buffer_mock = flexmock(@i.buffer)
-      buffer_mock.should_receive(:write).once.with({m => [es.map{|t,r| [t,r].to_json }.join, es.size]}, bulk: true, enqueue: false)
+      buffer_mock.should_receive(:write).once.with({m => es.map{|t,r| [t,r].to_json }}, format: nil, enqueue: false)
 
       @i.execute_chunking("mytag.test", es)
     end
@@ -290,7 +290,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
       es = test_event_stream
 
       buffer_mock = flexmock(@i.buffer)
-      buffer_mock.should_receive(:write).once.with({m => [es.map{|t,r| [t,r].to_json }.join, es.size]}, bulk: true, enqueue: false)
+      buffer_mock.should_receive(:write).once.with({m => es.map{|t,r| [t,r].to_json}}, format: nil, enqueue: false)
 
       @i.execute_chunking("mytag.test", es)
     end
@@ -323,7 +323,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
           m1 => es1.map{|t,r| [t,r].to_json },
           m2 => es2.map{|t,r| [t,r].to_json },
           m3 => es3.map{|t,r| [t,r].to_json },
-        }, bulk: false, enqueue: false).once
+        }, enqueue: false).once
 
       es = test_event_stream
       @i.execute_chunking("mytag.test", es)
@@ -353,7 +353,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
       buffer_mock.should_receive(:write).with({
           m1 => es1.map{|t,r| [t,r].to_json },
           m2 => es2.map{|t,r| [t,r].to_json },
-        }, bulk: false, enqueue: false).once
+        }, enqueue: false).once
 
       es = test_event_stream
       @i.execute_chunking("mytag.test", es)

--- a/test/test_event.rb
+++ b/test/test_event.rb
@@ -114,6 +114,35 @@ module EventTest
       assert_true ArrayEventStream.new([]).empty?
     end
 
+    test 'size' do
+      assert_equal 2, @es.size
+      assert_equal 0, ArrayEventStream.new([]).size
+    end
+
+    test 'slice' do
+      sliced = @es.slice(1,1)
+      assert_kind_of EventStream, sliced
+      assert_equal 1, sliced.size
+
+      sliced.each do |time, record|
+        assert_equal @times[1], time
+        assert_equal 'v2', record['k']
+        assert_equal 2, record['n']
+      end
+
+      sliced = @es.slice(0,2)
+      assert_kind_of EventStream, sliced
+      assert_equal 2, sliced.size
+
+      counter = 0
+      sliced.each do |time, record|
+        assert_equal @times[counter], time
+        assert_equal @records[counter]['k'], record['k']
+        assert_equal @records[counter]['n'], record['n']
+        counter += 1
+      end
+    end
+
     test 'each' do
       i = 0
       @es.each { |time, record|
@@ -164,6 +193,35 @@ module EventTest
       assert_true MultiEventStream.new.empty?
     end
 
+    test 'size' do
+      assert_equal 2, @es.size
+      assert_equal 0, MultiEventStream.new.size
+    end
+
+    test 'slice' do
+      sliced = @es.slice(1,1)
+      assert_kind_of EventStream, sliced
+      assert_equal 1, sliced.size
+
+      sliced.each do |time, record|
+        assert_equal @times[1], time
+        assert_equal 'v2', record['k']
+        assert_equal 2, record['n']
+      end
+
+      sliced = @es.slice(0,2)
+      assert_kind_of EventStream, sliced
+      assert_equal 2, sliced.size
+
+      counter = 0
+      sliced.each do |time, record|
+        assert_equal @times[counter], time
+        assert_equal @records[counter]['k'], record['k']
+        assert_equal @records[counter]['n'], record['n']
+        counter += 1
+      end
+    end
+
     test 'each' do
       i = 0
       @es.each { |time, record|
@@ -204,14 +262,49 @@ module EventTest
       assert_kind_of MessagePackEventStream, dupped
       assert_not_equal @es.object_id, dupped.object_id
       assert_duplicated_records @es, dupped
+
+      # After iteration of events (done in assert_duplicated_records),
+      # duplicated event stream still has unpacked objects and correct size
+      dupped = @es.dup
+      assert_equal 2, dupped.instance_eval{ @size }
     end
 
     test 'empty?' do
       assert_false @es.empty?
+      assert_true MessagePackEventStream.new('', 0).empty?
+    end
+
+    test 'size' do
+      assert_equal 2, @es.size
+      assert_equal 0, MessagePackEventStream.new('').size
     end
 
     test 'repeatable?' do
       assert_true @es.repeatable?
+    end
+
+    test 'slice' do
+      sliced = @es.slice(1,1)
+      assert_kind_of EventStream, sliced
+      assert_equal 1, sliced.size
+
+      sliced.each do |time, record|
+        assert_equal @times[1], time
+        assert_equal 'v2', record['k']
+        assert_equal 2, record['n']
+      end
+
+      sliced = @es.slice(0,2)
+      assert_kind_of EventStream, sliced
+      assert_equal 2, sliced.size
+
+      counter = 0
+      sliced.each do |time, record|
+        assert_equal @times[counter], time
+        assert_equal @records[counter]['k'], record['k']
+        assert_equal @records[counter]['n'], record['n']
+        counter += 1
+      end
     end
 
     test 'each' do


### PR DESCRIPTION
This change make it possible to emit large event stream into some chunks.
It can't be done at v0.10/v0.12, but it should be done to remove warnings about chunks larger than chunk limit size.

When I was writing this change, I found some problems about locking chunks and buffer global lock.
I also improved it because the buffer with this change will operate much more chunks than ever.