### PR TITLE
Lifecycle method called correctly once

### DIFF
--- a/lib/fluent/agent.rb
+++ b/lib/fluent/agent.rb
@@ -92,12 +92,6 @@ module Fluent
         else
           lifecycle_control_list[:output] << o
         end
-
-        if o.respond_to?(:outputs)
-          o.outputs.each do |store|
-            recursive_output_traverse.call(store)
-          end
-        end
       }
       outputs.each do |o|
         recursive_output_traverse.call(o)

--- a/lib/fluent/agent.rb
+++ b/lib/fluent/agent.rb
@@ -126,7 +126,7 @@ module Fluent
       output.router = @event_router if output.respond_to?(:router=)
       output.configure(conf)
       @outputs << output
-      if output.respond_to?(:outputs) && (output.respond_to?(:multi_output?) && output.multi_output? || output.is_a?(Fluent::MultiOutput))
+      if output.respond_to?(:outputs) && output.respond_to?(:multi_output?) && output.multi_output?
         # TODO: ruby 2.3 or later: replace `output.respond_to?(:multi_output?) && output.multi_output?` with output&.multi_output?
         outputs = if output.respond_to?(:static_outputs)
                     output.static_outputs

--- a/lib/fluent/agent.rb
+++ b/lib/fluent/agent.rb
@@ -86,15 +86,12 @@ module Fluent
           lifecycle_control_list[:input] << i
         end
       end
-      recursive_output_traverse = ->(o) {
+      outputs.each do |o|
         if o.has_router?
           lifecycle_control_list[:output_with_router] << o
         else
           lifecycle_control_list[:output] << o
         end
-      }
-      outputs.each do |o|
-        recursive_output_traverse.call(o)
       end
       filters.each do |f|
         lifecycle_control_list[:filter] << f

--- a/lib/fluent/agent.rb
+++ b/lib/fluent/agent.rb
@@ -131,7 +131,12 @@ module Fluent
       @outputs << output
       if output.respond_to?(:outputs) && (output.respond_to?(:multi_output?) && output.multi_output? || output.is_a?(Fluent::MultiOutput))
         # TODO: ruby 2.3 or later: replace `output.respond_to?(:multi_output?) && output.multi_output?` with output&.multi_output?
-        @outputs.push(*output.outputs)
+        outputs = if output.respond_to?(:static_outputs)
+                    output.static_outputs
+                  else
+                    output.outputs
+                  end
+        @outputs.push(*outputs)
       end
       @event_router.add_rule(pattern, output)
 

--- a/lib/fluent/plugin/multi_output.rb
+++ b/lib/fluent/plugin/multi_output.rb
@@ -32,7 +32,7 @@ module Fluent
         config_param :@type, :string, default: nil
       end
 
-      attr_reader :outputs
+      attr_reader :outputs, :outputs_statically_created
 
       def process(tag, es)
         raise NotImplementedError, "BUG: output plugins MUST implement this method"
@@ -41,8 +41,7 @@ module Fluent
       def initialize
         super
         @outputs = []
-
-        @compat = false
+        @outputs_statically_created = false
 
         @counters_monitor = Monitor.new
         # TODO: well organized counters
@@ -78,10 +77,71 @@ module Fluent
         end
       end
 
+      def static_outputs
+        @outputs_statically_created = true
+        @outputs
+      end
+
       # Child plugin's lifecycles are controlled by agent automatically.
       # It calls `outputs` to traverse plugins, and invoke start/stop/*shutdown/close/terminate on these directly.
       # * `start` of this plugin will be called after child plugins
       # * `stop`, `*shutdown`, `close` and `terminate` of this plugin will be called before child plugins
+
+      # But when MultiOutput plugins are created dynamically (by forest plugin or others), agent cannot find
+      # sub-plugins. So child plugins' lifecycles MUST be controlled by MultiOutput plugin itself.
+      # TODO: this hack will be removed at v2.
+      def call_lifecycle_method(method_name, checker_name)
+        return if @outputs_statically_created
+        @outputs.each do |o|
+          begin
+            log.debug "calling #{method_name} on output plugin dynamically created", type: Fluent::Plugin.lookup_type_from_class(o.class), plugin_id: o.plugin_id
+            o.send(method_name) unless o.send(checker_name)
+          rescue Exception => e
+            log.warn "unexpected error while calling #{method_name} on output plugin dynamically created", plugin: o.class, plugin_id: o.plugin_id, error: e
+            log.warn_backtrace
+          end
+        end
+      end
+
+      def start
+        super
+        call_lifecycle_method(:start, :started?)
+      end
+
+      def after_start
+        super
+        call_lifecycle_method(:after_start, :after_started?)
+      end
+
+      def stop
+        super
+        call_lifecycle_method(:stop, :stopped?)
+      end
+
+      def before_shutdown
+        super
+        call_lifecycle_method(:before_shutdown, :before_shutdown?)
+      end
+
+      def shutdown
+        super
+        call_lifecycle_method(:shutdown, :shutdown?)
+      end
+
+      def after_shutdown
+        super
+        call_lifecycle_method(:after_shutdown, :after_shutdown?)
+      end
+
+      def close
+        super
+        call_lifecycle_method(:close, :closed?)
+      end
+
+      def terminate
+        super
+        call_lifecycle_method(:terminate, :terminated?)
+      end
 
       def emit_sync(tag, es)
         @counters_monitor.synchronize{ @emit_count += 1 }

--- a/lib/fluent/test/log.rb
+++ b/lib/fluent/test/log.rb
@@ -21,13 +21,15 @@ module Fluent
   module Test
     class DummyLogDevice
       attr_reader :logs
+      attr_accessor :flush_logs
 
       def initialize
         @logs = []
+        @flush_logs = true
       end
 
       def reset
-        @logs = []
+        @logs = [] if @flush_logs
       end
 
       def tty?


### PR DESCRIPTION
This change is to fix both of #1161 and #1222.

To fix #1222, RootAgent (and Agent) should not retrieve `outputs` of output plugins dynamically in `#lifecycle`. Removing it solves the problem to call shutdown methods twice.

But this fix re-opens #1161 problem.
If all plugins are flat/static plugins or MultiOutput plugins which initialize all stores by static configuration, all plugin instances are registered in `agent.outputs`.
But once MultiOutput plugin is initialized dynamically by any plugins (e.g., fluent-plugin-forest), its sub-store/sub-plugin instances are not registered in `agent.outputs`. Lifecycle methods of these plugins are never called.

This change will add a feature to call lifecycle methods in MultiOutput. It's a kind of dirty workaround, but works well.