### PR TITLE
Updates dependencies and reduce warnings

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -19,28 +19,28 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.1'
 
-  gem.add_runtime_dependency("msgpack", [">= 0.7.0"])
+  gem.add_runtime_dependency("msgpack", [">= 0.7.0", "< 2.0.0"])
   gem.add_runtime_dependency("yajl-ruby", ["~> 1.0"])
   gem.add_runtime_dependency("cool.io", [">= 1.4.3", "< 2.0.0"])
   gem.add_runtime_dependency("serverengine", ["~> 2.0"])
   gem.add_runtime_dependency("http_parser.rb", [">= 0.5.1", "< 0.7.0"])
   gem.add_runtime_dependency("sigdump", ["~> 0.2.2"])
-  gem.add_runtime_dependency("tzinfo", [">= 1.0.0"])
-  gem.add_runtime_dependency("tzinfo-data", [">= 1.0.0"])
+  gem.add_runtime_dependency("tzinfo", ["~> 1.0"])
+  gem.add_runtime_dependency("tzinfo-data", ["~> 1.0"])
   if /mswin|mingw/ =~ RUBY_PLATFORM
     gem.add_runtime_dependency("win32-service", ["~> 0.8.3"])
     gem.add_runtime_dependency("win32-ipc", ["~> 0.6.1"])
     gem.add_runtime_dependency("win32-event", ["~> 0.6.1"])
     gem.add_runtime_dependency("windows-pr", ["~> 1.2.5"])
   end
-  gem.add_runtime_dependency("strptime", [">= 0.1.7"])
+  gem.add_runtime_dependency("strptime", ["~> 0.1.7"])
 
   gem.add_development_dependency("rake", ["~> 11.0"])
   gem.add_development_dependency("flexmock", ["~> 2.0"])
-  gem.add_development_dependency("parallel_tests", [">= 0.15.3"])
+  gem.add_development_dependency("parallel_tests", ["~> 0.15.3"])
   gem.add_development_dependency("simplecov", ["~> 0.7"])
-  gem.add_development_dependency("rr", [">= 1.0.0"])
-  gem.add_development_dependency("timecop", [">= 0.3.0"])
+  gem.add_development_dependency("rr", ["~> 1.0"])
+  gem.add_development_dependency("timecop", ["~> 0.3"])
   gem.add_development_dependency("test-unit", ["~> 3.2"])
   gem.add_development_dependency("test-unit-rr", ["~> 1.0"])
   gem.add_development_dependency("oj", ["~> 2.14"])

--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.1'
 
   gem.add_runtime_dependency("msgpack", [">= 0.7.0"])
-  gem.add_runtime_dependency("json", [">= 1.4.3"])
   gem.add_runtime_dependency("yajl-ruby", ["~> 1.0"])
   gem.add_runtime_dependency("cool.io", [">= 1.4.3", "< 2.0.0"])
   gem.add_runtime_dependency("serverengine", ["~> 2.0"])
@@ -36,13 +35,13 @@ Gem::Specification.new do |gem|
   end
   gem.add_runtime_dependency("strptime", [">= 0.1.7"])
 
-  gem.add_development_dependency("rake", [">= 0.9.2"])
-  gem.add_development_dependency("flexmock", ["~> 2.0.5"])
+  gem.add_development_dependency("rake", ["~> 11.0"])
+  gem.add_development_dependency("flexmock", ["~> 2.0"])
   gem.add_development_dependency("parallel_tests", [">= 0.15.3"])
-  gem.add_development_dependency("simplecov", ["~> 0.6.4"])
+  gem.add_development_dependency("simplecov", ["~> 0.7"])
   gem.add_development_dependency("rr", [">= 1.0.0"])
   gem.add_development_dependency("timecop", [">= 0.3.0"])
-  gem.add_development_dependency("test-unit", ["~> 3.1.4"])
-  gem.add_development_dependency("test-unit-rr", ["~> 1.0.3"])
+  gem.add_development_dependency("test-unit", ["~> 3.2"])
+  gem.add_development_dependency("test-unit-rr", ["~> 1.0"])
   gem.add_development_dependency("oj", ["~> 2.14"])
 end

--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency("msgpack", [">= 0.7.0", "< 2.0.0"])
   gem.add_runtime_dependency("yajl-ruby", ["~> 1.0"])
-  gem.add_runtime_dependency("cool.io", [">= 1.4.3", "< 2.0.0"])
+  gem.add_runtime_dependency("cool.io", ["~> 1.4.5"])
   gem.add_runtime_dependency("serverengine", ["~> 2.0"])
   gem.add_runtime_dependency("http_parser.rb", [">= 0.5.1", "< 0.7.0"])
   gem.add_runtime_dependency("sigdump", ["~> 0.2.2"])

