### PR TITLE
appveyor: Add Ruby 2.3 matrix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,10 @@ branches:
 
 environment:
   matrix:
+    - ruby_version: "23-x64"
+      devkit: C:\Ruby23-x64\DevKit
+    - ruby_version: "23"
+      devkit: C:\Ruby23\DevKit
     - ruby_version: "22-x64"
       devkit: C:\Ruby23-x64\DevKit
     - ruby_version: "22"


### PR DESCRIPTION
Now, `win32-api` supports Ruby 2.3.
It's time to start to run CI Ruby 2.3 on AppVeyor!

But, this patch increases CI time on AppVeyor. (approx. 20min.)
Is this acceptable?