### PR TITLE
Reduce test execution time in syslog

### DIFF
--- a/test/plugin/test_in_syslog.rb
+++ b/test/plugin/test_in_syslog.rb
@@ -59,16 +59,12 @@ class SyslogInputTest < Test::Unit::TestCase
         {'msg' => '<6>Dec 11 00:00:00 localhost logger: foo', 'expected' => Fluent::EventTime.from_time(Time.strptime('Dec 11 00:00:00', '%b %d %H:%M:%S'))},
         {'msg' => '<6>Dec  1 00:00:00 localhost logger: foo', 'expected' => Fluent::EventTime.from_time(Time.strptime('Dec  1 00:00:00', '%b  %d %H:%M:%S'))},
       ]
-      d.end_if do
-        d.emit_count >= 2
-      end
       d.run(expect_emits: 2) do
         u = Fluent::SocketUtil.create_udp_socket(k)
         u.connect(k, PORT)
         tests.each {|test|
           u.send(test['msg'], 0)
         }
-        sleep(0.1) until d.stop?
       end
 
       events = d.events
@@ -82,16 +78,12 @@ class SyslogInputTest < Test::Unit::TestCase
     d = create_driver
     tests = create_test_case
 
-    d.end_if do
-      d.emit_count >= 2
-    end
     d.run(expect_emits: 2) do
       u = UDPSocket.new
       u.connect('127.0.0.1', PORT)
       tests.each {|test|
         u.send(test['msg'], 0)
       }
-      sleep(0.1) until d.stop?
     end
 
     compare_test_result(d.events, tests)
@@ -101,16 +93,12 @@ class SyslogInputTest < Test::Unit::TestCase
     d = create_driver([CONFIG, 'protocol_type tcp'].join("\n"))
     tests = create_test_case
 
-    d.end_if do
-      d.emit_count >= 2
-    end
     d.run(expect_emits: 2) do
       tests.each {|test|
         TCPSocket.open('127.0.0.1', PORT) do |s|
           s.send(test['msg'], 0)
         end
       }
-      sleep(0.1) until d.stop?
     end
 
     compare_test_result(d.events, tests)
@@ -120,16 +108,12 @@ class SyslogInputTest < Test::Unit::TestCase
     d = create_driver([CONFIG, 'protocol_type tcp'].join("\n"))
     tests = create_test_case
 
-    d.end_if do
-      d.emit_count >= 2
-    end
     d.run(expect_emits: 2) do
       TCPSocket.open('127.0.0.1', PORT) do |s|
         tests.each {|test|
           s.send(test['msg'], 0)
         }
       end
-      sleep(0.1) until d.stop?
     end
 
     compare_test_result(d.events, tests)
@@ -143,16 +127,12 @@ class SyslogInputTest < Test::Unit::TestCase
       {'msg' => '<6>' + event.to_json + "\n", 'expected' => msg}
     }
 
-    d.end_if do
-      d.emit_count >= 2
-    end
     d.run(expect_emits: 2) do
       u = UDPSocket.new
       u.connect('127.0.0.1', PORT)
       tests.each {|test|
         u.send(test['msg'], 0)
       }
-      sleep(0.1) until d.stop?
     end
 
     compare_test_result(d.events, tests)
@@ -163,9 +143,6 @@ class SyslogInputTest < Test::Unit::TestCase
     tests = create_test_case
 
     host = nil
-    d.end_if do
-      d.emit_count >= 2
-    end
     d.run(expect_emits: 2) do
       u = UDPSocket.new
       u.connect('127.0.0.1', PORT)
@@ -173,7 +150,6 @@ class SyslogInputTest < Test::Unit::TestCase
       tests.each {|test|
         u.send(test['msg'], 0)
       }
-      sleep(0.1) until d.stop?
     end
 
     compare_test_result(d.events, tests, host)

--- a/test/plugin/test_in_syslog.rb
+++ b/test/plugin/test_in_syslog.rb
@@ -59,15 +59,16 @@ class SyslogInputTest < Test::Unit::TestCase
         {'msg' => '<6>Dec 11 00:00:00 localhost logger: foo', 'expected' => Fluent::EventTime.from_time(Time.strptime('Dec 11 00:00:00', '%b %d %H:%M:%S'))},
         {'msg' => '<6>Dec  1 00:00:00 localhost logger: foo', 'expected' => Fluent::EventTime.from_time(Time.strptime('Dec  1 00:00:00', '%b  %d %H:%M:%S'))},
       ]
-
+      d.end_if do
+        d.emit_count >= 2
+      end
       d.run(expect_emits: 2) do
-        size = d.event_streams.size
         u = Fluent::SocketUtil.create_udp_socket(k)
         u.connect(k, PORT)
         tests.each {|test|
           u.send(test['msg'], 0)
         }
-        sleep(0.1) until d.emit_count >= size + 1
+        sleep(0.1) until d.stop?
       end
 
       events = d.events
@@ -81,14 +82,16 @@ class SyslogInputTest < Test::Unit::TestCase
     d = create_driver
     tests = create_test_case
 
