### PR TITLE
Migrate in_monitor_agent to v0.14 API

### DIFF
--- a/lib/fluent/plugin/in_monitor_agent.rb
+++ b/lib/fluent/plugin/in_monitor_agent.rb
@@ -22,6 +22,7 @@ require 'cool.io'
 
 require 'fluent/plugin/input'
 require 'fluent/plugin/output'
+require 'fluent/plugin/multi_output'
 require 'fluent/plugin/filter'
 
 module Fluent::Plugin
@@ -281,7 +282,7 @@ module Fluent::Plugin
     # from the plugin `pe` recursively
     def self.collect_children(pe, array=[])
       array << pe
-      if pe.is_a?(Fluent::MultiOutput) && pe.respond_to?(:outputs)
+      if pe.is_a?(Fluent::Plugin::MultiOutput) && pe.respond_to?(:outputs)
         pe.outputs.each {|nop|
           collect_children(nop, array)
         }
@@ -295,7 +296,7 @@ module Fluent::Plugin
       matches = Fluent::Engine.root_agent.event_router.instance_variable_get(:@match_rules)
       matches.each { |rule|
         if rule.match?(tag)
-          if rule.collector.is_a?(Fluent::Output)
+          if rule.collector.is_a?(Fluent::Plugin::Output)
             return get_monitor_info(rule.collector, opts)
           end
         end

--- a/lib/fluent/plugin/in_monitor_agent.rb
+++ b/lib/fluent/plugin/in_monitor_agent.rb
@@ -221,14 +221,14 @@ module Fluent::Plugin
       @srv.mount('/api/plugins.json', JSONMonitorServlet, self)
       @srv.mount('/api/config', LTSVConfigMonitorServlet, self)
       @srv.mount('/api/config.json', JSONConfigMonitorServlet, self)
-      thread_create :servlet do
+      thread_create :in_monitor_agent_servlet do
         @srv.start
       end
       if @tag
         log.debug "tag parameter is specified. Emit plugins info to '#{@tag}'"
 
         opts = {with_config: false}
-        timer_execute(:monitor_emit, @emit_interval, repeat: true) {
+        timer_execute(:in_monitor_agent_emit, @emit_interval, repeat: true) {
           es = Fluent::MultiEventStream.new
           now = Fluent::Engine.now
           plugins_info_all(opts).each { |record|

--- a/lib/fluent/plugin/in_monitor_agent.rb
+++ b/lib/fluent/plugin/in_monitor_agent.rb
@@ -296,7 +296,7 @@ module Fluent::Plugin
       matches = Fluent::Engine.root_agent.event_router.instance_variable_get(:@match_rules)
       matches.each { |rule|
         if rule.match?(tag)
-          if rule.collector.is_a?(Fluent::Plugin::Output)
+          if rule.collector.is_a?(Fluent::Plugin::Output) || rule.collector.is_a?(Fluent::Output)
             return get_monitor_info(rule.collector, opts)
           end
         end

--- a/lib/fluent/plugin/in_monitor_agent.rb
+++ b/lib/fluent/plugin/in_monitor_agent.rb
@@ -282,7 +282,7 @@ module Fluent::Plugin
     # from the plugin `pe` recursively
     def self.collect_children(pe, array=[])
       array << pe
-      if pe.is_a?(Fluent::Plugin::MultiOutput) && pe.respond_to?(:outputs)
+      if pe.is_a?(Fluent::Plugin::MultiOutput) || pe.is_a?(Fluent::MultiOutput) && pe.respond_to?(:outputs)
         pe.outputs.each {|nop|
           collect_children(nop, array)
         }

--- a/test/plugin/test_in_monitor_agent.rb
+++ b/test/plugin/test_in_monitor_agent.rb
@@ -271,24 +271,24 @@ plugin_id:test_filter\tplugin_category:filter\ttype:test_filter\toutput_plugin:f
       d.instance.start
       expected_test_in_response =
         {"config" => {
-          "@id"=>"test_in",
-          "@type"=>"test_in"
+          "@id"   => "test_in",
+          "@type" => "test_in"
         },
-        "output_plugin"=>false,
-        "plugin_category"=>"input",
-        "plugin_id"=>"test_in",
-        "retry_count"=>nil,
-        "type"=>"test_in"}
+        "output_plugin"   => false,
+        "plugin_category" => "input",
+        "plugin_id"       => "test_in",
+        "retry_count"     => nil,
+        "type"            => "test_in"}
       expected_null_response =
         {"config" => {
-          "@id"=>"null",
-          "@type"=>"null"
+          "@id"   => "null",
+          "@type" => "null"
         },
-        "output_plugin"=>true,
-        "plugin_category"=>"output",
-        "plugin_id"=>"null",
-        "retry_count"=>0,
-        "type"=>"null"}
+        "output_plugin"   => true,
+        "plugin_category" => "output",
+        "plugin_id"       => "null",
+        "retry_count"     => 0,
+        "type"            => "null"}
       response = JSON.parse(get("http://127.0.0.1:#{@port}/api/plugins.json"))
       test_in_response = response["plugins"][0]
       null_response = response["plugins"][5]

--- a/test/plugin/test_in_monitor_agent.rb
+++ b/test/plugin/test_in_monitor_agent.rb
@@ -154,6 +154,36 @@ EOC
                     FluentTest::FluentTestOutput,
                     Fluent::Plugin::NullOutput], plugins)
     end
+
+    test "emit" do
+      d = create_driver("
+  @type monitor_agent
+  bind '127.0.0.1'
+  port #{@port}
+  tag monitor
+  emit_interval 1
+")
+      d.instance.start
+      d.end_if do
+        d.events.size >= 5
+      end
+      d.run
+      expect_relabel_record = {
+        "plugin_id"       => "test_relabel",
+        "plugin_category" => "output",
+        "type"            => "relabel",
+        "output_plugin"   => true,
+        "retry_count"     => 0}
+      expect_test_out_record = {
+        "plugin_id"       => "test_out",
+        "plugin_category" => "output",
+        "type"            => "test_out",
+        "output_plugin"   => true,
+        "retry_count"     => 0
+      }
+      assert_equal(expect_relabel_record, d.events[1][2])
+      assert_equal(expect_test_out_record, d.events[3][2])
+    end
   end
 
   def get(uri, header = {})

--- a/test/plugin/test_in_monitor_agent.rb
+++ b/test/plugin/test_in_monitor_agent.rb
@@ -1,6 +1,11 @@
 require_relative '../helper'
 require 'fluent/test/driver/input'
 require 'fluent/plugin/in_monitor_agent'
+require 'fluent/engine'
+require 'fluent/config'
+require 'fluent/event_router'
+require 'fluent/supervisor'
+require_relative '../test_plugin_classes'
 
 class MonitorAgentInputTest < Test::Unit::TestCase
   def setup
@@ -11,11 +16,128 @@ class MonitorAgentInputTest < Test::Unit::TestCase
     Fluent::Test::Driver::Input.new(Fluent::Plugin::MonitorAgentInput).configure(conf)
   end
 
+  def configure_ra(ra, conf_str)
+    conf = Fluent::Config.parse(conf_str, "(test)", "(test_dir)", true)
+    ra.configure(conf)
+    ra
+  end
+
   def test_configure
     d = create_driver
     assert_equal("0.0.0.0", d.instance.bind)
     assert_equal(24220, d.instance.port)
     assert_equal(nil, d.instance.tag)
     assert_equal(60, d.instance.emit_interval)
+  end
+
+  sub_test_case "collect plugin information" do
+    setup do
+      # check @type and type in one configuration
+      conf = <<-EOC
+<source>
+  @type test_in
+  @id test_in
+</source>
+<filter>
+  type test_filter
+  id test_filter
+</filter>
+<match **>
+  @type relabel
+  @id test_relabel
+  @label @test
+</match>
+<label @test>
+  <match **>
+    type test_out
+    id test_out
+  </match>
+</label>
+<label @ERROR>
+  <match>
+    @type null
+  </match>
+</label>
+EOC
+      @ra = Fluent::RootAgent.new(log: $log)
+      stub(Fluent::Engine).root_agent { @ra }
+      @ra = configure_ra(@ra, conf)
+    end
+
+    test "plugin_category" do
+      d = create_driver
+      test_label = @ra.labels['@test']
+      error_label = @ra.labels['@ERROR']
+      assert_equal("input", d.instance.plugin_category(@ra.inputs.first))
+      assert_equal("filter", d.instance.plugin_category(@ra.filters.first))
+      assert_equal("output", d.instance.plugin_category(test_label.outputs.first))
+      assert_equal("output", d.instance.plugin_category(error_label.outputs.first))
+    end
+
+    test "get_monitor_info" do
+      d = create_driver
+      test_label = @ra.labels['@test']
+      error_label = @ra.labels['@ERROR']
+      input_info = {
+        "config" => {
+          "@id"   => "test_in",
+          "@type" => "test_in"
+        },
+        "output_plugin"  => false,
+        "plugin_category"=> "input",
+        "plugin_id"      => "test_in",
+        "retry_count"    => nil,
+        "type"           => "test_in"
+      }
+      filter_info = {
+        "config" => {
+          "id"   => "test_filter",
+          "type" => "test_filter"
+        },
+        "output_plugin"   => false,
+        "plugin_category" => "filter",
+        "plugin_id"       => "test_filter",
+        "retry_count"     => nil,
+        "type"            => "test_filter"
+      }
+      output_info = {
+        "config" => {
+          "id"   => "test_out",
+          "type" => "test_out"
+        },
+        "output_plugin"   => true,
+        "plugin_category" => "output",
+        "plugin_id"       => "test_out",
+        "retry_count"     => 0,
+        "type"            => "test_out"
+      }
+      assert_equal(input_info, d.instance.get_monitor_info(@ra.inputs.first))
+      assert_equal(filter_info, d.instance.get_monitor_info(@ra.filters.first))
+      assert_equal(output_info, d.instance.get_monitor_info(test_label.outputs.first))
+    end
+
+    test "fluentd opts" do
+      d = create_driver
+      opts = Fluent::Supervisor.default_options
+      Fluent::Supervisor.new(opts)
+      expected_opts = {
+        "config_path" => "/etc/fluent/fluent.conf",
+        "pid_file"    => nil,
+        "plugin_dirs" => ["/etc/fluent/plugin"],
+        "log_path"    => nil
+      }
+      assert_equal(expected_opts, d.instance.fluentd_opts)
+    end
+
+    test "all_plugins" do
+      d = create_driver
+      plugins = []
+      d.instance.all_plugins.each {|plugin| plugins << plugin.class }
+      assert_equal([FluentTest::FluentTestInput,
+                    Fluent::Plugin::RelabelOutput,
+                    FluentTest::FluentTestFilter,
+                    FluentTest::FluentTestOutput,
+                    Fluent::Plugin::NullOutput], plugins)
+    end
   end
 end

--- a/test/plugin/test_in_monitor_agent.rb
+++ b/test/plugin/test_in_monitor_agent.rb
@@ -1,0 +1,21 @@
+require_relative '../helper'
+require 'fluent/test'
+require 'fluent/plugin/in_monitor_agent'
+
+class MonitorAgentInputTest < Test::Unit::TestCase
+  def setup
+    Fluent::Test.setup
+  end
+
+  def create_driver(conf = '')
+    Fluent::Test::InputTestDriver.new(Fluent::MonitorAgentInput).configure(conf)
+  end
+
+  def test_configure
+    d = create_driver
+    assert_equal("0.0.0.0", d.instance.bind)
+    assert_equal(24220, d.instance.port)
+    assert_equal(nil, d.instance.tag)
+    assert_equal(60, d.instance.emit_interval)
+  end
+end

--- a/test/plugin/test_in_monitor_agent.rb
+++ b/test/plugin/test_in_monitor_agent.rb
@@ -39,8 +39,8 @@ class MonitorAgentInputTest < Test::Unit::TestCase
   @id test_in
 </source>
 <filter>
-  type test_filter
-  id test_filter
+  @type test_filter
+  @id test_filter
 </filter>
 <match **>
   @type relabel
@@ -49,8 +49,8 @@ class MonitorAgentInputTest < Test::Unit::TestCase
 </match>
 <label @test>
   <match **>
-    type test_out
-    id test_out
+    @type test_out
+    @id test_out
   </match>
 </label>
 <label @ERROR>
@@ -92,8 +92,8 @@ EOC
       }
       filter_info = {
         "config" => {
-          "id"   => "test_filter",
-          "type" => "test_filter"
+          "@id"   => "test_filter",
+          "@type" => "test_filter"
         },
         "output_plugin"   => false,
         "plugin_category" => "filter",
@@ -103,8 +103,8 @@ EOC
       }
       output_info = {
         "config" => {
-          "id"   => "test_out",
-          "type" => "test_out"
+          "@id"   => "test_out",
+          "@type" => "test_out"
         },
         "output_plugin"   => true,
         "plugin_category" => "output",

--- a/test/plugin/test_in_monitor_agent.rb
+++ b/test/plugin/test_in_monitor_agent.rb
@@ -219,16 +219,16 @@ EOC
   tag monitor
 ")
       d.instance.start
-      expected_response = "\
-plugin_id:test_in\tplugin_category:input\ttype:test_in\toutput_plugin:false\tretry_count:
-plugin_id:monitor_agent\tplugin_category:input\ttype:monitor_agent\toutput_plugin:false\tretry_count:
-plugin_id:test_relabel\tplugin_category:output\ttype:relabel\toutput_plugin:true\tretry_count:0
-plugin_id:test_filter\tplugin_category:filter\ttype:test_filter\toutput_plugin:false\tretry_count:
-plugin_id:test_out\tplugin_category:output\ttype:test_out\toutput_plugin:true\tretry_count:0
-plugin_id:null\tplugin_category:output\ttype:null\toutput_plugin:true\tretry_count:0
-"
+      expected_test_in_response = "\
+plugin_id:test_in\tplugin_category:input\ttype:test_in\toutput_plugin:false\tretry_count:"
+      expected_test_filter_response = "\
+plugin_id:test_filter\tplugin_category:filter\ttype:test_filter\toutput_plugin:false\tretry_count:"
 
-      assert_equal(expected_response, get("http://127.0.0.1:#{@port}/api/plugins"))
+      response = get("http://127.0.0.1:#{@port}/api/plugins")
+      test_in = response.split("\n")[0]
+      test_filter = response.split("\n")[3]
+      assert_equal(expected_test_in_response, test_in)
+      assert_equal(expected_test_filter_response, test_filter)
     end
 
     test "/api/plugins.json" do
@@ -239,67 +239,31 @@ plugin_id:null\tplugin_category:output\ttype:null\toutput_plugin:true\tretry_cou
   tag monitor
 ")
       d.instance.start
-      expected_response = {"plugins"=>
-        [{"config" => {
-             "@id"=>"test_in",
-             "@type"=>"test_in"
-           },
-           "output_plugin"=>false,
-           "plugin_category"=>"input",
-           "plugin_id"=>"test_in",
-           "retry_count"=>nil,
-           "type"=>"test_in"},
-         {"config"=>{
-             "@id"=>"monitor_agent",
-             "@type"=>"monitor_agent",
-             "bind"=>"127.0.0.1",
-             "port"=>"24220",
-             "tag"=>"monitor"
-           },
-           "output_plugin"=>false,
-           "plugin_category"=>"input",
-           "plugin_id"=>"monitor_agent",
-           "retry_count"=>nil,
-           "type"=>"monitor_agent"},
-         {"config" => {
-             "@id"=>"test_relabel",
-             "@label"=>"@test",
-             "@type"=>"relabel"
-           },
-           "output_plugin"=>true,
-           "plugin_category"=>"output",
-           "plugin_id"=>"test_relabel",
-           "retry_count"=>0,
-           "type"=>"relabel"},
-         {"config" => {
-             "@id"=>"test_filter",
-             "@type"=>"test_filter"
-           },
-           "output_plugin"=>false,
-           "plugin_category"=>"filter",
-           "plugin_id"=>"test_filter",
-           "retry_count"=>nil,
-           "type"=>"test_filter"},
-         {"config" => {
-             "@id"=>"test_out",
-             "@type"=>"test_out"
-           },
-           "output_plugin"=>true,
-           "plugin_category"=>"output",
-           "plugin_id"=>"test_out",
-           "retry_count"=>0,
-           "type"=>"test_out"},
-         {"config" => {
-             "@id"=>"null",
-             "@type"=>"null"
-           },
-           "output_plugin"=>true,
-           "plugin_category"=>"output",
-           "plugin_id"=>"null",
-           "retry_count"=>0,
-           "type"=>"null"}]}
-      assert_equal(expected_response,
-                   JSON.parse(get("http://127.0.0.1:#{@port}/api/plugins.json")))
+      expected_test_in_response =
+        {"config" => {
+          "@id"=>"test_in",
+          "@type"=>"test_in"
+        },
+        "output_plugin"=>false,
+        "plugin_category"=>"input",
+        "plugin_id"=>"test_in",
+        "retry_count"=>nil,
+        "type"=>"test_in"}
+      expected_null_response =
+        {"config" => {
+          "@id"=>"null",
+          "@type"=>"null"
+        },
+        "output_plugin"=>true,
+        "plugin_category"=>"output",
+        "plugin_id"=>"null",
+        "retry_count"=>0,
+        "type"=>"null"}
+      response = JSON.parse(get("http://127.0.0.1:#{@port}/api/plugins.json"))
+      test_in_response = response["plugins"][0]
+      null_response = response["plugins"][5]
+      assert_equal(expected_test_in_response, test_in_response)
+      assert_equal(expected_null_response, null_response)
     end
 
     test "/api/config" do

--- a/test/plugin/test_in_monitor_agent.rb
+++ b/test/plugin/test_in_monitor_agent.rb
@@ -56,6 +56,7 @@ class MonitorAgentInputTest < Test::Unit::TestCase
 <label @ERROR>
   <match>
     @type null
+    @id null
   </match>
 </label>
 EOC
@@ -111,9 +112,21 @@ EOC
         "retry_count"     => 0,
         "type"            => "test_out"
       }
+      error_label_info = {
+        "config" => {
+          "@id"=>"null",
+          "@type" => "null"
+        },
+        "output_plugin"   => true,
+        "plugin_category" => "output",
+        "plugin_id"       => "null",
+        "retry_count"     => 0,
+        "type"            => "null"
+      }
       assert_equal(input_info, d.instance.get_monitor_info(@ra.inputs.first))
       assert_equal(filter_info, d.instance.get_monitor_info(@ra.filters.first))
       assert_equal(output_info, d.instance.get_monitor_info(test_label.outputs.first))
+      assert_equal(error_label_info, d.instance.get_monitor_info(error_label.outputs.first))
     end
 
     test "fluentd opts" do

--- a/test/plugin/test_in_monitor_agent.rb
+++ b/test/plugin/test_in_monitor_agent.rb
@@ -1,5 +1,5 @@
 require_relative '../helper'
-require 'fluent/test'
+require 'fluent/test/driver/input'
 require 'fluent/plugin/in_monitor_agent'
 
 class MonitorAgentInputTest < Test::Unit::TestCase
@@ -8,7 +8,7 @@ class MonitorAgentInputTest < Test::Unit::TestCase
   end
 
   def create_driver(conf = '')
-    Fluent::Test::InputTestDriver.new(Fluent::MonitorAgentInput).configure(conf)
+    Fluent::Test::Driver::Input.new(Fluent::Plugin::MonitorAgentInput).configure(conf)
   end
 
   def test_configure


### PR DESCRIPTION
I've migrated in_monitor_agent plugin to v0.14 API.

### Remaining tasks

- [x] Write more test cases for in_monitor_agent

### Not for this PR tasks

* support more plugin classes in in_monitor_agent (e.g. parser and storage plugins support)