### PR TITLE
fix bug to depend on class name of Fluent::Plugin::MultiOutput

### DIFF
--- a/lib/fluent/agent.rb
+++ b/lib/fluent/agent.rb
@@ -135,7 +135,8 @@ module Fluent
       output.router = @event_router if output.respond_to?(:router=)
       output.configure(conf)
       @outputs << output
-      if output.respond_to?(:outputs) && (output.is_a?(Fluent::Plugin::MultiOutput) || output.is_a?(Fluent::MultiOutput))
+      if output.respond_to?(:outputs) && (output.respond_to?(:multi_output?) && output.multi_output? || output.is_a?(Fluent::MultiOutput))
+        # TODO: ruby 2.3 or later: replace `output.respond_to?(:multi_output?) && output.multi_output?` with output&.multi_output?
         @outputs.push(*output.outputs)
       end
       @event_router.add_rule(pattern, output)

--- a/lib/fluent/plugin/multi_output.rb
+++ b/lib/fluent/plugin/multi_output.rb
@@ -53,6 +53,10 @@ module Fluent
         # @rollback_count = 0
       end
 
+      def multi_output?
+        true
+      end
+
       def configure(conf)
         super
 


### PR DESCRIPTION
Basically, checking objects with its class name is wrong practice in Ruby. It's should be done with method calls.
When v0.14 MultiOutput plugins are used, Plugin.new_output requires the class at first, so Fluent::Plugin::MultiOutput reference
can succeed. When v0.12 MultiOutput plugins are used, it fails.
Refenrencing classes in core code makes circular dependencies, so we should use method calls to check objects.

This change fixes #1205.