### PR TITLE
backport: Add option to receive longer udp syslog messages

### DIFF
--- a/lib/fluent/plugin/in_syslog.rb
+++ b/lib/fluent/plugin/in_syslog.rb
@@ -92,6 +92,7 @@ module Fluent
     desc 'Specify key of source host when include_source_host is true.'
     config_param :source_host_key, :string, default: 'source_host'.freeze
     config_param :blocking_timeout, :time, default: 0.5
+    config_param :message_length_limit, :size, default: 2048
 
     def configure(conf)
       super
@@ -183,7 +184,7 @@ module Fluent
       if @protocol_type == :udp
         @usock = SocketUtil.create_udp_socket(@bind)
         @usock.bind(@bind, @port)
-        SocketUtil::UdpHandler.new(@usock, log, 2048, callback)
+        SocketUtil::UdpHandler.new(@usock, log, @message_length_limit, callback)
       else
         # syslog family add "\n" to each message and this seems only way to split messages in tcp stream
         Coolio::TCPServer.new(@bind, @port, SocketUtil::TcpHandler, log, "\n", callback)

--- a/test/plugin/test_in_dummy.rb
+++ b/test/plugin/test_in_dummy.rb
@@ -42,6 +42,10 @@ class DummyTest < Test::Unit::TestCase
       assert_equal 10, d.instance.rate
     end
 
+    def json_error_messages_regexp
+      /JSON::ParserError|got incomplete JSON|0th element of dummy, foo, is not a hash/
+    end
+
     test 'dummy' do
       # hash is okay
       d = create_driver(config + %[dummy {"foo":"bar"}])
@@ -51,7 +55,7 @@ class DummyTest < Test::Unit::TestCase
       d = create_driver(config + %[dummy [{"foo":"bar"}]])
       assert_equal [{"foo"=>"bar"}], d.instance.dummy
 
-      assert_raise_message(/JSON::ParserError|got incomplete JSON/) do
+      assert_raise_message(json_error_messages_regexp) do
         create_driver(config + %[dummy "foo"])
       end
 


### PR DESCRIPTION
backported: #1127 
```
Merge pull request #1127 from fluent/configurable-body-size-limit-for-syslog-input

Add option to receive longer udp syslog messages
```