### PR TITLE
Port parser filter from fluent-plugin-parser. fix #1189

### DIFF
--- a/lib/fluent/plugin/filter_parser.rb
+++ b/lib/fluent/plugin/filter_parser.rb
@@ -1,0 +1,114 @@
+require 'fluent/plugin/filter'
+require 'fluent/plugin/parser'
+
+module Fluent::Plugin
+  class ParserFilter < Filter
+    Fluent::Plugin.register_filter('parser', self)
+
+    config_param :key_name, :string
+    config_param :reserve_data, :bool, default: false
+    config_param :inject_key_prefix, :string, default: nil
+    config_param :replace_invalid_sequence, :bool, default: false
+    config_param :hash_value_field, :string, default: nil
+    config_param :suppress_parse_error_log, :bool, default: false
+    config_param :time_parse, :bool, default: true
+    config_param :ignore_key_not_exist, :bool, default: false
+
+    attr_reader :parser
+
+    def initialize
+      super
+      require 'time'
+    end
+
+    def configure(conf)
+      super
+
+      @parser = Fluent::TextParser.new
+      @parser.estimate_current_event = false
+      @parser.configure(conf)
+      if !@time_parse && @parser.parser.respond_to?("time_key=".to_sym)
+        # disable parse time
+        @parser.parser.time_key = nil
+      end
+
+      self
+    end
+
+    def filter_stream(tag, es)
+      new_es = Fluent::MultiEventStream.new
+      es.each do |time, record|
+        raw_value = record[@key_name]
+        if raw_value.nil?
+          log.warn "#{@key_name} does not exist" unless @ignore_key_not_exist
+          new_es.add(time, handle_parsed(tag, record, time, {})) if @reserve_data
+          next
+        end
+        begin
+          @parser.parse(raw_value) do |t, values|
+            if values
+              t ||= time
+              r = handle_parsed(tag, record, t, values)
+              new_es.add(t, r)
+            else
+              log.warn "pattern not match with data '#{raw_value}'" unless @suppress_parse_error_log
+              if @reserve_data
+                t = time
+                r = handle_parsed(tag, record, time, {})
+                new_es.add(t, r)
+              end
+            end
+          end
+        rescue Fluent::TextParser::ParserError => e
+          log.warn e.message unless @suppress_parse_error_log
+        rescue ArgumentError => e
+          if @replace_invalid_sequence
+            unless e.message.index("invalid byte sequence in") == 0
+              raise
+            end
+            replaced_string = replace_invalid_byte(raw_value)
+            @parser.parse(replaced_string) do |t, values|
+              if values
+                t ||= time
+                r = handle_parsed(tag, record, t, values)
+                new_es.add(t, r)
+              else
+                log.warn "pattern not match with data '#{raw_value}'" unless @suppress_parse_error_log
+                if @reserve_data
+                  t = time
+                  r = handle_parsed(tag, record, time, {})
+                  new_es.add(t, r)
+                end
+              end
+            end
+          else
+            raise
+          end
+        rescue => e
+          log.warn "parse failed #{e.message}" unless @suppress_parse_error_log
+        end
+      end
+      new_es
+    end
+
+    private
+
+    def handle_parsed(tag, record, t, values)
+      if values && @inject_key_prefix
+        values = Hash[values.map { |k, v| [@inject_key_prefix + k, v] }]
+      end
+      r = @hash_value_field ? {@hash_value_field => values} : values
+      if @reserve_data
+        r = r ? record.merge(r) : record
+      end
+      r
+    end
+
+    def replace_invalid_byte(string)
+      replace_options = {invalid: :replace, undef: :replace, replace: '?'}
+      original_encoding = string.encoding
+      temporal_encoding = (original_encoding == Encoding::UTF_8 ? Encoding::UTF_16BE : Encoding::UTF_8)
+      string.encode(temporal_encoding, original_encoding, replace_options).encode(original_encoding)
+    end
+  end
+end

--- a/lib/fluent/plugin/filter_parser.rb
+++ b/lib/fluent/plugin/filter_parser.rb
@@ -46,7 +46,8 @@ module Fluent::Plugin
       @parser = parser_create
     end
 
-    FAILED_RESULT = [nil, nil].freeze # reduce allocation cost 
+    FAILED_RESULT = [nil, nil].freeze # reduce allocation cost
+    REPLACE_CHAR = '?'.freeze
 
     def filter_with_time(tag, time, record)
       raw_value = record[@key_name]
@@ -87,7 +88,7 @@ module Fluent::Plugin
           unless e.message.index("invalid byte sequence in") == 0
             raise
           end
-          replaced_string = replace_invalid_byte(raw_value)
+          replaced_string = raw_value.scrub(REPLACE_CHAR)
           @parser.parse(replaced_string) do |t, values|
             if values
               t ||= time
@@ -124,13 +125,6 @@ module Fluent::Plugin
         r = r ? record.merge(r) : record
       end
       r
-    end
-
-    def replace_invalid_byte(string)
-      replace_options = {invalid: :replace, undef: :replace, replace: '?'}
-      original_encoding = string.encoding
-      temporal_encoding = (original_encoding == Encoding::UTF_8 ? Encoding::UTF_16BE : Encoding::UTF_8)
-      string.encode(temporal_encoding, original_encoding, replace_options).encode(original_encoding)
     end
   end
 end

--- a/lib/fluent/plugin/filter_parser.rb
+++ b/lib/fluent/plugin/filter_parser.rb
@@ -33,9 +33,6 @@ module Fluent::Plugin
     config_param :replace_invalid_sequence, :bool, default: false
     config_param :hash_value_field, :string, default: nil
 
-    config_section :parse do
-    end
-
     attr_reader :parser
 
     def configure(conf)

--- a/lib/fluent/plugin_helper/compat_parameters.rb
+++ b/lib/fluent/plugin_helper/compat_parameters.rb
@@ -52,8 +52,6 @@ module Fluent
         "types" => nil,
         "types_delimiter" => nil,
         "types_label_delimiter" => nil,
-        "null_value_pattern" => "null_value_pattern",
-        "null_empty_string" => "null_empty_string",
         "keys" => "keys", # CSVParser, TSVParser (old ValuesParser)
         "time_key"    => "time_key",
         "time_format" => "time_format",

