### PR TITLE
Optimize multiple filters call

### DIFF
--- a/example/multi_filters.conf
+++ b/example/multi_filters.conf
@@ -1,0 +1,61 @@
+# This example is to measure optimized filter pipeline performance.
+
+<source>
+  @type dummy
+  tag   test
+  size 1000
+</source>
+
+<filter test>
+  @type grep
+  exclude1 hello .
+</filter>
+
+<filter test>
+  @type grep
+  exclude1 hello .
+</filter>
+
+<filter test>
+  @type grep
+  exclude1 hello .
+</filter>
+
+<filter test>
+  @type grep
+  exclude1 hello .
+</filter>
+
+<filter test>
+  @type grep
+  exclude1 hello .
+</filter>
+
+<filter test>
+  @type grep
+  exclude1 hello .
+</filter>
+
+<filter test>
+  @type grep
+  exclude1 hello .
+</filter>
+
+<filter test>
+  @type grep
+  exclude1 hello .
+</filter>
+
+<filter test>
+  @type grep
+  exclude1 hello .
+</filter>
+
+<filter test>
+  @type grep
+  exclude1 hello .
+</filter>
+
+<match test>
+  @type buffered_null
+</match>

--- a/lib/fluent/plugin/filter.rb
+++ b/lib/fluent/plugin/filter.rb
@@ -30,6 +30,8 @@ module Fluent
 
       helpers :event_emitter
 
+      attr_reader :has_filter_with_time
+
       def initialize
         super
         @has_filter_with_time = has_filter_with_time?

--- a/test/test_event_router.rb
+++ b/test/test_event_router.rb
@@ -184,28 +184,14 @@ class EventRouterTest < ::Test::Unit::TestCase
     end
 
     sub_test_case 'filter' do
-      test 'filter should be called when tag matched and with optimized' do
-        event_router.add_rule('test', filter)
-
-        now = Engine.now
-        record = {'k' => 'v'}
-        assert_rr do
-          mock(filter).filter('test', now, record) { events }
-          event_router.emit('test', now, record)
-        end
-      end
-
-      test 'filter should be called when tag matched and without optimized' do
+      test 'filter should be called when tag matched' do
         filter = Class.new(FluentTestFilter) { |x|
-          def filter_stream(_tag, es)
-            es
-          end
+          def filter_stream(_tag, es); end
         }.new
 
         event_router.add_rule('test', filter)
 
         assert_rr do
-          mock($log).info("Filtering works with worse performance, because #{[filter].map(&:class)} uses `#filter_stream` method.")
           mock(filter).filter_stream('test', is_a(OneEventStream)) { events }
           event_router.emit('test', Engine.now, 'k' => 'v')
         end
@@ -244,6 +230,89 @@ class EventRouterTest < ::Test::Unit::TestCase
         assert_equal 0, output.events['test'].first['__test__']
         assert_equal 0, output.events['test'].first['__hoge__']
         assert_equal 'v', output.events['test'].first['k']
+      end
+    end
+
+    sub_test_case 'optimized filter' do
+      setup do
+        @record = { 'k' => 'v' }
+        @now = Engine.now
+      end
+
+      test 'call optimized filter when the filter plugin implements #filter without #filter_stream' do
+        event_router.add_rule('test', filter)
+
+        assert_rr do
+          mock(filter).filter('test', @now, @record) { @record }
+          event_router.emit('test', @now, @record)
+        end
+      end
+
+      test 'call optimized filter when the filter plugin implements #filter_with_time without #filter_stream' do
+        filter = Class.new(FluentTestFilter) {
+          undef_method :filter
+          def filter_with_time(tag, time, record); end
+        }.new
+
+        event_router.add_rule('test', filter)
+
+        assert_rr do
+          mock(filter).filter_with_time('test', @now, @record) { [time, @record] }
+          event_router.emit('test', @now, @record)
+        end
+      end
+
+      test "don't call optimized filter when filter plugins implement #filter_stream" do
+        filter = Class.new(FluentTestFilter) {
+          undef_method :filter
+          def filter_stream(tag, time, record); end
+        }.new
+
+        event_router.add_rule('test', filter)
+
+        assert_rr do
+          mock(filter).filter_stream('test', is_a(OneEventStream)) { OneEventStream.new(@now, @record) }
+          event_router.emit('test', @now, @record)
+        end
+      end
+
+      test 'call optimized filter when filter plugins have #filter_with_time instead of #filter' do
+        filter_with_time = Class.new(FluentTestFilter) {
+          undef_method :filter
+          def filter_with_time(tag, time, record); end
+        }.new
+
+        event_router.add_rule('test', filter_with_time)
+        event_router.add_rule('test', filter)
+
+        assert_rr do
+          mock(filter_with_time).filter_with_time('test', @now, @record) { [@now + 1, @record] }
+          mock(filter).filter('test', @now + 1, @record) { @record }
+          event_router.emit('test', @now, @record)
+        end
+      end
+
+      test "don't call optimized filter even if just a filter of some filters implements #filter_stream method" do
+        filter_stream = Class.new(FluentTestFilter) {
+          def filter_stream(tag, record); end
+        }.new
+
+        filter_with_time = Class.new(FluentTestFilter) {
+          undef_method :filter
+          def filter_with_time(tag, time, record); end
+        }.new
+
+        filters = [filter_stream, filter_with_time, filter]
+        filters.each { |f| event_router.add_rule('test', f) }
+
+        e = OneEventStream.new(@now, @record)
+        assert_rr do
+          mock($log).info("Filtering works with worse performance, because #{[filter_stream].map(&:class)} uses `#filter_stream` method.")
+          mock(filter_stream).filter_stream('test', is_a(OneEventStream)) { e }
+          mock(filter).filter_stream('test', is_a(OneEventStream)) { e }
+          mock(filter_with_time).filter_stream('test', is_a(OneEventStream)) { e }
+          event_router.emit('test', @now, @record)
+        end
       end
     end
 


