### PR TITLE
Use new test driver syntax in in_gc_stat test cases

### DIFF
--- a/test/plugin/test_in_gc_stat.rb
+++ b/test/plugin/test_in_gc_stat.rb
@@ -27,13 +27,18 @@ class GCStatInputTest < Test::Unit::TestCase
     stub(GC).stat { stat }
 
     d = create_driver
+    d.end_if do
+      d.emit_count >= 2
+    end
     d.run do
-      sleep 2
+      sleep(0.1) until d.stop?
     end
 
     events = d.events
     assert(events.length > 0)
-    assert_equal(stat, events[0][2])
-    assert(events[0][1].is_a?(Fluent::EventTime))
+    events.each_index {|i|
+      assert_equal(stat, events[i][2])
+      assert(events[i][1].is_a?(Fluent::EventTime))
+    }
   end
 end

--- a/test/plugin/test_in_gc_stat.rb
+++ b/test/plugin/test_in_gc_stat.rb
@@ -27,12 +27,7 @@ class GCStatInputTest < Test::Unit::TestCase
     stub(GC).stat { stat }
 
     d = create_driver
-    d.end_if do
-      d.emit_count >= 2
-    end
-    d.run do
-      sleep(0.1) until d.stop?
-    end
+    d.run(expect_emits: 2)
 
     events = d.events
     assert(events.length > 0)


### PR DESCRIPTION
We should use new test driver notations in test_in_gc_stat.