### PR TITLE
Add nanoseconds to stdout plugin

### DIFF
--- a/lib/fluent/plugin/out_stdout.rb
+++ b/lib/fluent/plugin/out_stdout.rb
@@ -23,6 +23,7 @@ module Fluent::Plugin
     helpers :inject, :formatter, :compat_parameters
 
     DEFAULT_FORMAT_TYPE = 'json'
+    TIME_FORMAT = '%Y-%m-%d %H:%M:%S.%9N %z'
 
     config_section :buffer do
       config_set_default :chunk_keys, ['tag']
@@ -69,7 +70,7 @@ module Fluent::Plugin
 
     def format(tag, time, record)
       record = inject_values_to_record(tag, time, record)
-      "#{Time.at(time).localtime} #{tag}: #{@formatter.format(tag, time, record).chomp}\n"
+      "#{Time.at(time).localtime.strftime(TIME_FORMAT)} #{tag}: #{@formatter.format(tag, time, record).chomp}\n"
     end
 
     def write(chunk)

--- a/test/plugin/test_out_stdout.rb
+++ b/test/plugin/test_out_stdout.rb
@@ -9,6 +9,7 @@ class StdoutOutputTest < Test::Unit::TestCase
 
   CONFIG = %[
   ]
+  TIME_FORMAT = '%Y-%m-%d %H:%M:%S.%9N %z'
 
   def create_driver(conf = CONFIG)
     Fluent::Test::Driver::Output.new(Fluent::Plugin::StdoutOutput).configure(conf)
@@ -40,7 +41,7 @@ class StdoutOutputTest < Test::Unit::TestCase
           d.feed(time, {'test' => 'test1'})
         end
       end
-      assert_equal "#{Time.at(time).localtime} test: {\"test\":\"test1\"}\n", out
+      assert_equal "#{Time.at(time).localtime.strftime(TIME_FORMAT)} test: {\"test\":\"test1\"}\n", out
     end
 
     data('oj' => 'oj', 'yajl' => 'yajl')
@@ -52,14 +53,14 @@ class StdoutOutputTest < Test::Unit::TestCase
           d.feed(time, {'test' => 'test1'})
         end
       end
-      assert_equal "#{Time.at(time).localtime} test: {\"test\":\"test1\"}\n", out
+      assert_equal "#{Time.at(time).localtime.strftime(TIME_FORMAT)} test: {\"test\":\"test1\"}\n", out
 
       if data == 'yajl'
         # NOTE: Float::NAN is not jsonable
         assert_raise(Yajl::EncodeError) { d.feed('test', time, {'test' => Float::NAN}) }
       else
         out = capture_log { d.feed('test', time, {'test' => Float::NAN}) }
-        assert_equal "#{Time.at(time).localtime} test: {\"test\":NaN}\n", out
+        assert_equal "#{Time.at(time).localtime.strftime(TIME_FORMAT)} test: {\"test\":NaN}\n", out
       end
     end
 
@@ -71,11 +72,11 @@ class StdoutOutputTest < Test::Unit::TestCase
           d.feed(time, {'test' => 'test2'})
         end
       end
-      assert_equal "#{Time.at(time).localtime} test: {\"test\"=>\"test2\"}\n", out
+      assert_equal "#{Time.at(time).localtime.strftime(TIME_FORMAT)} test: {\"test\"=>\"test2\"}\n", out
 
       # NOTE: Float::NAN is not jsonable, but hash string can output it.
       out = capture_log { d.feed('test', time, {'test' => Float::NAN}) }
-      assert_equal "#{Time.at(time).localtime} test: {\"test\"=>NaN}\n", out
+      assert_equal "#{Time.at(time).localtime.strftime(TIME_FORMAT)} test: {\"test\"=>NaN}\n", out
     end
   end
 
@@ -113,7 +114,7 @@ class StdoutOutputTest < Test::Unit::TestCase
             d.feed(time, {'test' => 'test'})
           end
         end
-        assert_equal "#{Time.at(time).localtime} test: {\"test\":\"test\"}\n", out
+        assert_equal "#{Time.at(time).localtime.strftime(TIME_FORMAT)} test: {\"test\":\"test\"}\n", out
       end
     end
 
@@ -128,7 +129,7 @@ class StdoutOutputTest < Test::Unit::TestCase
             d.feed(time, {'test' => 'test'})
           end
         end
-        assert_equal "#{Time.at(time).localtime} test: {\"test\":\"test\"}\n", out
+        assert_equal "#{Time.at(time).localtime.strftime(TIME_FORMAT)} test: {\"test\":\"test\"}\n", out
       end
 
       data('oj' => 'oj', 'yajl' => 'yajl')
@@ -143,7 +144,7 @@ class StdoutOutputTest < Test::Unit::TestCase
           end
         end
 
-        assert_equal "#{Time.at(time).localtime} test: {\"test\":\"test\"}\n", out
+        assert_equal "#{Time.at(time).localtime.strftime(TIME_FORMAT)} test: {\"test\":\"test\"}\n", out
       end
     end
 
@@ -158,7 +159,7 @@ class StdoutOutputTest < Test::Unit::TestCase
           end
         end
 
-        assert_equal "#{Time.at(time).localtime} test: {\"test\"=>\"test\"}\n", out
+        assert_equal "#{Time.at(time).localtime.strftime(TIME_FORMAT)} test: {\"test\"=>\"test\"}\n", out
       end
 
       test '#try_write(asynchronous)' do
@@ -172,7 +173,7 @@ class StdoutOutputTest < Test::Unit::TestCase
           end
         end
 
-        assert_equal "#{Time.at(time).localtime} test: {\"test\"=>\"test\"}\n", out
+        assert_equal "#{Time.at(time).localtime.strftime(TIME_FORMAT)} test: {\"test\"=>\"test\"}\n", out
       end
     end
   end


### PR DESCRIPTION
Now that Fluentd supports nanosecond-resolution timestamps as of v0.14,
it follows that the stdout output plugin should print the full
timestamp.

This is a very simple patch, instead of using the default `to_s`
formatting, we call `strftime` with a custom formatting.

Right now it always prints the nanoseconds, even on second-resolution
timestamps.  This means second-resolution timestamps will display like
`2013-06-27 12:34:56.000000000 -0700`, which may be undesirable.  If so,
we can adjust the implement to print a condensed formatting for
second-resolution timestamps.