### PR TITLE
config_param options to specify deprecated/obsoleted parameters

### DIFF
--- a/lib/fluent/config/configure_proxy.rb
+++ b/lib/fluent/config/configure_proxy.rb
@@ -235,6 +235,10 @@ module Fluent
           config_set_desc(name, opts[:desc])
         end
 
+        if opts[:deprecated] && opts[:obsoleted]
+          raise ArgumentError, "#{name}: both of deprecated and obsoleted cannot be specified at once"
+        end
+
         [name, block, opts]
       end
 

--- a/lib/fluent/config/configure_proxy.rb
+++ b/lib/fluent/config/configure_proxy.rb
@@ -208,6 +208,12 @@ module Fluent
         end
       end
 
+      def option_value_type!(name, opts, key, klass)
+        if opts.has_key?(key) && !opts[key].is_a?(klass)
+          raise ArgumentError, "#{name}: #{key} must be a #{klass}, but #{opts[key].class}"
+        end
+      end
+
       def parameter_configuration(name, type = nil, **kwargs, &block)
         name = name.to_sym
 
@@ -226,6 +232,17 @@ module Fluent
           # override error message
           raise ArgumentError, "#{name}: unknown config_argument type `#{type}'"
         end
+
+        option_value_type!(name, opts, :desc, String)
+        option_value_type!(name, opts, :alias, Symbol)
+        option_value_type!(name, opts, :deprecated, String)
+        option_value_type!(name, opts, :obsoleted, String)
+        if type == :enum
+          if !opts.has_key?(:list) || !opts[:list].all?{|v| v.is_a?(Symbol) }
+            raise ArgumentError, "#{name}: enum parameter requires :list of Symbols"
+          end
+        end
+        option_value_type!(name, opts, :value_type, Symbol) # hash, array
 
         if opts.has_key?(:default)
           config_set_default(name, opts[:default])

--- a/lib/fluent/config/configure_proxy.rb
+++ b/lib/fluent/config/configure_proxy.rb
@@ -216,7 +216,7 @@ module Fluent
         opts.merge!(kwargs)
 
         if block && type
-          raise ArgumentError, "#{self.name}: both of block and type cannot be specified"
+          raise ArgumentError, "#{name}: both of block and type cannot be specified"
         end
 
         begin
@@ -224,7 +224,7 @@ module Fluent
           block ||= @type_lookup.call(type)
         rescue ConfigError
           # override error message
-          raise ArgumentError, "#{self.name}: unknown config_argument type `#{type}'"
+          raise ArgumentError, "#{name}: unknown config_argument type `#{type}'"
         end
 
         if opts.has_key?(:default)
@@ -296,7 +296,7 @@ module Fluent
 
       def config_section(name, **kwargs, &block)
         unless block_given?
-          raise ArgumentError, "#{self.name}: config_section requires block parameter"
+          raise ArgumentError, "#{name}: config_section requires block parameter"
         end
         name = name.to_sym
 
@@ -305,10 +305,10 @@ module Fluent
 
         if sub_proxy.init?
           if sub_proxy.argument && !sub_proxy.defaults.has_key?(sub_proxy.argument.first)
-            raise ArgumentError, "#{self.name}: init is specified, but default value of argument is missing"
+            raise ArgumentError, "#{name}: init is specified, but default value of argument is missing"
           end
           if sub_proxy.params.keys.any?{|param_name| !sub_proxy.defaults.has_key?(param_name)}
-            raise ArgumentError, "#{self.name}: init is specified, but there're parameters without default values"
+            raise ArgumentError, "#{name}: init is specified, but there're parameters without default values"
           end
         end
 

--- a/lib/fluent/config/error.rb
+++ b/lib/fluent/config/error.rb
@@ -20,4 +20,7 @@ module Fluent
 
   class ConfigParseError < ConfigError
   end
+
+  class ObsoletedParameterError < ConfigError
+  end
 end

--- a/lib/fluent/config/section.rb
+++ b/lib/fluent/config/section.rb
@@ -147,11 +147,11 @@ module Fluent
             #             because they are expected to be removed entirely sometime in the future.
             # Obsoleted: These obsolete features have been entirely removed from JavaScript and can no longer be used.
             if opts[:deprecated]
-              logger.warn "'#{name}' paramenter isn't recommended to use now."
+              logger.warn "'#{name}' parameter is deprecated: #{opts[:deprecated]}"
             end
             if opts[:obsoleted]
               logger.error "config error in:\n#{conf}" if logger
