### PR TITLE
Make CI faster for Windows environment

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,11 @@ Rake::TestTask.new(:base_test) do |t|
   #  $ bundle exec rake base_test TEST=test/test_specified_path.rb
   #  $ bundle exec rake base_test TEST=test/test_*.rb
   t.libs << "test"
-  t.test_files = Dir["test/**/test_*.rb"].sort
+  t.test_files = if ENV["WIN_RAPID"]
+                   ["test/test_event.rb", "test/test_supervisor.rb", "test/plugin_helper/test_event_loop.rb"]
+                 else
+                   Dir["test/**/test_*.rb"].sort
+                 end
   t.verbose = true
   t.warning = true
   t.ruby_opts = ["-Eascii-8bit:ascii-8bit"]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ install:
   - bundle install
 build: off
 test_script:
-  - bundle exec rake test TESTOPTS=-v
+  - bundle exec rake test
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,10 +30,12 @@ environment:
       devkit: C:\Ruby23-x64\DevKit
     - ruby_version: "22"
       devkit: C:\Ruby23\DevKit
+      WIN_RAPID: true
     - ruby_version: "21-x64"
       devkit: C:\Ruby23-x64\DevKit
     - ruby_version: "21"
       devkit: C:\Ruby23\DevKit
+      WIN_RAPID: true
 matrix:
   allow_failures:
     - ruby_version: "21"


### PR DESCRIPTION
Currently we are running 6 test jobs on AppVeyer per builds (ruby [2.1, 2.2, 2.3] * [x86, x64]). But it requires 40minutes even with 2 concurrent jobs.

My idea is:
* run full tests just 4 times (2.3-x86, 2.3-x64, 2.2-x64, 2.2-x64)
* create a very short test to confirm that minimal test cases run successfully

Some gems which fluentd depends on are binary gems, which contains some versions of binary for versions of ruby, and architectures of compute (x86/x64). These combinations should be tested.

But running full tests is too much for that purpose.
So I think we can reduce total time of CI tasks by replacing full tests with very short/simple tests for some combinations of environments.