### PR TITLE
Fix to prevent overwriting reserved placeholder keys such as tag

### DIFF
--- a/lib/fluent/plugin/filter_record_transformer.rb
+++ b/lib/fluent/plugin/filter_record_transformer.rb
@@ -204,7 +204,9 @@ module Fluent::Plugin
             end
           elsif value.kind_of?(Hash) # record, etc
             value.each do |k, v|
-              placeholders.store("${#{k}}", v) # foo
+              unless placeholder_values.has_key?(k) # prevent overwriting reserved keys such as tag
+                placeholders.store("${#{k}}", v) # foo
+              end
               placeholders.store(%Q[${#{key}["#{k}"]}], v) # record["foo"]
             end
           else # string, interger, float, and others?


### PR DESCRIPTION
when same keys exist in record. The bug appeared only with on `enable_ruby false`

Same thing with https://github.com/sonots/fluent-plugin-record-reformer/pull/42