### PR TITLE
Add from_encoding parameter to in_tail plugin

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -115,19 +115,18 @@ module Fluent
     end
 
     def configure_encoding
-      if @encoding
-        @encoding = parse_encoding_param(@encoding)
+      unless @encoding
         if @from_encoding
-          @from_encoding = parse_encoding_param(@from_encoding)
-        end
-      else
-        if @from_encoding
-          $log.warn "'from_encoding' parameter must be specified in conjunction with 'encoding' paramter."
-          $log.warn "these parameter set to nil."
+          log.warn "'from_encoding' parameter must be specified with 'encoding' parameter."
+          log.warn "'from_encoding' is ignored"
           @encoding = nil
           @from_encoding = nil
+          return
         end
       end
+
+      @encoding = parse_encoding_param(@encoding) if @encoding
+      @from_encoding = parse_encoding_param(@from_encoding) if @from_encoding
     end
 
     def parse_encoding_param(encoding_name)

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -117,11 +117,7 @@ module Fluent
     def configure_encoding
       unless @encoding
         if @from_encoding
-          log.warn "'from_encoding' parameter must be specified with 'encoding' parameter."
-          log.warn "'from_encoding' is ignored"
-          @encoding = nil
-          @from_encoding = nil
-          return
+          raise ConfigError, "tail: 'from_encoding' parameter must be specified with 'encoding' parameter."
         end
       end
 

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -65,9 +65,9 @@ module Fluent
     desc 'Enable the additional watch timer.'
     config_param :enable_watch_timer, :bool, default: true
     desc 'The encoding after conversion of the input.'
-    config_param :encoding, default: nil
+    config_param :encoding, :string, default: nil
     desc 'The encoding of the input.'
-    config_param :from_encoding, default: nil
+    config_param :from_encoding, :string, default: nil
     desc 'Add the log path being tailed to records. Specify the field name to be used.'
     config_param :path_key, :string, default: nil
 

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -88,8 +88,7 @@ module Fluent
 
       configure_parser(conf)
       configure_tag
-      @encoding = parse_encoding_param(conf['encoding'])
-      @from_encoding = parse_encoding_param(conf['from_encoding'])
+      configure_encoding
 
       @multiline_mode = conf['format'] =~ /multiline/
       @receive_handler = if @multiline_mode
@@ -112,6 +111,22 @@ module Fluent
       else
         @tag_prefix = nil
         @tag_suffix = nil
+      end
+    end
+
+    def configure_encoding
+      if @encoding
+        @encoding = parse_encoding_param(@encoding)
+        if @from_encoding
+          @from_encoding = parse_encoding_param(@from_encoding)
+        end
+      else
+        if @from_encoding
+          $log.warn "'from_encoding' parameter must be specified in conjunction with 'encoding' paramter."
+          $log.warn "these parameter set to nil."
+          @encoding = nil
+          @from_encoding = nil
+        end
       end
     end
 

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -267,10 +267,12 @@ module Fluent
     def flush_buffer(tw)
       if lb = tw.line_buffer
         lb.chomp!
