### PR TITLE
in_tail: Add a missing parser_multiline require

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -20,6 +20,7 @@ require 'fluent/plugin/input'
 require 'fluent/config/error'
 require 'fluent/event'
 require 'fluent/plugin/buffer'
+require 'fluent/plugin/parser_multiline'
 
 if Fluent.windows?
   require_relative 'file_wrapper'


### PR DESCRIPTION
Otherwise, it causes `Fluent::Plugin::MultilineParser` error as follows:

```log
% bundle exec fluentd -c example/in_tail.conf -p lib/fluent/plugin
2016-09-07 15:38:04 +0900 [info]: reading config file path="example/in_tail.conf"
2016-09-07 15:38:04 +0900 [info]: starting fluentd-0.14.5
2016-09-07 15:38:04 +0900 [info]: spawn command to main: /home/hhatake/.rbenv/versions/2.3.0/bin/ruby -Eascii-8bit:ascii-8bit  -rbundler/setup /home/hhatake/Github/fluentd/vendor/bundle/ruby/2.3.0/bin/fluentd -c example/in_tail.conf -p lib/fluent/plugin --under-supervisor
2016-09-07 15:38:05 +0900 [info]: reading config file path="example/in_tail.conf"
2016-09-07 15:38:05 +0900 [info]: starting fluentd-0.14.5 without supervision
2016-09-07 15:38:05 +0900 [info]: gem 'fluentd' version '0.14.5'
2016-09-07 15:38:05 +0900 [info]: adding match pattern="test" type="stdout"
2016-09-07 15:38:05 +0900 [info]: adding source type="tail"
2016-09-07 15:38:05 +0900 [error]: unexpected error error="uninitialized constant Fluent::Plugin::MultilineParser"
  2016-09-07 15:38:05 +0900 [error]: /home/hhatake/Github/fluentd/lib/fluent/plugin/in_tail.rb:88:in `configure'
  2016-09-07 15:38:05 +0900 [error]: /home/hhatake/Github/fluentd/lib/fluent/root_agent.rb:237:in `add_source'
  2016-09-07 15:38:05 +0900 [error]: /home/hhatake/Github/fluentd/lib/fluent/root_agent.rb:95:in `block in configure'
  2016-09-07 15:38:05 +0900 [error]: /home/hhatake/Github/fluentd/lib/fluent/root_agent.rb:92:in `each'
  2016-09-07 15:38:05 +0900 [error]: /home/hhatake/Github/fluentd/lib/fluent/root_agent.rb:92:in `configure'
  2016-09-07 15:38:05 +0900 [error]: /home/hhatake/Github/fluentd/lib/fluent/engine.rb:119:in `configure'
  2016-09-07 15:38:05 +0900 [error]: /home/hhatake/Github/fluentd/lib/fluent/engine.rb:93:in `run_configure'
  2016-09-07 15:38:05 +0900 [error]: /home/hhatake/Github/fluentd/lib/fluent/supervisor.rb:673:in `run_configure'
  2016-09-07 15:38:05 +0900 [error]: /home/hhatake/Github/fluentd/lib/fluent/supervisor.rb:435:in `block in run_worker'
  2016-09-07 15:38:05 +0900 [error]: /home/hhatake/Github/fluentd/lib/fluent/supervisor.rb:606:in `main_process'
  2016-09-07 15:38:05 +0900 [error]: /home/hhatake/Github/fluentd/lib/fluent/supervisor.rb:431:in `run_worker'
  2016-09-07 15:38:05 +0900 [error]: /home/hhatake/Github/fluentd/lib/fluent/command/fluentd.rb:271:in `<top (required)>'
  2016-09-07 15:38:05 +0900 [error]: /home/hhatake/Github/fluentd/bin/fluentd:5:in `require'
  2016-09-07 15:38:05 +0900 [error]: /home/hhatake/Github/fluentd/bin/fluentd:5:in `<top (required)>'
  2016-09-07 15:38:05 +0900 [error]: /home/hhatake/Github/fluentd/vendor/bundle/ruby/2.3.0/bin/fluentd:23:in `load'
  2016-09-07 15:38:05 +0900 [error]: /home/hhatake/Github/fluentd/vendor/bundle/ruby/2.3.0/bin/fluentd:23:in `<main>'
```