### PR TITLE
Fix to stop Fluentd worker process by Ctrl-C when --no-supervisor specified

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -487,6 +487,13 @@ module Fluent
       # worker process SHOULD NOT do anything with SIGINT, SHOULD just ignore.
       trap :INT do
         $log.debug "fluentd main process get SIGINT"
+
+        # When Fluentd is launched without supervisor, worker should handle ctrl-c by itself
+        if @standalone_worker
+          @finished = true
+          $log.debug "getting start to shutdown main process"
+          Fluent::Engine.stop
+        end
       end
 
       trap :TERM do


### PR DESCRIPTION
Currently, if a user launches Fluentd on console with `--no-supervisor` option, that process cannot be shutdown by Ctrl-C.
This change fixes it.