### PR TITLE
fix to return the block value as expected by many rubyists

### DIFF
--- a/lib/fluent/test/driver/base.rb
+++ b/lib/fluent/test/driver/base.rb
@@ -139,8 +139,9 @@ module Fluent
             raise ArgumentError, "no stop conditions nor block specified"
           end
 
+          return_value = nil
           proc = if block_given?
-                   ->(){ block.call; sleep(0.1) until stop? }
+                   ->(){ return_value = block.call; sleep(0.1) until stop? }
                  else
                    ->(){ sleep(0.1) until stop? }
                  end
@@ -156,6 +157,7 @@ module Fluent
           else
             proc.call
           end
+          return_value
         end
 
         def stop?

--- a/lib/fluent/test/driver/multi_output.rb
+++ b/lib/fluent/test/driver/multi_output.rb
@@ -37,10 +37,11 @@ module Fluent
         end
 
         def run_actual(**kwargs, &block)
-          super(**kwargs, &block)
+          val = super(**kwargs, &block)
           if @flush_buffer_at_cleanup
             @instance.outputs.each{|o| o.force_flush }
           end
+          val
         end
 
         def flush

--- a/lib/fluent/test/driver/output.rb
+++ b/lib/fluent/test/driver/output.rb
@@ -41,11 +41,12 @@ module Fluent
         end
 
         def run_actual(**kwargs, &block)
-          super(**kwargs, &block)
+          val = super(**kwargs, &block)
           if @flush_buffer_at_cleanup
             @instance.force_flush
             Timeout.timeout(10){ sleep 0.1 until !@instance.buffer || @instance.buffer.queue.size == 0 }
           end
+          val
         end
 
         def formatted

--- a/test/test_test_drivers.rb
+++ b/test/test_test_drivers.rb
@@ -1,0 +1,70 @@
+require_relative 'helper'
+require 'fluent/plugin/input'
+require 'fluent/test/driver/input'
+require 'fluent/plugin/output'
+require 'fluent/test/driver/output'
+require 'fluent/plugin/filter'
+require 'fluent/test/driver/filter'
+require 'fluent/plugin/multi_output'
+require 'fluent/test/driver/multi_output'
+require 'fluent/plugin/parser'
+require 'fluent/test/driver/parser'
+require 'fluent/plugin/formatter'
+require 'fluent/test/driver/formatter'
+
+class TestDriverTest < ::Test::Unit::TestCase
+  def setup
+    Fluent::Test.setup
+  end
+
+  sub_test_case 'plugin test driver' do
+    data(
+      'input plugin test driver'  => [Fluent::Test::Driver::Input, Fluent::Plugin::Input],
+      'multi_output plugin test driver' => [Fluent::Test::Driver::MultiOutput, Fluent::Plugin::MultiOutput],
+      'parser plugin test driver'       => [Fluent::Test::Driver::Parser, Fluent::Plugin::Parser],
+      'formatter plugin test driver'    => [Fluent::Test::Driver::Formatter, Fluent::Plugin::Formatter],
+    )
+    test 'returns the block value as the return value of #run' do |args|
+      driver_class, plugin_class = args
+      d = driver_class.new(Class.new(plugin_class))
+      v = d.run do
+        x = 1 + 2
+        y = 2 + 4
+        3 || x || y
+      end
+      assert_equal 3, v
+    end
+  end
+
+  sub_test_case 'output plugin test driver' do
+    test 'returns the block value as the return value of #run' do
+      d = Fluent::Test::Driver::Output.new(Class.new(Fluent::Plugin::Output)) do
+        def process(tag, es)
+          # drop
+        end
+      end
+      v = d.run do
+        x = 1 + 2
+        y = 2 + 4
+        3 || x || y
+      end
+      assert_equal 3, v
+    end
+  end
+
+  sub_test_case 'filter plugin test driver' do
+    test 'returns the block value as the return value of #run' do
+      d = Fluent::Test::Driver::Filter.new(Class.new(Fluent::Plugin::Filter)) do
+        def filter(tag, time, record)
+          record
+        end
+      end
+      v = d.run do
+        x = 1 + 2
+        y = 2 + 4
+        3 || x || y
+      end
+      assert_equal 3, v
+    end
+  end
+end


### PR DESCRIPTION
`test_driver.run` doesn't return the value of block specified. In standard ruby way, the behavior below is expected (but not yet).
```ruby
v = d.run do
  1
  2
end
v == 2 # expected
```

This change fixes #1268.