--- a/lib/fluent/plugin_helper/compat_parameters.rb
+++ b/lib/fluent/plugin_helper/compat_parameters.rb
@@ -58,6 +58,9 @@ module Fluent
         "time_key"    => "time_key",
         "time_format" => "time_format",
         "delimiter"   => "delimiter",
+        "keep_time_key" => "keep_time_key",
+        "null_empty_string" => "null_empty_string", # ValuesParser
+        "null_value_pattern" => "null_value_pattern", # ValuesParser
         "json_parser"      => "json_parser", # JSONParser
         "label_delimiter"  => "label_delimiter", # LabeledTSVParser
         "format_firstline" => "format_firstline", # MultilineParser

--- a/lib/fluent/plugin_helper/compat_parameters.rb
+++ b/lib/fluent/plugin_helper/compat_parameters.rb
@@ -57,8 +57,8 @@ module Fluent
         "time_format" => "time_format",
         "delimiter"   => "delimiter",
         "keep_time_key" => "keep_time_key",
-        "null_empty_string" => "null_empty_string", # ValuesParser
-        "null_value_pattern" => "null_value_pattern", # ValuesParser
+        "null_empty_string" => "null_empty_string",
+        "null_value_pattern" => "null_value_pattern",
         "json_parser"      => "json_parser", # JSONParser
         "label_delimiter"  => "label_delimiter", # LabeledTSVParser
         "format_firstline" => "format_firstline", # MultilineParser

--- a/test/plugin/test_filter_parser.rb
+++ b/test/plugin/test_filter_parser.rb
@@ -11,6 +11,10 @@ class ParserFilterTest < Test::Unit::TestCase
     Timecop.freeze(@default_time)
   end
 
