### PR TITLE
Fix TestDriver to let plugin instance always to have its class name

### DIFF
--- a/lib/fluent/test/base.rb
+++ b/lib/fluent/test/base.rb
@@ -30,7 +30,9 @@ module Fluent
           if block
             # Create new class for test w/ overwritten methods
             #   klass.dup is worse because its ancestors does NOT include original class name
+            klass_name = klass.name
             klass = Class.new(klass)
+            klass.define_singleton_method("name") { klass_name }
             klass.module_eval(&block)
           end
           @instance = klass.new

--- a/lib/fluent/test/driver/base.rb
+++ b/lib/fluent/test/driver/base.rb
@@ -31,7 +31,9 @@ module Fluent
             if block
               # Create new class for test w/ overwritten methods
               #   klass.dup is worse because its ancestors does NOT include original class name
+              klass_name = klass.name
               klass = Class.new(klass)
+              klass.define_singleton_method("name") { klass_name }
               klass.module_eval(&block)
             end
             @instance = klass.new

--- a/lib/fluent/test/formatter_test.rb
+++ b/lib/fluent/test/formatter_test.rb
@@ -26,7 +26,9 @@ module Fluent
           if block
             # Create new class for test w/ overwritten methods
             #   klass.dup is worse because its ancestors does NOT include original class name
+            klass_name = klass_or_str.name
             klass_or_str = Class.new(klass_or_str)
+            klass_or_str.define_singleton_method("name") { klass_name }
             klass_or_str.module_eval(&block)
           end
           @instance = klass_or_str.new

--- a/lib/fluent/test/parser_test.rb
+++ b/lib/fluent/test/parser_test.rb
@@ -25,7 +25,9 @@ module Fluent
           if block
             # Create new class for test w/ overwritten methods
             #   klass.dup is worse because its ancestors does NOT include original class name
+            klass_name = klass_or_str.name
             klass_or_str = Class.new(klass_or_str)
+            klass_or_str.define_singleton_method("name") { klass_name }
             klass_or_str.module_eval(&block)
           end
           case klass_or_str.instance_method(:initialize).arity


### PR DESCRIPTION
Noticed via https://github.com/fluent/fluent-plugin-s3/pull/154

v0.14 TestLogger currently outputs as:

```
2011-01-03 13:07:36 +0000 [warn]: [] out_s3: delayed events were put
```

when a TestDriver is created with a block.

v0.14 TestLogger tries to add optional_header like `[#{self.class.name}]`

```ruby
From: fluent/fluentd/lib/fluent/log.rb @ line 426 Fluent::PluginLoggerMixin#configure:

    422: def configure(conf)
    423:   super

    428:   if level = conf['@log_level']
    429:     unless @log.is_a?(PluginLogger)
    430:       @log = PluginLogger.new($log.dup)
    431:     end
    432:     @log.level = level
    433:     @log.optional_header = "[#{self.class.name}#{plugin_id_configured? ? "(" + @id + ")" : ""}] "
    434:     @log.optional_attrs = {}
    435:   end
    436: end
```

but, TestDriver creates plugin instance with Class.new if block is given, therefore, it does not have class name. In such case we get the extra `[]`.

With this fix, we will get `[Fluent::S3Output]` as we expect.