### PR TITLE
key-only line (without newline) should be parsed with empty string value

### DIFF
--- a/lib/fluent/config/v1_parser.rb
+++ b/lib/fluent/config/v1_parser.rb
@@ -106,7 +106,7 @@ module Fluent
           else
             k = scan_string(SPACING)
             spacing_without_comment
-            if prev_match.include?("\n") # support 'tag_mapped' like "without value" configuration
+            if prev_match.include?("\n") || eof? # support 'tag_mapped' like "without value" configuration
               attrs[k] = ""
             else
               if k == '@include'

--- a/test/config/test_config_parser.rb
+++ b/test/config/test_config_parser.rb
@@ -86,6 +86,12 @@ module Fluent::Config
         assert_text_parsed_as(e('ROOT', '', {"k1" => "a  b  c"}), "k1 a  b  c")
       end
 
+      test "parses value into empty string if only key exists" do
+        # value parser parses empty string as true for bool type
+        assert_text_parsed_as(e('ROOT', '', {"k1" => ""}), "k1\n")
+        assert_text_parsed_as(e('ROOT', '', {"k1" => ""}), "k1")
+      end
+
       sub_test_case 'non-quoted string' do
         test "remains text starting with '#'" do
           assert_text_parsed_as(e('ROOT', '', {"k1" => "#not_comment"}), "  k1 #not_comment")


### PR DESCRIPTION
v0 parser parses "k1" into `{"k1" => ""}`, but v1 parser parses into `{"k1" => nil}`.
It's bug, because empty string means true in bool type, but nil means false.

It affects tests only, because attributes are terminated with newline or end of section (`</match>`) in regular configuration files.