### PR TITLE
Ignore non buffer chunk files when resumed

### DIFF
--- a/lib/fluent/plugin/buf_file.rb
+++ b/lib/fluent/plugin/buf_file.rb
@@ -122,14 +122,17 @@ module Fluent
           m = new_metadata() # this metadata will be overwritten by resuming .meta file content
                              # so it should not added into @metadata_list for now
           mode = Fluent::Plugin::Buffer::FileChunk.assume_chunk_state(path)
+          if mode == :unknown
+            log.debug "uknown state chunk found", path: path
+            next
+          end
+
           chunk = Fluent::Plugin::Buffer::FileChunk.new(m, path, mode) # file chunk resumes contents of metadata
           case chunk.state
           when :staged
             stage[chunk.metadata] = chunk
           when :queued
             queue << chunk
-          else
-            raise "BUG: unexpected chunk state '#{chunk.state}' for path '#{path}'"
           end
         end
 

--- a/lib/fluent/plugin/buffer/file_chunk.rb
+++ b/lib/fluent/plugin/buffer/file_chunk.rb
@@ -149,7 +149,9 @@ module Fluent
           if /\.(b|q)([0-9a-f]+)\.[^\/]*\Z/n =~ path # //n switch means explicit 'ASCII-8BIT' pattern
             $1 == 'b' ? :staged : :queued
           else
-            :queued
+            # files which matches to glob of buffer file pattern
+            # it includes files which are created by out_file
+            :unknown
           end
         end
 

--- a/test/plugin/test_buf_file.rb
+++ b/test/plugin/test_buf_file.rb
@@ -500,4 +500,72 @@ class FileBufferTest < Test::Unit::TestCase
       assert_equal Time.parse('2016-04-17 14:01:22 -0700'), queue[3].modified_at
     end
   end
+
+  sub_test_case 'there are some non-buffer chunk files, with a path without buffer chunk ids' do
+    setup do
+      @bufdir = File.expand_path('../../tmp/buffer_file', __FILE__)
+
+      @c1id = Fluent::UniqueId.generate
+      p1 = File.join(@bufdir, "etest.201604171358.q#{Fluent::UniqueId.hex(@c1id)}.log")
+      File.open(p1, 'wb') do |f|
+        f.write ["t1.test", event_time('2016-04-17 13:58:15 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+        f.write ["t2.test", event_time('2016-04-17 13:58:17 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+        f.write ["t3.test", event_time('2016-04-17 13:58:21 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+        f.write ["t4.test", event_time('2016-04-17 13:58:22 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+      end
+      FileUtils.touch(p1, mtime: Time.parse('2016-04-17 13:58:28 -0700'))
+
+      @not_chunk = File.join(@bufdir, 'etest.20160416.log')
+      File.open(@not_chunk, 'wb') do |f|
+        f.write ["t1.test", event_time('2016-04-16 23:58:15 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+        f.write ["t2.test", event_time('2016-04-16 23:58:17 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+        f.write ["t3.test", event_time('2016-04-16 23:58:21 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+        f.write ["t4.test", event_time('2016-04-16 23:58:22 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+      end
+      FileUtils.touch(@not_chunk, mtime: Time.parse('2016-04-17 00:00:00 -0700'))
+
+      @bufpath = File.join(@bufdir, 'etest.*.log')
+
+      Fluent::Test.setup
+      @d = FluentPluginFileBufferTest::DummyOutputPlugin.new
+      @p = Fluent::Plugin::FileBuffer.new
+      @p.owner = @d
+      @p.configure(config_element('buffer', '', {'path' => @bufpath}))
+      @p.start
+    end
+
+    teardown do
+      if @p
+        @p.stop unless @p.stopped?
+        @p.before_shutdown unless @p.before_shutdown?
+        @p.shutdown unless @p.shutdown?
+        @p.after_shutdown unless @p.after_shutdown?
+        @p.close unless @p.closed?
+        @p.terminate unless @p.terminated?
+      end
+      if @bufdir
+        Dir.glob(File.join(@bufdir, '*')).each do |path|
+          next if ['.', '..'].include?(File.basename(path))
+          File.delete(path)
+        end
+      end
+    end
+
+    test '#resume returns queued chunks for files without metadata, while ignoring non-chunk looking files' do
+      assert_equal 0, @p.stage.size
+      assert_equal 1, @p.queue.size
+
+      queue = @p.queue
+
+      m = metadata()
+
+      assert_equal @c1id, queue[0].unique_id
+      assert_equal m, queue[0].metadata
+      assert_equal 0, queue[0].size
+      assert_equal :queued, queue[0].state
+      assert_equal Time.parse('2016-04-17 13:58:28 -0700'), queue[0].modified_at
+
+      assert File.exist?(@not_chunk)
+    end
+  end
 end

--- a/test/plugin/test_buffer_file_chunk.rb
+++ b/test/plugin/test_buffer_file_chunk.rb
@@ -49,8 +49,9 @@ class BufferFileChunkTest < Test::Unit::TestCase
     data(
       correct_staged: ['/mydir/mypath/myfile.b00ff.log', :staged],
       correct_queued: ['/mydir/mypath/myfile.q00ff.log', :queued],
-      incorrect_staged: ['/mydir/mypath/myfile.b00ff.log/unknown', :queued],
-      incorrect_queued: ['/mydir/mypath/myfile.q00ff.log/unknown', :queued],
+      incorrect_staged: ['/mydir/mypath/myfile.b00ff.log/unknown', :unknown],
+      incorrect_queued: ['/mydir/mypath/myfile.q00ff.log/unknown', :unknown],
+      output_file: ['/mydir/mypath/myfile.20160716.log', :unknown],
     )
     test 'can .assume_chunk_state' do |data|
       path, expected = data


### PR DESCRIPTION
This fixes #1098.

`buf_file` in v0.14 loads all files which matches with glob for buffer file path as queued. That behavior is to read files as much as possible when upgrading Fluentd.
But there is a bug to read files as queued, which is written by `out_file` in the same directory with buffer chunk files.

This change is to fix not to load files which doesn't have a part like `(b|q)[0-9a-f]+`, which shows that file is a buffer chunk.

#### note about #1098 
#1098 is a result of combination of this bug and `append true`, which does read data from buffer chunk file (this file) and also does write these data to output file (this file) - it is infinite loop of read & write.

The minimum steps to reproduce it is:
1. execute command: `echo "foobar" > temperature.\`ruby -e 'puts Time.now.strftime("%Y%m%d")'\`.log`
2. execute fluentd with configuration below:
3. use ctrl-z to stop Fluentd process without shutdown sequence (shutdown calls flushing)
```
# no <source> needed
<match demo.temperature>
  @type file
  path temperature
  flush_interval 1s
  append true
</match>
```
