### PR TITLE
Run TailWatcher#on_notify before attaching triggers

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -428,8 +428,8 @@ module Fluent::Plugin
       end
 
       def attach
-        yield self
         on_notify
+        yield self
       end
 
       def detach


### PR DESCRIPTION
relate to #1229

This commit runs `TailWatcher#on_notify` before attaching `stat_trigger` and `timer_trigger` and prevents `TailWatcher#on_notify` from running in two different threads(main and event loop thread) at the same time.

This change fixes the `can't modify string; temporarily locked` error.

I think fluentd v0.12 does not raise the `can't modify string; temporarily locked` error because it runs `stat_trigger` and `timer_trigger` after `TailInput#start` finishes and   thus `TailWatcher#on_notify` is not executed in two threads simultaneously.


```ruby
# fluentd v0.12
# in_tail.rb
def start
  @loop = Coolio::Loop.new
  refresh_watchers

  @thread = Thread.new(&method(:run))
end

def run
  @loop.run
end
```

### reproduction steps
same as described in #1229

1. Create large log files by using append.rb
2. Remove a pos file (rm tmp/logs/tail.pos)
3. Run fluentd
4. Run append.rb on another terminal