-              raise ObsoletedParameterError, "'#{name}' parameter is already removed. Don't use it." + section_stack
+              raise ObsoletedParameterError, "'#{name}' parameter is already removed: #{opts[:obsoleted]}" + section_stack
             end
           end
           unless section_params.has_key?(varname)

--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -89,22 +89,11 @@ module Fluent
 
     attr_reader :nodes
 
-    # backward compatibility
-    config_param :port, :integer, default: LISTEN_PORT
-    config_param :host, :string, default: nil
+    config_param :port, :integer, default: LISTEN_PORT, obsoleted: true
+    config_param :host, :string, default: nil, obsoleted: true
 
     def configure(conf)
       super
-
-      # backward compatibility
-      if host = conf['host']
-        log.warn "'host' option in forward output is obsoleted. Use '<server> host xxx </server>' instead."
-        port = conf['port']
-        port = port ? port.to_i : LISTEN_PORT
-        element = conf.add_element('server')
-        element['host'] = host
-        element['port'] = port.to_s
-      end
 
       recover_sample_size = @recover_wait / @heartbeat_interval
 

--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -89,8 +89,8 @@ module Fluent
 
     attr_reader :nodes
 
-    config_param :port, :integer, default: LISTEN_PORT, obsoleted: true
-    config_param :host, :string, default: nil, obsoleted: true
+    config_param :port, :integer, default: LISTEN_PORT, obsoleted: "User <server> section instead."
+    config_param :host, :string, default: nil, obsoleted: "Use <server> section instead."
 
     def configure(conf)
       super

--- a/test/config/test_configurable.rb
+++ b/test/config/test_configurable.rb
@@ -345,8 +345,8 @@ module ConfigurableSpec
   class UnRecommended
     include Fluent::Configurable
     attr_accessor :log
-    config_param :key1, :string, default: 'deprecated', deprecated: true
-    config_param :key2, :string, default: 'obsoleted', obsoleted: true
+    config_param :key1, :string, default: 'deprecated', deprecated: "key1 will be removed."
+    config_param :key2, :string, default: 'obsoleted', obsoleted: "key2 has been removed."
   end
 end
 
@@ -1108,17 +1108,65 @@ module Fluent::Config
         end
       end
     end
-    # class UnRecommended
-    #   include Fluent::Configurable
-    #   config_param :key1, :string, default: 'deprecated', deprecated: true
-    #   config_param :key2, :string, default: 'obsoleted', obsoleted: true
-    # end
+    sub_test_case 'non-required options for config_param' do
+      test 'desc must be a string if specified' do
+        assert_raise ArgumentError.new("key: desc must be a String, but Symbol") do
+          class InvalidDescClass
+            include Fluent::Configurable
+            config_param :key, :string, default: '', desc: :invalid_description
+          end
+        end
+      end
+      test 'alias must be a symbol if specified' do
+        assert_raise ArgumentError.new("key: alias must be a Symbol, but String") do
+          class InvalidAliasClass
+            include Fluent::Configurable
+            config_param :key, :string, default: '', alias: 'yay'
+          end
+        end
+      end
+      test 'deprecated must be a string if specified' do
+        assert_raise ArgumentError.new("key: deprecated must be a String, but TrueClass") do
+          class InvalidDeprecatedClass
+            include Fluent::Configurable
+            config_param :key, :string, default: '', deprecated: true
+          end
+        end
+      end
+      test 'obsoleted must be a string if specified' do
+        assert_raise ArgumentError.new("key: obsoleted must be a String, but TrueClass") do
+          class InvalidObsoletedClass
+            include Fluent::Configurable
+            config_param :key, :string, default: '', obsoleted: true
+          end
+        end
+      end
+      test 'value_type for hash must be a symbol' do
+        assert_raise ArgumentError.new("key: value_type must be a Symbol, but String") do
+          class InvalidValueTypeOfHashClass
+            include Fluent::Configurable
+            config_param :key, :hash, value_type: 'yay'
+          end
+        end
+      end
+      test 'value_type for array must be a symbol' do
+        assert_raise ArgumentError.new("key: value_type must be a Symbol, but String") do
+          class InvalidValueTypeOfArrayClass
+            include Fluent::Configurable
+            config_param :key, :array, value_type: 'yay'
+          end
+        end
+      end
+    end
+    sub_test_case 'enum parameters' do
+      test 'list must be specified as an array of symbols'
+    end
     sub_test_case 'deprecated/obsoleted parameters' do
       test 'both cannot be specified at once' do
         assert_raise ArgumentError.new("param1: both of deprecated and obsoleted cannot be specified at once") do
           class Buggy1
             include Fluent::Configurable
