### PR TITLE
Add option to receive longer udp syslog messages

### DIFF
--- a/lib/fluent/plugin/in_syslog.rb
+++ b/lib/fluent/plugin/in_syslog.rb
@@ -94,6 +94,7 @@ module Fluent::Plugin
     desc 'Specify key of source host when include_source_host is true.'
     config_param :source_host_key, :string, default: 'source_host'.freeze
     config_param :blocking_timeout, :time, default: 0.5
+    config_param :message_length_limit, :integer, default: 2048
 
     def configure(conf)
       super
@@ -181,7 +182,7 @@ module Fluent::Plugin
       client = ServerEngine::SocketManager::Client.new(socket_manager_path)
       if @protocol_type == :udp
         @usock = client.listen_udp(@bind, @port)
-        SocketUtil::UdpHandler.new(@usock, log, 2048, callback)
+        SocketUtil::UdpHandler.new(@usock, log, @message_length_limit, callback)
       else
         # syslog family add "\n" to each message and this seems only way to split messages in tcp stream
         lsock = client.listen_tcp(@bind, @port)

--- a/lib/fluent/plugin/in_syslog.rb
+++ b/lib/fluent/plugin/in_syslog.rb
@@ -94,7 +94,7 @@ module Fluent::Plugin
     desc 'Specify key of source host when include_source_host is true.'
     config_param :source_host_key, :string, default: 'source_host'.freeze
     config_param :blocking_timeout, :time, default: 0.5
-    config_param :message_length_limit, :integer, default: 2048
+    config_param :message_length_limit, :size, default: 2048
 
     def configure(conf)
       super

--- a/test/plugin/test_in_syslog.rb
+++ b/test/plugin/test_in_syslog.rb
@@ -93,7 +93,7 @@ class SyslogInputTest < Test::Unit::TestCase
 
   def test_msg_size_udp_for_large_msg
     d = create_driver(CONFIG + %[
-      message_length_limit 5120
+      message_length_limit 5k
     ])
     tests = create_test_case(large_message: true)
 


### PR DESCRIPTION
This option is useful when users transfer web access logs via syslog protocol.
Fixes #1123.