### PR TITLE
Fix not to overwrite something unexpectedly

### DIFF
--- a/lib/fluent/configurable.rb
+++ b/lib/fluent/configurable.rb
@@ -144,9 +144,10 @@ module Fluent
       end
 
       def config_section(name, **kwargs, &block)
+        section_already_exists = !!merged_configure_proxy.sections[name]
         configure_proxy(self.name).config_section(name, **kwargs, &block)
         variable_name = configure_proxy(self.name).sections[name].variable_name
-        unless self.respond_to?(variable_name)
+        if !section_already_exists && !self.respond_to?(variable_name)
           attr_accessor variable_name
         end
       end

--- a/lib/fluent/plugin_helper/formatter.rb
+++ b/lib/fluent/plugin_helper/formatter.rb
@@ -17,6 +17,7 @@
 require 'fluent/plugin'
 require 'fluent/plugin/formatter'
 require 'fluent/config/element'
+require 'fluent/configurable'
 
 module Fluent
   module PluginHelper
@@ -52,14 +53,17 @@ module Fluent
         formatter
       end
 
-      def self.included(mod)
-        mod.instance_eval do
-          # minimum section definition to instantiate formatter plugin instances
-          config_section :format, required: false, multi: true, param_name: :formatter_configs do
-            config_argument :usage, :string, default: ''
-            config_param    :@type, :string
-          end
+      module FormatterParams
+        include Fluent::Configurable
+        # minimum section definition to instantiate formatter plugin instances
+        config_section :format, required: false, multi: true, param_name: :formatter_configs do
+          config_argument :usage, :string, default: ''
+          config_param    :@type, :string
         end
+      end
+
+      def self.included(mod)
+        mod.include FormatterParams
       end
 
       attr_reader :_formatters # for tests

--- a/lib/fluent/plugin_helper/inject.rb
+++ b/lib/fluent/plugin_helper/inject.rb
@@ -74,6 +74,7 @@ module Fluent
 
       def initialize
         super
+        @_inject_enabled = false
         @_inject_hostname_key = nil
         @_inject_hostname = nil
         @_inject_tag_key = nil

--- a/lib/fluent/plugin_helper/inject.rb
+++ b/lib/fluent/plugin_helper/inject.rb
@@ -16,6 +16,7 @@
 
 require 'fluent/event'
 require 'time'
+require 'fluent/configurable'
 
 module Fluent
   module PluginHelper
@@ -58,18 +59,21 @@ module Fluent
         new_es
       end
 
-      def self.included(mod)
-        mod.instance_eval do
-          config_section :inject, required: false, multi: false, param_name: :inject_config do
-            config_param :hostname_key, :string, default: nil
-            config_param :hostname, :string, default: nil
-            config_param :tag_key, :string, default: nil
-            config_param :time_key, :string, default: nil
-            config_param :time_type, :enum, list: [:float, :unixtime, :string], default: :float
-            config_param :time_format, :string, default: nil
-            config_param :timezone, :string, default: "#{Time.now.strftime('%z')}" # localtime
-          end
+      module InjectParams
+        include Fluent::Configurable
+        config_section :inject, required: false, multi: false, param_name: :inject_config do
+          config_param :hostname_key, :string, default: nil
+          config_param :hostname, :string, default: nil
+          config_param :tag_key, :string, default: nil
+          config_param :time_key, :string, default: nil
+          config_param :time_type, :enum, list: [:float, :unixtime, :string], default: :float
+          config_param :time_format, :string, default: nil
+          config_param :timezone, :string, default: "#{Time.now.strftime('%z')}" # localtime
         end
+      end
+
+      def self.included(mod)
+        mod.include InjectParams
       end
 
       def initialize

--- a/lib/fluent/plugin_helper/parser.rb
+++ b/lib/fluent/plugin_helper/parser.rb
@@ -17,6 +17,7 @@
 require 'fluent/plugin'
 require 'fluent/plugin/parser'
 require 'fluent/config/element'
+require 'fluent/configurable'
 
 module Fluent
   module PluginHelper
@@ -52,14 +53,17 @@ module Fluent
         parser
       end
 
-      def self.included(mod)
-        mod.instance_eval do
-          # minimum section definition to instantiate parser plugin instances
-          config_section :parse, required: false, multi: true, param_name: :parser_configs do
-            config_argument :usage, :string, default: ''
-            config_param    :@type, :string
-          end
+      module ParserParams
+        include Fluent::Configurable
+        # minimum section definition to instantiate parser plugin instances
+        config_section :parse, required: false, multi: true, param_name: :parser_configs do
+          config_argument :usage, :string, default: ''
+          config_param    :@type, :string
         end
+      end
+
+      def self.included(mod)
+        mod.include ParserParams
       end
 
       attr_reader :_parsers # for tests

--- a/lib/fluent/plugin_helper/storage.rb
+++ b/lib/fluent/plugin_helper/storage.rb
@@ -20,6 +20,7 @@ require 'fluent/plugin'
 require 'fluent/plugin/storage'
 require 'fluent/plugin_helper/timer'
 require 'fluent/config/element'
+require 'fluent/configurable'
 
 module Fluent
   module PluginHelper
@@ -63,14 +64,17 @@ module Fluent
         s.storage
       end
 
-      def self.included(mod)
-        mod.instance_eval do
-          # minimum section definition to instantiate storage plugin instances
-          config_section :storage, required: false, multi: true, param_name: :storage_configs do
-            config_argument :usage, :string, default: ''
-            config_param    :@type, :string, default: Fluent::Plugin::Storage::DEFAULT_TYPE
-          end
+      module StorageParams
+        include Fluent::Configurable
+        # minimum section definition to instantiate storage plugin instances
+        config_section :storage, required: false, multi: true, param_name: :storage_configs do
+          config_argument :usage, :string, default: ''
+          config_param    :@type, :string, default: Fluent::Plugin::Storage::DEFAULT_TYPE
         end