+  def teardown
+    Timecop.return
+  end
+
   CONFIG = %[
     key_name     message
     format       /^(?<x>.)(?<y>.) (?<time>.+)$/

--- a/test/plugin/test_filter_parser.rb
+++ b/test/plugin/test_filter_parser.rb
@@ -1,0 +1,713 @@
+require_relative '../helper'
+require 'fluent/test/driver/filter'
+require 'fluent/plugin/filter_parser'
+
+class ParserFilterTest < Test::Unit::TestCase
+  def setup
+    Fluent::Test.setup
+  end
+
+  CONFIG = %[
+    key_name      message
+    format        /^(?<x>.)(?<y>.) (?<time>.+)$/
+    time_format   %Y%m%d%H%M%S
+    reserve_data  true
+  ]
+
+  def create_driver(conf=CONFIG,tag='test')
+    Fluent::Test::FilterTestDriver.new(Fluent::Plugin::ParserFilter, tag).configure(conf)
+  end
+
+  def test_configure
+    assert_raise(Fluent::ConfigError) {
+      create_driver('')
+    }
+    assert_raise(Fluent::ConfigError) {
+      create_driver %[
+        format unknown_format_that_will_never_be_implemented
+        key_name foo
+      ]
+    }
+    assert_nothing_raised {
+      create_driver %[
+        format /(?<x>.)/
+        key_name foo
+      ]
+    }
+    assert_nothing_raised {
+      create_driver %[
+        format /(?<x>.)/
+        key_name foo
+      ]
+    }
+    assert_nothing_raised {
+      create_driver %[
+        format /(?<x>.)/
+        key_name foo
+      ]
+    }
+    assert_nothing_raised {
+      create_driver %[
+        format /(?<x>.)/
+        key_name foo
+      ]
+    }
+    assert_nothing_raised {
+      create_driver %[
+        format json
+        key_name foo
+      ]
+    }
+    assert_nothing_raised {
+      create_driver %[
+        format ltsv
+        key_name foo
+      ]
+    }
+    assert_nothing_raised {
+      create_driver %[
+        format /^col1=(?<col1>.+) col2=(?<col2>.+)$/
+        key_name message
+        suppress_parse_error_log true
+      ]
+    }
+    assert_nothing_raised {
+      create_driver %[
+        format /^col1=(?<col1>.+) col2=(?<col2>.+)$/
+        key_name message
+        suppress_parse_error_log false
+      ]
+    }
+    d = create_driver %[
+      key_name foo
+      format /(?<x>.)/
+    ]
+    assert_equal false, d.instance.reserve_data
+  end
+
+  # CONFIG = %[
+  #   remove_prefix test
+  #   add_prefix    parsed
+  #   key_name      message
+  #   format        /^(?<x>.)(?<y>.) (?<time>.+)$/
+  #   time_format   %Y%m%d%H%M%S
+  #   reserve_data  true
+  # ]
+  def test_filter
+    d1 = create_driver(CONFIG, 'test.no.change')
+    time = Time.parse("2012-01-02 13:14:15").to_i
+    d1.run do
+      d1.filter({'message' => '12 20120402182059'}, time)
+      d1.filter({'message' => '34 20120402182100'}, time)
+      d1.filter({'message' => '56 20120402182100'}, time)
+      d1.filter({'message' => '78 20120402182101'}, time)
+      d1.filter({'message' => '90 20120402182100'}, time)
+    end
+    filtered = d1.filtered_as_array
+    assert_equal 5, filtered.length
+
+    first = filtered[0]
+    assert_equal 'test.no.change', first[0]
+    assert_equal Time.parse("2012-04-02 18:20:59").to_i, first[1]
+    assert_equal '1', first[2]['x']
+    assert_equal '2', first[2]['y']
+    assert_equal '12 20120402182059', first[2]['message']
+
+    second = filtered[1]
+    assert_equal 'test.no.change', second[0]
+    assert_equal Time.parse("2012-04-02 18:21:00").to_i, second[1]
+    assert_equal '3', second[2]['x']
+    assert_equal '4', second[2]['y']
+
+    third = filtered[2]
+    assert_equal 'test.no.change', third[0]
+    assert_equal Time.parse("2012-04-02 18:21:00").to_i, third[1]
+    assert_equal '5', third[2]['x']
+    assert_equal '6', third[2]['y']
+
+    fourth = filtered[3]
+    assert_equal 'test.no.change', fourth[0]
+    assert_equal Time.parse("2012-04-02 18:21:01").to_i, fourth[1]
+    assert_equal '7', fourth[2]['x']
+    assert_equal '8', fourth[2]['y']
+
+    fifth = filtered[4]
+    assert_equal 'test.no.change', fifth[0]
+    assert_equal Time.parse("2012-04-02 18:21:00").to_i, fifth[1]
+    assert_equal '9', fifth[2]['x']
+    assert_equal '0', fifth[2]['y']
+
+    d2 = create_driver(%[
+      tag parsed
+      key_name      data
+      format        /^(?<x>.)(?<y>.) (?<t>.+)$/
+    ], 'test.no.change')
+    time = Time.parse("2012-04-02 18:20:59").to_i
+    d2.run do
+      d2.filter({'data' => '12 20120402182059'}, time)
+      d2.filter({'data' => '34 20120402182100'}, time)
+    end
+    filtered = d2.filtered_as_array
+    assert_equal 2, filtered.length
+
+    first = filtered[0]
+    assert_equal 'test.no.change', first[0]
+    assert_equal time, first[1]
+    assert_nil first[2]['data']
+    assert_equal '1', first[2]['x']
+    assert_equal '2', first[2]['y']
+    assert_equal '20120402182059', first[2]['t']
+
+    second = filtered[1]
+    assert_equal 'test.no.change', second[0]
+    assert_equal time, second[1]
+    assert_nil second[2]['data']
+    assert_equal '3', second[2]['x']
+    assert_equal '4', second[2]['y']
+    assert_equal '20120402182100', second[2]['t']
+
+    d3 = create_driver(%[
+      tag parsed
+      key_name      data
+      format        /^(?<x>[0-9])(?<y>[0-9]) (?<t>.+)$/
+    ], 'test.no.change')
+    time = Time.parse("2012-04-02 18:20:59").to_i
+    d3.run do
+      d3.filter({'data' => '12 20120402182059'}, time)
+      d3.filter({'data' => '34 20120402182100'}, time)
+      d3.filter({'data' => 'xy 20120402182101'}, time)
+    end
+    filtered = d3.filtered_as_array
+    assert_equal 2, filtered.length
+
+    d3x = create_driver(%[
+      tag parsed
+      key_name      data
+      format        /^(?<x>\\d)(?<y>\\d) (?<t>.+)$/
+      reserve_data  yes
+    ], 'test.no.change')
+    time = Time.parse("2012-04-02 18:20:59").to_i
+    d3x.run do
+      d3x.filter({'data' => '12 20120402182059'}, time)
+      d3x.filter({'data' => '34 20120402182100'}, time)
+      d3x.filter({'data' => 'xy 20120402182101'}, time)
+    end
+    filtered = d3x.filtered_as_array
+    assert_equal 3, filtered.length
+
+    d4 = create_driver(%[
+      tag parsed
+      key_name      data
+      format        json
+    ], 'test.no.change')
+    time = Time.parse("2012-04-02 18:20:59").to_i
+    d4.run do
+      d4.filter({'data' => '{"xxx":"first","yyy":"second"}', 'xxx' => 'x', 'yyy' => 'y'}, time)
+      d4.filter({'data' => 'foobar', 'xxx' => 'x', 'yyy' => 'y'}, time)
+    end
+    filtered = d4.filtered_as_array
+    assert_equal 1, filtered.length
+
+    d4x = create_driver(%[
+      tag parsed
+      key_name      data
+      format        json
+      reserve_data  yes
+    ], 'test.no.change')
+    time = Time.parse("2012-04-02 18:20:59").to_i
+    d4x.run do
+      d4x.filter({'data' => '{"xxx":"first","yyy":"second"}', 'xxx' => 'x', 'yyy' => 'y'}, time)
+      d4x.filter({'data' => 'foobar', 'xxx' => 'x', 'yyy' => 'y'}, time)
+    end
+    filtered = d4x.filtered_as_array
+    assert_equal 2, filtered.length
+
+    first = filtered[0]
+    assert_equal 'test.no.change', first[0]
+    assert_equal time, first[1]
+    assert_equal '{"xxx":"first","yyy":"second"}', first[2]['data']
+    assert_equal 'first', first[2]['xxx']
+    assert_equal 'second', first[2]['yyy']
+
+    second = filtered[1]
+    assert_equal 'test.no.change', second[0]
+    assert_equal time, second[1]
+    assert_equal 'foobar', second[2]['data']
+    assert_equal 'x', second[2]['xxx']
+    assert_equal 'y', second[2]['yyy']
+  end
+
+  CONFIG_LTSV =  %[
+    format ltsv
+    key_name data
+  ]
+  def test_filter_ltsv
+    d = create_driver(CONFIG_LTSV, 'test.no.change')
+    time = Time.parse("2012-04-02 18:20:59").to_i
+    d.run do
+      d.filter({'data' => "xxx:first\tyyy:second", 'xxx' => 'x', 'yyy' => 'y'}, time)
+      d.filter({'data' => "xxx:first\tyyy:second2", 'xxx' => 'x', 'yyy' => 'y'}, time)
+    end
+    filtered = d.filtered_as_array
+    assert_equal 2, filtered.length
+
+    first = filtered[0]
+    assert_equal 'test.no.change', first[0]
+    assert_equal time, first[1]
+    assert_nil first[2]['data']
+    assert_equal 'first', first[2]['xxx']
+    assert_equal 'second', first[2]['yyy']
+
+    second = filtered[1]
+    assert_equal 'test.no.change', second[0]
+    assert_equal time, second[1]
+    assert_nil first[2]['data']
+    assert_equal 'first', second[2]['xxx']
+    assert_equal 'second2', second[2]['yyy']
+
+    d = create_driver(CONFIG_LTSV + %[
+      reserve_data yes
+    ], 'test.no.change')
+    time = Time.parse("2012-04-02 18:20:59").to_i
+    d.run do
+      d.filter({'data' => "xxx:first\tyyy:second", 'xxx' => 'x', 'yyy' => 'y'}, time)
+      d.filter({'data' => "xxx:first\tyyy:second2", 'xxx' => 'x', 'yyy' => 'y'}, time)
+    end
+    filtered = d.filtered_as_array
+    assert_equal 2, filtered.length
+
+    first = filtered[0]
+    assert_equal 'test.no.change', first[0]
+    assert_equal time, first[1]
+    assert_equal "xxx:first\tyyy:second", first[2]['data']
+    assert_equal 'first', first[2]['xxx']
+    assert_equal 'second', first[2]['yyy']
+
+    second = filtered[1]
+    assert_equal 'test.no.change', second[0]
+    assert_equal time, second[1]
+    assert_equal "xxx:first\tyyy:second", first[2]['data']
+    assert_equal 'first', second[2]['xxx']
+    assert_equal 'second2', second[2]['yyy']
+
+    # convert types
+    d = create_driver(CONFIG_LTSV + %[
+      types i:integer,s:string,f:float,b:bool
+    ], 'test.no.change')
+    time = Time.parse("2012-04-02 18:20:59").to_i
+    d.run do
+      d.filter({'data' => "i:1\ts:2\tf:3\tb:true\tx:123"}, time)
+    end
+    filtered = d.filtered_as_array
+    assert_equal 1, filtered.length
+
+    first = filtered[0]
+    assert_equal 'test.no.change', first[0]
+    assert_equal time, first[1]
+    assert_equal 1, first[2]['i']
+    assert_equal '2', first[2]['s']
+    assert_equal 3.0, first[2]['f']
+    assert_equal true, first[2]['b']
+    assert_equal '123', first[2]['x']
+  end
+
+  CONFIG_TSV =  %[
+    format tsv
+    key_name data
+    keys key1,key2,key3
+  ]
+  def test_filter_tsv
+    d = create_driver(CONFIG_TSV, 'test.no.change')
+    time = Time.parse("2012-04-02 18:20:59").to_i
+    d.run do
+      d.filter({'data' => "value1\tvalue2\tvalueThree", 'xxx' => 'x', 'yyy' => 'y'}, time)
+    end
+    filtered = d.filtered_as_array
+    assert_equal 1, filtered.length
+
+    first = filtered[0]
+    assert_equal 'test.no.change', first[0]
+    assert_equal time, first[1]
+    assert_nil first[2]['data']
+    assert_equal 'value1', first[2]['key1']
+    assert_equal 'value2', first[2]['key2']
+    assert_equal 'valueThree', first[2]['key3']
+  end
+
+  CONFIG_CSV =  %[
+    format csv
+    key_name data
+    keys key1,key2,key3
+  ]
+  def test_filter_csv
+    d = create_driver(CONFIG_CSV, 'test.no.change')
+    time = Time.parse("2012-04-02 18:20:59").to_i
+    d.run do
+      d.filter({'data' => 'value1,"value2","value""ThreeYes!"', 'xxx' => 'x', 'yyy' => 'y'}, time)
+    end
+    filtered = d.filtered_as_array
+    assert_equal 1, filtered.length
+
+    first = filtered[0]
+    assert_equal 'test.no.change', first[0]
+    assert_equal time, first[1]
+    assert_nil first[2]['data']
+    assert_equal 'value1', first[2]['key1']
+    assert_equal 'value2', first[2]['key2']
+    assert_equal 'value"ThreeYes!', first[2]['key3']
+  end
+
+  CONFIG_HASH_VALUE_FIELD = %[
+    format       json
+    key_name     data
+    hash_value_field parsed
+  ]
+  CONFIG_HASH_VALUE_FIELD_RESERVE_DATA = %[
+    format       json
+    key_name     data
+    reserve_data yes
+    hash_value_field parsed
+  ]
+  CONFIG_HASH_VALUE_FIELD_WITH_INJECT_KEY_PREFIX = %[
+    format       json
+    key_name     data
+    hash_value_field parsed
+    inject_key_prefix data.
+  ]
+  def test_filter_inject_hash_value_field
+    original = {'data' => '{"xxx":"first","yyy":"second"}', 'xxx' => 'x', 'yyy' => 'y'}
+
+    d = create_driver(CONFIG_HASH_VALUE_FIELD, 'test.no.change')
+    time = Time.parse("2012-04-02 18:20:59").to_i
+    d.run do
+      d.filter(original, time)
+    end
+    filtered = d.filtered_as_array
+    assert_equal 1, filtered.length
+
+    first = filtered[0]
+    assert_equal 'test.no.change', first[0]
+    assert_equal time, first[1]
+
+    record = first[2]
+    assert_equal 1, record.keys.size
+    assert_equal({"xxx"=>"first","yyy"=>"second"}, record['parsed'])
+
+    d = create_driver(CONFIG_HASH_VALUE_FIELD_RESERVE_DATA, 'test.no.change')
+    time = Time.parse("2012-04-02 18:20:59").to_i
+    d.run do
+      d.filter(original, time)
+    end
+    filtered = d.filtered_as_array
+    assert_equal 1, filtered.length
+
+    first = filtered[0]
+    assert_equal 'test.no.change', first[0]
+    assert_equal time, first[1]
+
+    record = first[2]
+    assert_equal 4, record.keys.size
+    assert_equal original['data'], record['data']
+    assert_equal original['xxx'], record['xxx']
+    assert_equal original['yyy'], record['yyy']
+    assert_equal({"xxx"=>"first","yyy"=>"second"}, record['parsed'])
+
+    d = create_driver(CONFIG_HASH_VALUE_FIELD_WITH_INJECT_KEY_PREFIX, 'test.no.change')
+    time = Time.parse("2012-04-02 18:20:59").to_i
+    d.run do
+      d.filter(original, time)
+    end
+    filtered = d.filtered_as_array
+    assert_equal 1, filtered.length
+
+    first = filtered[0]
+    assert_equal 'test.no.change', first[0]
+    assert_equal time, first[1]
+
+    record = first[2]
+    assert_equal 1, record.keys.size
+    assert_equal({"data.xxx"=>"first","data.yyy"=>"second"}, record['parsed'])
+  end
+
+  CONFIG_DONT_PARSE_TIME = %[
+    key_name data
+    format json
+    time_parse no
+  ]
+  def test_time_should_be_reserved
+    t = Time.now.to_i
+    d = create_driver(CONFIG_DONT_PARSE_TIME, 'test.no.change')
+
+    d.run do
+      d.filter({'data' => '{"time":1383190430, "f1":"v1"}'}, t)
+      d.filter({'data' => '{"time":"1383190430", "f1":"v1"}'}, t)
+      d.filter({'data' => '{"time":"2013-10-31 12:34:03 +0900", "f1":"v1"}'}, t)
+    end
+    filtered = d.filtered_as_array
+    assert_equal 3, filtered.length
+
+    assert_equal 'test.no.change', filtered[0][0]
+    assert_equal 'v1', filtered[0][2]['f1']
+    assert_equal 1383190430, filtered[0][2]['time']
+    assert_equal t, filtered[0][1]
+
+    assert_equal 'test.no.change', filtered[1][0]
+    assert_equal 'v1', filtered[1][2]['f1']
+    assert_equal "1383190430", filtered[1][2]['time']
+    assert_equal t, filtered[1][1]
+
+    assert_equal 'test.no.change', filtered[2][0]
+    assert_equal 'v1', filtered[2][2]['f1']
+    assert_equal '2013-10-31 12:34:03 +0900', filtered[2][2]['time']
+    assert_equal t, filtered[2][1]
+  end
+
+  CONFIG_INVALID_TIME_VALUE = %[
+    remove_prefix test
+    key_name data
+    format json
+  ] # 'time' is implicit @time_key
+  def test_filter_invalid_time_data
+    # should not raise errors
+    t = Time.now.to_i
+    d = create_driver(CONFIG_INVALID_TIME_VALUE, 'test.no.change')
+    assert_nothing_raised {
+      d.run do
+        d.filter({'data' => '{"time":[], "f1":"v1"}'}, t)
+        d.filter({'data' => '{"time":"thisisnottime", "f1":"v1"}'}, t)
+      end
+    }
+    filtered = d.filtered_as_array
+    assert_equal 1, filtered.length
+
+    assert_equal 'test.no.change', filtered[0][0]
+    assert_equal 0, filtered[0][1]
+    assert_equal 'v1', filtered[0][2]['f1']
+    assert_equal 0, filtered[0][2]['time'].to_i
+  end
+
+  # REGEXP = /^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$/
+
+  CONFIG_NOT_REPLACE = %[
+    remove_prefix test
+    key_name      data
+    format        /^(?<message>.*)$/
+  ]
+  CONFIG_INVALID_BYTE = CONFIG_NOT_REPLACE + %[
+    replace_invalid_sequence true
+  ]
+  def test_filter_invalid_byte
+    invalid_utf8 = "\xff".force_encoding('UTF-8')
+
+    d = create_driver(CONFIG_NOT_REPLACE, 'test.no.change')
+    assert_raise(ArgumentError) {
+      d.run do
+        d.filter({'data' => invalid_utf8}, Time.now.to_i)
+      end
+    }
+
+    d = create_driver(CONFIG_INVALID_BYTE, 'test.in')
+    assert_nothing_raised {
+      d.run do
+        d.emit({'data' => invalid_utf8}, Time.now.to_i)
+      end
+    }
+    filtered = d.filtered_as_array
+    assert_equal 1, filtered.length
+    assert_nil filtered[0][2]['data']
+    assert_equal '?'.force_encoding('UTF-8'), filtered[0][2]['message']
+
+    d = create_driver(CONFIG_INVALID_BYTE + %[
+      reserve_data yes
+    ], 'test.no.change')
+    assert_nothing_raised {
+      d.run do
+        d.filter({'data' => invalid_utf8}, Time.now.to_i)
+      end
+    }
+    filtered = d.filtered_as_array
+    assert_equal 1, filtered.length
+    assert_equal invalid_utf8, filtered[0][2]['data']
+    assert_equal '?'.force_encoding('UTF-8'), filtered[0][2]['message']
+
+    invalid_ascii = "\xff".force_encoding('US-ASCII')
+    d = create_driver(CONFIG_INVALID_BYTE, 'test.no.change')
+    assert_nothing_raised {
+      d.run do
+        d.filter({'data' => invalid_ascii}, Time.now.to_i)
+      end
+    }
+    filtered = d.filtered_as_array
+    assert_equal 1, filtered.length
+    assert_nil filtered[0][2]['data']
+    assert_equal '?'.force_encoding('US-ASCII'), filtered[0][2]['message']
+  end
+
+  CONFIG_NOT_IGNORE = %[
+    remove_prefix    test
+    key_name         data
+    format           json
+    hash_value_field parsed
+  ]
+  CONFIG_IGNORE = CONFIG_NOT_IGNORE + %[
+    ignore_key_not_exist true
+  ]
+  CONFIG_PASS_SAME_RECORD = CONFIG_IGNORE + %[
+    reserve_data true
+  ]
+  def test_filter_key_not_exist
+    d = create_driver(CONFIG_NOT_IGNORE, 'test.no.ignore')
+    assert_nothing_raised {
+      d.run do
+        d.filter({'foo' => 'bar'}, Time.now.to_i)
+      end
+    }
+    assert_match(/data does not exist/, d.instance.log.out.logs.first)
+
+    d = create_driver(CONFIG_IGNORE, 'test.ignore')
+    assert_nothing_raised {
+      d.run do
+        d.filter({'foo' => 'bar'}, Time.now.to_i)
+      end
+    }
+    assert_not_match(/data does not exist/, d.instance.log.out.logs.first)
+
+    d = create_driver(CONFIG_PASS_SAME_RECORD, 'test.pass_same_record')
+    assert_nothing_raised {
+      d.run do
+        d.filter({'foo' => 'bar'}, Time.now.to_i)
+      end
+    }
+    filtered = d.filtered_as_array
+    assert_equal 1, filtered.length
+    assert_nil filtered[0][2]['data']
+    assert_equal 'bar', filtered[0][2]['foo']
+  end
+
+  # suppress_parse_error_log test
+  CONFIG_DISABELED_SUPPRESS_PARSE_ERROR_LOG = %[
+    tag hogelog
+    format /^col1=(?<col1>.+) col2=(?<col2>.+)$/
+    key_name message
+    suppress_parse_error_log false
+  ]
+  CONFIG_ENABELED_SUPPRESS_PARSE_ERROR_LOG = %[
+    tag hogelog
+    format /^col1=(?<col1>.+) col2=(?<col2>.+)$/
+    key_name message
+    suppress_parse_error_log true
+  ]
+  CONFIG_DEFAULT_SUPPRESS_PARSE_ERROR_LOG = %[
+    tag hogelog
+    format /^col1=(?<col1>.+) col2=(?<col2>.+)$/
+    key_name message
+  ]
+
+  INVALID_MESSAGE = 'foo bar'
+  VALID_MESSAGE   = 'col1=foo col2=bar'
+
+  # if call warn() raise exception
+  class DummyLoggerWarnedException < StandardError; end
+  class DummyLogger
+    def reset
+    end
+    def warn(message)
+      raise DummyLoggerWarnedException
+    end
+  end
+
+  def swap_logger(instance)
+    raise "use with block" unless block_given?
+    dummy = DummyLogger.new
+    saved_logger = instance.log
+    instance.log = dummy
+    restore = lambda { instance.log = saved_logger }
+
+    yield
+
+    restore.call
+  end
+
+  def test_parser_error_warning
+    d = create_driver(CONFIG_INVALID_TIME_VALUE, 'test.no.change')
+    swap_logger(d.instance) do
+      assert_raise(DummyLoggerWarnedException) {
+        d.run do
+          d.filter({'data' => '{"time":[], "f1":"v1"}'}, Time.now.to_i)
+        end
+      }
+    end
+  end
+
+  class DefaultSuppressParseErrorLogTest < self
+    def setup
+      # default(disabled) 'suppress_parse_error_log' is not specify
+      @d = create_driver(CONFIG_DEFAULT_SUPPRESS_PARSE_ERROR_LOG, 'test.no.change')
+    end
+
+    def test_raise_exception
+      swap_logger(@d.instance) do
+        assert_raise(DummyLoggerWarnedException) {
+          @d.run do
+            @d.filter({'message' => INVALID_MESSAGE}, Time.now.to_i)
+          end
+        }
+      end
+    end
+
+    def test_nothing_raised
+      swap_logger(@d.instance) do
+      assert_nothing_raised {
+        @d.run do
+          @d.filter({'message' => VALID_MESSAGE}, Time.now.to_i)
+        end
+      }
+      end
+    end
+  end
+
+  class DisabledSuppressParseErrorLogTest < self
+    def setup
+      # disabled 'suppress_parse_error_log'
+      @d = create_driver(CONFIG_DISABELED_SUPPRESS_PARSE_ERROR_LOG, 'test.no.change')
+    end
+
+    def test_raise_exception
+      swap_logger(@d.instance) do
+        assert_raise(DummyLoggerWarnedException) {
+          @d.run do
+            @d.filter({'message' => INVALID_MESSAGE}, Time.now.to_i)
+          end
+        }
+      end
+    end
+
+    def test_nothing_raised
+      swap_logger(@d.instance) do
+      assert_nothing_raised {
+        @d.run do
+          @d.filter({'message' => VALID_MESSAGE}, Time.now.to_i)
+        end
+      }
+      end
+    end
+  end
+
+  class EnabledSuppressParseErrorLogTest < self
+    def setup
+      # enabled 'suppress_parse_error_log'
+      @d = create_driver(CONFIG_ENABELED_SUPPRESS_PARSE_ERROR_LOG, 'test.no.change')
+    end
+
+    def test_nothing_raised
+      swap_logger(@d.instance) do
+      assert_nothing_raised {
+        @d.run do
+          @d.filter({'message' => INVALID_MESSAGE}, Time.now.to_i)
+          @d.filter({'message' => VALID_MESSAGE},   Time.now.to_i)
+        end
+      }
+      end
+    end
+  end
+end

--- a/test/plugin/test_filter_parser.rb
+++ b/test/plugin/test_filter_parser.rb
@@ -118,12 +118,12 @@ class ParserFilterTest < Test::Unit::TestCase
   def test_filter
     d1 = create_driver(CONFIG)
     time = Time.parse("2012-01-02 13:14:15").to_i
-    d1.run do
-      d1.feed(@tag, time, {'message' => '12 20120402182059'})
-      d1.feed(@tag, time, {'message' => '34 20120402182100'})
-      d1.feed(@tag, time, {'message' => '56 20120402182100'})
-      d1.feed(@tag, time, {'message' => '78 20120402182101'})
-      d1.feed(@tag, time, {'message' => '90 20120402182100'})
+    d1.run(default_tag: @tag) do
+      d1.feed(time, {'message' => '12 20120402182059'})
+      d1.feed(time, {'message' => '34 20120402182100'})
+      d1.feed(time, {'message' => '56 20120402182100'})
+      d1.feed(time, {'message' => '78 20120402182101'})
+      d1.feed(time, {'message' => '90 20120402182100'})
     end
     filtered = d1.filtered
     assert_equal 5, filtered.length
@@ -159,9 +159,9 @@ class ParserFilterTest < Test::Unit::TestCase
       format   /^(?<x>.)(?<y>.) (?<t>.+)$/
     ])
     time = Fluent::EventTime.from_time(@default_time) # EventTime emit test
