### PR TITLE
Add Fluent::Plugin::Base#after_start to detect end of #start

### DIFF
--- a/lib/fluent/plugin/base.rb
+++ b/lib/fluent/plugin/base.rb
@@ -24,11 +24,11 @@ module Fluent
       include Configurable
       include SystemConfig::Mixin
 
-      State = Struct.new(:configure, :start, :stop, :before_shutdown, :shutdown, :after_shutdown, :close, :terminate)
+      State = Struct.new(:configure, :start, :after_start, :stop, :before_shutdown, :shutdown, :after_shutdown, :close, :terminate)
 
       def initialize
         super
-        @_state = State.new(false, false, false, false, false, false, false, false)
+        @_state = State.new(false, false, false, false, false, false, false, false, false)
       end
 
       def has_router?
@@ -37,13 +37,18 @@ module Fluent
 
       def configure(conf)
         super
-        @_state ||= State.new(false, false, false, false, false, false, false, false)
+        @_state ||= State.new(false, false, false, false, false, false, false, false, false)
         @_state.configure = true
         self
       end
 
       def start
         @_state.start = true
+        self
+      end
+
+      def after_start
+        @_state.after_start = true
         self
       end
 
@@ -83,6 +88,10 @@ module Fluent
 
       def started?
         @_state.start
+      end
+
+      def after_started?
+        @_state.after_start
       end
 
       def stopped?

--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -928,7 +928,7 @@ module Fluent
         end
 
         while !self.after_started? && !self.stopped?
-          sleep interval
+          sleep 0.5
         end
         log.debug "enqueue_thread actually running"
 
@@ -980,7 +980,7 @@ module Fluent
         state.next_time = Process.clock_gettime(clock_id) + flush_thread_interval
 
         while !self.after_started? && !self.stopped?
-          sleep flush_thread_interval
+          sleep 0.5
         end
         log.debug "flush_thread actually running"
 

--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -137,6 +137,9 @@ module Fluent
       lifecycle(desc: true) do |i| # instance
         i.start unless i.started?
       end
+      lifecycle(desc: true) do |i|
+        i.after_start unless i.after_started?
+      end
     end
 
     def flush!

--- a/lib/fluent/test/base.rb
+++ b/lib/fluent/test/base.rb
@@ -64,6 +64,7 @@ module Fluent
       # num_waits is for checking thread status. This will be removed after improved plugin API
       def run(num_waits = 10, &block)
         @instance.start
+        @instance.after_start
         begin
           # wait until thread starts
           num_waits.times { sleep 0.05 }

--- a/lib/fluent/test/driver/base.rb
+++ b/lib/fluent/test/driver/base.rb
@@ -88,6 +88,9 @@ module Fluent
             @instance.start
             instance_hook_after_started
           end
+          unless @instance.after_started?
+            @instance.after_start
+          end
         end
 
         def instance_hook_after_started

--- a/test/plugin/test_output.rb
+++ b/test/plugin/test_output.rb
@@ -192,6 +192,9 @@ class OutputTest < Test::Unit::TestCase
       assert !@i.started?
       @i.start
       assert @i.started?
+      assert !@i.after_started?
+      @i.after_start
+      assert @i.after_started?
       assert !@i.stopped?
       @i.stop
       assert @i.stopped?
@@ -329,6 +332,7 @@ class OutputTest < Test::Unit::TestCase
       i.register(:process){|tag, es| process_called = true }
       i.configure(config_element())
       i.start
+      i.after_start
 
       t = event_time()
       i.emit_events('tag', Fluent::ArrayEventStream.new([ [t, {"key" => "value1"}], [t, {"key" => "value2"}] ]))
@@ -344,6 +348,7 @@ class OutputTest < Test::Unit::TestCase
       i.register(:format){|tag, time, record| format_called_times += 1; '' }
       i.configure(config_element())
       i.start
+      i.after_start
 
       t = event_time()
       i.emit_events('tag', Fluent::ArrayEventStream.new([ [t, {"key" => "value1"}], [t, {"key" => "value2"}] ]))
@@ -364,6 +369,7 @@ class OutputTest < Test::Unit::TestCase
       i.configure(config_element())
       i.register(:prefer_buffered_processing){ false } # delayed decision is possible to change after (output's) configure
       i.start
+      i.after_start
 
       assert !i.prefer_buffered_processing
 
