### PR TITLE
Add Fluent namespace to ConfigError in v0.14 API based plugins

### DIFF
--- a/lib/fluent/plugin/filter_grep.rb
+++ b/lib/fluent/plugin/filter_grep.rb
@@ -38,8 +38,8 @@ module Fluent::Plugin
       (1..REGEXP_MAX_NUM).each do |i|
         next unless conf["regexp#{i}"]
         key, regexp = conf["regexp#{i}"].split(/ /, 2)
-        raise ConfigError, "regexp#{i} does not contain 2 parameters" unless regexp
-        raise ConfigError, "regexp#{i} contains a duplicated key, #{key}" if @regexps[key]
+        raise Fluent::ConfigError, "regexp#{i} does not contain 2 parameters" unless regexp
+        raise Fluent::ConfigError, "regexp#{i} contains a duplicated key, #{key}" if @regexps[key]
         @regexps[key] = Regexp.compile(regexp)
       end
 
@@ -47,8 +47,8 @@ module Fluent::Plugin
       (1..REGEXP_MAX_NUM).each do |i|
         next unless conf["exclude#{i}"]
         key, exclude = conf["exclude#{i}"].split(/ /, 2)
-        raise ConfigError, "exclude#{i} does not contain 2 parameters" unless exclude
-        raise ConfigError, "exclude#{i} contains a duplicated key, #{key}" if @excludes[key]
+        raise Fluent::ConfigError, "exclude#{i} does not contain 2 parameters" unless exclude
+        raise Fluent::ConfigError, "exclude#{i} contains a duplicated key, #{key}" if @excludes[key]
         @excludes[key] = Regexp.compile(exclude)
       end
     end

--- a/lib/fluent/plugin/in_syslog.rb
+++ b/lib/fluent/plugin/in_syslog.rb
@@ -86,7 +86,7 @@ module Fluent::Plugin
       when 'udp'
         :udp
       else
-        raise ConfigError, "syslog input protocol type should be 'tcp' or 'udp'"
+        raise Fluent::ConfigError, "syslog input protocol type should be 'tcp' or 'udp'"
       end
     end
     desc 'If true, add source host to event record.'

--- a/lib/fluent/plugin/out_exec.rb
+++ b/lib/fluent/plugin/out_exec.rb
@@ -42,7 +42,7 @@ module Fluent::Plugin
     desc "The format used to map the incoming events to the program input. (#{Fluent::ExecUtil::SUPPORTED_FORMAT.keys.join(',')})"
     config_param :format, default: :tsv, skip_accessor: true do |val|
       f = Fluent::ExecUtil::SUPPORTED_FORMAT[val]
-      raise ConfigError, "Unsupported format '#{val}'" unless f
+      raise Fluent::ConfigError, "Unsupported format '#{val}'" unless f
       f
     end
     config_param :localtime, :bool, default: false

--- a/lib/fluent/plugin/parser.rb
+++ b/lib/fluent/plugin/parser.rb
@@ -66,11 +66,11 @@ module Fluent
         super
 
         if @time_key && !@keys.include?(@time_key) && @estimate_current_event
-          raise ConfigError, "time_key (#{@time_key.inspect}) is not included in keys (#{@keys.inspect})"
+          raise Fluent::ConfigError, "time_key (#{@time_key.inspect}) is not included in keys (#{@keys.inspect})"
         end
 
         if @time_format && !@time_key
-          raise ConfigError, "time_format parameter is ignored because time_key parameter is not set. at #{conf.inspect}"
+          raise Fluent::ConfigError, "time_format parameter is ignored because time_key parameter is not set. at #{conf.inspect}"
         end
 
         @time_parser = time_parser_create

--- a/lib/fluent/plugin/parser_multiline.rb
+++ b/lib/fluent/plugin/parser_multiline.rb
@@ -38,7 +38,7 @@ module Fluent
           @parser = Fluent::Plugin::RegexpParser.new
           @parser.configure(conf + regexp_conf)
         rescue => e
-          raise ConfigError, "Invalid regexp '#{formats}': #{e}"
+          raise Fluent::ConfigError, "Invalid regexp '#{formats}': #{e}"
         end
 
         if @format_firstline
@@ -68,7 +68,7 @@ module Fluent
         (1..FORMAT_MAX_NUM).map { |i|
           format = conf["format#{i}"]
           if (i > 1) && prev_format.nil? && !format.nil?
-            raise ConfigError, "Jump of format index found. format#{i - 1} is missing."
+            raise Fluent::ConfigError, "Jump of format index found. format#{i - 1} is missing."
           end
           prev_format = format
           next if format.nil?
@@ -84,7 +84,7 @@ module Fluent
           m ? !((1..FORMAT_MAX_NUM).include?(m[1].to_i)) : false
         }
         unless invalid_formats.empty?
-          raise ConfigError, "Invalid formatN found. N should be 1 - #{FORMAT_MAX_NUM}: " + invalid_formats.join(",")
+          raise Fluent::ConfigError, "Invalid formatN found. N should be 1 - #{FORMAT_MAX_NUM}: " + invalid_formats.join(",")
         end
       end
 
@@ -93,10 +93,10 @@ module Fluent
           begin
             Regexp.new(format[1..-2], Regexp::MULTILINE)
           rescue => e
-            raise ConfigError, "Invalid regexp in #{key}: #{e}"
+            raise Fluent::ConfigError, "Invalid regexp in #{key}: #{e}"
           end
         else
-          raise ConfigError, "format should be Regexp, need //, in #{key}: '#{format}'"
+          raise Fluent::ConfigError, "format should be Regexp, need //, in #{key}: '#{format}'"
         end
       end
     end


### PR DESCRIPTION
One user reports following error:

```
2016-09-09 09:01:49 +0000 [error]: fluent/supervisor.rb:567:rescue in main_process: unexpected error error="uninitialized constant Fluent::Plugin::GrepFilter::ConfigError
```