-    d2.run do
-      d2.feed(@tag, time, {'data' => '12 20120402182059'})
-      d2.feed(@tag, time, {'data' => '34 20120402182100'})
+    d2.run(default_tag: @tag) do
+      d2.feed(time, {'data' => '12 20120402182059'})
+      d2.feed(time, {'data' => '34 20120402182100'})
     end
     filtered = d2.filtered
     assert_equal 2, filtered.length
@@ -188,10 +188,10 @@ class ParserFilterTest < Test::Unit::TestCase
       </parse>
     ])
     time = Time.parse("2012-04-02 18:20:59").to_i
-    d3.run do
-      d3.feed(@tag, time, {'data' => '12 20120402182059'})
-      d3.feed(@tag, time, {'data' => '34 20120402182100'})
-      d3.feed(@tag, time, {'data' => 'xy 20120402182101'})
+    d3.run(default_tag: @tag) do
+      d3.feed(time, {'data' => '12 20120402182059'})
+      d3.feed(time, {'data' => '34 20120402182100'})
+      d3.feed(time, {'data' => 'xy 20120402182101'})
     end
     filtered = d3.filtered
     assert_equal 2, filtered.length
@@ -205,10 +205,10 @@ class ParserFilterTest < Test::Unit::TestCase
       </parse>
     ])
     time = Time.parse("2012-04-02 18:20:59").to_i
