### PR TITLE
[WIP] Fix stopping Windows Service Fluentd

### DIFF
--- a/lib/fluent/winsvc.rb
+++ b/lib/fluent/winsvc.rb
@@ -66,7 +66,7 @@ class FluentdService < Win32::Daemon
   def service_stop
     begin
       $logger.call("waiting process stopped")
-      Porcess.waitpid(@pid)
+      Process.waitpid(@pid)
       $logger.call("child process successfully stopped")
     rescue Errno::ECHILD, Errno::ESRCH, Errno::EPERM
       # specified process is already dead


### PR DESCRIPTION
This change is to solve #1084. But there are still some problems.

* `Process.kill(:TERM, pid)` seems not to work as expected from the process as a Windows Service: Errno::INVALID raised (Invalid argument)
* `Process.kill(:INT, pid)` seems not to work as expected too: Errno::EBADF raised (Bad file descriptor)
* `Process.kill(:KILL, pid)` works as expected, but it kills Fluentd without shutdown sequence

Moreover, using `KILL` kills supervisor process only, without killing worker process. It is not what we want. Making `--no-supervisor` default helps this problem, but a big problem (shutdown sequence isn't called) still exists.