--- a/lib/fluent/event_router.rb
+++ b/lib/fluent/event_router.rb
@@ -156,6 +156,7 @@ module Fluent
       class FilterOptimizer
         def initialize(filters = [])
           @filters = filters
+          @optimizable = nil
         end
 
         def filters=(filters)

--- a/test/plugin/test_filter.rb
+++ b/test/plugin/test_filter.rb
@@ -60,6 +60,10 @@ class FilterPluginTest < Test::Unit::TestCase
     end
   end
 
+  setup do
+    @p = nil
+  end
+
   teardown do
     if @p
       @p.stop unless @p.stopped?

--- a/test/plugin/test_in_monitor_agent.rb
+++ b/test/plugin/test_in_monitor_agent.rb
@@ -156,10 +156,11 @@ EOC
     end
 
     test "emit" do
+      port = unused_port
       d = create_driver("
   @type monitor_agent
   bind '127.0.0.1'
-  port 24200
+  port #{port}
   tag monitor
   emit_interval 1
 ")

--- a/test/plugin/test_in_monitor_agent.rb
+++ b/test/plugin/test_in_monitor_agent.rb
@@ -159,7 +159,7 @@ EOC
       d = create_driver("
   @type monitor_agent
   bind '127.0.0.1'
-  port #{@port}
+  port 24200
   tag monitor
   emit_interval 1
 ")
@@ -210,7 +210,7 @@ EOC
 <source>
   @type monitor_agent
   bind "127.0.0.1"
-  port 24220
+  port #{@port}
   tag monitor
   @id monitor_agent
 </source>

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -74,7 +74,7 @@ class TailInputTest < Test::Unit::TestCase
   def test_configure_from_encoding
     # If only specified from_encoding raise ConfigError
     assert_raise(Fluent::ConfigError) do
-      d = create_driver(SINGLE_LINE_CONFIG + 'from_encoding utf-8')
+      create_driver(SINGLE_LINE_CONFIG + 'from_encoding utf-8')
     end
 
     # valid setting

--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -454,6 +454,7 @@ class ForwardOutputTest < Test::Unit::TestCase
             option
           }
           @source = nil
+          @peeraddr = nil
         end
 
         if do_respond

--- a/test/test_plugin_classes.rb
+++ b/test/test_plugin_classes.rb
@@ -1,10 +1,10 @@
 require_relative 'helper'
-require 'fluent/input'
-require 'fluent/output'
-require 'fluent/filter'
+require 'fluent/plugin/input'
+require 'fluent/plugin/output'
+require 'fluent/plugin/filter'
 
 module FluentTest
-  class FluentTestInput < ::Fluent::Input
+  class FluentTestInput < ::Fluent::Plugin::Input
     ::Fluent::Plugin.register_input('test_in', self)
 
     attr_reader :started
@@ -20,7 +20,7 @@ module FluentTest
     end
   end
 
-  class FluentTestOutput < ::Fluent::Output
+  class FluentTestOutput < ::Fluent::Plugin::Output
     ::Fluent::Plugin.register_output('test_out', self)
 
     def initialize
@@ -41,14 +41,14 @@ module FluentTest
       super
     end
 
-    def emit(tag, es, chain)
-      es.each { |time, record|
+    def process(tag, es)
+      es.each do |time, record|
         @events[tag] << record
-      }
+      end
     end
   end
 
-  class FluentTestErrorOutput < ::Fluent::BufferedOutput
+  class FluentTestErrorOutput < ::Fluent::Plugin::Output
     ::Fluent::Plugin.register_output('test_out_error', self)
 
     def format(tag, time, record)


### PR DESCRIPTION
This change is to reduce warnings when we run `rake test`.
Almost all warnings are about uninitialized variables, and some others are about unused variables.

I did 2 changes at the same time:

### Updating dependencies

There seems no reason to specify minor version dependency for some gems. I updated these to depends on (recent) major versions. I think this operation doesn't make any problems, because all of these are development dependencies.

I also remove `json` runtime dependency, to use bundled json of Ruby runtime.
Specifying `json` version is bad practice, because it makes problem between ruby version limitations and other module's dependencies

### Fix implementation of `in_monitor_agent`

The previous implementation depends on the behavior of `eval` for string expression, NoMethodError for nil objects and rescuing all errors (and do nothing).
It hides any types of unexpected errors... very bad practice.

I rewrote that code with `instance_exec` with proc objects, and `throw-catch` for explicit skip for objects in unexpected states. It shows warnings for unexpected errors in logs.