+    d.end_if do
+      d.emit_count >= 2
+    end
     d.run(expect_emits: 2) do
-      size = d.event_streams.size
       u = UDPSocket.new
       u.connect('127.0.0.1', PORT)
       tests.each {|test|
         u.send(test['msg'], 0)
       }
-      sleep(0.1) until d.emit_count >= size + 1
+      sleep(0.1) until d.stop?
     end
 
     compare_test_result(d.events, tests)
@@ -98,14 +101,16 @@ class SyslogInputTest < Test::Unit::TestCase
     d = create_driver([CONFIG, 'protocol_type tcp'].join("\n"))
     tests = create_test_case
 
+    d.end_if do
+      d.emit_count >= 2
+    end
     d.run(expect_emits: 2) do
-      size = d.event_streams.size
       tests.each {|test|
         TCPSocket.open('127.0.0.1', PORT) do |s|
           s.send(test['msg'], 0)
         end
       }
-      sleep(0.1) until d.emit_count >= size + 1
+      sleep(0.1) until d.stop?
     end
 
     compare_test_result(d.events, tests)
@@ -115,14 +120,16 @@ class SyslogInputTest < Test::Unit::TestCase
     d = create_driver([CONFIG, 'protocol_type tcp'].join("\n"))
     tests = create_test_case
 
+    d.end_if do
+      d.emit_count >= 2
+    end
     d.run(expect_emits: 2) do
-      size = d.event_streams.size
       TCPSocket.open('127.0.0.1', PORT) do |s|
         tests.each {|test|
           s.send(test['msg'], 0)
         }
       end
-      sleep(0.1) until d.emit_count >= size + 1
+      sleep(0.1) until d.stop?
     end
 
     compare_test_result(d.events, tests)
@@ -136,14 +143,16 @@ class SyslogInputTest < Test::Unit::TestCase
       {'msg' => '<6>' + event.to_json + "\n", 'expected' => msg}
     }
 
+    d.end_if do
+      d.emit_count >= 2
+    end
     d.run(expect_emits: 2) do
-      size = d.event_streams.size
       u = UDPSocket.new
       u.connect('127.0.0.1', PORT)
       tests.each {|test|
         u.send(test['msg'], 0)
       }
-      sleep(0.1) until d.emit_count >= size + 1
+      sleep(0.1) until d.stop?
     end
 
     compare_test_result(d.events, tests)
@@ -154,15 +163,17 @@ class SyslogInputTest < Test::Unit::TestCase
     tests = create_test_case
 
     host = nil
+    d.end_if do
+      d.emit_count >= 2
+    end
     d.run(expect_emits: 2) do
-      size = d.event_streams.size
       u = UDPSocket.new
       u.connect('127.0.0.1', PORT)
       host = u.peeraddr[2]
       tests.each {|test|
         u.send(test['msg'], 0)
       }
-      sleep(0.1) until d.emit_count >= size + 1
+      sleep(0.1) until d.stop?
     end
 
     compare_test_result(d.events, tests, host)

--- a/test/plugin/test_in_syslog.rb
+++ b/test/plugin/test_in_syslog.rb
@@ -68,6 +68,7 @@ class SyslogInputTest < Test::Unit::TestCase
       end
 
       events = d.events
+      assert(events.size > 0)
       events.each_index {|i|
         assert_equal_event_time(tests[i]['expected'], events[i][1])
       }
@@ -86,6 +87,7 @@ class SyslogInputTest < Test::Unit::TestCase
       }
     end
 
+    assert(d.events.size > 0)
     compare_test_result(d.events, tests)
   end
 
@@ -101,6 +103,7 @@ class SyslogInputTest < Test::Unit::TestCase
       }
     end
 
+    assert(d.events.size > 0)
     compare_test_result(d.events, tests)
   end
 
@@ -116,6 +119,7 @@ class SyslogInputTest < Test::Unit::TestCase
       end
     end
 
+    assert(d.events.size > 0)
     compare_test_result(d.events, tests)
   end
 
@@ -135,6 +139,7 @@ class SyslogInputTest < Test::Unit::TestCase
       }
     end
 
+    assert(d.events.size > 0)
     compare_test_result(d.events, tests)
   end
 
@@ -152,6 +157,7 @@ class SyslogInputTest < Test::Unit::TestCase
       }
     end
 
+    assert(d.events.size > 0)
     compare_test_result(d.events, tests, host)
   end
 


### PR DESCRIPTION
```log
# master
% bundle exec ruby test/plugin/test_in_syslog.rb
Loaded suite test/plugin/test_in_syslog
Started
.......

Finished in 10.643330534 seconds.
--------------------------------------------------------------------------------
7 tests, 34 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------
0.66 tests/s, 3.19 assertions/s

# This branch
% bundle exec ruby test/plugin/test_in_syslog.rb
Loaded suite test/plugin/test_in_syslog
Started
.......

Finished in 7.054952274 seconds.
--------------------------------------------------------------------------------
7 tests, 34 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------
0.99 tests/s, 4.82 assertions/s
```