@@ -389,6 +395,7 @@ class OutputTest < Test::Unit::TestCase
       i.configure(config_element())
       i.register(:prefer_buffered_processing){ true } # delayed decision is possible to change after (output's) configure
       i.start
+      i.after_start
 
       assert i.prefer_buffered_processing
 
@@ -408,6 +415,7 @@ class OutputTest < Test::Unit::TestCase
 
       i.configure(config_element('ROOT', '', {}, [config_element('buffer', '', {"flush_mode" => "immediate"})]))
       i.start
+      i.after_start
 
       t = event_time()
       i.emit_events('tag', Fluent::ArrayEventStream.new([ [t, {"key" => "value1"}], [t, {"key" => "value2"}] ]))
@@ -427,6 +435,7 @@ class OutputTest < Test::Unit::TestCase
 
       i.configure(config_element('ROOT', '', {}, [config_element('buffer', '', {"flush_mode" => "immediate"})]))
       i.start
+      i.after_start
 
       t = event_time()
       i.emit_events('tag', Fluent::ArrayEventStream.new([ [t, {"key" => "value1"}], [t, {"key" => "value2"}] ]))
@@ -449,6 +458,7 @@ class OutputTest < Test::Unit::TestCase
       i.configure(config_element('ROOT', '', {}, [config_element('buffer', '', {"flush_mode" => "immediate"})]))
       i.register(:prefer_delayed_commit){ false } # delayed decision is possible to change after (output's) configure
       i.start
+      i.after_start
 
       assert !i.prefer_delayed_commit
 
@@ -474,6 +484,7 @@ class OutputTest < Test::Unit::TestCase
       i.configure(config_element('ROOT', '', {}, [config_element('buffer', '', {"flush_mode" => "immediate"})]))
       i.register(:prefer_delayed_commit){ true } # delayed decision is possible to change after (output's) configure
       i.start
+      i.after_start
 
       assert i.prefer_delayed_commit
 
@@ -542,6 +553,7 @@ class OutputTest < Test::Unit::TestCase
       @i.register(:process){|tag, es| ary << [tag, es] }
       @i.configure(config_element())
       @i.start
+      @i.after_start
 
       t = event_time()
       es = Fluent::ArrayEventStream.new([ [t, {"key" => "value1"}], [t, {"key" => "value2"}] ])

--- a/test/plugin/test_output_as_buffered.rb
+++ b/test/plugin/test_output_as_buffered.rb
@@ -145,6 +145,7 @@ class BufferedOutputTest < Test::Unit::TestCase
       @i.configure(config_element('ROOT','',{},[config_element('buffer',chunk_keys,@hash)]))
       logs = @i.log.out.logs.dup
       @i.start
+      @i.after_start
       assert{ logs.select{|log| log.include?('[warn]') }.size == 0 }
     end
 
@@ -154,6 +155,7 @@ class BufferedOutputTest < Test::Unit::TestCase
       logs = @i.log.out.logs.dup
 
       @i.start # this calls `log.reset`... capturing logs about configure must be done before this line
+      @i.after_start
       assert_equal ['key1', 'key2', 'key3', 'key4'], @i.chunk_keys
 
       assert{ logs.select{|log| log.include?('[warn]: many chunk keys specified, and it may cause too many chunks on your system.') }.size == 1 }
@@ -164,6 +166,7 @@ class BufferedOutputTest < Test::Unit::TestCase
       @i.configure(config_element('ROOT','',{},[config_element('buffer',chunk_keys,@hash)]))
       logs = @i.log.out.logs.dup
       @i.start # this calls `log.reset`... capturing logs about configure must be done before this line
+      @i.after_start
       assert{ logs.select{|log| log.include?('[warn]: many chunk keys specified, and it may cause too many chunks on your system.') }.size == 1 }
     end
 
@@ -172,6 +175,7 @@ class BufferedOutputTest < Test::Unit::TestCase
       @i.configure(config_element('ROOT','',{},[config_element('buffer',chunk_keys,@hash)]))
       logs = @i.log.out.logs.dup
       @i.start
+      @i.after_start
       assert{ logs.select{|log| log.include?('[warn]') }.size == 0 }
     end
   end
@@ -187,6 +191,7 @@ class BufferedOutputTest < Test::Unit::TestCase
       @i = create_output(:buffered)
       @i.configure(config_element('ROOT','',{},[config_element('buffer','',hash)]))
       @i.start
+      @i.after_start
     end
 
     test '#start does not create enqueue thread, but creates flush threads' do
