### PR TITLE
parser/formatter plugin helper with default @type in plugin side

### DIFF
--- a/lib/fluent/config/configure_proxy.rb
+++ b/lib/fluent/config/configure_proxy.rb
@@ -339,15 +339,6 @@ module Fluent
         sub_proxy = ConfigureProxy.new(name, type_lookup: @type_lookup, **kwargs)
         sub_proxy.instance_exec(&block)
 
-        if sub_proxy.init?
-          if sub_proxy.argument && !sub_proxy.defaults.has_key?(sub_proxy.argument.first)
-            raise ArgumentError, "#{name}: init is specified, but default value of argument is missing"
-          end
-          if sub_proxy.params.keys.any?{|param_name| !sub_proxy.defaults.has_key?(param_name)}
-            raise ArgumentError, "#{name}: init is specified, but there're parameters without default values"
-          end
-        end
-
         @params.delete(name)
         @sections[name] = sub_proxy
 

--- a/lib/fluent/config/section.rb
+++ b/lib/fluent/config/section.rb
@@ -166,6 +166,13 @@ module Fluent
           varname = subproxy.variable_name
           elements = (conf.respond_to?(:elements) ? conf.elements : []).select{ |e| e.name == subproxy.name.to_s || e.name == subproxy.alias.to_s }
           if elements.empty? && subproxy.init?
+            if subproxy.argument && !subproxy.defaults.has_key?(subproxy.argument.first)
+              raise ArgumentError, "#{name}: init is specified, but default value of argument is missing"
+            end
+            missing_keys = subproxy.params.keys.select{|param_name| !subproxy.defaults.has_key?(param_name)}
+            if !missing_keys.empty?
+              raise ArgumentError, "#{name}: init is specified, but there're parameters without default values:#{missing_keys.join(',')}"
+            end
             elements << Fluent::Config::Element.new(subproxy.name.to_s, '', {}, [])
           end
 

--- a/lib/fluent/plugin/filter_stdout.rb
+++ b/lib/fluent/plugin/filter_stdout.rb
@@ -34,7 +34,7 @@ module Fluent::Plugin
     def configure(conf)
       compat_parameters_convert(conf, :inject, :formatter)
       super
-      @formatter = formatter_create(conf: @config.elements('format').first, default_type: DEFAULT_FORMAT_TYPE)
+      @formatter = formatter_create
     end
 
     def filter_stream(tag, es)

--- a/lib/fluent/plugin/formatter_stdout.rb
+++ b/lib/fluent/plugin/formatter_stdout.rb
@@ -21,6 +21,8 @@ module Fluent
     class StdoutFormatter < Formatter
       Plugin.register_formatter('stdout', self)
 
+      TIME_FORMAT = '%Y-%m-%d %H:%M:%S.%9N %z'
+
       config_param :output_type, :string, default: 'json'
 
       def configure(conf)
@@ -36,8 +38,7 @@ module Fluent
       end
 
       def format(tag, time, record)
-        header = "#{Time.now.localtime} #{tag}: "
-        "#{header}#{@sub_formatter.format(tag, time, record)}"
+        "#{Time.at(time).localtime.strftime(TIME_FORMAT)} #{tag}: #{@sub_formatter.format(tag, time, record).chomp}\n"
       end
 
       def stop

--- a/lib/fluent/plugin_helper/parser.rb
+++ b/lib/fluent/plugin_helper/parser.rb
@@ -24,7 +24,7 @@ module Fluent
     module Parser
       def parser_create(usage: '', type: nil, conf: nil, default_type: nil)
         parser = @_parsers[usage]
-        return parser if parser
+        return parser if parser && !type && !conf
 
         type = if type
                  type
@@ -61,9 +61,9 @@ module Fluent
       module ParserParams
         include Fluent::Configurable
         # minimum section definition to instantiate parser plugin instances
-        config_section :parse, required: false, multi: true, param_name: :parser_configs do
+        config_section :parse, required: false, multi: true, init: true, param_name: :parser_configs do
           config_argument :usage, :string, default: ''
-          config_param    :@type, :string
+          config_param    :@type, :string # config_set_default required for :@type
         end
       end
 

--- a/test/config/test_configure_proxy.rb
+++ b/test/config/test_configure_proxy.rb
@@ -184,49 +184,6 @@ module Fluent::Config
         end
       end
 
