### PR TITLE
Set 0 to umask for keeping v0.12 behaviour. fix #1019

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -240,6 +240,7 @@ module Fluent
           logger_initializer: logger_initializer,
           chuser: chuser,
           chgroup: chgroup,
+          chumask: 0,
           suppress_repeated_stacktrace: suppress_repeated_stacktrace,
           daemonize: daemonize,
           rpc_endpoint: rpc_endpoint,


### PR DESCRIPTION
Fluentd v0.12 sets `0` to umask but this code is missing in v0.14.

https://github.com/fluent/fluentd/blob/1f7cdffdb7bcae2560e536ec9cd796eff5777fc2/lib/fluent/supervisor.rb#L250

fluentd should pass chumask parameter to ServerEngine. This also fixes #1019 problem.