### PR TITLE
Handle Windows event correctly when using winsvc.rb

### DIFF
--- a/lib/fluent/winsvc.rb
+++ b/lib/fluent/winsvc.rb
@@ -47,7 +47,6 @@ begin
     @pid = 0
 
     def service_main
-      opt = read_fluentdopt
       @pid = service_main_start
       while running?
         sleep 10

--- a/lib/fluent/winsvc.rb
+++ b/lib/fluent/winsvc.rb
@@ -30,7 +30,7 @@ begin
   def read_fluentdopt
     require 'win32/Registry'
     Win32::Registry::HKEY_LOCAL_MACHINE.open("SYSTEM\\CurrentControlSet\\Services\\fluentdwinsvc") do |reg|
-      reg.read("fluentdopt")[1]
+      reg.read("fluentdopt")[1] rescue ""
     end
   end
 


### PR DESCRIPTION
When invoking fluentd as a Windows Service via winsvc.rb, winsvc.rb expects that fluetnd handle the Windows event passed by `-x` option.
But currently fluentd simply ignores it.
This patch implements to handle the event, and fixes a part of #1084.