### PR TITLE
raise ConfigError when same label appears twice, or no match appears in label

### DIFF
--- a/lib/fluent/label.rb
+++ b/lib/fluent/label.rb
@@ -27,6 +27,14 @@ module Fluent
 
     attr_accessor :root_agent
 
+    def configure(conf)
+      super
+
+      if conf.elements('match').size == 0
+        raise ConfigError, "Missing <match> sections in <label #{@context}> section"
+      end
+    end
+
     def emit_error_event(tag, time, record, e)
       @root_agent.emit_error_event(tag, time, record, e)
     end

--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -242,6 +242,7 @@ module Fluent
 
     def add_label(name)
       label = Label.new(name, log: log)
+      raise ConfigError, "Section <label #{name}> appears twice" if @labels[name]
       label.root_agent = self
       @labels[name] = label
     end

--- a/test/test_root_agent.rb
+++ b/test/test_root_agent.rb
@@ -89,6 +89,41 @@ EOC
       end
     end
 
+    test 'raises configuration error if there are two same label section' do
+      conf = <<-EOC
+<source>
+  @type test_in
+  @label @test
+</source>
+<label @test>
+  @type test_out
+</label>
+<label @test>
+  @type test_out
+</label>
+EOC
+      errmsg = "Section <label @test> appears twice"
+      assert_raise Fluent::ConfigError.new(errmsg) do
+        configure_ra(conf)
+      end
+    end
+
+    test 'raises configuration error if there are not match sections in label section' do
+      conf = <<-EOC
+<source>
+  @type test_in
+  @label @test
+</source>
+<label @test>
+  @type test_out
+</label>
+EOC
+      errmsg = "Missing <match> sections in <label @test> section"
+      assert_raise Fluent::ConfigError.new(errmsg) do
+        configure_ra(conf)
+      end
+    end
+
     test 'with plugins' do
       # check @type and type in one configuration
       conf = <<-EOC


### PR DESCRIPTION
This change fixes the 2 `<label>` related bugs:

### no `<match>` sections in `<label>` isn't reported

```apache
<label @test>
  @type stdout
</label>
```

This is clearly wrong configuration, and warning "no patterns matched" appears always for `@test` label.
This change raises configuration error for such configuration.

### same label configured twice

```apache
<label @test>
  # first
</label>
<label @test>
  # last
</label>
```

Currently, Fluentd uses the last configuration for same labels without any errors nor warnings.
This configuration is clearly a misconfiguration. So this change is to make to report such configurations as errors.