+      end
+
+      def self.included(mod)
+        mod.include StorageParams
       end
 
       attr_reader :_storages # for tests

--- a/test/plugin_helper/test_formatter.rb
+++ b/test/plugin_helper/test_formatter.rb
@@ -19,6 +19,13 @@ class FormatterHelperTest < Test::Unit::TestCase
     helpers :formatter
   end
 
+  class Dummy2 < Fluent::Plugin::TestBase
+    helpers :formatter
+    config_section :format do
+      config_set_default :@type, 'example2'
+    end
+  end
+
   setup do
     @d = nil
   end
@@ -35,6 +42,19 @@ class FormatterHelperTest < Test::Unit::TestCase
   test 'can be initialized without any formatters at first' do
     d = Dummy.new
     assert_equal 0, d._formatters.size
+  end
+
+  test 'can override default configuration parameters, but not overwrite whole definition' do
+    d = Dummy.new
+    assert_equal [], d.formatter_configs
+
+    d = Dummy2.new
+    d.configure(config_element('ROOT', '', {}, [config_element('format', '', {}, [])]))
+    assert_raise NoMethodError do
+      d.format
+    end
+    assert_equal 1, d.formatter_configs.size
+    assert_equal 'example2', d.formatter_configs.first[:@type]
   end
 
   test 'can be configured without format sections' do

--- a/test/plugin_helper/test_inject.rb
+++ b/test/plugin_helper/test_inject.rb
@@ -8,6 +8,13 @@ class InjectHelperTest < Test::Unit::TestCase
     helpers :inject
   end
 
+  class Dummy2 < Fluent::Plugin::TestBase
+    helpers :inject
+    config_section :inject do
+      config_set_default :hostname_key, 'host'
+    end
+  end
+
   def config_inject_section(hash = {})
     config_element('ROOT', '', {}, [config_element('inject', '', hash)])
   end
@@ -24,6 +31,17 @@ class InjectHelperTest < Test::Unit::TestCase
       @d.close unless @d.closed?
       @d.terminate unless @d.terminated?
     end
+  end
+
+  test 'can override default parameters, but not overwrite whole definition' do
+    d = Dummy.new
+    d.configure(config_element())
+    assert_nil d.inject_config
+
+    d = Dummy2.new
+    d.configure(config_element('ROOT', '', {}, [config_element('inject')]))
+    assert d.inject_config
+    assert_equal 'host', d.inject_config.hostname_key
   end
 
   test 'do nothing in default' do

--- a/test/plugin_helper/test_parser.rb
+++ b/test/plugin_helper/test_parser.rb
@@ -30,6 +30,13 @@ class ParserHelperTest < Test::Unit::TestCase
     helpers :parser
   end
 
+  class Dummy2 < Fluent::Plugin::TestBase
+    helpers :parser
+    config_section :parse do
+      config_set_default :@type, 'example2'
+    end
+  end
+
   setup do
     @d = nil
   end
@@ -46,6 +53,19 @@ class ParserHelperTest < Test::Unit::TestCase
   test 'can be initialized without any parsers at first' do
     d = Dummy.new
     assert_equal 0, d._parsers.size
+  end
+
+  test 'can override default configuration parameters, but not overwrite whole definition' do
+    d = Dummy.new
+    assert_equal [], d.parser_configs
+
+    d = Dummy2.new
+    d.configure(config_element('ROOT', '', {}, [config_element('parse', '', {}, [])]))
+    assert_raise NoMethodError do
+      d.parse
+    end
+    assert_equal 1, d.parser_configs.size
+    assert_equal 'example2', d.parser_configs.first[:@type]
   end
 
   test 'can be configured without parse sections' do

--- a/test/plugin_helper/test_storage.rb
+++ b/test/plugin_helper/test_storage.rb
@@ -73,6 +73,14 @@ class StorageHelperTest < Test::Unit::TestCase
     helpers :storage
   end
 
+  class Dummy2 < Fluent::Plugin::TestBase
+    helpers :storage
+    config_section :storage do
+      config_set_default :@type, 'ex2'
+      config_set_default :dummy_path, '/tmp/yay'
+    end
+  end
+
   setup do
     @d = nil
   end
@@ -89,6 +97,21 @@ class StorageHelperTest < Test::Unit::TestCase
   test 'can be initialized without any storages at first' do
     d = Dummy.new
     assert_equal 0, d._storages.size
+  end
+
+  test 'can override default configuration parameters, but not overwrite whole definition' do
+    d = Dummy.new
+    d.configure(config_element())
+    assert_equal [], d.storage_configs
+
+    d = Dummy2.new
+    d.configure(config_element('ROOT', '', {}, [config_element('storage', '', {}, [])]))
+    assert_raise NoMethodError do
+      d.storage
+    end
+    assert_equal 1, d.storage_configs.size
+    assert_equal 'ex2', d.storage_configs.first[:@type]
+    assert_equal '/tmp/yay', d.storage_configs.first.dummy_path
   end
 
   test 'can be configured without storage sections' do


### PR DESCRIPTION
Originally, some plugin helpers (e.g., storage, formatter, parser, ...) defines `config_section` for sets of parameters by `included` hook. It calls `config_section` with plugin class as receivers.
But, if plugin class calls `config_section` to override default value, that **overwrites** the section definition defined by plugin helpers.
It makes many unexpected behaviors (including breaking instance variables).

This change is to prevent overwriting section definitions by plugins. By inserting a mixin module, `config_section` definition in plugin classes overrides definitions in plugin helpers, instead of overwriting it.