@@ -289,6 +294,7 @@ class BufferedOutputTest < Test::Unit::TestCase
       @i = create_output(:buffered)
       @i.configure(config_element('ROOT','',{},[config_element('buffer','',hash)]))
       @i.start
+      @i.after_start
     end
 
     test '#start creates enqueue thread and flush threads' do
@@ -398,6 +404,7 @@ class BufferedOutputTest < Test::Unit::TestCase
       @i = create_output(:buffered)
       @i.configure(config_element('ROOT','',{},[config_element('buffer','',hash)]))
       @i.start
+      @i.after_start
     end
 
     test '#start does not create enqueue thread, but creates flush threads' do
@@ -491,6 +498,7 @@ class BufferedOutputTest < Test::Unit::TestCase
       @i = create_output(:buffered)
       @i.configure(config_element('ROOT','',{},[config_element('buffer',chunk_key,hash)]))
       @i.start
+      @i.after_start
     end
 
     test '#configure raises config error if timekey is not specified' do
@@ -706,6 +714,7 @@ class BufferedOutputTest < Test::Unit::TestCase
       @i = create_output(:buffered)
       @i.configure(config_element('ROOT','',{},[config_element('buffer',chunk_key,hash)]))
       @i.start
+      @i.after_start
     end
 
     test 'default flush_mode is set to :interval' do
@@ -922,6 +931,7 @@ class BufferedOutputTest < Test::Unit::TestCase
       @i = create_output(:buffered)
       @i.configure(config_element('ROOT','',{},[config_element('buffer',chunk_key,hash)]))
       @i.start
+      @i.after_start
     end
 
     test 'default flush_mode is set to :interval' do
@@ -1134,6 +1144,7 @@ class BufferedOutputTest < Test::Unit::TestCase
       @i = create_output(:buffered)
       @i.configure(config_element('ROOT','',{},[config_element('buffer',chunk_key,hash)]))
       @i.start
+      @i.after_start
 
       assert_equal :interval, @i.instance_eval{ @flush_mode }
     end
@@ -1150,6 +1161,7 @@ class BufferedOutputTest < Test::Unit::TestCase
       @i = create_output(:buffered)
       @i.configure(config_element('ROOT','',{},[config_element('buffer',chunk_key,hash)]))
       @i.start
+      @i.after_start
 
       assert_equal :lazy, @i.instance_eval{ @flush_mode }
     end
@@ -1168,6 +1180,7 @@ class BufferedOutputTest < Test::Unit::TestCase
       @i = create_output(:delayed)
       @i.configure(config_element('ROOT','',{},[config_element('buffer',chunk_key,hash)]))
       @i.start
+      @i.after_start
     end
 
     test '#format is called for each event streams' do

--- a/test/plugin/test_output_as_buffered_overflow.rb
+++ b/test/plugin/test_output_as_buffered_overflow.rb
@@ -70,6 +70,7 @@ class BufferedOutputOverflowTest < Test::Unit::TestCase
       @i = create_output()
       @i.configure(config_element('ROOT','',{},[config_element('buffer','tag',hash)]))
       @i.start
+      @i.after_start
     end
 
     test '#emit_events raises error when buffer is full' do
@@ -108,6 +109,7 @@ class BufferedOutputOverflowTest < Test::Unit::TestCase
       @i = create_output()
       @i.configure(config_element('ROOT','',{'log_level' => 'debug'},[config_element('buffer','tag',hash)]))
       @i.start
+      @i.after_start
     end
 
     test '#emit_events blocks until any queues are flushed' do
@@ -169,6 +171,7 @@ class BufferedOutputOverflowTest < Test::Unit::TestCase
       @i = create_output()
       @i.configure(config_element('ROOT','',{'log_level' => 'debug'},[config_element('buffer','tag',hash)]))
       @i.start
+      @i.after_start
     end
 
     test '#emit_events will success by dropping oldest chunk' do

--- a/test/plugin/test_output_as_buffered_retries.rb
+++ b/test/plugin/test_output_as_buffered_retries.rb
@@ -127,6 +127,7 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
       @i.configure(config_element('ROOT','',{},[config_element('buffer',chunk_key,hash)]))
       @i.register(:prefer_buffered_processing){ true }
       @i.start
+      @i.after_start
 
       assert_equal :exponential_backoff, @i.buffer_config.retry_type
       assert_equal 1, @i.buffer_config.retry_wait