-    d3x.run do
-      d3x.feed(@tag, time, {'data' => '12 20120402182059'})
-      d3x.feed(@tag, time, {'data' => '34 20120402182100'})
-      d3x.feed(@tag, time, {'data' => 'xy 20120402182101'})
+    d3x.run(default_tag: @tag) do
+      d3x.feed(time, {'data' => '12 20120402182059'})
+      d3x.feed(time, {'data' => '34 20120402182100'})
+      d3x.feed(time, {'data' => 'xy 20120402182101'})
     end
     filtered = d3x.filtered
     assert_equal 3, filtered.length
@@ -220,9 +220,9 @@ class ParserFilterTest < Test::Unit::TestCase
       </parse>
     ])
     time = Time.parse("2012-04-02 18:20:59").to_i
-    d4.run do
-      d4.feed(@tag, time, {'data' => '{"xxx":"first","yyy":"second"}', 'xxx' => 'x', 'yyy' => 'y'})
-      d4.feed(@tag, time, {'data' => 'foobar', 'xxx' => 'x', 'yyy' => 'y'})
+    d4.run(default_tag: @tag) do
+      d4.feed(time, {'data' => '{"xxx":"first","yyy":"second"}', 'xxx' => 'x', 'yyy' => 'y'})
+      d4.feed(time, {'data' => 'foobar', 'xxx' => 'x', 'yyy' => 'y'})
     end
     filtered = d4.filtered
     assert_equal 1, filtered.length
