### PR TITLE
Mark configuration errors as unrecoverable

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("json", [">= 1.4.3"])
   gem.add_runtime_dependency("yajl-ruby", ["~> 1.0"])
   gem.add_runtime_dependency("cool.io", [">= 1.4.3", "< 2.0.0"])
-  gem.add_runtime_dependency("serverengine", ["= 2.0.0pre1"])
+  gem.add_runtime_dependency("serverengine", ["= 2.0.0pre2"])
   gem.add_runtime_dependency("http_parser.rb", [">= 0.5.1", "< 0.7.0"])
   gem.add_runtime_dependency("sigdump", ["~> 0.2.2"])
   gem.add_runtime_dependency("tzinfo", [">= 1.0.0"])

--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("json", [">= 1.4.3"])
   gem.add_runtime_dependency("yajl-ruby", ["~> 1.0"])
   gem.add_runtime_dependency("cool.io", [">= 1.4.3", "< 2.0.0"])
-  gem.add_runtime_dependency("serverengine", [">= 1.6.4"])
+  gem.add_runtime_dependency("serverengine", ["= 2.0.0pre1"])
   gem.add_runtime_dependency("http_parser.rb", [">= 0.5.1", "< 0.7.0"])
   gem.add_runtime_dependency("sigdump", ["~> 0.2.2"])
   gem.add_runtime_dependency("tzinfo", [">= 1.0.0"])

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -61,10 +61,6 @@ module Fluent
     end
 
     def after_run
-      if Time.now - @start_time < 1
-        $log.warn "process died within 1 second. exit."
-      end
-
       stop_rpc_server if @rpc_endpoint
     end
 

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -625,7 +625,7 @@ module Fluent
     end
 
     def change_privilege
-      ServerEngine::Daemon.change_privilege(@chuser, @chgroup)
+      ServerEngine::Privilege.change(@chuser, @chgroup)
     end
 
     def init_engine


### PR DESCRIPTION
This change is to tell serverengine not to restart for configuration errors.
This feature depends on ServerEngine 2.0.0 APIs and features.

Fixes #1180.