-      sub_test_case '#config_param without default values cause error if section is configured as init:true' do
-        setup do
-          @proxy = Fluent::Config::ConfigureProxy.new(:section, type_lookup: @type_lookup)
-        end
-
-        test 'with simple config_param with default value' do
-          assert_nothing_raised do
-            @proxy.config_section :subsection, init: true do
-              config_param :param1, :integer, default: 1
-            end
-          end
-        end
-        test 'with simple config_param without default value' do
-          assert_raise ArgumentError do
-            @proxy.config_section :subsection, init: true do
-              config_param :param1, :integer
-            end
-          end
-        end
-        test 'with config_param with config_set_default' do
-          assert_nothing_raised do
-            @proxy.config_section :subsection, init: true do
-              config_param :param1, :integer
-              config_set_default :param1, 1
-            end
-          end
-        end
-        test 'with config_argument' do
-          assert_raise ArgumentError do
-            @proxy.config_section :subsection, init: true do
-              config_argument :param0, :string
-            end
-          end
-        end
-        test 'with config_argument with default value' do
-          assert_nothing_raised do
-            @proxy.config_section :subsection, init: true do
-              config_argument :param0, :string, default: ''
-            end
-          end
-        end
-      end
-
       sub_test_case '#config_set_desc' do
         setup do
           @proxy = Fluent::Config::ConfigureProxy.new(:section, type_lookup: @type_lookup)

--- a/test/plugin/test_filter_stdout.rb
+++ b/test/plugin/test_filter_stdout.rb
@@ -67,10 +67,9 @@ class StdoutFilterTest < Test::Unit::TestCase
 
     def test_output_type_json
       d = create_driver(CONFIG + config_element("", "", { "output_type" => "json" }))
-      etime = event_time
-      time = Time.at(etime.sec)
+      etime = event_time("2016-10-07 21:09:31.012345678 UTC")
       out = capture_log(d) { filter(d, etime, {'test' => 'test'}) }
-      assert_equal "#{time.localtime} filter.test: {\"test\":\"test\"}\n", out
+      assert_equal "2016-10-07 21:09:31.012345678 +0000 filter.test: {\"test\":\"test\"}\n", out
 
       # NOTE: Float::NAN is not jsonable
       d = create_driver(CONFIG + config_element("", "", { "output_type" => "json" }))
@@ -80,15 +79,14 @@ class StdoutFilterTest < Test::Unit::TestCase
 
     def test_output_type_hash
       d = create_driver(CONFIG + config_element("", "", { "output_type" => "hash" }))
-      etime = event_time
-      time = Time.at(etime.sec)
+      etime = event_time("2016-10-07 21:09:31.012345678 UTC")
       out = capture_log(d) { filter(d, etime, {'test' => 'test'}) }
-      assert_equal "#{time.localtime} filter.test: {\"test\"=>\"test\"}\n", out
+      assert_equal "2016-10-07 21:09:31.012345678 +0000 filter.test: {\"test\"=>\"test\"}\n", out
 
       # NOTE: Float::NAN is not jsonable, but hash string can output it.
       d = create_driver(CONFIG + config_element("", "", { "output_type" => "hash" }))
       out = capture_log(d) { filter(d, etime, {'test' => Float::NAN}) }
-      assert_equal "#{time.localtime} filter.test: {\"test\"=>NaN}\n", out
+      assert_equal "2016-10-07 21:09:31.012345678 +0000 filter.test: {\"test\"=>NaN}\n", out
     end
 
     # Use include_time_key to output the message's time
@@ -99,11 +97,9 @@ class StdoutFilterTest < Test::Unit::TestCase
                                 "localtime" => false
                               })
       d = create_driver(config)
-      etime = event_time
-      time = Time.at(etime.sec)
-      message_time = event_time("2011-01-02 13:14:15 UTC")
-      out = capture_log(d) { filter(d, message_time, {'test' => 'test'}) }
-      assert_equal "#{time.localtime} filter.test: {\"test\":\"test\",\"time\":\"2011-01-02T13:14:15Z\"}\n", out
+      etime = event_time("2016-10-07 21:09:31.012345678 UTC")
+      out = capture_log(d) { filter(d, etime, {'test' => 'test'}) }
+      assert_equal "2016-10-07 21:09:31.012345678 +0000 filter.test: {\"test\":\"test\",\"time\":\"2016-10-07T21:09:31Z\"}\n", out
     end
 
     # out_stdout formatter itself can also be replaced