@@ -235,9 +235,9 @@ class ParserFilterTest < Test::Unit::TestCase
       </parse>
     ])
     time = @default_time.to_i
-    d4x.run do
-      d4x.feed(@tag, time, {'data' => '{"xxx":"first","yyy":"second"}', 'xxx' => 'x', 'yyy' => 'y'})
-      d4x.feed(@tag, time, {'data' => 'foobar', 'xxx' => 'x', 'yyy' => 'y'})
+    d4x.run(default_tag: @tag) do
+      d4x.feed(time, {'data' => '{"xxx":"first","yyy":"second"}', 'xxx' => 'x', 'yyy' => 'y'})
+      d4x.feed(time, {'data' => 'foobar', 'xxx' => 'x', 'yyy' => 'y'})
     end
     filtered = d4x.filtered
     assert_equal 2, filtered.length
@@ -271,9 +271,9 @@ class ParserFilterTest < Test::Unit::TestCase
   def test_filter_ltsv
     d = create_driver(CONFIG_LTSV)
     time = @default_time.to_i
-    d.run do
-      d.feed(@tag, time, {'data' => "xxx:first\tyyy:second", 'xxx' => 'x', 'yyy' => 'y'})
-      d.feed(@tag, time, {'data' => "xxx:first\tyyy:second2", 'xxx' => 'x', 'yyy' => 'y'})
+    d.run(default_tag: @tag) do
+      d.feed(time, {'data' => "xxx:first\tyyy:second", 'xxx' => 'x', 'yyy' => 'y'})
+      d.feed(time, {'data' => "xxx:first\tyyy:second2", 'xxx' => 'x', 'yyy' => 'y'})
     end
     filtered = d.filtered
     assert_equal 2, filtered.length