-            config_param :param1, :string, default: '', deprecated: true, obsoleted: true
+            config_param :param1, :string, default: '', deprecated: 'yay', obsoleted: 'foo!'
           end
         end
       end
@@ -1130,14 +1178,14 @@ module Fluent::Config
 
         assert_equal 'yay', obj.key1
         first_log = obj.log.logs.first
-        assert{ first_log && first_log.include?("[warn]") && first_log.include?("'key1' paramenter isn't recommended to use now.") }
+        assert{ first_log && first_log.include?("[warn]") && first_log.include?("'key1' parameter is deprecated: key1 will be removed.") }
       end
 
       test 'error raised if obsoleted parameter is configured' do
         obj = ConfigurableSpec::UnRecommended.new
         obj.log = Fluent::Test::TestLogger.new
 
-        assert_raise Fluent::ObsoletedParameterError.new("'key2' parameter is already removed. Don't use it.") do
+        assert_raise Fluent::ObsoletedParameterError.new("'key2' parameter is already removed: key2 has been removed.") do
           obj.configure(config_element('ROOT', '', {'key2' => 'yay'}, []))
         end
       end

--- a/test/config/test_types.rb
+++ b/test/config/test_types.rb
@@ -72,9 +72,9 @@ class TestConfigTypes < ::Test::Unit::TestCase
       assert_equal :val, Config::ENUM_TYPE.call('val', {list: [:val, :value, :v]})
       assert_equal :v, Config::ENUM_TYPE.call('v', {list: [:val, :value, :v]})
       assert_equal :value, Config::ENUM_TYPE.call('value', {list: [:val, :value, :v]})
-      assert_raises(Fluent::ConfigError){ Config::ENUM_TYPE.call('x', {list: [:val, :value, :v]}) }
-      assert_raises(RuntimeError){ Config::ENUM_TYPE.call('val', {}) }
-      assert_raises(RuntimeError){ Config::ENUM_TYPE.call('val', {list: ["val", "value", "v"]}) }
+      assert_raises(Fluent::ConfigError.new("valid options are val,value,v but got x")){ Config::ENUM_TYPE.call('x', {list: [:val, :value, :v]}) }
+      assert_raises(RuntimeError.new("Plugin BUG: config type 'enum' requires :list of symbols")){ Config::ENUM_TYPE.call('val', {}) }
+      assert_raises(RuntimeError.new("Plugin BUG: config type 'enum' requires :list of symbols")){ Config::ENUM_TYPE.call('val', {list: ["val", "value", "v"]}) }
     end
 
     test 'integer' do
@@ -138,6 +138,8 @@ class TestConfigTypes < ::Test::Unit::TestCase
 
       assert_equal({"x"=>1,"y"=>60,"z"=>3600}, Config::HASH_TYPE.call('{"x":"1s","y":"1m","z":"1h"}', {value_type: :time}))
       assert_equal({"x"=>1,"y"=>60,"z"=>3600}, Config::HASH_TYPE.call('x:1s,y:1m,z:1h',               {value_type: :time}))
+
+      assert_raise(RuntimeError.new("unknown type in REFORMAT: foo")){ Config::HASH_TYPE.call("x:1,y:2", {value_type: :foo}) }
     end
 
     test 'array' do
@@ -162,6 +164,8 @@ class TestConfigTypes < ::Test::Unit::TestCase
       }
       assert_equal(["1","2"], Config::ARRAY_TYPE.call('["1","2"]', array_options))
       assert_equal(["3"], Config::ARRAY_TYPE.call('["3"]', array_options))
+
+      assert_raise(RuntimeError.new("unknown type in REFORMAT: foo")){ Config::ARRAY_TYPE.call("1,2", {value_type: :foo}) }
     end
   end
 end


### PR DESCRIPTION
This change adds 2 options for `config_param`.
And I marked `host`, `port` of `out_forward` without `<server>` sections as obsoleted.

### deprecated
Unrecommended parameter, and will be removed in future.
If users specify this parameter, Fluentd warns it in logs.

### obsoleted
Configuration parameter which is already removed.
If users specify this parameter, Fluentd stops with an error (a kind of configuration errors).
