### PR TITLE
Use separate search prefix for gems and additional plugin path

### DIFF
--- a/lib/fluent/plugin.rb
+++ b/lib/fluent/plugin.rb
@@ -26,15 +26,15 @@ module Fluent
     #   ex: storage, buffer chunk, ...
 
     # first class plugins (instantiated by Engine)
-    INPUT_REGISTRY     = Registry.new(:input,     'fluent/plugin/in_')
-    OUTPUT_REGISTRY    = Registry.new(:output,    'fluent/plugin/out_')
-    FILTER_REGISTRY    = Registry.new(:filter,    'fluent/plugin/filter_')
+    INPUT_REGISTRY     = Registry.new(:input,     'fluent/plugin/in_',         dir_search_prefix: 'in_')
+    OUTPUT_REGISTRY    = Registry.new(:output,    'fluent/plugin/out_',        dir_search_prefix: 'out_')
+    FILTER_REGISTRY    = Registry.new(:filter,    'fluent/plugin/filter_',     dir_search_prefix: 'filter_')
 
     # feature plugin: second class plugins (instanciated by Plugins or Helpers)
-    BUFFER_REGISTRY    = Registry.new(:buffer,    'fluent/plugin/buf_')
-    PARSER_REGISTRY    = Registry.new(:parser,    'fluent/plugin/parser_')
-    FORMATTER_REGISTRY = Registry.new(:formatter, 'fluent/plugin/formatter_')
-    STORAGE_REGISTRY   = Registry.new(:storage,   'fluent/plugin/storage_')
+    BUFFER_REGISTRY    = Registry.new(:buffer,    'fluent/plugin/buf_',        dir_search_prefix: 'buf_')
+    PARSER_REGISTRY    = Registry.new(:parser,    'fluent/plugin/parser_',     dir_search_prefix: 'parser_')
+    FORMATTER_REGISTRY = Registry.new(:formatter, 'fluent/plugin/formatter_',  dir_search_prefix: 'formatter_')
+    STORAGE_REGISTRY   = Registry.new(:storage,   'fluent/plugin/storage_',    dir_search_prefix: 'storage_')
 
     REGISTRIES = [INPUT_REGISTRY, OUTPUT_REGISTRY, FILTER_REGISTRY, BUFFER_REGISTRY, PARSER_REGISTRY, FORMATTER_REGISTRY, STORAGE_REGISTRY]
 

--- a/lib/fluent/registry.rb
+++ b/lib/fluent/registry.rb
@@ -20,9 +20,10 @@ module Fluent
   class Registry
     DEFAULT_PLUGIN_PATH = File.expand_path('../plugin', __FILE__)
 
-    def initialize(kind, search_prefix)
+    def initialize(kind, search_prefix, dir_search_prefix: nil)
       @kind = kind
       @search_prefix = search_prefix
+      @dir_search_prefix = dir_search_prefix
       @map = {}
       @paths = [DEFAULT_PLUGIN_PATH]
     end
@@ -54,11 +55,10 @@ module Fluent
     end
 
     def search(type)
-      path = "#{@search_prefix}#{type}"
-
-      # prefer LOAD_PATH than gems
-      [@paths, $LOAD_PATH].each do |paths|
-        files = paths.map { |lp|
+      # search from additional plugin directories
+      if @dir_search_prefix
+        path = "#{@dir_search_prefix}#{type}"
+        files = @paths.map { |lp|
           lpath = File.expand_path(File.join(lp, "#{path}.rb"))
           File.exist?(lpath) ? lpath : nil
         }.compact
@@ -67,6 +67,19 @@ module Fluent
           require files.sort.last
           return
         end
+      end
+
+      path = "#{@search_prefix}#{type}"
+
+      # prefer LOAD_PATH than gems
+      files = $LOAD_PATH.map { |lp|
+        lpath = File.expand_path(File.join(lp, "#{path}.rb"))
+        File.exist?(lpath) ? lpath : nil
+      }.compact
+      unless files.empty?
+        # prefer newer version
+        require files.sort.last
+        return
       end
 
       specs = Gem::Specification.find_all { |spec|


### PR DESCRIPTION
Allow to search plugin from multiple prefix directory. 

Related with issue #1131 (v0.14 doesn't load plugins from directory specified by "-p" option)