@@ -292,9 +292,9 @@ class ParserFilterTest < Test::Unit::TestCase
 
     d = create_driver(CONFIG_LTSV + %[reserve_data yes])
     time = @default_time.to_i
-    d.run do
-      d.feed(@tag, time, {'data' => "xxx:first\tyyy:second", 'xxx' => 'x', 'yyy' => 'y'})
-      d.feed(@tag, time, {'data' => "xxx:first\tyyy:second2", 'xxx' => 'x', 'yyy' => 'y'})
+    d.run(default_tag: @tag) do
+      d.feed(time, {'data' => "xxx:first\tyyy:second", 'xxx' => 'x', 'yyy' => 'y'})
+      d.feed(time, {'data' => "xxx:first\tyyy:second2", 'xxx' => 'x', 'yyy' => 'y'})
     end
     filtered = d.filtered
     assert_equal 2, filtered.length
@@ -479,10 +479,10 @@ class ParserFilterTest < Test::Unit::TestCase
   def test_time_should_be_reserved(conf)
     t = Time.now.to_i
     d = create_driver(conf)
-    d.run do
-      d.feed(@tag, t, {'data' => '{"time":1383190430, "f1":"v1"}'})
-      d.feed(@tag, t, {'data' => '{"time":"1383190430", "f1":"v1"}'})
-      d.feed(@tag, t, {'data' => '{"time":"2013-10-31 12:34:03 +0900", "f1":"v1"}'})
+    d.run(default_tag: @tag) do
+      d.feed(t, {'data' => '{"time":1383190430, "f1":"v1"}'})
+      d.feed(t, {'data' => '{"time":"1383190430", "f1":"v1"}'})
+      d.feed(t, {'data' => '{"time":"2013-10-31 12:34:03 +0900", "f1":"v1"}'})
     end
     filtered = d.filtered
     assert_equal 3, filtered.length
@@ -511,9 +511,9 @@ class ParserFilterTest < Test::Unit::TestCase
     time = Time.now.to_i
     d = create_driver(CONFIG_INVALID_TIME_VALUE)
     assert_nothing_raised {
-      d.run do
-        d.feed(@tag, time, {'data' => '{"time":[], "f1":"v1"}'})
-        d.feed(@tag, time, {'data' => '{"time":"thisisnottime", "f1":"v1"}'})
+      d.run(default_tag: @tag) do
+        d.feed(time, {'data' => '{"time":[], "f1":"v1"}'})
+        d.feed(time, {'data' => '{"time":"thisisnottime", "f1":"v1"}'})
       end
     }
     filtered = d.filtered
@@ -721,9 +721,9 @@ class ParserFilterTest < Test::Unit::TestCase
     def test_nothing_raised
       flexmock(@d.instance.router).should_receive(:emit_error_event).
         with(String, Integer, Hash, ParserError).once
-      @d.run do
-        @d.feed(@tag, Fluent::EventTime.now.to_i, {'message' => INVALID_MESSAGE})
-        @d.feed(@tag, Fluent::EventTime.now.to_i, {'message' => VALID_MESSAGE})
+      @d.run(default_tag: @tag) do
+        @d.feed(Fluent::EventTime.now.to_i, {'message' => INVALID_MESSAGE})
+        @d.feed(Fluent::EventTime.now.to_i, {'message' => VALID_MESSAGE})
       end
     end
   end

