### PR TITLE
handle ERROR_PATH_NOT_FOUND

### DIFF
--- a/lib/fluent/plugin/file_wrapper.rb
+++ b/lib/fluent/plugin/file_wrapper.rb
@@ -78,7 +78,7 @@ module Fluent
                      0, creationdisposition, FILE_ATTRIBUTE_NORMAL, 0)
       if @file_handle == INVALID_HANDLE_VALUE
         err = GetLastError.call
-        if err == ERROR_FILE_NOT_FOUND || err == ERROR_ACCESS_DENIED
+        if err == ERROR_FILE_NOT_FOUND || err == ERROR_PATH_NOT_FOUND || err == ERROR_ACCESS_DENIED
           raise SystemCallError.new(2)
         end
         raise SystemCallError.new(err)


### PR DESCRIPTION
On Windows, WindowsFile.new (i.e., in_tail plugin) raises an unhandled error if the path is under non-existent directory.
This has been since FileWrapper.stat() changed not to use FileWrapper.io(), which returns ENOENT unless _open_osfhandle() returns valid fd.

I'm not sure this wouldn't cause any side effect but I report it anyway :)

