### PR TITLE
Fix regression about RPC /api/config.reload

### DIFF
--- a/example/in_forward.conf
+++ b/example/in_forward.conf
@@ -1,3 +1,7 @@
+<system>
+  rpc_endpoint 0.0.0.0:24444
+</system>
+
 <source>
   @type forward
 </source>

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -114,10 +114,19 @@ module Fluent
     end
 
     def install_supervisor_signal_handlers
+      trap :HUP do
+        $log.debug "fluentd supervisor process get SIGHUP"
+        supervisor_sighup_handler
+      end unless Fluent.windows?
+
       trap :USR1 do
         $log.debug "fluentd supervisor process get SIGUSR1"
         supervisor_sigusr1_handler
       end unless Fluent.windows?
+    end
+
+    def supervisor_sighup_handler
+      kill_worker
     end
 
     def supervisor_sigusr1_handler
@@ -136,7 +145,7 @@ module Fluent
         if Fluent.windows?
           Process.kill :KILL, pid
         else
-          Process.kill :INT, pid
+          Process.kill :TERM, pid
         end
       end
     end


### PR DESCRIPTION
* ServerEngine handles HUP as IMMEDIATE_RESTART, and it sends SIGQUIT to workers
* QUIT isn't valid signal for Fluentd worker processes

Without this change, Fluentd worker process died without shutdown sequence of plugins.
```
2016-07-08 19:09:47 +0900 [info]: Received immediate restart
2016-07-08 19:09:48 +0900 [error]: unexpected error error_class=SignalException error="SIGQUIT"
  2016-07-08 19:09:48 +0900 [error]: /Users/tagomoris/github/fluentd/lib/fluent/engine.rb:182:in `sleep'
  2016-07-08 19:09:48 +0900 [error]: /Users/tagomoris/github/fluentd/lib/fluent/engine.rb:182:in `run'
  2016-07-08 19:09:48 +0900 [error]: /Users/tagomoris/github/fluentd/lib/fluent/supervisor.rb:605:in `run_engine'
  2016-07-08 19:09:48 +0900 [error]: /Users/tagomoris/github/fluentd/lib/fluent/supervisor.rb:390:in `block in run_worker'
  2016-07-08 19:09:48 +0900 [error]: /Users/tagomoris/github/fluentd/lib/fluent/supervisor.rb:534:in `main_process'
  2016-07-08 19:09:48 +0900 [error]: /Users/tagomoris/github/fluentd/lib/fluent/supervisor.rb:385:in `run_worker'
  2016-07-08 19:09:48 +0900 [error]: /Users/tagomoris/github/fluentd/lib/fluent/command/fluentd.rb:271:in `<top (required)>'
  2016-07-08 19:09:48 +0900 [error]: bin/fluentd:5:in `require'
  2016-07-08 19:09:48 +0900 [error]: bin/fluentd:5:in `<main>'
2016-07-08 19:09:49 +0900 [info]: Worker 0 finished with signal SIGQUIT
```

With this change, worker exits successfully.
```
2016-07-08 19:48:03 +0900 [debug]: fluent/supervisor.rb:118:block in install_supervisor_signal_handlers: fluentd supervisor process get SIGHUP
2016-07-08 19:48:03 +0900 [debug]: fluent/supervisor.rb:509:block in install_main_process_signal_handlers: fluentd main process get SIGTERM
2016-07-08 19:48:03 +0900 [debug]: fluent/supervisor.rb:512:block in install_main_process_signal_handlers: getting start to shutdown main process
2016-07-08 19:48:04 +0900 [info]: fluent/engine.rb:190:run: shutting down fluentd
2016-07-08 19:48:04 +0900 [debug]: fluent/root_agent.rb:170:block (2 levels) in shutdown: calling stop on input plugin type=:forward plugin_id="object:3ffaba52ae14"
2016-07-08 19:48:04 +0900 [debug]: fluent/root_agent.rb:170:block (2 levels) in shutdown: calling stop on output plugin type=:stdout plugin_id="object:3ffaba1f1d10"
2016-07-08 19:48:04 +0900 [info]: fluent/root_agent.rb:196:block (3 levels) in shutdown: preparing shutdown input plugin type=:forward plugin_id="object:3ffaba52ae14"
2016-07-08 19:48:04 +0900 [info]: fluent/root_agent.rb:196:block (3 levels) in shutdown: preparing shutdown output plugin type=:stdout plugin_id="object:3ffaba1f1d10"
2016-07-08 19:48:04 +0900 [info]: fluent/root_agent.rb:196:block (3 levels) in shutdown: shutting down input plugin type=:forward plugin_id="object:3ffaba52ae14"
2016-07-08 19:48:04 +0900 [info]: fluent/root_agent.rb:196:block (3 levels) in shutdown: shutting down output plugin type=:stdout plugin_id="object:3ffaba1f1d10"
2016-07-08 19:48:04 +0900 [debug]: fluent/root_agent.rb:170:block (2 levels) in shutdown: calling after_shutdown on input plugin type=:forward plugin_id="object:3ffaba52ae14"
2016-07-08 19:48:04 +0900 [debug]: fluent/root_agent.rb:170:block (2 levels) in shutdown: calling after_shutdown on output plugin type=:stdout plugin_id="object:3ffaba1f1d10"
2016-07-08 19:48:04 +0900 [info]: fluent/root_agent.rb:196:block (3 levels) in shutdown: closing input plugin type=:forward plugin_id="object:3ffaba52ae14"
2016-07-08 19:48:04 +0900 [info]: fluent/root_agent.rb:196:block (3 levels) in shutdown: closing output plugin type=:stdout plugin_id="object:3ffaba1f1d10"
2016-07-08 19:48:04 +0900 [debug]: fluent/root_agent.rb:170:block (2 levels) in shutdown: calling terminate on input plugin type=:forward plugin_id="object:3ffaba52ae14"
2016-07-08 19:48:04 +0900 [debug]: fluent/root_agent.rb:170:block (2 levels) in shutdown: calling terminate on output plugin type=:stdout plugin_id="object:3ffaba1f1d10"
2016-07-08 19:48:04 +0900 [info]: serverengine/multi_process_server.rb:124:alive?: Worker 0 finished unexpectedly with status 0
2016-07-08 19:48:05 +0900 [info]: fluent/supervisor.rb:573:read_config: reading config file path="example/in_forward.conf"
2016-07-08 19:48:05 +0900 [info]: fluent/supervisor.rb:392:run_worker: starting fluentd-0.14.1 without supervision
2016-07-08 19:48:05 +0900 [info]: fluent/engine.rb:116:block in configure: gem 'fluentd' version '0.14.1'
2016-07-08 19:48:05 +0900 [info]: fluent/agent.rb:131:add_match: adding match pattern="test" type="stdout"
```