@@ -150,10 +146,9 @@ class StdoutFilterTest < Test::Unit::TestCase
         conf = config_element
         conf.elements << config_element("format", "", { "@type" => "stdout", "output_type" => "json" })
         d = create_driver(conf)
-        etime = event_time
-        time = Time.at(etime.sec)
+        etime = event_time("2016-10-07 21:09:31.012345678 UTC")
         out = capture_log(d) { filter(d, etime, {'test' => 'test'}) }
-        assert_equal "#{time.localtime} filter.test: {\"test\":\"test\"}\n", out
+        assert_equal "2016-10-07 21:09:31.012345678 +0000 filter.test: {\"test\":\"test\"}\n", out
       end
 
       def test_json_nan
@@ -161,7 +156,7 @@ class StdoutFilterTest < Test::Unit::TestCase
         conf = config_element
         conf.elements << config_element("format", "", { "@type" => "stdout", "output_type" => "json" })
         d = create_driver(conf)
-        etime = event_time
+        etime = event_time("2016-10-07 21:09:31.012345678 UTC")
         flexmock(d.instance.router).should_receive(:emit_error_event)
         filter(d, etime, {'test' => Float::NAN})
       end
@@ -170,10 +165,9 @@ class StdoutFilterTest < Test::Unit::TestCase
         conf = config_element
         conf.elements << config_element("format", "", { "@type" => "stdout", "output_type" => "hash" })
         d = create_driver(conf)
-        etime = event_time
-        time = Time.at(etime.sec)
+        etime = event_time("2016-10-07 21:09:31.012345678 UTC")
         out = capture_log(d) { filter(d, etime, {'test' => 'test'}) }
-        assert_equal "#{time.localtime} filter.test: {\"test\"=>\"test\"}\n", out
+        assert_equal "2016-10-07 21:09:31.012345678 +0000 filter.test: {\"test\"=>\"test\"}\n", out
       end
 
       def test_hash_nan
@@ -181,10 +175,9 @@ class StdoutFilterTest < Test::Unit::TestCase
         conf = config_element
         conf.elements << config_element("format", "", { "@type" => "stdout", "output_type" => "hash" })
         d = create_driver(conf)
-        etime = event_time
-        time = Time.at(etime.sec)
+        etime = event_time("2016-10-07 21:09:31.012345678 UTC")
         out = capture_log(d) { filter(d, etime, {'test' => Float::NAN}) }
-        assert_equal "#{time.localtime} filter.test: {\"test\"=>NaN}\n", out
+        assert_equal "2016-10-07 21:09:31.012345678 +0000 filter.test: {\"test\"=>NaN}\n", out
       end
 
       # Use include_time_key to output the message's time
@@ -200,11 +193,9 @@ class StdoutFilterTest < Test::Unit::TestCase
                                           "localtime" => false
                                           })
         d = create_driver(conf)
-        etime = event_time
-        time = Time.at(etime.sec)
-        message_time = event_time("2011-01-02 13:14:15 UTC")
-        out = capture_log(d) { filter(d, message_time, {'test' => 'test'}) }
-        assert_equal "#{time.localtime} filter.test: {\"test\":\"test\",\"time\":\"2011-01-02T13:14:15Z\"}\n", out
+        etime = event_time("2016-10-07 21:09:31.012345678 UTC")
+        out = capture_log(d) { filter(d, etime, {'test' => 'test'}) }
+        assert_equal "2016-10-07 21:09:31.012345678 +0000 filter.test: {\"test\":\"test\",\"time\":\"2016-10-07T21:09:31Z\"}\n", out
       end
     end
   end

--- a/test/plugin/test_out_stdout.rb
+++ b/test/plugin/test_out_stdout.rb
@@ -18,15 +18,19 @@ class StdoutOutputTest < Test::Unit::TestCase
   sub_test_case 'non-buffered' do
     test 'configure' do
       d = create_driver
-      assert_equal [], d.instance.formatter_configs
+      assert_equal 1, d.instance.formatter_configs.size # init: true
+      assert_kind_of Fluent::Plugin::StdoutFormatter, d.instance.formatter
+      assert_equal 'json', d.instance.formatter.output_type
     end
 
     test 'configure output_type' do
       d = create_driver(CONFIG + "\noutput_type json")
-      assert_equal 'json', d.instance.formatter_configs.first[:@type]
+      assert_kind_of Fluent::Plugin::StdoutFormatter, d.instance.formatter
+      assert_equal 'json', d.instance.formatter.output_type
 
       d = create_driver(CONFIG + "\noutput_type hash")