@@ -160,6 +161,7 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
       @i.register(:format){|tag,time,record| [tag,time.to_i,record].to_json + "\n" }
       @i.register(:write){|chunk| raise "yay, your #write must fail" }
       @i.start
+      @i.after_start
 
       @i.interrupt_flushes
 
@@ -201,6 +203,7 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
       @i.register(:format){|tag,time,record| [tag,time.to_i,record].to_json + "\n" }
       @i.register(:write){|chunk| raise "yay, your #write must fail" }
       @i.start
+      @i.after_start
 
       @i.interrupt_flushes
 
@@ -255,6 +258,7 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
       @i.register(:format){|tag,time,record| [tag,time.to_i,record].to_json + "\n" }
       @i.register(:write){|chunk| written_tags << chunk.metadata.tag; raise "yay, your #write must fail" }
       @i.start
+      @i.after_start
 
       @i.interrupt_flushes
 
@@ -344,6 +348,7 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
       @i.register(:format){|tag,time,record| [tag,time.to_i,record].to_json + "\n" }
       @i.register(:write){|chunk| written_tags << chunk.metadata.tag; raise "yay, your #write must fail" }
       @i.start
+      @i.after_start
 
       @i.interrupt_flushes
 
@@ -424,6 +429,7 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
       @i.register(:format){|tag,time,record| [tag,time.to_i,record].to_json + "\n" }
       @i.register(:write){|chunk| raise "yay, your #write must fail" }
       @i.start
+      @i.after_start
 
       @i.interrupt_flushes
 
@@ -469,6 +475,7 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
       @i.register(:format){|tag,time,record| [tag,time.to_i,record].to_json + "\n" }
       @i.register(:write){|chunk| written_tags << chunk.metadata.tag; raise "yay, your #write must fail" }
       @i.start
+      @i.after_start
 
       @i.interrupt_flushes
 
@@ -563,6 +570,7 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
       @i.register(:format){|tag,time,record| [tag,time.to_i,record].to_json + "\n" }
       @i.register(:write){|chunk| written_tags << chunk.metadata.tag; raise "yay, your #write must fail" }
       @i.start
+      @i.after_start
 
       @i.interrupt_flushes
 
@@ -660,6 +668,7 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
       @i.register(:format){|tag,time,record| [tag,time.to_i,record].to_json + "\n" }
       @i.register(:write){|chunk| written_tags << chunk.metadata.tag; raise "yay, your #write must fail" }
       @i.start
+      @i.after_start
 
       @i.interrupt_flushes
 
@@ -730,6 +739,7 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
       @i.register(:format){|tag,time,record| [tag,time.to_i,record].to_json + "\n" }
       @i.register(:write){|chunk| written_tags << chunk.metadata.tag; raise "yay, your #write must fail" }
       @i.start
+      @i.after_start
 
       @i.interrupt_flushes
 
@@ -797,6 +807,7 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
       @i.register(:format){|tag,time,record| [tag,time.to_i,record].to_json + "\n" }
       @i.register(:try_write){|chunk| raise "yay, your #write must fail" }
       @i.start
+      @i.after_start
 
       @i.interrupt_flushes
 

--- a/test/plugin/test_output_as_buffered_secondary.rb
+++ b/test/plugin/test_output_as_buffered_secondary.rb
@@ -170,6 +170,10 @@ class BufferedOutputSecondaryTest < Test::Unit::TestCase
       i.start
       assert i.secondary.started?
 
+      assert !i.secondary.after_started?
+      i.after_start
+      assert i.secondary.after_started?
+
       assert !i.secondary.stopped?
       i.stop
       assert i.secondary.stopped?
@@ -207,6 +211,7 @@ class BufferedOutputSecondaryTest < Test::Unit::TestCase
       @i.secondary.register(:prefer_delayed_commit){ false }
       @i.secondary.register(:write){|chunk| chunk.read.split("\n").each{|line| written << JSON.parse(line) } }
       @i.start
+      @i.after_start
 
       @i.interrupt_flushes
 
@@ -271,6 +276,7 @@ class BufferedOutputSecondaryTest < Test::Unit::TestCase
       @i.secondary.register(:prefer_delayed_commit){ false }
       @i.secondary.register(:write){|chunk| chunk.read.split("\n").each{|line| written << JSON.parse(line) } }
       @i.start
+      @i.after_start
 
       @i.interrupt_flushes
 
