### PR TITLE
LoggerInitializer updated to create directory when it doesn't exists.

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -268,7 +268,8 @@ module Fluent
 
       def init
         if @path && @path != "-"
-          @io = File.open(@path, "a")
+          Dir.mkdir(File.dirname(@path)) unless File.exists?(@path)
+	  @io = File.open(@path, "a")
           if @chuser || @chgroup
             chuid = @chuser ? ServerEngine::Daemon.get_etc_passwd(@chuser).uid : nil
             chgid = @chgroup ? ServerEngine::Daemon.get_etc_group(@chgroup).gid : nil


### PR DESCRIPTION
The intent of this change is to allow fluentd to create a directory that is passed by --log and don't exists on the system.

Cheers