-      assert_equal 'hash', d.instance.formatter_configs.first[:@type]
+      assert_kind_of Fluent::Plugin::StdoutFormatter, d.instance.formatter
+      assert_equal 'hash', d.instance.formatter.output_type
 
       assert_raise(Fluent::ConfigError) do
         d = create_driver(CONFIG + "\noutput_type foo")
@@ -83,7 +87,9 @@ class StdoutOutputTest < Test::Unit::TestCase
   sub_test_case 'buffered' do
     test 'configure' do
       d = create_driver(config_element("ROOT", "", {}, [config_element("buffer")]))
-      assert_equal [], d.instance.formatter_configs
+      assert_equal 1, d.instance.formatter_configs.size
+      assert_kind_of Fluent::Plugin::StdoutFormatter, d.instance.formatter
+      assert_equal 'json', d.instance.formatter.output_type
       assert_equal 10 * 1024, d.instance.buffer_config.chunk_limit_size
       assert d.instance.buffer_config.flush_at_shutdown
       assert_equal ['tag'], d.instance.buffer_config.chunk_keys
@@ -94,10 +100,12 @@ class StdoutOutputTest < Test::Unit::TestCase
 
     test 'configure with output_type' do
       d = create_driver(config_element("ROOT", "", {"output_type" => "json"}, [config_element("buffer")]))
-      assert_equal 'json', d.instance.formatter_configs.first[:@type]
+      assert_kind_of Fluent::Plugin::StdoutFormatter, d.instance.formatter
+      assert_equal 'json', d.instance.formatter.output_type
 
       d = create_driver(config_element("ROOT", "", {"output_type" => "hash"}, [config_element("buffer")]))
-      assert_equal 'hash', d.instance.formatter_configs.first[:@type]
+      assert_kind_of Fluent::Plugin::StdoutFormatter, d.instance.formatter
+      assert_equal 'hash', d.instance.formatter.output_type
 
       assert_raise(Fluent::ConfigError) do
         create_driver(config_element("ROOT", "", {"output_type" => "foo"}, [config_element("buffer")]))

--- a/test/plugin_helper/test_formatter.rb
+++ b/test/plugin_helper/test_formatter.rb
@@ -17,6 +17,9 @@ class FormatterHelperTest < Test::Unit::TestCase
   end
   class Dummy < Fluent::Plugin::TestBase
     helpers :formatter
+    config_section :format do
+      config_set_default :@type, 'example'
+    end
   end
 
   class Dummy2 < Fluent::Plugin::TestBase
@@ -77,12 +80,12 @@ class FormatterHelperTest < Test::Unit::TestCase
     end
   end
 
-  test 'can be configured without format sections' do
+  test 'can be configured with default type without format sections' do
     d = Dummy.new
     assert_nothing_raised do
       d.configure(config_element())
     end
-    assert_equal 0, d._formatters.size
+    assert_equal 1, d._formatters.size
   end
 
   test 'can be configured with a format section' do

--- a/test/plugin_helper/test_parser.rb
+++ b/test/plugin_helper/test_parser.rb
@@ -28,6 +28,9 @@ class ParserHelperTest < Test::Unit::TestCase
   end
   class Dummy < Fluent::Plugin::TestBase
     helpers :parser
+    config_section :parse do
+      config_set_default :@type, 'example'
+    end
   end
 
   class Dummy2 < Fluent::Plugin::TestBase
@@ -88,12 +91,10 @@ class ParserHelperTest < Test::Unit::TestCase
     end
   end
 
-  test 'can be configured without parse sections' do
+  test 'can be configured with default type without parse sections' do
     d = Dummy.new
-    assert_nothing_raised do
-      d.configure(config_element())
-    end
-    assert_equal 0, d._parsers.size
+    d.configure(config_element())
+    assert_equal 1, d._parsers.size
   end
 
   test 'can be configured with a parse section' do


### PR DESCRIPTION
Adding `multi: true` for `config_section :parse` and `config_section :format` helps plugin authors not to use `conf` or `default_type` argument in `parser_create` and `formatter_create`.

With this change, plugin authors can write code to create parser(formatter) instances with default parser(formatter).

```ruby
helpers :parser

config_section :parse do
  config_set_default :@type, 'myparser'
end

def configure(conf)
  super
  @parser = parser_create
end
```

After this change, parser(formatter) plugin helpers **always** requires default `@type` definition.
I believe that it's reasonable change for all plugins which uses parsers/formatters.