@@ -336,6 +342,7 @@ class BufferedOutputSecondaryTest < Test::Unit::TestCase
       @i.secondary.register(:prefer_delayed_commit){ true }
       @i.secondary.register(:try_write){|chunk| chunks << chunk; chunk.read.split("\n").each{|line| written << JSON.parse(line) } }
       @i.start
+      @i.after_start
 
       @i.interrupt_flushes
 
@@ -412,6 +419,7 @@ class BufferedOutputSecondaryTest < Test::Unit::TestCase
       @i.secondary.register(:prefer_delayed_commit){ true }
       @i.secondary.register(:try_write){|chunk| chunks << chunk; chunk.read.split("\n").each{|line| written << JSON.parse(line) } }
       @i.start
+      @i.after_start
 
       @i.interrupt_flushes
 
@@ -489,6 +497,7 @@ class BufferedOutputSecondaryTest < Test::Unit::TestCase
       @i.secondary.register(:try_write){|chunk| chunks << chunk; chunk.read.split("\n").each{|line| written << JSON.parse(line) } }
       @i.secondary.register(:write){|chunk| raise "don't use this" }
       @i.start
+      @i.after_start
 
       @i.interrupt_flushes
 
@@ -573,6 +582,7 @@ class BufferedOutputSecondaryTest < Test::Unit::TestCase
       @i.secondary.register(:prefer_delayed_commit){ false }
       @i.secondary.register(:write){|chunk| raise "your secondary is also useless." }
       @i.start
+      @i.after_start
 
       @i.interrupt_flushes
 
@@ -643,6 +653,7 @@ class BufferedOutputSecondaryTest < Test::Unit::TestCase
       @i.secondary.register(:prefer_delayed_commit){ false }
       @i.secondary.register(:write){|chunk| chunk.read.split("\n").each{|line| written << JSON.parse(line) } }
       @i.start
+      @i.after_start
 
       @i.interrupt_flushes
 
@@ -713,6 +724,7 @@ class BufferedOutputSecondaryTest < Test::Unit::TestCase
       @i.secondary.register(:prefer_delayed_commit){ false }
       @i.secondary.register(:write){|chunk| raise "your secondary is also useless." }
       @i.start
+      @i.after_start
 
       @i.interrupt_flushes
 

--- a/test/plugin/test_output_as_standard.rb
+++ b/test/plugin/test_output_as_standard.rb
@@ -85,6 +85,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
       @i = create_output(:standard)
       @i.configure(config_element())
       @i.start
+      @i.after_start
 
       m = create_metadata()
       es = test_event_stream
@@ -99,6 +100,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
       @i = create_output(:standard)
       @i.configure(config_element('ROOT','',{"time_as_integer"=>"true"}))
       @i.start
+      @i.after_start
 
       m = create_metadata()
       es = test_event_stream
@@ -115,6 +117,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
       @i = create_output(:standard)
       @i.configure(config_element('ROOT','',{},[config_element('buffer','tag',{'flush_thread_burst_interval' => 0.01})]))
       @i.start
+      @i.after_start
 
       m = create_metadata(tag: "mytag.test")
       es = test_event_stream
@@ -129,6 +132,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
       @i = create_output(:standard)
       @i.configure(config_element('ROOT','',{"time_as_integer"=>"true"},[config_element('buffer','tag',{'flush_thread_burst_interval' => 0.01})]))
       @i.start
+      @i.after_start
 
       m = create_metadata(tag: "mytag.test")
       es = test_event_stream
@@ -145,6 +149,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
       @i = create_output(:standard)
       @i.configure(config_element('ROOT','',{},[config_element('buffer','time',{"timekey" => "60",'flush_thread_burst_interval' => 0.01})]))
       @i.start
+      @i.after_start
 
       m1 = create_metadata(timekey: Time.parse('2016-04-21 17:19:00 -0700').to_i)
       m2 = create_metadata(timekey: Time.parse('2016-04-21 17:20:00 -0700').to_i)
@@ -177,6 +182,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
       @i = create_output(:standard)
       @i.configure(config_element('ROOT','',{"time_as_integer" => "true"},[config_element('buffer','time',{"timekey" => "60",'flush_thread_burst_interval' => 0.01})]))
       @i.start
+      @i.after_start
 
       m1 = create_metadata(timekey: Time.parse('2016-04-21 17:19:00 -0700').to_i)
       m2 = create_metadata(timekey: Time.parse('2016-04-21 17:20:00 -0700').to_i)
