### PR TITLE
Fix to wakeup threads to quit loop in threads

### DIFF
--- a/lib/fluent/plugin_helper/thread.rb
+++ b/lib/fluent/plugin_helper/thread.rb
@@ -70,7 +70,7 @@ module Fluent
             thread_exit = true
             raise
           ensure
-            unless thread_exit
+            if ::Thread.current.alive? && !thread_exit
               log.warn "thread doesn't exit correctly (killed or other reason)", plugin: self.class, title: title, thread: ::Thread.current, error: $!
             end
             @_threads_mutex.synchronize do
@@ -110,10 +110,30 @@ module Fluent
 
       def stop
         super
+        wakeup_threads = []
         @_threads_mutex.synchronize do
-          @_threads.each_pair do |obj_id, thread|
+          @_threads.values.each do |thread|
             thread[:_fluentd_plugin_helper_thread_running] = false
+            wakeup_threads << thread if thread.alive? && thread.status == "sleep"
           end
+        end
+        wakeup_threads.each do |thread|
+          if thread.alive?
+            thread.wakeup
+          end
+        end
+      end
+
+      def after_shutdown
+        super
+        wakeup_threads = []
+        @_threads_mutex.synchronize do
+          @_threads.values.each do |thread|
+            wakeup_threads << thread if thread.alive? && thread.status == "sleep"
+          end
+        end
+        wakeup_threads.each do |thread|
+          thread.wakeup if thread.alive?
         end
       end
 

--- a/lib/fluent/plugin_helper/thread.rb
+++ b/lib/fluent/plugin_helper/thread.rb
@@ -112,7 +112,7 @@ module Fluent
         super
         wakeup_threads = []
         @_threads_mutex.synchronize do
-          @_threads.values.each do |thread|
+          @_threads.each_value do |thread|
             thread[:_fluentd_plugin_helper_thread_running] = false
             wakeup_threads << thread if thread.alive? && thread.status == "sleep"
           end
@@ -128,7 +128,7 @@ module Fluent
         super
         wakeup_threads = []
         @_threads_mutex.synchronize do
-          @_threads.values.each do |thread|
+          @_threads.each_value do |thread|
             wakeup_threads << thread if thread.alive? && thread.status == "sleep"
           end
         end


### PR DESCRIPTION
It's done before returning from stop/after_shutdown, but after setting flag to break while-loop.
This change suppresses log messages like 'thread doesn't exit correctly (killed or other reason)' in shutdown sequence.