-        if @encoding && @from_encoding
-          lb.encode!(@encoding, @from_encoding)
-        elsif @encoding
-          lb.force_encoding(@encoding)
+        if @encoding
+          if @from_encoding
+            lb.encode!(@encoding, @from_encoding)
+          else
+            lb.force_encoding(@encoding)
+          end
         end
         @parser.parse(lb) { |time, record|
           if time && record
@@ -320,10 +322,12 @@ module Fluent
     def convert_line_to_event(line, es, tail_watcher)
       begin
         line.chomp!  # remove \n
-        if @encoding && @from_encoding
-          line.encode!(@encoding, @from_encoding)
-        elsif @encoding
-          line.force_encoding(@encoding)
+        if @encoding
+          if @from_encoding
+            line.encode!(@encoding, @from_encoding)
+          else
+            line.force_encoding(@encoding)
+          end
         end
         @parser.parse(line) { |time, record|
           if time && record

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -72,13 +72,27 @@ class TailInputTest < Test::Unit::TestCase
   end
 
   def test_configure_from_encoding
-    # valid from_encoding
+    # If only specified from_encoding set to nil
     d = create_driver(SINGLE_LINE_CONFIG + 'from_encoding utf-8')
+    assert_equal nil, d.instance.from_encoding
+
+    # valid setting
+    d = create_driver %[
+      format /(?<message>.*)/
+      read_from_head true
+      from_encoding utf-8
+      encoding utf-8
+    ]
     assert_equal Encoding::UTF_8, d.instance.from_encoding
 
     # invalid from_encoding
     assert_raise(Fluent::ConfigError) do
-      create_driver(SINGLE_LINE_CONFIG + 'from_encoding no-such-encoding')
+      d = create_driver %[
+        format /(?<message>.*)/
+        read_from_head true
+        from_encoding no-such-encoding
+        encoding utf-8
+      ]
     end
   end
 

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -72,9 +72,10 @@ class TailInputTest < Test::Unit::TestCase
   end
 
   def test_configure_from_encoding
-    # If only specified from_encoding set to nil
-    d = create_driver(SINGLE_LINE_CONFIG + 'from_encoding utf-8')
-    assert_equal nil, d.instance.from_encoding
+    # If only specified from_encoding raise ConfigError
+    assert_raise(Fluent::ConfigError) do
+      d = create_driver(SINGLE_LINE_CONFIG + 'from_encoding utf-8')
+    end
 
     # valid setting
     d = create_driver %[

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -71,6 +71,17 @@ class TailInputTest < Test::Unit::TestCase
     end
   end
 
+  def test_configure_from_encoding
+    # valid from_encoding
+    d = create_driver(SINGLE_LINE_CONFIG + 'from_encoding utf-8')
+    assert_equal Encoding::UTF_8, d.instance.from_encoding
+
+    # invalid from_encoding
+    assert_raise(Fluent::ConfigError) do
+      create_driver(SINGLE_LINE_CONFIG + 'from_encoding no-such-encoding')
+    end
+  end
+
   # TODO: Should using more better approach instead of sleep wait
 
   def test_emit
@@ -403,6 +414,28 @@ class TailInputTest < Test::Unit::TestCase
     assert_equal(encoding, emits[0][2]['message'].encoding)
   end
 
+  def test_from_encoding
+    d = create_driver %[
+      format /(?<message>.*)/
+      read_from_head true
+      from_encoding cp932
+      encoding utf-8
+    ]
+
+    d.run do
+      sleep 1
+
+      File.open("#{TMP_DIR}/tail.txt", "w:cp932") {|f|
+        f.puts "\x82\xCD\x82\xEB\x81\x5B\x82\xED\x81\x5B\x82\xE9\x82\xC7".force_encoding(Encoding::CP932)
+      }
+      sleep 1
+    end
+
+    emits = d.emits
+    assert_equal("\x82\xCD\x82\xEB\x81\x5B\x82\xED\x81\x5B\x82\xE9\x82\xC7".force_encoding(Encoding::CP932).encode(Encoding::UTF_8), emits[0][2]['message'])
+    assert_equal(Encoding::UTF_8, emits[0][2]['message'].encoding)
+  end
+
   # multiline mode test
 
   def test_multiline
@@ -504,6 +537,31 @@ class TailInputTest < Test::Unit::TestCase
       emits = d.emits
       assert_equal(1, emits.length)
       assert_equal(encoding, emits[0][2]['message1'].encoding)
+    end
+  end
+
+  def test_multiline_from_encoding_of_flushed_record
+    d = create_driver %[
+      format multiline
+      format1 /^s (?<message1>[^\\n]+)(\\nf (?<message2>[^\\n]+))?(\\nf (?<message3>.*))?/
+      format_firstline /^[s]/
+      multiline_flush_interval 2s
+      read_from_head true
+      from_encoding cp932
+      encoding utf-8
+    ]
+
+    d.run do
+      sleep 1
+      File.open("#{TMP_DIR}/tail.txt", "w:cp932") { |f|
+        f.puts "s \x82\xCD\x82\xEB\x81\x5B\x82\xED\x81\x5B\x82\xE9\x82\xC7".force_encoding(Encoding::CP932)
+      }
+
+      sleep 4
+      emits = d.emits
+      assert_equal(1, emits.length)
+      assert_equal("\x82\xCD\x82\xEB\x81\x5B\x82\xED\x81\x5B\x82\xE9\x82\xC7".force_encoding(Encoding::CP932).encode(Encoding::UTF_8), emits[0][2]['message1'])
+      assert_equal(Encoding::UTF_8, emits[0][2]['message1'].encoding)
     end
   end
 


### PR DESCRIPTION
Encoding parameter was added in_tail on v.0.12.24 and I used it.
When I reading logs encoded in CP932+LF, fluentd output warn log like a below.
```
2016-06-01 05:14:40 +0000 [warn]: ... error="invalid byte sequence in UTF-8"
```
```
<source>
  @type tail
  path /path/to/log/foo.log
  pos_file /path/to/log/foo.log.pos
  tag foo.var
  encoding utf-8
  format /^ something to read $/
</source>
<match **>
  @type stdout
</match>
```
