### PR TITLE
Shrink buffer api

### DIFF
--- a/lib/fluent/plugin/buffer/chunk.rb
+++ b/lib/fluent/plugin/buffer/chunk.rb
@@ -63,9 +63,9 @@ module Fluent
 
         # data is array of formatted record string
         def append(data)
-          adding = ''.force_encoding(Encoding::ASCII_8BIT)
+          adding = ''.b
           data.each do |d|
-            adding << d.force_encoding(Encoding::ASCII_8BIT)
+            adding << d.b
           end
           concat(adding, data.size)
         end

--- a/lib/fluent/plugin/buffer/chunk.rb
+++ b/lib/fluent/plugin/buffer/chunk.rb
@@ -63,7 +63,11 @@ module Fluent
 
         # data is array of formatted record string
         def append(data)
-          raise NotImplementedError, "Implement this method in child class"
+          adding = ''.force_encoding(Encoding::ASCII_8BIT)
+          data.each do |d|
+            adding << d.force_encoding(Encoding::ASCII_8BIT)
+          end
+          concat(adding, data.size)
         end
 
         # for event streams which is packed or zipped (and we want not to unpack/uncompress)

--- a/lib/fluent/plugin/buffer/file_chunk.rb
+++ b/lib/fluent/plugin/buffer/file_chunk.rb
@@ -55,24 +55,6 @@ module Fluent
           end
         end
 
-        def append(data)
-          raise "BUG: appending to non-staged chunk, now '#{self.state}'" unless self.staged?
-
-          bytes = 0
-          adding = ''.force_encoding(Encoding::ASCII_8BIT)
-          data.each do |d|
-            x = d.force_encoding(Encoding::ASCII_8BIT)
-            bytes += x.bytesize
-            adding << x
-          end
-          @chunk.write adding
-
-          @adding_bytes += bytes
-          @adding_size += data.size
-
-          true
-        end
-
         def concat(bulk, bulk_size)
           raise "BUG: appending to non-staged chunk, now '#{self.state}'" unless self.staged?
 

--- a/lib/fluent/plugin/buffer/memory_chunk.rb
+++ b/lib/fluent/plugin/buffer/memory_chunk.rb
@@ -28,16 +28,6 @@ module Fluent
           @adding_size = 0
         end
 
-        def append(data)
-          raise "BUG: appending to non-staged chunk, now '#{self.state}'" unless self.staged?
-
-          adding = data.join.force_encoding(Encoding::ASCII_8BIT)
-          @chunk << adding
-          @adding_bytes += adding.bytesize
-          @adding_size += data.size
-          true
-        end
-
         def concat(bulk, bulk_size)
           raise "BUG: appending to non-staged chunk, now '#{self.state}'" unless self.staged?
 

--- a/test/plugin/test_buffer.rb
+++ b/test/plugin/test_buffer.rb
@@ -25,11 +25,6 @@ module FluentPluginBufferTest
       @purged = false
       @failing = false
     end
-    def append(data)
-      @append_count += 1
-      raise DummyMemoryChunkError if @failing
-      super
-    end
     def concat(data, size)
       @append_count += 1
       raise DummyMemoryChunkError if @failing

--- a/test/plugin/test_buffer_chunk.rb
+++ b/test/plugin/test_buffer_chunk.rb
@@ -30,7 +30,7 @@ class BufferChunkTest < Test::Unit::TestCase
       assert chunk.respond_to?(:open)
       assert chunk.respond_to?(:write_to)
       assert chunk.respond_to?(:msgpack_each)
-      assert_raise(NotImplementedError){ chunk.append(nil) }
+      assert_raise(NotImplementedError){ chunk.append([]) }
       assert_raise(NotImplementedError){ chunk.commit }
       assert_raise(NotImplementedError){ chunk.rollback }
       assert_raise(NotImplementedError){ chunk.bytesize }


### PR DESCRIPTION
This change is needed to minimize points to be overridden for 3rd party plugins which want to interrupt writing operations.