### PR TITLE
Add an RPC API call to flush buffers and stop daemon gracefully

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -82,6 +82,14 @@ module Fluent
         end
         nil
       }
+      @rpc_server.mount_proc('/api/plugins.flushBuffersAndKillWorkers') { |req, res|
+        $log.debug "fluentd RPC got /api/plugins.flushBuffersAndKillWorkers request"
+        unless Fluent.windows?
+          Process.kill :USR1, $$
+          Process.kill :TERM, $$
+        end
+        nil
+      }
       @rpc_server.mount_proc('/api/config.reload') { |req, res|
         $log.debug "fluentd RPC got /api/config.reload request"
         if Fluent.windows?


### PR DESCRIPTION
**Why this PR?** 
Fluentd already supports SIGUSR1 to flush buffers and SIGINT/SIGTERM to
stop the daemon gracefully. It would be really good to at least support
an RPC API call that could do both i.e. flush the buffers and stop the
daemon gracefully.

**What this PR does?**
Adds support for an RPC API call that would flush the
buffers and stop the daemon gracefully.