### PR DESCRIPTION
**Please merge this PR after #1140 is merged, Becasue this PR depends on https://github.com/fluent/fluentd/pull/1140.**


If your code can be optimized, the speed of `filter_stream` will be about 1.2 times faster.
This result is caused by avoiding to call a lot of `Fluent::MultiEventStream#add`.

the requirement of running optimization is that filter plugins that you are using don't implement `filter_stream`.

the executed command is here.
```
bundle exec fluentd -c example/multi_filters.conf
```


The measured code, as shown below. (https://github.com/fluent/fluentd/pull/1145/files#diff-c18beef6caee95367d6268a4c181f913R166)

```rb
def filter_stream(tag, es)
  require 'ruby-prof'
  RubyProf.start

  if optimizable?
    processed = optimized_filter_stream(tag, es)
  else
    processed = @filters.reduce(es) { |acc, filter| filter.filter_stream(tag, acc) }
  end

  result = RubyProf.stop
  printer = RubyProf::FlatPrinter.new(result)
  printer.print(STDOUT)
  processed
end
```


The result o calling `optimized_filter_stream`

```
* indicates recursively called methods
Measure Mode: wall_time
Thread ID: 70252402759920
Fiber ID: 70252404764700
Total: 0.051646
Sort by: self_time

 %self      total      self      wait     child     calls  name
 19.05      0.024     0.010     0.000     0.014    20000   Hash#each
 15.70      0.041     0.008     0.000     0.033    10000   Fluent::Plugin::GrepFilter#filter
 11.29      0.006     0.006     0.000     0.000    10000   Regexp#match
 10.95      0.011     0.006     0.000     0.006    10000   <Module::Fluent::Compat::StringUtil>#match_regexp
  4.66      0.002     0.002     0.000     0.000    10000   NilClass#to_s
  1.78      0.051     0.001     0.000     0.050    11000  *Kernel#catch
  1.29      0.052     0.001     0.000     0.051     1001  *Array#each
  1.15      0.001     0.001     0.000     0.000     1000   Fluent::MultiEventStream#add
  0.02      0.052     0.000     0.000     0.052        1   Fluent::EventRouter::Pipeline::FilterOptimizer#optimized_filter_stream
  0.02      0.052     0.000     0.000     0.052        1   Fluent::EventRouter::Pipeline::FilterOptimizer#filter_stream
  0.01      0.000     0.000     0.000     0.000        1   Fluent::MultiEventStream#initialize
  0.01      0.000     0.000     0.000     0.000        1   Class#new
  0.00      0.052     0.000     0.000     0.052        1   Fluent::ArrayEventStream#each
```


This result of calling `@filters.reduce(es) { |acc, filter| filter.filter_stream(tag, acc) }`

```
* indicates recursively called methods
Measure Mode: wall_time
Thread ID: 70231922124020
Fiber ID: 70231922694520
Total: 0.063186
Sort by: self_time

 %self      total      self      wait     child     calls  name
 17.57      0.026     0.011     0.000     0.015    20000   Hash#each
 17.14      0.037     0.011     0.000     0.026    10000   Kernel#catch
 16.16      0.057     0.010     0.000     0.047        9   Range#each
 14.94      0.046     0.009     0.000     0.037    10000   Fluent::Plugin::GrepFilter#filter
 10.08      0.012     0.006     0.000     0.006    10000   <Module::Fluent::Compat::StringUtil>#match_regexp
  9.56      0.006     0.006     0.000     0.000    10000   Regexp#match
  8.69      0.005     0.005     0.000     0.000    10000   Fluent::MultiEventStream#add
  4.23      0.003     0.003     0.000     0.000    10000   NilClass#to_s
  0.04      0.063     0.000     0.000     0.063       10   Fluent::Plugin::Filter#filter_stream
  0.03      0.000     0.000     0.000     0.000       10   Class#new
  0.03      0.057     0.000     0.000     0.057        9   Fluent::MultiEventStream#each
  0.02      0.063     0.000     0.000     0.063        2  *Array#each
  0.02      0.000     0.000     0.000     0.000       10   Fluent::MultiEventStream#initialize
  0.02      0.063     0.000     0.000     0.063        1   Fluent::EventRouter::Pipeline::FilterOptimizer#filter_stream
  0.01      0.006     0.000     0.000     0.006        1   Fluent::ArrayEventStream#each
  0.01      0.063     0.000     0.000     0.063        1   Enumerable#reduce

```

### Environment

* Tool : https://github.com/ruby-prof/ruby-prof
* OS: 
```
ProductName:    Mac OS X
ProductVersion: 10.11.6
BuildVersion:   15G31
```
* PROCESSOR: `2.7 GHz Intel Core i5`
* MEMORY: `8 GB 1867 MHz DDR3`

