### PR TITLE
Event router for secondary output

### DIFF
--- a/lib/fluent/agent.rb
+++ b/lib/fluent/agent.rb
@@ -123,7 +123,7 @@ module Fluent
       log.info "adding match#{@context.nil? ? '' : " in #{@context}"}", pattern: pattern, type: type
 
       output = Plugin.new_output(type)
-      output.router = @event_router if output.respond_to?(:router=)
+      output.context_router = @event_router
       output.configure(conf)
       @outputs << output
       if output.respond_to?(:outputs) && output.respond_to?(:multi_output?) && output.multi_output?
@@ -144,7 +144,7 @@ module Fluent
       log.info "adding filter#{@context.nil? ? '' : " in #{@context}"}", pattern: pattern, type: type
 
       filter = Plugin.new_filter(type)
-      filter.router = @event_router
+      filter.context_router = @event_router
       filter.configure(conf)
       @filters << filter
       @event_router.add_rule(pattern, filter)

--- a/lib/fluent/plugin/base.rb
+++ b/lib/fluent/plugin/base.rb
@@ -31,6 +31,7 @@ module Fluent
       def initialize
         super
         @_state = State.new(false, false, false, false, false, false, false, false, false)
+        @_context_router = nil
         @under_plugin_development = false
       end
 
@@ -43,6 +44,14 @@ module Fluent
         @_state ||= State.new(false, false, false, false, false, false, false, false, false)
         @_state.configure = true
         self
+      end
+
+      def context_router=(router)
+        @_context_router = router
+      end
+
+      def context_router
+        @_context_router
       end
 
       def start

--- a/lib/fluent/plugin/multi_output.rb
+++ b/lib/fluent/plugin/multi_output.rb
@@ -69,9 +69,7 @@ module Fluent
           log.debug "adding store", type: type
 
           output = Fluent::Plugin.new_output(type)
-          if output.has_router?
-            output.router = router
-          end
+          output.context_router = self.context_router
           output.configure(store_conf)
           @outputs << output
         end

--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -207,6 +207,7 @@ module Fluent
           @timekey_zone = @primary_instance.timekey_zone
           @output_time_formatter_cache = {}
         end
+        self.context_router = primary.context_router
 
         (class << self; self; end).module_eval do
           define_method(:commit_write){ |chunk_id| @primary_instance.commit_write(chunk_id, delayed: delayed_commit, secondary: true) }
@@ -317,7 +318,6 @@ module Fluent
           @secondary = Plugin.new_output(secondary_type)
           @secondary.acts_as_secondary(self)
           @secondary.configure(secondary_conf)
-          @secondary.router = router if @secondary.has_router?
           if (self.class != @secondary.class) && (@custom_format || @secondary.implement?(:custom_format))
             log.warn "secondary type should be same with primary one", primary: self.class.to_s, secondary: @secondary.class.to_s
           end

--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -233,7 +233,7 @@ module Fluent
       # <source> emits events to the top-level event router (RootAgent#event_router).
       # Input#configure overwrites event_router to a label's event_router if it has `@label` parameter.
       # See also 'fluentd/plugin/input.rb'
-      input.router = @event_router
+      input.context_router = @event_router
       input.configure(conf)
       @inputs << input
 

--- a/test/test_plugin_classes.rb
+++ b/test/test_plugin_classes.rb
@@ -110,6 +110,26 @@ module FluentTest
     end
   end
 
+  class FluentTestBufferedOutput < ::Fluent::Plugin::Output
+    ::Fluent::Plugin.register_output('test_out_buffered', self)
+    def write(chunk)
+      # drop everything
+    end
+  end
+
+  class FluentTestEmitOutput < ::Fluent::Plugin::Output
+    ::Fluent::Plugin.register_output('test_out_emit', self)
+    helpers :event_emitter
+    def write(chunk)
+      tag = chunk.metadata.tag || 'test'
+      array = []
+      chunk.each do |time, record|
+        array << [time, record]
+      end
+      router.emit_array(tag, array)
+    end
+  end
+
   class FluentTestErrorOutput < ::Fluent::Plugin::Output
     ::Fluent::Plugin.register_output('test_out_error', self)
 


### PR DESCRIPTION
This change introduces `context_router` for all plugin types to provide event_router to secondary output plugins.
`context_router` is the default event router for filters/outputs in `<label>` sections.

This fixes #1271.