### PR TITLE
Add size key to option in forward protocol

### DIFF
--- a/lib/fluent/compat/output.rb
+++ b/lib/fluent/compat/output.rb
@@ -111,6 +111,10 @@ module Fluent
       def size
         self.bytesize
       end
+
+      def size_of_events
+        @size + @adding_size
+      end
     end
 
     module BufferedChunkMixin

--- a/lib/fluent/plugin/in_forward.rb
+++ b/lib/fluent/plugin/in_forward.rb
@@ -169,10 +169,11 @@ module Fluent
 
       if entries.class == String
         # PackedForward
-        es = MessagePackEventStream.new(entries)
+        option = msg[2]
+        size = (option && option['size']) || 0
+        es = MessagePackEventStream.new(entries, nil, size.to_i)
         es = check_and_skip_invalid_event(tag, es, source) if @skip_invalid_event
         router.emit_stream(tag, es)
-        option = msg[2]
 
       elsif entries.class == Array
         # Forward
@@ -265,7 +266,7 @@ module Fluent
           @y = Yajl::Parser.new
           @y.on_parse_complete = lambda { |obj|
             option = @on_message.call(obj, @chunk_counter, @source)
-            respond option if option
+            respond option
             @chunk_counter = 0
           }
         else

--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -107,7 +107,6 @@ class ForwardOutputTest < Test::Unit::TestCase
 
   def test_wait_response_timeout_config
     d = create_driver(CONFIG)
-    assert_equal false, d.instance.extend_internal_protocol
     assert_equal false, d.instance.require_ack_response
     assert_equal 190, d.instance.ack_response_timeout
 
@@ -115,7 +114,6 @@ class ForwardOutputTest < Test::Unit::TestCase
       require_ack_response true
       ack_response_timeout 2s
     ])
-    assert d.instance.extend_internal_protocol
     assert d.instance.require_ack_response
     assert_equal 2, d.instance.ack_response_timeout
   end

--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -530,6 +530,8 @@ class ForwardOutputTest < Test::Unit::TestCase
     assert_equal node.available, true
   end
 
+  # To suppress calling `ForwardInput#start` in `DummyEngineDriver`,
+  # `DummyEnigneDriver` should avoid calling CallSuperMixin.prepend at `Fluent::Compat::Input#initialize`.
   module SuppressCallSuperMixin
     def start
       _start


### PR DESCRIPTION
ref issue is #1135
But this patch some differences form  #1135 proposed.
Because all we want to do is to suppress calling `MessagePackEventStream#ensure_unpacked!` , this patch did not add `size` to argument of MultiEventStream#initialize



