### PR TITLE
Instantiate a section with default values even for `multi: true` sections

### DIFF
--- a/lib/fluent/config/section.rb
+++ b/lib/fluent/config/section.rb
@@ -165,7 +165,7 @@ module Fluent
         proxy.sections.each do |name, subproxy|
           varname = subproxy.variable_name
           elements = (conf.respond_to?(:elements) ? conf.elements : []).select{ |e| e.name == subproxy.name.to_s || e.name == subproxy.alias.to_s }
-          if elements.empty? && subproxy.init? && !subproxy.multi?
+          if elements.empty? && subproxy.init?
             elements << Fluent::Config::Element.new(subproxy.name.to_s, '', {}, [])
           end
 

--- a/test/config/test_configurable.rb
+++ b/test/config/test_configurable.rb
@@ -720,7 +720,8 @@ module Fluent::Config
           assert_nothing_raised { init0.configure(conf) }
           assert init0.sec1
           assert_equal "sec1", init0.sec1.name
-          assert_equal [], init0.sec2
+          assert_equal 1, init0.sec2.size
+          assert_equal "sec1", init0.sec2.first.name
         end
 
         test 'accepts configuration values as string representation' do


### PR DESCRIPTION
Previously, "init: true, multi: false" sections were not instantiated (just `[]` for instance variable).
But with this behavior, we cannot use default values of these sections, except for the case to set a
blank Config::Element into `conf.elements`.
It looks abnormal, and non-useful feature for plugin authors.

So, this change will improve the situation.

Currently, there are some example without this fix:
```ruby
config_section :parse do
  config_set_default :@type, "yay"
end

def configure(conf)
  super
  # ...
  @parser = parser_create(conf: conf.elements('parse').first, default_type: "yay")
end
```

This code has default type specification twice: `config_set_default` and `default_type`.
With this change:

```ruby
config_section :parse do
  config_set_default :@type, "yay"
end

def configure(conf)
  super
  # ...
  @parser = parser_create(conf: conf.elements('parse').first)
end
```

Furthermore, this code works as you expected (for `<parse>` section without any argument).

```ruby
config_section :parse do
  config_set_default :@type, "yay"
end

def configure(conf)
  super
  @parser = parser_create # default usage(argument) is ''
end
```

This looks better than ever.