### PR TITLE
Ensure strict mode is used for Oj parser.

### DIFF
--- a/lib/fluent/plugin/parser_json.rb
+++ b/lib/fluent/plugin/parser_json.rb
@@ -39,7 +39,7 @@ module Fluent
         begin
           raise LoadError unless @json_parser == 'oj'
           require 'oj'
-          Oj.default_options = {bigdecimal_load: :float}
+          Oj.default_options = {bigdecimal_load: :float, mode: :strict}
           @load_proc = Oj.method(:load)
           @error_class = Oj::ParseError
         rescue LoadError


### PR DESCRIPTION
If we don't use strict mode strings that start with ":" are converted to symbols:
```
irb(main):002:0> Oj.load('{"log":"::1 - - [04/Aug/2016:16:15:13 +0000] \"OPTIONS * HTTP/1.0\" 200 126 \"-\" \"Apache/2.4.10 (Debian) PHP/5.6.24 (internal dummy connection)\"\n","stream":"stdout","time":"2016-08-04T16:15:13.726932176Z"}')
=> {"log"=>:":1 - - [04/Aug/2016:16:15:13 +0000] \"OPTIONS * HTTP/1.0\" 200 126 \"-\" \"Apache/2.4.10 (Debian) PHP/5.6.24 (internal dummy connection)\"\n", "stream"=>"stdout", "time"=>"2016-08-04T16:15:13.726932176Z"}
```
Using strict mode this does not happen:
```
irb(main):003:0> Oj.default_options = {bigdecimal_load: :float, :mode => :strict}
=> {:bigdecimal_load=>:float, :mode=>:strict}
irb(main):004:0> Oj.load('{"log":"::1 - - [04/Aug/2016:16:15:13 +0000] \"OPTIONS * HTTP/1.0\" 200 126 \"-\" \"Apache/2.4.10 (Debian) PHP/5.6.24 (internal dummy connection)\"\n","stream":"stdout","time":"2016-08-04T16:15:13.726932176Z"}')
=> {"log"=>"::1 - - [04/Aug/2016:16:15:13 +0000] \"OPTIONS * HTTP/1.0\" 200 126 \"-\" \"Apache/2.4.10 (Debian) PHP/5.6.24 (internal dummy connection)\"\n", "stream"=>"stdout", "time"=>"2016-08-04T16:15:13.726932176Z"}
```
Obtaining symbols instead of strings causes havoc for some downstream plugins.