### PR TITLE
Fix json gem dependency

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("flexmock", ["< 2.0.0"])
   gem.add_development_dependency("parallel_tests", [">= 0.15.3", "< 2.0.0"])
   gem.add_development_dependency("simplecov", ["~> 0.6.4"])
-  gem.add_development_dependency("rr", [">= 1.0.0"])
+  gem.add_development_dependency("rr", ["~> 1.1.2"])
   gem.add_development_dependency("timecop", [">= 0.3.0"])
   gem.add_development_dependency("test-unit", ["~> 3.0.2"])
 end

--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("tzinfo-data", [">= 1.0.0"])
 
   gem.add_development_dependency("rake", [">= 0.9.2"])
-  gem.add_development_dependency("flexmock")
+  gem.add_development_dependency("flexmock", ["< 2.0.0"])
   gem.add_development_dependency("parallel_tests", [">= 0.15.3"])
   gem.add_development_dependency("simplecov", ["~> 0.6.4"])
   gem.add_development_dependency("rr", [">= 1.0.0"])

--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency("msgpack", [">= 0.4.4", "!= 0.5.0", "!= 0.5.1", "!= 0.5.2", "!= 0.5.3", "!= 0.5.4",
                                          "!= 0.5.5", "!= 0.5.6", "!= 0.5.7", "!= 0.5.8", "!= 0.5.9", "!= 0.5.10", "< 0.6.0"])
-  gem.add_runtime_dependency("json", [">= 1.4.3"])
+  gem.add_runtime_dependency("json", [">= 1.4.3", "< 2.0.0"])
   gem.add_runtime_dependency("yajl-ruby", ["~> 1.0"])
   gem.add_runtime_dependency("cool.io", [">= 1.1.1", "!= 1.2.0", "< 2.0.0"])
   gem.add_runtime_dependency("http_parser.rb", [">= 0.5.1", "< 0.7.0"])

--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency("rake", [">= 0.9.2"])
   gem.add_development_dependency("flexmock", ["< 2.0.0"])
-  gem.add_development_dependency("parallel_tests", [">= 0.15.3"])
+  gem.add_development_dependency("parallel_tests", [">= 0.15.3", "< 2.0.0"])
   gem.add_development_dependency("simplecov", ["~> 0.6.4"])
   gem.add_development_dependency("rr", [">= 1.0.0"])
   gem.add_development_dependency("timecop", [">= 0.3.0"])


### PR DESCRIPTION
json gem 2.0.0 or later doesn't support Ruby1.9.3