### PR TITLE
fix to raise ConfigError for type missing, and its tests

### DIFF
--- a/lib/fluent/agent.rb
+++ b/lib/fluent/agent.rb
@@ -63,6 +63,7 @@ module Fluent
       conf.elements('filter', 'match').each { |e|
         pattern = e.arg.empty? ? '**' : e.arg
         type = e['@type']
+        raise ConfigError, "Missing 'type' parameter on <#{e.name}> directive" unless type
         if e.name == 'filter'
           add_filter(type, pattern, e)
         else

--- a/lib/fluent/agent.rb
+++ b/lib/fluent/agent.rb
@@ -63,7 +63,7 @@ module Fluent
       conf.elements('filter', 'match').each { |e|
         pattern = e.arg.empty? ? '**' : e.arg
         type = e['@type']
-        raise ConfigError, "Missing 'type' parameter on <#{e.name}> directive" unless type
+        raise ConfigError, "Missing '@type' parameter on <#{e.name}> directive" unless type
         if e.name == 'filter'
           add_filter(type, pattern, e)
         else

--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -91,7 +91,7 @@ module Fluent
       else
         conf.elements(name: 'source').each { |e|
           type = e['@type']
-          raise ConfigError, "Missing 'type' parameter on <source> directive" unless type
+          raise ConfigError, "Missing '@type' parameter on <source> directive" unless type
           add_source(type, e)
         }
       end

--- a/test/test_root_agent.rb
+++ b/test/test_root_agent.rb
@@ -52,7 +52,7 @@ class RootAgentTest < ::Test::Unit::TestCase
 <source>
 </source>
 EOC
-      errmsg = "Missing 'type' parameter on <source> directive"
+      errmsg = "Missing '@type' parameter on <source> directive"
       assert_raise Fluent::ConfigError.new(errmsg) do
         configure_ra(conf)
       end
@@ -66,7 +66,7 @@ EOC
 <match *.**>
 </match>
 EOC
-      errmsg = "Missing 'type' parameter on <match> directive"
+      errmsg = "Missing '@type' parameter on <match> directive"
       assert_raise Fluent::ConfigError.new(errmsg) do
         configure_ra(conf)
       end
@@ -83,7 +83,7 @@ EOC
   @type test_out
 </match>
 EOC
-      errmsg = "Missing 'type' parameter on <filter> directive"
+      errmsg = "Missing '@type' parameter on <filter> directive"
       assert_raise Fluent::ConfigError.new(errmsg) do
         configure_ra(conf)
       end

--- a/test/test_root_agent.rb
+++ b/test/test_root_agent.rb
@@ -47,6 +47,48 @@ class RootAgentTest < ::Test::Unit::TestCase
       assert_nil ra.error_collector
     end
 
+    test 'raises configuration error for missing type of source' do
+      conf = <<-EOC
+<source>
+</source>
+EOC
+      errmsg = "Missing 'type' parameter on <source> directive"
+      assert_raise Fluent::ConfigError.new(errmsg) do
+        configure_ra(conf)
+      end
+    end
+
+    test 'raises configuration error for missing type of match' do
+      conf = <<-EOC
+<source>
+  @type test_in
+</source>
+<match *.**>
+</match>
+EOC
+      errmsg = "Missing 'type' parameter on <match> directive"
+      assert_raise Fluent::ConfigError.new(errmsg) do
+        configure_ra(conf)
+      end
+    end
+
+    test 'raises configuration error for missing type of filter' do
+      conf = <<-EOC
+<source>
+  @type test_in
+</source>
+<filter *.**>
+</filter>
+<match *.**>
+  @type test_out
+</match>
+EOC
+      errmsg = "Missing 'type' parameter on <filter> directive"
+      assert_raise Fluent::ConfigError.new(errmsg) do
+        configure_ra(conf)
+      end
+    end
+
     test 'with plugins' do
       # check @type and type in one configuration
       conf = <<-EOC


### PR DESCRIPTION
Previously, it raises NeMethodError for nil.
```
2016-09-02 09:45:47 +0900 [error]: unexpected error error="undefined method `to_sym' for nil:NilClass\nDid you mean?  to_s"
  2016-09-02 09:45:47 +0900 [error]: /Users/tagomoris/github/fluentd/lib/fluent/registry.rb:39:in `lookup'
  2016-09-02 09:45:47 +0900 [error]: /Users/tagomoris/github/fluentd/lib/fluent/plugin.rb:146:in `new_impl'
  2016-09-02 09:45:47 +0900 [error]: /Users/tagomoris/github/fluentd/lib/fluent/plugin.rb:104:in `new_output'
  2016-09-02 09:45:47 +0900 [error]: /Users/tagomoris/github/fluentd/lib/fluent/agent.rb:133:in `add_match'
  2016-09-02 09:45:47 +0900 [error]: /Users/tagomoris/github/fluentd/lib/fluent/agent.rb:69:in `block in configure'
  2016-09-02 09:45:47 +0900 [error]: /Users/tagomoris/github/fluentd/lib/fluent/agent.rb:63:in `each'
  2016-09-02 09:45:47 +0900 [error]: /Users/tagomoris/github/fluentd/lib/fluent/agent.rb:63:in `configure'
  2016-09-02 09:45:47 +0900 [error]: /Users/tagomoris/github/fluentd/lib/fluent/root_agent.rb:86:in `configure'
  2016-09-02 09:45:47 +0900 [error]: /Users/tagomoris/github/fluentd/lib/fluent/engine.rb:119:in `configure'
  2016-09-02 09:45:47 +0900 [error]: /Users/tagomoris/github/fluentd/lib/fluent/engine.rb:93:in `run_configure'
  2016-09-02 09:45:47 +0900 [error]: /Users/tagomoris/github/fluentd/lib/fluent/supervisor.rb:673:in `run_configure'
  2016-09-02 09:45:47 +0900 [error]: /Users/tagomoris/github/fluentd/lib/fluent/supervisor.rb:435:in `block in run_worker'
  2016-09-02 09:45:47 +0900 [error]: /Users/tagomoris/github/fluentd/lib/fluent/supervisor.rb:606:in `main_process'
  2016-09-02 09:45:47 +0900 [error]: /Users/tagomoris/github/fluentd/lib/fluent/supervisor.rb:431:in `run_worker'
  2016-09-02 09:45:47 +0900 [error]: /Users/tagomoris/github/fluentd/lib/fluent/command/fluentd.rb:271:in `<top (required)>'
  2016-09-02 09:45:47 +0900 [error]: bin/fluentd:5:in `require'
  2016-09-02 09:45:47 +0900 [error]: bin/fluentd:5:in `<main>'
```

This fix makes the situation better.
```
2016-09-02 09:48:17 +0900 [error]: config error file="example/match_without_type.conf" error="Missing 'type' parameter on <match> directive"
```

fix #1201.