### PR TITLE
Use new test driver syntax in_exec test cases

### DIFF
--- a/test/plugin/test_in_exec.rb
+++ b/test/plugin/test_in_exec.rb
@@ -86,12 +86,7 @@ class ExecInputTest < Test::Unit::TestCase
   def test_emit
     d = create_driver
 
-    d.end_if do
-       d.emit_count >= 2
-    end
-    d.run do
-      sleep(0.1) until d.stop?
-    end
+    d.run(expect_emits: 2)
 
     assert_equal true, d.events.length > 0
     d.events.each_with_index {|event, i|
@@ -102,12 +97,8 @@ class ExecInputTest < Test::Unit::TestCase
 
   def test_emit_json
     d = create_driver json_config
-    d.end_if do
-       d.emit_count >= 2
-    end
-    d.run do
-      sleep(0.1) until d.stop?
-    end
+
+    d.run(expect_emits: 2)
 
     assert_equal true, d.events.length > 0
     d.events.each_with_index {|event, i|
@@ -119,12 +110,7 @@ class ExecInputTest < Test::Unit::TestCase
   def test_emit_msgpack
     d = create_driver msgpack_config
 
-    d.end_if do
-       d.emit_count >= 2
-    end
-    d.run do
-      sleep(0.1) until d.stop?
-    end
+    d.run(expect_emits: 2)
 
     assert_equal true, d.events.length > 0
     d.events.each_with_index {|event, i|
@@ -136,12 +122,7 @@ class ExecInputTest < Test::Unit::TestCase
   def test_emit_regexp
     d = create_driver regexp_config
 
-    d.end_if do
-       d.emit_count >= 2
-    end
-    d.run do
-      sleep(0.1) until d.stop?
-    end
+    d.run(expect_emits: 2)
 
     assert_equal true, d.events.length > 0
     d.events.each_with_index {|event, i|

--- a/test/plugin/test_in_exec.rb
+++ b/test/plugin/test_in_exec.rb
@@ -93,10 +93,11 @@ class ExecInputTest < Test::Unit::TestCase
       sleep(0.1) until d.stop?
     end
 
-    emits = d.events
-    assert_equal true, emits.length > 0
-    assert_equal ["tag1", @test_time, {"k1"=>"ok"}], emits[0]
-    assert_equal_event_time(@test_time, emits[0][1])
+    assert_equal true, d.events.length > 0
+    d.events.each_with_index {|event, i|
+      assert_equal ["tag1", @test_time, {"k1"=>"ok"}], event
+      assert_equal_event_time(@test_time, event[1])
+    }
   end
 
   def test_emit_json
@@ -108,10 +109,11 @@ class ExecInputTest < Test::Unit::TestCase
       sleep(0.1) until d.stop?
     end
 
-    emits = d.events
-    assert_equal true, emits.length > 0
-    assert_equal ["tag1", @test_time, {"k1"=>"ok"}], emits[0]
-    assert_equal_event_time(@test_time, emits[0][1])
+    assert_equal true, d.events.length > 0
+    d.events.each_with_index {|event, i|
+      assert_equal ["tag1", @test_time, {"k1"=>"ok"}], event
+      assert_equal_event_time(@test_time, event[1])
+    }
   end
 
   def test_emit_msgpack
@@ -124,10 +126,11 @@ class ExecInputTest < Test::Unit::TestCase
       sleep(0.1) until d.stop?
     end
 
-    emits = d.events
-    assert_equal true, emits.length > 0
-    assert_equal ["tag1", @test_time, {"k1"=>"ok"}], emits[0]
-    assert_equal_event_time(@test_time, emits[0][1])
+    assert_equal true, d.events.length > 0
+    d.events.each_with_index {|event, i|
+      assert_equal ["tag1", @test_time, {"k1"=>"ok"}], event
+      assert_equal_event_time(@test_time, event[1])
+    }
   end
 
   def test_emit_regexp
@@ -140,9 +143,10 @@ class ExecInputTest < Test::Unit::TestCase
       sleep(0.1) until d.stop?
     end
 
-    emits = d.events
-    assert_equal true, emits.length > 0
-    assert_equal ["regex_tag", @test_time, {"message"=>"hello"}], emits[0]
-    assert_equal_event_time(@test_time, emits[0][1])
+    assert_equal true, d.events.length > 0
+    d.events.each_with_index {|event, i|
+      assert_equal ["regex_tag", @test_time, {"message"=>"hello"}], event
+      assert_equal_event_time(@test_time, event[1])
+    }
   end
 end

--- a/test/plugin/test_in_exec.rb
+++ b/test/plugin/test_in_exec.rb
@@ -86,8 +86,11 @@ class ExecInputTest < Test::Unit::TestCase
   def test_emit
     d = create_driver
 
+    d.end_if do
+       d.emit_count >= 2
+    end
     d.run do
-      sleep 2
+      sleep(0.1) until d.stop?
     end
 
     emits = d.events
@@ -98,9 +101,11 @@ class ExecInputTest < Test::Unit::TestCase
 
   def test_emit_json
     d = create_driver json_config
-
+    d.end_if do
+       d.emit_count >= 2
+    end
     d.run do
-      sleep 2
+      sleep(0.1) until d.stop?
     end
 
     emits = d.events
@@ -112,8 +117,11 @@ class ExecInputTest < Test::Unit::TestCase
   def test_emit_msgpack
     d = create_driver msgpack_config
 
+    d.end_if do
+       d.emit_count >= 2
+    end
     d.run do
-      sleep 2
+      sleep(0.1) until d.stop?
     end
 
     emits = d.events
@@ -125,8 +133,11 @@ class ExecInputTest < Test::Unit::TestCase
   def test_emit_regexp
     d = create_driver regexp_config
 
+    d.end_if do
+       d.emit_count >= 2
+    end
     d.run do
-      sleep 2
+      sleep(0.1) until d.stop?
     end
 
     emits = d.events


### PR DESCRIPTION
We should use new test driver syntax and brush up more rigid test cases in test_in_exec.