### PR TITLE
Set expect_emits properly

### DIFF
--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -401,7 +401,7 @@ class TailInputTest < Test::Unit::TestCase
 
     d = create_driver
 
-    d.run do
+    d.run(expect_emits: 1) do
       File.open("#{TMP_DIR}/tail.txt", "ab") {|f|
         f.print "test3"
       }
@@ -410,7 +410,6 @@ class TailInputTest < Test::Unit::TestCase
       File.open("#{TMP_DIR}/tail.txt", "ab") {|f|
         f.puts "test4"
       }
-      sleep 1
     end
 
     events = d.events


### PR DESCRIPTION
This can avoid occasional test failure.

This is related to https://travis-ci.org/fluent/fluentd/jobs/163340180