--- a/test/plugin/test_filter_parser.rb
+++ b/test/plugin/test_filter_parser.rb
@@ -218,7 +218,7 @@ class ParserFilterTest < Test::Unit::TestCase
         expression /^(?<x>\\d)(?<y>\\d) (?<t>.+)$/
       </parse>
     ])
-    time = Time.parse("2012-04-02 18:20:59").to_i
+    time = event_time("2012-04-02 18:20:59")
     d1.run(default_tag: @tag) do
       d1.feed(time, {'data' => '12 20120402182059'})
       d1.feed(time, {'data' => '34 20120402182100'})
@@ -234,7 +234,7 @@ class ParserFilterTest < Test::Unit::TestCase
         @type json
       </parse>
     ])
-    time = @default_time.to_i
+    time = Fluent::EventTime.from_time(@default_time)
     d2.run(default_tag: @tag) do
       d2.feed(time, {'data' => '{"xxx":"first","yyy":"second"}', 'xxx' => 'x', 'yyy' => 'y'})
       d2.feed(time, {'data' => 'foobar', 'xxx' => 'x', 'yyy' => 'y'})
@@ -243,13 +243,13 @@ class ParserFilterTest < Test::Unit::TestCase
     assert_equal 2, filtered.length
 
     first = filtered[0]
-    assert_equal time, first[0]
+    assert_equal_event_time time, first[0]
     assert_equal '{"xxx":"first","yyy":"second"}', first[1]['data']
     assert_equal 'first', first[1]['xxx']
     assert_equal 'second', first[1]['yyy']
 
     second = filtered[1]
-    assert_equal time, second[0]
+    assert_equal_event_time time, second[0]
     assert_equal 'foobar', second[1]['data']
     assert_equal 'x', second[1]['xxx']
     assert_equal 'y', second[1]['yyy']

--- a/test/plugin/test_filter_parser.rb
+++ b/test/plugin/test_filter_parser.rb
@@ -421,7 +421,8 @@ class ParserFilterTest < Test::Unit::TestCase
   CONFIG_DONT_PARSE_TIME = %[
     key_name data
     format json
-    time_parse no
+    keep_time_key true
+    reserve_time true
   ]
   def test_time_should_be_reserved
     t = Time.now.to_i
@@ -465,9 +466,9 @@ class ParserFilterTest < Test::Unit::TestCase
     filtered = d.filtered
     assert_equal 1, filtered.length
 
-    assert_equal 0, filtered[0][0]
+    assert_equal 0, filtered[0][0].to_i
     assert_equal 'v1', filtered[0][1]['f1']
-    assert_equal 0, filtered[0][1]['time'].to_i
+    assert_equal nil, filtered[0][1]['time']
   end
 
   # REGEXP = /^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$/

--- a/test/plugin/test_filter_parser.rb
+++ b/test/plugin/test_filter_parser.rb
@@ -605,11 +605,11 @@ class ParserFilterTest < Test::Unit::TestCase
     assert_equal 'bar', filtered[0][1]['foo']
   end
 
-  # suppress_parse_error_log test
+  # emit_error_event test
   INVALID_MESSAGE = 'foo bar'
   VALID_MESSAGE   = 'col1=foo col2=bar'
 
-  def test_parser_error_warning
+  def test_call_emit_error_event_when_parser_error
     d = create_driver(CONFIG_INVALID_TIME_VALUE)
     flexmock(d.instance.router).should_receive(:emit_error_event).
       with(String, Integer, Hash, ParserError).once
@@ -618,7 +618,7 @@ class ParserFilterTest < Test::Unit::TestCase
     end
   end
 
-  CONFIG_DEFAULT_SUPPRESS_PARSE_ERROR_LOG = %[
+  CONFIG_UNMATCHED_PATTERN_LOG = %[
     key_name message
     <parse>
       @type regexp
@@ -626,12 +626,12 @@ class ParserFilterTest < Test::Unit::TestCase
     </parse>
   ]
 
-  class DefaultSuppressParseErrorLogTest < self
+  class UnmatchedPatternLogTest < self
     setup do
-      @d = create_driver(CONFIG_DEFAULT_SUPPRESS_PARSE_ERROR_LOG)
+      @d = create_driver(CONFIG_UNMATCHED_PATTERN_LOG)
     end
 
-    def test_raise_exception
+    def test_call_emit_error_event_when_pattern_is_mismached
       flexmock(@d.instance.router).should_receive(:emit_error_event).
         with(String, Integer, Hash, ParserError.new("pattern not match with data '#{INVALID_MESSAGE}'")).once
       @d.run do
@@ -639,7 +639,7 @@ class ParserFilterTest < Test::Unit::TestCase
       end
     end
 
-    def test_nothing_raised
+    def test_not_call_emit_error_event_when_pattern_is_mached
       flexmock(@d.instance.router).should_receive(:emit_error_event).never
       @d.run do
         @d.feed(@tag, Fluent::EventTime.now.to_i, {'message' => VALID_MESSAGE})

--- a/test/plugin/test_filter_parser.rb
+++ b/test/plugin/test_filter_parser.rb
@@ -547,13 +547,12 @@ class ParserFilterTest < Test::Unit::TestCase
     invalid_utf8 = "\xff".force_encoding('UTF-8')
 
     d = create_driver(CONFIG_NOT_REPLACE)
-    d.run(shutdown: false) do
+    d.run do
       d.feed(@tag, Fluent::EventTime.now.to_i, {'data' => invalid_utf8})
     end
     error_event = d.error_events.first
     assert_equal "test", error_event[0]
     assert_instance_of ArgumentError, error_event[3]
-    d.instance_shutdown      
 
     d = create_driver(CONFIG_INVALID_BYTE)
     assert_nothing_raised {
@@ -605,11 +604,10 @@ class ParserFilterTest < Test::Unit::TestCase
     flexmock(d.instance.router).should_receive(:emit_error_event).
       with(String, Integer, Hash, ArgumentError.new("data does not exist")).once
     assert_nothing_raised {
-      d.run(shutdown: false) do
+      d.run do
         d.feed(@tag, Fluent::EventTime.now.to_i, {'foo' => 'bar'})
       end
     }
-    d.instance_shutdown
 
     d = create_driver(CONFIG_PASS_SAME_RECORD)
     assert_nothing_raised {


### PR DESCRIPTION
Changes from original code:
- Use v0.14 namespace
- Use v0.14 API (Now working)
- Remove warnings like unused variable
