### PR TITLE
Fix supervisor to pass RUBYOPT to worker process

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -439,14 +439,17 @@ module Fluent
     def supervise
       $log.info "starting fluentd-#{Fluent::VERSION}"
 
+      rubyopt = ENV["RUBYOPT"]
       if Fluent.windows?
         fluentd_spawn_cmd = ServerEngine.ruby_bin_path + " -Eascii-8bit:ascii-8bit "
+        fluentd_spawn_cmd << ' "' + rubyopt.gsub('"', '""') + '" ' if rubyopt
         fluentd_spawn_cmd << ' "' + $0.gsub('"', '""') + '" '
         $fluentdargv.each{|a|
           fluentd_spawn_cmd << ('"' + a.gsub('"', '""') + '" ')
         }
       else
         fluentd_spawn_cmd = ServerEngine.ruby_bin_path + " -Eascii-8bit:ascii-8bit "
+        fluentd_spawn_cmd << ' ' + rubyopt + ' ' if rubyopt
         fluentd_spawn_cmd << $0.shellescape + ' '
         $fluentdargv.each{|a|
           fluentd_spawn_cmd << (a.shellescape + " ")

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -441,6 +441,7 @@ module Fluent
 
       rubyopt = ENV["RUBYOPT"]
       if Fluent.windows?
+        # Shellwords doesn't work on windows, then used gsub for adapting space char instead of Shellwords
         fluentd_spawn_cmd = ServerEngine.ruby_bin_path + " -Eascii-8bit:ascii-8bit "
         fluentd_spawn_cmd << ' "' + rubyopt.gsub('"', '""') + '" ' if rubyopt
         fluentd_spawn_cmd << ' "' + $0.gsub('"', '""') + '" '


### PR DESCRIPTION
Fix https://github.com/fluent/fluentd/issues/1042

I did't use shellescape in unix for setting various values directly.