### PR TITLE
out_forward: fix undefined variables

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -522,7 +522,7 @@ module Fluent
             sock.close
           end
         when :udp
-          @usock.send "\0", 0, Socket.pack_sockaddr_in(n.port, n.resolved_host)
+          @usock.send "\0", 0, Socket.pack_sockaddr_in(@port, resolved_host)
         when :none # :none doesn't use this class
           raise "BUG: heartbeat_type none must not use Node"
         else

--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -598,4 +598,20 @@ class ForwardOutputTest < Test::Unit::TestCase
     node.tick
     assert_equal node.available, true
   end
+
+  def test_heartbeat_type_udp
+    d = create_driver(CONFIG + "\nheartbeat_type udp")
+
+    d.instance.start
+    usock = d.instance.instance_variable_get(:@usock)
+    timer = d.instance.instance_variable_get(:@timer)
+    hb = d.instance.instance_variable_get(:@hb)
+    assert_equal UDPSocket, usock.class
+    assert_equal Fluent::ForwardOutput::HeartbeatRequestTimer, timer.class
+    assert_equal Fluent::ForwardOutput::HeartbeatHandler, hb.class
+
+    mock(usock).send("\0", 0, Socket.pack_sockaddr_in(TARGET_PORT, '127.0.0.1')).once
+    timer.disable # call send_heartbeat at just once
+    timer.on_timer
+  end
 end


### PR DESCRIPTION
UDP heartbeat doesn't work after https://github.com/fluent/fluentd/pull/1136

I found 'undefined variable' bugs in `Node#send_heartbeat`.