### PR TITLE
Fix wrong message for unsupported parameter. fix #1039

### DIFF
--- a/lib/fluent/config/section.rb
+++ b/lib/fluent/config/section.rb
@@ -151,6 +151,10 @@ module Fluent
         elems = conf.respond_to?(:elements) ? conf.elements : []
         elems.each { |e|
           next if plugin_class.nil? && Fluent::Config::V1Parser::ELEM_SYMBOLS.include?(e.name) # skip pre-defined non-plugin elements because it doens't have proxy section
+          # In v0.12, buffer and output parameters are defined in same place.
+          # It causes same configuration is used in different buffer / output
+          # and buffer plugin's sections are always empty. It should be skipped.
+          next if proxy.sections.empty?
 
           unless proxy.sections.any? { |name, subproxy| e.name == subproxy.name.to_s || e.name == subproxy.alias.to_s }
             parent_name = if conf.arg.empty?


### PR DESCRIPTION
Result is here:

```
2016-07-29 21:05:29 +0900 [info]: using configuration file: <ROOT>
  <source>
    @type forward
    port 24271
    bind 0.0.0.0
  </source>
  <match **>
    @type secure_forward
    buffer_type file
    buffer_path /home/ec2-user/
    buffer_chunk_limit 1048k
    buffer_queue_limit 1000000
    flush_interval 1s
    num_threads 15
    shared_key xxxxxx
    secure no
    self_hostname myserver.local
    <server>
      host localhost
      port 24281
      weight 100
    </server>
  </match>
</ROOT>
2016-07-29 21:05:29 +0900 [warn]: parameter 'weight' in <server>
  host localhost
  port 24281
  weight 100
</server> is not used.
```