### PR TITLE
Use Fluent::Plugin::Filter instead Fluent::Filter to cover all filter classes

### DIFF
--- a/lib/fluent/event_router.rb
+++ b/lib/fluent/event_router.rb
@@ -159,7 +159,7 @@ module Fluent
       pipeline = nil
       @match_rules.each_with_index { |rule, i|
         if rule.match?(tag)
-          if rule.collector.is_a?(Filter)
+          if rule.collector.is_a?(Plugin::Filter)
             pipeline ||= Pipeline.new
             pipeline.add_filter(rule.collector)
           else

--- a/test/test_event_router.rb
+++ b/test/test_event_router.rb
@@ -9,6 +9,7 @@ class EventRouterTest < ::Test::Unit::TestCase
   teardown do
     @output = nil
     @filter = nil
+    @compat_filter = nil
     @error_output = nil
     @emit_handler = nil
     @default_collector = nil
@@ -20,6 +21,10 @@ class EventRouterTest < ::Test::Unit::TestCase
 
   def filter
     @filter ||= FluentTestFilter.new
+  end
+
+  def compat_filter
+    @compat_filter ||= FluentCompatTestFilter.new
   end
 
   def error_output
@@ -107,16 +112,20 @@ class EventRouterTest < ::Test::Unit::TestCase
         @pipeline.set_output(output)
       end
 
-      test 'set one filer' do
-        @pipeline.add_filter(filter)
+      data('Filter plugin' => 'filter',
+           'Compat::Filter plugin' => 'compat_filter')
+      test 'set one filer' do |filter_type|
+        @pipeline.add_filter(filter_type == 'filter' ? filter : compat_filter)
         @pipeline.emit_events('test', @es)
         assert_equal 1, output.events.size
         assert_equal 'value', output.events['test'].first['key']
         assert_equal 0, output.events['test'].first['__test__']
       end
 
-      test 'set one filer with multi events' do
-        @pipeline.add_filter(filter)
+      data('Filter plugin' => 'filter',
+           'Compat::Filter plugin' => 'compat_filter')
+      test 'set one filer with multi events' do |filter_type|
+        @pipeline.add_filter(filter_type == 'filter' ? filter : compat_filter)
         @pipeline.emit_events('test', events)
         assert_equal 1, output.events.size
         assert_equal 5, output.events['test'].size

--- a/test/test_plugin_classes.rb
+++ b/test/test_plugin_classes.rb
@@ -56,7 +56,34 @@ module FluentTest
     end
   end
 
-  class FluentTestFilter < ::Fluent::Filter
+  class FluentCompatTestFilter < ::Fluent::Filter
+    ::Fluent::Plugin.register_filter('test_compat_filter', self)
+
+    def initialize(field = '__test__')
+      super()
+      @num = 0
+      @field = field
+    end
+
+    attr_reader :num
+    attr_reader :started
+
+    def start
+      @started = true
+    end
+
+    def shutdown
+      @started = false
+    end
+
+    def filter(tag, time, record)
+      record[@field] = @num
+      @num += 1
+      record
+    end
+  end
+
+  class FluentTestFilter < ::Fluent::Plugin::Filter
     ::Fluent::Plugin.register_filter('test_filter', self)
 
     def initialize(field = '__test__')


### PR DESCRIPTION
`is_a?(Filter)` can't detect `Fluent::Plugin::Filter` and it causes non compat filter is registered as a Output plugin.

I changed test filter classes for testing this case but I'm not sure this is good or not...