@@ -211,6 +217,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
       @i = create_output(:standard)
       @i.configure(config_element('ROOT','',{},[config_element('buffer','key,name',{'flush_thread_burst_interval' => 0.01})]))
       @i.start
+      @i.after_start
 
       m1 = create_metadata(variables: {key: "my value", name: "moris1"})
       es1 = Fluent::MultiEventStream.new
@@ -238,6 +245,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
       @i = create_output(:standard)
       @i.configure(config_element('ROOT','',{"time_as_integer" => "true"},[config_element('buffer','key,name',{'flush_thread_burst_interval' => 0.01})]))
       @i.start
+      @i.after_start
 
       m1 = create_metadata(variables: {key: "my value", name: "moris1"})
       es1 = Fluent::MultiEventStream.new
@@ -268,6 +276,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
       @i.register(:format){|tag, time, record| [time, record].to_json }
       @i.configure(config_element())
       @i.start
+      @i.after_start
 
       m = create_metadata()
       es = test_event_stream
@@ -285,6 +294,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
       @i.register(:format){|tag, time, record| [time, record].to_json }
       @i.configure(config_element('ROOT','',{},[config_element('buffer','tag',{'flush_thread_burst_interval' => 0.01})]))
       @i.start
+      @i.after_start
 
       m = create_metadata(tag: "mytag.test")
       es = test_event_stream
@@ -301,6 +311,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
       @i.register(:format){|tag, time, record| [time, record].to_json }
       @i.configure(config_element('ROOT','',{},[config_element('buffer','time',{"timekey" => "60",'flush_thread_burst_interval' => 0.01})]))
       @i.start
+      @i.after_start
 
       m1 = create_metadata(timekey: Time.parse('2016-04-21 17:19:00 -0700').to_i)
       m2 = create_metadata(timekey: Time.parse('2016-04-21 17:20:00 -0700').to_i)
@@ -336,6 +347,7 @@ class StandardBufferedOutputTest < Test::Unit::TestCase
       @i.register(:format){|tag, time, record| [time, record].to_json }
       @i.configure(config_element('ROOT','',{},[config_element('buffer','key,name',{'flush_thread_burst_interval' => 0.01})]))
       @i.start
+      @i.after_start
 
       m1 = create_metadata(variables: {key: "my value", name: "moris1"})
       es1 = Fluent::MultiEventStream.new

--- a/test/plugin_helper/test_compat_parameters.rb
+++ b/test/plugin_helper/test_compat_parameters.rb
@@ -186,6 +186,7 @@ class CompatParameterTest < Test::Unit::TestCase
       @i = DummyO4.new
       @i.configure(conf)
       @i.start
+      @i.after_start
 
       assert_equal 'file', @i.buffer_config[:@type]
       assert_equal 10, @i.buffer_config.flush_thread_count
@@ -219,6 +220,7 @@ class CompatParameterTest < Test::Unit::TestCase
       @i = DummyO4.new
       @i.configure(conf)
       @i.start
+      @i.after_start
 
       assert_equal 'file', @i.buffer_config[:@type]
       assert_equal 10, @i.buffer_config.flush_thread_count

--- a/test/test_output.rb
+++ b/test/test_output.rb
@@ -204,6 +204,7 @@ module FluentOutputTest
       test "emit with invalid event" do
         d = create_driver
         d.instance.start
+        d.instance.after_start
         assert_raise ArgumentError, "time must be a Fluent::EventTime (or Integer)" do
           d.instance.emit_events('test', OneEventStream.new('string', 10))
         end

--- a/test/test_root_agent.rb
+++ b/test/test_root_agent.rb
@@ -169,6 +169,10 @@ EOC
       assert_equal [true], @ra.filters.map{|i| i.started? }
       assert_equal [true, true, true], @ra.outputs.map{|i| i.started? }
 
+      assert_equal [true], @ra.inputs.map{|i| i.after_started? }
+      assert_equal [true], @ra.filters.map{|i| i.after_started? }
+      assert_equal [true, true, true], @ra.outputs.map{|i| i.after_started? }
+
       @ra.shutdown
       assert_equal [true], @ra.inputs.map{|i| i.stopped? }
       assert_equal [true], @ra.filters.map{|i| i.stopped? }


### PR DESCRIPTION
This method (and flag which shows this method is called properly) helps threads to start its actual process when all preparations are done.
This fixes #1187.