### PR TITLE
Protect buffer operations in force_flush

### DIFF
--- a/lib/fluent/output.rb
+++ b/lib/fluent/output.rb
@@ -291,7 +291,8 @@ module Fluent
     #end
 
     def enqueue_buffer(force = false)
-      @buffer.keys.each {|key|
+      buf_keys = @buffer.synchronize { @buffer.keys }
+      buf_keys.each { |key|
         @buffer.push(key)
       }
     end
@@ -587,7 +588,8 @@ module Fluent
 
     def enqueue_buffer(force = false)
       if force
-        @buffer.keys.each {|key|
+        buf_keys = @buffer.synchronize { @buffer.keys }
+        buf_keys.each { |key|
           @buffer.push(key)
         }
       else

--- a/lib/fluent/output.rb
+++ b/lib/fluent/output.rb
@@ -291,8 +291,7 @@ module Fluent
     #end
 
     def enqueue_buffer(force = false)
-      buf_keys = @buffer.synchronize { @buffer.keys }
-      buf_keys.each { |key|
+      @buffer.keys.each { |key|
         @buffer.push(key)
       }
     end
@@ -405,7 +404,9 @@ module Fluent
       @num_errors_lock.synchronize do
         @next_retry_time = Time.now.to_f - 1
       end
-      enqueue_buffer(true)
+      @buffer.synchronize {
+        enqueue_buffer(true)
+      }
       submit_flush
     end
 
@@ -588,8 +589,7 @@ module Fluent
 
     def enqueue_buffer(force = false)
       if force
-        buf_keys = @buffer.synchronize { @buffer.keys }
-        buf_keys.each { |key|
+        @buffer.keys.each { |key|
           @buffer.push(key)
         }
       else


### PR DESCRIPTION
force_flush is called from another thread, so accessing buffer should be guarded.

See: https://github.com/fluent/fluentd/issues/1129
