### PR TITLE
Fix fluent-cat command to send sub-second precision time

### DIFF
--- a/lib/fluent/command/cat.rb
+++ b/lib/fluent/command/cat.rb
@@ -16,6 +16,8 @@
 
 require 'optparse'
 require 'fluent/env'
+require 'fluent/time'
+require 'fluent/engine'
 
 op = OptionParser.new
 
@@ -143,7 +145,7 @@ class Writer
       raise ArgumentError, "Input must be a map (got #{record.class})"
     end
 
-    entry = [Time.now.to_i, record]
+    entry = [Fluent::EventTime.now, record]
     synchronize {
       unless write_impl([entry])
         # write failed
@@ -200,7 +202,8 @@ class Writer
     end
 
     begin
-      socket.write [@tag, array].to_msgpack
+      packer = Fluent::Engine.msgpack_factory.packer
+      socket.write packer.pack([@tag, array])
       socket.flush
     rescue
       $stderr.puts "write failed: #{$!}"

--- a/lib/fluent/command/cat.rb
+++ b/lib/fluent/command/cat.rb
@@ -17,7 +17,7 @@
 require 'optparse'
 require 'fluent/env'
 require 'fluent/time'
-require 'fluent/engine'
+require 'fluent/msgpack_factory'
 
 op = OptionParser.new
 
@@ -202,7 +202,7 @@ class Writer
     end
 
     begin
-      packer = Fluent::Engine.msgpack_factory.packer
+      packer = Fluent::MessagePackFactory.packer
       socket.write packer.pack([@tag, array])
       socket.flush
     rescue


### PR DESCRIPTION
Fix https://github.com/fluent/fluentd/issues/1276