### PR TITLE
Fix to add plugin instances created by MultiOutput plugins, into agents

### DIFF
--- a/lib/fluent/agent.rb
+++ b/lib/fluent/agent.rb
@@ -134,6 +134,9 @@ module Fluent
       output.router = @event_router if output.respond_to?(:router=)
       output.configure(conf)
       @outputs << output
+      if output.respond_to?(:outputs) && (output.is_a?(Fluent::Plugin::MultiOutput) || output.is_a?(Fluent::MultiOutput))
+        @outputs.push(*output.outputs)
+      end
       @event_router.add_rule(pattern, output)
 
       output

--- a/test/test_plugin_classes.rb
+++ b/test/test_plugin_classes.rb
@@ -10,11 +10,13 @@ module FluentTest
     attr_reader :started
 
     def start
+      super
       @started = true
     end
 
     def shutdown
       @started = false
+      super
     end
   end
 
@@ -30,11 +32,13 @@ module FluentTest
     attr_reader :started
 
     def start
+      super
       @started = true
     end
 
     def shutdown
       @started = false
+      super
     end
 
     def emit(tag, es, chain)
@@ -69,11 +73,13 @@ module FluentTest
     attr_reader :started
 
     def start
+      super
       @started = true
     end
 
     def shutdown
       @started = false
+      super
     end
 
     def filter(tag, time, record)
@@ -96,11 +102,13 @@ module FluentTest
     attr_reader :started
 
     def start
+      super
       @started = true
     end
 
     def shutdown
       @started = false
+      super
     end
 
     def filter(tag, time, record)


### PR DESCRIPTION
MultiOutput plugins create plugin instances by themselves, but plugins' start/shutdown management are done by agents (kicked by RootAgent).
So these plugin instances must be pushed into agents.

This change fixes #1161.