### PR TITLE
make sure to set binary mode on #open, and to wait write operation

### DIFF
--- a/lib/fluent/command/binlog_reader.rb
+++ b/lib/fluent/command/binlog_reader.rb
@@ -164,7 +164,7 @@ module BinlogReaderCommand
     def call
       @formatter = lookup_formatter(@options[:format], @options[:config_params])
 
-      File.open(@path, 'r') do |io|
+      File.open(@path, 'rb') do |io|
         i = 1
         Fluent::MessagePackFactory.unpacker(io).each do |(time, record)|
           print @formatter.format(@path, time, record) # path is used for tag

--- a/test/command/test_binlog_reader.rb
+++ b/test/command/test_binlog_reader.rb
@@ -58,8 +58,12 @@ class TestBaseCommand < ::Test::Unit::TestCase
   def create_message_packed_file(path, times = [event_time], records = [{ 'message' => 'dummy' }])
     es = Fluent::MultiEventStream.new(times, records)
     v = es.to_msgpack_stream
-    File.open("#{TMP_DIR}/#{path}", 'w') do |f|
+    out_path = "#{TMP_DIR}/#{path}"
+    File.open(out_path, 'wb') do |f|
       f.print(v)
+    end
+    waiting(5) do
+      sleep 0.5 until File.size(out_path) == v.bytesize
     end
   end
 


### PR DESCRIPTION
This improves test stability on Windows environment (appveyor).