### PR TITLE
Migrate exec plugins to v0.14 api

### DIFF
--- a/example/out_exec_filter.conf
+++ b/example/out_exec_filter.conf
@@ -1,0 +1,42 @@
+<source>
+  @type dummy
+  @label @exec
+  tag exec_input
+  rate 10
+  auto_increment_key num
+  dummy {"data":"mydata"}
+</source>
+
+<label @exec>
+  <match exec_input>
+    @type exec_filter
+    @label @stdout
+    tag result
+    command ruby -e 'STDOUT.sync = true; proc = ->(){line = STDIN.readline.chomp; puts line + "\t" + Process.pid.to_s}; 1000.times{ proc.call }'
+    num_children 3
+    child_respawn -1
+    <inject>
+      time_key time
+      time_type float
+    </inject>
+    <format>
+      @type tsv
+      keys data, num, time
+    </format>
+    <parse>
+      @type tsv
+      keys data, num, time, pid
+    </parse>
+    <extract>
+      time_key time
+      time_type float
+    </extract>
+  </match>
+</label>
+
+<label @stdout>
+  <match result>
+    @type stdout
+  </match>
+</label>
+

--- a/lib/fluent/plugin/formatter.rb
+++ b/lib/fluent/plugin/formatter.rb
@@ -26,6 +26,11 @@ module Fluent
 
       configured_in :format
 
+      PARSER_TYPES = [:text_per_line, :text, :binary]
+      def formatter_type
+        :text_per_line
+      end
+
       def format(tag, time, record)
         raise NotImplementedError, "Implement this method in child class"
       end

--- a/lib/fluent/plugin/formatter_msgpack.rb
+++ b/lib/fluent/plugin/formatter_msgpack.rb
@@ -21,6 +21,10 @@ module Fluent
     class MessagePackFormatter < Formatter
       Plugin.register_formatter('msgpack', self)
 
+      def formatter_type
+        :binary
+      end
+
       def format(tag, time, record)
         record.to_msgpack
       end

--- a/lib/fluent/plugin/formatter_tsv.rb
+++ b/lib/fluent/plugin/formatter_tsv.rb
@@ -14,24 +14,20 @@
 #    limitations under the License.
 #
 
-require 'fluent/plugin/parser'
-
-require 'csv'
+require 'fluent/plugin/formatter'
 
 module Fluent
   module Plugin
-    class CSVParser < Parser
-      Plugin.register_parser('csv', self)
+    class TSVFormatter < Formatter
+      Plugin.register_formatter('tsv', self)
 
       desc 'Names of fields included in each lines'
       config_param :keys, :array, value_type: :string
-      desc 'The delimiter character (or string) of CSV values'
-      config_param :delimiter, :string, default: ','
+      desc 'The delimiter character (or string) of TSV values'
+      config_param :delimiter, :string, default: "\t"
 
-      def parse(text, &block)
-        values = CSV.parse_line(text, col_sep: @delimiter)
-        r = Hash[@keys.zip(values)]
-        convert_values(parse_time(r), r, &block)
+      def format(tag, time, record)
+        @keys.map{|k| record[k].to_s }.join(@delimiter)
       end
     end
   end

--- a/lib/fluent/plugin/formatter_tsv.rb
+++ b/lib/fluent/plugin/formatter_tsv.rb
@@ -21,7 +21,7 @@ module Fluent
     class TSVFormatter < Formatter
       Plugin.register_formatter('tsv', self)
 
-      desc 'Names of fields included in each lines'
+      desc 'Field names included in each lines'
       config_param :keys, :array, value_type: :string
       desc 'The delimiter character (or string) of TSV values'
       config_param :delimiter, :string, default: "\t"

--- a/lib/fluent/plugin/in_exec.rb
+++ b/lib/fluent/plugin/in_exec.rb
@@ -98,7 +98,7 @@ module Fluent::Plugin
       router.emit(tag, time, record)
     rescue => e
       log.error "exec failed to emit", tag: tag, record: Yajl.dump(record), error: e
-      router.emit_error_event(tag, time, record, "exec failed to emit")
+      router.emit_error_event(tag, time, record, e) if tag && time && record
     end
   end
 end

--- a/lib/fluent/plugin/in_exec.rb
+++ b/lib/fluent/plugin/in_exec.rb
@@ -59,7 +59,7 @@ module Fluent::Plugin
       super
 
       if !@tag && (!@extract_config || !@extract_config.tag_key)
-        raise Fleunt::ConfigError, "'tag' or 'tag_key' option is required on exec input"
+        raise Fluent::ConfigError, "'tag' or 'tag_key' option is required on exec input"
       end
       @parser = parser_create
     end

--- a/lib/fluent/plugin/in_exec.rb
+++ b/lib/fluent/plugin/in_exec.rb
@@ -92,7 +92,6 @@ module Fluent::Plugin
     end
 
     def on_record(time, record)
-      tag = nil
       tag = extract_tag_from_record(record)
       tag ||= @tag
       time ||= extract_time_from_record(record) || Fluent::EventTime.now

--- a/lib/fluent/plugin/out_exec.rb
+++ b/lib/fluent/plugin/out_exec.rb
@@ -18,77 +18,40 @@ require 'tempfile'
 
 require 'fluent/plugin/output'
 require 'fluent/config/error'
-require 'fluent/plugin/exec_util'
-require 'fluent/mixin' # for TimeFormatter
 
 module Fluent::Plugin
   class ExecOutput < Output
     Fluent::Plugin.register_output('exec', self)
 
-    helpers :compat_parameters
+    helpers :inject, :formatter, :compat_parameters
 
     desc 'The command (program) to execute. The exec plugin passes the path of a TSV file as the last argumen'
     config_param :command, :string
-    desc 'Specify the comma-separated keys when using the tsv format.'
-    config_param :keys, default: [] do |val|
-      val.split(',')
-    end
-    desc 'The name of the key to use as the event tag. This replaces the value in the event record.'
-    config_param :tag_key, :string, default: nil
-    desc 'The name of the key to use as the event time. This replaces the the value in the event record.'
-    config_param :time_key, :string, default: nil
-    desc 'The format for event time used when the time_key parameter is specified. The default is UNIX time (integer).'
-    config_param :time_format, :string, default: nil
-    desc "The format used to map the incoming events to the program input. (#{Fluent::ExecUtil::SUPPORTED_FORMAT.keys.join(',')})"
-    config_param :format, default: :tsv, skip_accessor: true do |val|
-      f = Fluent::ExecUtil::SUPPORTED_FORMAT[val]
-      raise Fluent::ConfigError, "Unsupported format '#{val}'" unless f
-      f
-    end
-    config_param :localtime, :bool, default: false
-    config_param :timezone, :string, default: nil
 
-    def compat_parameters_default_chunk_key
-      'time'
+    config_section :format do
+      config_set_default :@type, 'tsv'
     end
+
+    config_section :inject do
+      config_set_default :time_type, :string
+      config_set_default :localtime, false
+    end
+
+    attr_reader :formatter # for tests
 
     def configure(conf)
-      compat_parameters_convert(conf, :buffer, default_chunk_key: 'time')
-
+      compat_parameters_convert(conf, :inject, :formatter, :buffer, default_chunk_key: 'time')
       super
-
-      @formatter = case @format
-                   when :tsv
-                     if @keys.empty?
-                       raise Fluent::ConfigError, "keys option is required on exec output for tsv format"
-                     end
-                     Fluent::ExecUtil::TSVFormatter.new(@keys)
-                   when :json
-                     Fluent::ExecUtil::JSONFormatter.new
-                   when :msgpack
-                     Fluent::ExecUtil::MessagePackFormatter.new
-                   end
-
-      if @time_key
-        if @time_format
-          tf = Fluent::TimeFormatter.new(@time_format, @localtime, @timezone)
-          @time_format_proc = tf.method(:format)
-        else
-          @time_format_proc = Proc.new { |time| time.to_s }
-        end
-      end
+      @formatter = formatter_create
     end
 
     def format(tag, time, record)
-      out = ''
-      if @time_key
-        record[@time_key] = @time_format_proc.call(time)
+      record = inject_values_to_record(tag, time, record)
+      if @formatter.formatter_type == :text_per_line
+        @formatter.format(tag, time, record).chomp + "\n"
+      else
+        @formatter.format(tag, time, record)
       end
-      if @tag_key
-        record[@tag_key] = tag
-      end
-      @formatter.call(record, out)
-      out
     end
 
     def write(chunk)

--- a/lib/fluent/plugin/out_exec.rb
+++ b/lib/fluent/plugin/out_exec.rb
@@ -51,10 +51,12 @@ module Fluent::Plugin
       @formatter = formatter_create
     end
 
+    NEWLINE = "\n"
+
     def format(tag, time, record)
       record = inject_values_to_record(tag, time, record)
       if @formatter.formatter_type == :text_per_line
-        @formatter.format(tag, time, record).chomp + "\n"
+        @formatter.format(tag, time, record).chomp + NEWLINE
       else
         @formatter.format(tag, time, record)
       end

--- a/lib/fluent/plugin/out_exec.rb
+++ b/lib/fluent/plugin/out_exec.rb
@@ -67,7 +67,7 @@ module Fluent::Plugin
       prog = if chunk.respond_to?(:path)
                "#{@command} #{chunk.path}"
              else
-               tmpfile = Tempfile.new("fluent-plugin-exec-")
+               tmpfile = Tempfile.new("fluent-plugin-out-exec-")
                tmpfile.binmode
                chunk.write_to(tmpfile)
                tmpfile.close

--- a/lib/fluent/plugin/out_exec_filter.rb
+++ b/lib/fluent/plugin/out_exec_filter.rb
@@ -13,74 +13,59 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
+require 'fluent/plugin/output'
+require 'fluent/env'
+require 'fluent/config/error'
 
 require 'yajl'
 
-require 'fluent/output'
-require 'fluent/env'
-require 'fluent/time'
-require 'fluent/timezone'
-require 'fluent/plugin/exec_util'
-require 'fluent/config/error'
+module Fluent::Plugin
+  class ExecFilterOutput < Output
+    Fluent::Plugin.register_output('exec_filter', self)
 
-module Fluent
-  class ExecFilterOutput < BufferedOutput
-    Plugin.register_output('exec_filter', self)
-
-    def initialize
-      super
-      require 'fluent/timezone'
-    end
+    helpers :compat_parameters, :inject, :formatter, :parser, :extract, :child_process, :event_emitter
 
     desc 'The command (program) to execute.'
     config_param :command, :string
 
-    config_param :remove_prefix, :string, default: nil
-    config_param :add_prefix, :string, default: nil
+    config_param :remove_prefix, :string, default: nil, deprecated: "use @label instead for event routing"
+    config_param :add_prefix, :string, default: nil, deprecated: "use @label instead for event routing"
 
-    desc "The format used to map the incoming event to the program input.(#{Fluent::ExecUtil::SUPPORTED_FORMAT.keys.join(',')})"
-    config_param :in_format, default: :tsv do |val|
-      f = Fluent::ExecUtil::SUPPORTED_FORMAT[val]
-      raise ConfigError, "Unsupported in_format '#{val}'" unless f
-      f
+    config_section :inject do
+      config_set_default :time_type, :unixtime
     end
-    desc 'Specify comma-separated values for tsv format.'
-    config_param :in_keys, default: [] do |val|
-      val.split(',')
-    end
-    desc 'The name of the key to use as the event tag.'
-    config_param :in_tag_key, default: nil
-    desc 'The name of the key to use as the event time.'
-    config_param :in_time_key, default: nil
-    desc 'The format for event time used when the in_time_key parameter is specified.(Defauls is UNIX time)'
-    config_param :in_time_format, default: nil
 
-    desc "The format used to process the program output.(#{Fluent::ExecUtil::SUPPORTED_FORMAT.keys.join(',')})"
-    config_param :out_format, default: :tsv do |val|
-      f = Fluent::ExecUtil::SUPPORTED_FORMAT[val]
-      raise ConfigError, "Unsupported out_format '#{val}'" unless f
-      f
+    config_section :format do
+      config_set_default :@type, 'tsv'
+      config_set_default :localtime, true
     end
-    desc 'Specify comma-separated values for tsv format.'
-    config_param :out_keys, default: [] do |val|  # for tsv format
-      val.split(',')
+
+    config_section :parse do
+      config_set_default :@type, 'tsv'
+      config_set_default :time_key, nil
+      config_set_default :time_format, nil
+      config_set_default :localtime, true
+      config_set_default :estimate_current_event, false
     end
-    desc 'The name of the key to use as the event tag.'
-    config_param :out_tag_key, default: nil
-    desc 'The name of the key to use as the event time.'
-    config_param :out_time_key, default: nil
-    desc 'The format for event time used when the in_time_key parameter is specified.(Defauls is UNIX time)'
-    config_param :out_time_format, default: nil
+
+    config_section :extract do
+      config_set_default :time_type, :float
+    end
+
+    config_section :buffer do
+      config_set_default :flush_mode, :interval
+      config_set_default :flush_interval, 1
+    end
 
     config_param :tag, :string, default: nil
 
-    config_param :time_key, :string, default: nil
-    config_param :time_format, :string, default: nil
+    config_param :tag_key, :string, default: nil, deprecated: "use 'tag_key' in <inject>/<extract> instead"
+    config_param :time_key, :string, default: nil, deprecated: "use 'time_key' in <inject>/<extract> instead"
+    config_param :time_format, :string, default: nil, deprecated: "use 'time_format' in <inject>/<extract> instead"
 
-    desc 'If true, use localtime with in_time_format.'
-    config_param :localtime, :bool, default: true
-    desc 'If true, use timezone with in_time_format.'
-    config_param :timezone, :string, default: nil
+    desc 'The default block size to read if parser requires partial read.'
+    config_param :read_block_size, :size, default: 10240 # 10k
+
     desc 'The number of spawned process for command.'
     config_param :num_children, :integer, default: 1
 
@@ -91,70 +76,80 @@ module Fluent
     # 0: output logs for all of messages to emit
     config_param :suppress_error_log_interval, :time, default: 0
 
-    config_set_default :flush_interval, 1
+    attr_reader :formatter, :parser # for tests
+    attr_reader :children # for tests (temp)
+
+    KEYS_FOR_IN_AND_OUT = {
+      'tag_key' => ['in_tag_key', 'out_tag_key'],
+      'time_key' => ['in_time_key', 'out_time_key'],
+      'time_format' => ['in_time_format', 'out_time_format'],
+    }
+    COMPAT_INJECT_PARAMS = {
+      'in_tag_key' => 'tag_key',
+      'in_time_key' => 'time_key',
+      'in_time_format' => 'time_format',
+    }
+    COMPAT_FORMAT_PARAMS = {
+      'in_format' => '@type',
+      'in_keys' => 'keys',
+    }
+    COMPAT_PARSE_PARAMS = {
+      'out_format' => '@type',
+      'out_keys' => 'keys',
+    }
+    COMPAT_EXTRACT_PARAMS = {
+      'out_tag_key' => 'tag_key',
+      'out_time_key' => 'time_key',
+      'out_time_format' => 'time_format',
+    }
+
+    def exec_filter_compat_parameters_copy_to_subsection!(conf, subsection_name, params)
+      return unless conf.elements(subsection_name).empty?
+      return unless params.keys.any?{|k| conf.has_key?(k) }
+      hash = {}
+      params.each_pair do |compat, current|
+        hash[current] = conf[compat] if conf.has_key?(compat)
+      end
+      conf.elements << Fluent::Config::Element.new(subsection_name, '', hash, [])
+    end
+
+    def exec_filter_compat_parameters_convert!(conf)
+      KEYS_FOR_IN_AND_OUT.each_pair do |inout, keys|
+        if conf.has_key?(inout)
+          keys.each do |k|
+            conf[k] = conf[inout]
+          end
+        end
+      end
+      exec_filter_compat_parameters_copy_to_subsection!(conf, 'inject', COMPAT_INJECT_PARAMS)
+      exec_filter_compat_parameters_copy_to_subsection!(conf, 'format', COMPAT_FORMAT_PARAMS)
+      exec_filter_compat_parameters_copy_to_subsection!(conf, 'parse', COMPAT_PARSE_PARAMS)
+      exec_filter_compat_parameters_copy_to_subsection!(conf, 'extract', COMPAT_EXTRACT_PARAMS)
+    end
 
     def configure(conf)
-      if tag_key = conf['tag_key']
-        # TODO obsoleted?
-        conf['in_tag_key'] = tag_key
-        conf['out_tag_key'] = tag_key
-      end
+      exec_filter_compat_parameters_convert!(conf)
+      compat_parameters_convert(conf, :buffer)
 
-      if time_key = conf['time_key']
-        # TODO obsoleted?
-        conf['in_time_key'] = time_key
-        conf['out_time_key'] = time_key
+      if inject_section = conf.elements('inject').first
+        if inject_section.has_key?('time_format')
+          inject_section['time_type'] ||= 'string'
+        end
       end
-
-      if time_format = conf['time_format']
-        # TODO obsoleted?
-        conf['in_time_format'] = time_format
-        conf['out_time_format'] = time_format
+      if extract_section = conf.elements('extract').first
+        if extract_section.has_key?('time_format')
+          extract_section['time_type'] ||= 'string'
+        end
       end
 
       super
 
-      if conf['localtime']
-        @localtime = true
-      elsif conf['utc']
-        @localtime = false
+      if !@tag && (!@extract_config || !@extract_config.tag_key)
+        raise Fluent::ConfigError, "'tag' or '<extract> tag_key </extract>' option is required on exec_filter output"
       end
 
-      if conf['timezone']
-        @timezone = conf['timezone']
-        Fluent::Timezone.validate!(@timezone)
-      end
-
-      if !@tag && !@out_tag_key
-        raise ConfigError, "'tag' or 'out_tag_key' option is required on exec_filter output"
-      end
-
-      if @in_time_key
-        if f = @in_time_format
-          tf = TimeFormatter.new(f, @localtime, @timezone)
-          @time_format_proc = tf.method(:format)
-        else
-          @time_format_proc = Proc.new {|time| time.to_s }
-        end
-      elsif @in_time_format
-        log.warn "in_time_format effects nothing when in_time_key is not specified: #{conf}"
-      end
-
-      if @out_time_key
-        if f = @out_time_format
-          @time_parse_proc =
-            begin
-              strptime = Strptime.new(f)
-              Proc.new { |str| Fluent::EventTime.from_time(strptime.exec(str)) }
-            rescue
-              Proc.new {|str| Fluent::EventTime.from_time(Time.strptime(str, f)) }
-            end
-        else
-          @time_parse_proc = Proc.new {|str| Fluent::EventTime.from_time(Time.at(str.to_f)) }
-        end
-      elsif @out_time_format
-        log.warn "out_time_format effects nothing when out_time_key is not specified: #{conf}"
-      end
+      @formatter = formatter_create
+      @parser = parser_create
 
       if @remove_prefix
         @removed_prefix_string = @remove_prefix + '.'
@@ -162,30 +157,6 @@ module Fluent
       end
       if @add_prefix
         @added_prefix_string = @add_prefix + '.'
-      end
-
-      case @in_format
-      when :tsv
-        if @in_keys.empty?
-          raise ConfigError, "in_keys option is required on exec_filter output for tsv in_format"
-        end
-        @formatter = Fluent::ExecUtil::TSVFormatter.new(@in_keys)
-      when :json
-        @formatter = Fluent::ExecUtil::JSONFormatter.new
-      when :msgpack
-        @formatter = Fluent::ExecUtil::MessagePackFormatter.new
-      end
-
-      case @out_format
-      when :tsv
-        if @out_keys.empty?
-          raise ConfigError, "out_keys option is required on exec_filter output for tsv in_format"
-        end
-        @parser = Fluent::ExecUtil::TSVParser.new(@out_keys, method(:on_message))
-      when :json
-        @parser = Fluent::ExecUtil::JSONParser.new(method(:on_message))
-      when :msgpack
-        @parser = Fluent::ExecUtil::MessagePackParser.new(method(:on_message))
       end
 
       @respawns = if @child_respawn.nil? or @child_respawn == 'none' or @child_respawn == '0'
@@ -205,11 +176,17 @@ module Fluent
     def start
       super
 
+      receiver = case
+                 when @parser.implement?(:parse_io) then method(:run_with_io)
+                 when @parser.implement?(:parse_partial_data) then method(:run_with_partial_read)
+                 else method(:run)
+                 end
+
       @children = []
       @rr = 0
       begin
         @num_children.times do
-          c = ChildProcess.new(@parser, @respawns, log)
+          c = ChildProcess.new(receiver, @respawns, log)
           c.start(@command)
           @children << c
         end
@@ -238,26 +215,23 @@ module Fluent
       super
     end
 
-    def format_stream(tag, es)
+    def tag_remove_prefix(tag)
       if @remove_prefix
-        if (tag[0, @removed_length] == @removed_prefix_string and tag.length > @removed_length) or tag == @removed_prefix
+        if (tag[0, @removed_length] == @removed_prefix_string and tag.length > @removed_length) or tag == @removed_prefix_string
           tag = tag[@removed_length..-1] || ''
         end
       end
+      tag
+    end
 
-      out = ''
-
-      es.each {|time,record|
-        if @in_time_key
-          record[@in_time_key] = @time_format_proc.call(time)
-        end
-        if @in_tag_key
-          record[@in_tag_key] = tag
-        end
-        @formatter.call(record, out)
-      }
-
-      out
+    def format(tag, time, record)
+      tag = tag_remove_prefix(tag)
+      record = inject_values_to_record(tag, time, record)
+      if @formatter.formatter_type == :text_per_line
+        @formatter.format(tag, time, record).chomp + "\n"
+      else
+        @formatter.format(tag, time, record)
+      end
     end
 
     def write(chunk)
@@ -268,10 +242,10 @@ module Fluent
     class ChildProcess
       attr_accessor :finished
 
-      def initialize(parser, respawns=0, log = $log)
+      def initialize(parser_proc, respawns=0, log = $log)
         @pid = nil
         @thread = nil
-        @parser = parser
+        @parser_proc = parser_proc
         @respawns = respawns
         @mutex = Mutex.new
         @finished = nil
@@ -340,7 +314,7 @@ module Fluent
           @io = IO.popen(@command, "r+")
           @pid = @io.pid
           @io.sync = true
-          @thread = Thread.new(&method(:run))
+          @thread = ::Thread.new(&method(:run))
 
           @respawns -= 1 if @respawns > 0
         end
@@ -349,10 +323,10 @@ module Fluent
       end
 
       def run
-        @parser.call(@io)
-      rescue
-        @log.error "exec_filter thread unexpectedly failed with an error.", command: @command, error: $!.to_s
-        @log.warn_backtrace $!.backtrace
+        @parser_proc.call(@io)
+      rescue => e
+        @log.error "exec_filter thread unexpectedly failed with an error.", command: @command, error: e
+        @log.warn_backtrace e.backtrace
       ensure
         _pid, stat = Process.waitpid2(@pid)
         unless @finished
@@ -364,30 +338,44 @@ module Fluent
       end
     end
 
-    def on_message(record)
-      if val = record.delete(@out_time_key)
-        time = @time_parse_proc.call(val)
-      else
-        time = Engine.now
-      end
+    def run_with_io(io)
+      @parser.parse_io(io, &method(:on_record))
+    end
 
-      if val = record.delete(@out_tag_key)
-        tag = if @add_prefix
-                @added_prefix_string + val
-              else
-                val
-              end
-      else
-        tag = @tag
+    def run_with_partial_read(io)
+      until io.eof?
+        @parser.parse_partial_data(io.readpartial(@read_block_size), &method(:on_record))
       end
+    rescue EOFError
+      # ignore
+    end
 
+    def run(io)
+      if @parser.parser_type == :text_per_line
+        io.each_line do |line|
+          @parser.parse(line.chomp, &method(:on_record))
+        end
+      else
+        @parser.parse(io.read, &method(:on_record))
+      end
+    rescue EOFError
+      # ignore
+    end
+
+    def on_record(time, record)
+      tag = nil
+      tag = extract_tag_from_record(record)
+      tag = @added_prefix_string + tag if tag && @add_prefix
+      tag ||= @tag
+      time ||= extract_time_from_record(record) || Fluent::EventTime.now
       router.emit(tag, time, record)
-    rescue
+    rescue => e
       if @suppress_error_log_interval == 0 || Time.now.to_i > @next_log_time
-        log.error "exec_filter failed to emit", error: $!, record: Yajl.dump(record)
-        log.warn_backtrace $!.backtrace
+        log.error "exec_filter failed to emit", record: Yajl.dump(record), error: e
+        log.warn_backtrace e.backtrace
         @next_log_time = Time.now.to_i + @suppress_error_log_interval
       end
+      router.emit_error_event(tag, time, record, "exec_filter failed to emit") if tag && time && record
     end
   end
 end

--- a/lib/fluent/plugin/out_exec_filter.rb
+++ b/lib/fluent/plugin/out_exec_filter.rb
@@ -305,7 +305,7 @@ module Fluent::Plugin
         log.error_backtrace e.backtrace
         @next_log_time = Time.now.to_i + @suppress_error_log_interval
       end
-      router.emit_error_event(tag, time, record, "exec_filter failed to emit") if tag && time && record
+      router.emit_error_event(tag, time, record, e) if tag && time && record
     end
   end
 end

--- a/lib/fluent/plugin/out_exec_filter.rb
+++ b/lib/fluent/plugin/out_exec_filter.rb
@@ -253,11 +253,13 @@ module Fluent::Plugin
       tag
     end
 
+    NEWLINE = "\n"
+
     def format(tag, time, record)
       tag = tag_remove_prefix(tag)
       record = inject_values_to_record(tag, time, record)
       if @formatter.formatter_type == :text_per_line
-        @formatter.format(tag, time, record).chomp + "\n"
+        @formatter.format(tag, time, record).chomp + NEWLINE
       else
         @formatter.format(tag, time, record)
       end

--- a/lib/fluent/plugin/out_exec_filter.rb
+++ b/lib/fluent/plugin/out_exec_filter.rb
@@ -219,12 +219,12 @@ module Fluent::Plugin
       end
 
       if @respawns != 0
-        thread_create do
+        thread_create(:out_exec_filter_respawn_monitor) do
           while thread_current_running?
             @children.each_with_index do |c, i|
               if c.mutex && c.mutex.synchronize{ c.pid.nil? && c.respawns != 0 }
                 respawns = c.mutex.synchronize do
-                  c.respawns -= 1 if c.respanws > 0
+                  c.respawns -= 1 if c.respawns > 0
                   c.respawns
                 end
                 log.info "respawning child process", num: i, respawn_counter: respawns

--- a/lib/fluent/plugin/out_exec_filter.rb
+++ b/lib/fluent/plugin/out_exec_filter.rb
@@ -77,7 +77,6 @@ module Fluent::Plugin
     config_param :suppress_error_log_interval, :time, default: 0
 
     attr_reader :formatter, :parser # for tests
-    attr_reader :children # for tests (temp)
 
     KEYS_FOR_IN_AND_OUT = {
       'tag_key' => ['in_tag_key', 'out_tag_key'],

--- a/lib/fluent/plugin/out_exec_filter.rb
+++ b/lib/fluent/plugin/out_exec_filter.rb
@@ -237,19 +237,6 @@ module Fluent::Plugin
       end
     end
 
-    def stop
-      @children.each_with_index do |c, i|
-        c.mutex.synchronize do
-          if c.pid
-            c.writeio.close rescue nil
-            c.writeio = nil
-          end
-        end
-      end
-
-      super
-    end
-
     def terminate
       @children = []
       super

--- a/lib/fluent/plugin/out_exec_filter.rb
+++ b/lib/fluent/plugin/out_exec_filter.rb
@@ -294,7 +294,6 @@ module Fluent::Plugin
     end
 
     def on_record(time, record)
-      tag = nil
       tag = extract_tag_from_record(record)
       tag = @added_prefix_string + tag if tag && @add_prefix
       tag ||= @tag

--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -889,10 +889,9 @@ module Fluent
       def commit_write(chunk_id, delayed: @delayed_commit, secondary: false)
         log.trace "committing write operation to a chunk", chunk: dump_unique_id_hex(chunk_id), delayed: delayed
         if delayed
-          r = @dequeued_chunks_mutex.synchronize do
-            @dequeued_chunks.reject!{ |info| info.chunk_id == chunk_id }
+          @dequeued_chunks_mutex.synchronize do
+            @dequeued_chunks.delete_if{ |info| info.chunk_id == chunk_id }
           end
-          raise "BUG: chunk is not committed, does plugin call #commit_write in #try_write ?" if r.nil? # nothing deleted from @dequeued_chunks
         end
         @buffer.purge_chunk(chunk_id)
 

--- a/lib/fluent/plugin/parser.rb
+++ b/lib/fluent/plugin/parser.rb
@@ -53,6 +53,11 @@ module Fluent
       # for tests
       attr_reader :type_converters
 
+      PARSER_TYPES = [:text_per_line, :text, :binary]
+      def parser_type
+        :text_per_line
+      end
+
       def configure(conf)
         super
 
@@ -70,6 +75,24 @@ module Fluent
         # Keep backward compatibility for existing plugins
         # TODO: warn when deprecated
         parse(*a, &b)
+      end
+
+      def implement?(feature)
+        methods_of_plugin = self.class.instance_methods(false)
+        case feature
+        when :parse_io then methods_of_plugin.include?(:parse_io)
+        when :parse_partial_data then methods_of_plugin.include?(:parse_partial_data)
+        else
+          raise ArgumentError, "Unknown feature for parser plugin: #{feature}"
+        end
+      end
+
+      def parse_io(io, &block)
+        raise NotImplementedError, "Optional API #parse_io is not implemented"
+      end
+
+      def parse_partial_data(data, &block)
+        raise NotImplementedError, "Optional API #parse_partial_data is not implemented"
       end
 
       def parse_time(record)

--- a/lib/fluent/plugin/parser_csv.rb
+++ b/lib/fluent/plugin/parser_csv.rb
@@ -31,7 +31,8 @@ module Fluent
       def parse(text, &block)
         values = CSV.parse_line(text, col_sep: @delimiter)
         r = Hash[@keys.zip(values)]
-        convert_values(parse_time(r), r, &block)
+        time, record = convert_values(parse_time(r), r)
+        yield time, record
       end
     end
   end

--- a/lib/fluent/plugin/parser_json.rb
+++ b/lib/fluent/plugin/parser_json.rb
@@ -64,6 +64,18 @@ module Fluent
       rescue @error_class
         yield nil, nil
       end
+
+      def parser_type
+        :text
+      end
+
+      def parse_io(io, &block)
+        y = Yajl::Parser.new
+        y.on_parse_complete = ->(record){
+          block.call(parse_time(record), record)
+        }
+        y.parse(io)
+      end
     end
   end
 end

--- a/lib/fluent/plugin/parser_msgpack.rb
+++ b/lib/fluent/plugin/parser_msgpack.rb
@@ -1,0 +1,50 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'fluent/plugin/parser'
+require 'fluent/msgpack_factory'
+
+module Fluent
+  module Plugin
+    class MessagePackParser < Parser
+      Plugin.register_parser('msgpack', self)
+
+      def configure(conf)
+        super
+        @unpacker = Fluent::MessagePackFactory.engine_factory.unpacker
+      end
+
+      def parser_type
+        :binary
+      end
+
+      def parse(data)
+        @unpacker.feed_each(data) do |obj|
+          yield convert_values(parse_time(obj), obj)
+        end
+      end
+      alias parse_partial_data parse
+
+      def parse_io(io)
+        u = Fluent::MessagePackFactory.engine_factory.unpacker(io)
+        u.each do |obj|
+          time, record = convert_values(parse_time(obj), obj)
+          yield time, record
+        end
+      end
+    end
+  end
+end

--- a/lib/fluent/plugin/parser_msgpack.rb
+++ b/lib/fluent/plugin/parser_msgpack.rb
@@ -38,7 +38,7 @@ module Fluent
       end
       alias parse_partial_data parse
 
-      def parse_io(io)
+      def parse_io(io, &block)
         u = Fluent::MessagePackFactory.engine_factory.unpacker(io)
         u.each do |obj|
           time, record = convert_values(parse_time(obj), obj)

--- a/lib/fluent/plugin_helper.rb
+++ b/lib/fluent/plugin_helper.rb
@@ -36,7 +36,14 @@ module Fluent
     end
 
     def helpers(*snake_case_symbols)
-      helper_modules = snake_case_symbols.map{|name| Fluent::PluginHelper.const_get(name.to_s.split('_').map(&:capitalize).join) }
+      helper_modules = []
+      snake_case_symbols.each do |name|
+        begin
+          helper_modules << Fluent::PluginHelper.const_get(name.to_s.split('_').map(&:capitalize).join)
+        rescue NameError
+          raise "Unknown plugin helper:#{name}"
+        end
+      end
       include(*helper_modules)
     end
   end

--- a/lib/fluent/plugin_helper/child_process.rb
+++ b/lib/fluent/plugin_helper/child_process.rb
@@ -265,6 +265,7 @@ module Fluent
           m.lock # run after plugin thread get pid, thread instance and i/o
           m.unlock
           begin
+            @_child_process_processes[pid].alive = true
             block.call(*io_objects)
           rescue EOFError => e
             log.debug "Process exit and I/O closed", title: title, pid: pid, command: command, arguments: arguments
@@ -286,7 +287,7 @@ module Fluent
         end
         thread[:_fluentd_plugin_helper_child_process_running] = true
         thread[:_fluentd_plugin_helper_child_process_pid] = pid
-        pinfo = ProcessInfo.new(title, thread, pid, readio, readio_in_use, writeio, writeio_in_use, stderrio, stderrio_in_use, wait_thread, true, nil)
+        pinfo = ProcessInfo.new(title, thread, pid, readio, readio_in_use, writeio, writeio_in_use, stderrio, stderrio_in_use, wait_thread, false, nil)
         @_child_process_mutex.synchronize do
           @_child_process_processes[pid] = pinfo
         end

--- a/lib/fluent/plugin_helper/child_process.rb
+++ b/lib/fluent/plugin_helper/child_process.rb
@@ -49,8 +49,18 @@ module Fluent
         ::Thread.current[:_fluentd_plugin_helper_child_process_pid]
       end
 
-      def child_process_exit_status
-        ::Thread.current[:_fluentd_plugin_helper_child_process_exit_status]
+      def child_process_exist?(pid)
+        pinfo = @_child_process_processes[pid]
+        return false unless pinfo
+
+        return false if pinfo.exit_status
+
+        if pinfo.wait_thread.status
+          return true
+        end
+
+        pinfo.exit_status = pinfo.wait_thread.value
+        false
       end
 
       def child_process_execute(
@@ -58,30 +68,41 @@ module Fluent
           arguments: nil, subprocess_name: nil, interval: nil, immediate: false, parallel: false,
           mode: [:read, :write], stderr: :discard, env: {}, unsetenv: false, chdir: nil,
           internal_encoding: 'utf-8', external_encoding: 'ascii-8bit', scrub: true, replace_string: nil,
+          wait_timeout: nil, on_exit_callback: nil,
           &block
       )
         raise ArgumentError, "BUG: title must be a symbol" unless title.is_a? Symbol
         raise ArgumentError, "BUG: arguments required if subprocess name is replaced" if subprocess_name && !arguments
 
+        mode ||= []
         raise ArgumentError, "BUG: invalid mode specification" unless mode.all?{|m| MODE_PARAMS.include?(m) }
         raise ArgumentError, "BUG: read_with_stderr is exclusive with :read and :stderr" if mode.include?(:read_with_stderr) && (mode.include?(:read) || mode.include?(:stderr))
         raise ArgumentError, "BUG: invalid stderr handling specification" unless STDERR_OPTIONS.include?(stderr)
 
-        raise ArgumentError, "BUG: block not specified which receive i/o object" unless block_given?
-        raise ArgumentError, "BUG: number of block arguments are different from size of mode" unless block.arity == mode.size
+        raise ArgumentError, "BUG: number of block arguments are different from size of mode" if block && block.arity != mode.size
 
         running = false
         callback = ->(*args) {
           running = true
           begin
-            block.call(*args)
+            block && block.call(*args)
           ensure
             running = false
           end
         }
 
+        execute_child_process = ->(){
+          child_process_execute_once(
+            title, command, arguments,
+            subprocess_name, mode, stderr, env, unsetenv, chdir,
+            internal_encoding, external_encoding, scrub, replace_string,
+            wait_timeout, on_exit_callback,
+            &callback
+          )
+        }
+
         if immediate || !interval
-          child_process_execute_once(title, command, arguments, subprocess_name, mode, stderr, env, unsetenv, chdir, internal_encoding, external_encoding, scrub, replace_string, &callback)
+          execute_child_process.call
         end
 
         if interval
@@ -89,7 +110,7 @@ module Fluent
             if !parallel && running
               log.warn "previous child process is still running. skipped.", title: title, command: command, arguments: arguments, interval: interval, parallel: parallel
             else
-              child_process_execute_once(title, command, arguments, subprocess_name, mode, stderr, env, unsetenv, chdir, internal_encoding, external_encoding, scrub, replace_string, &callback)
+              execute_child_process.call
             end
           end
         end
@@ -101,10 +122,6 @@ module Fluent
         @_child_process_exit_timeout = CHILD_PROCESS_DEFAULT_EXIT_TIMEOUT
         @_child_process_kill_timeout = CHILD_PROCESS_DEFAULT_KILL_TIMEOUT
         @_child_process_mutex = Mutex.new
-      end
-
-      def start
-        super
         @_child_process_processes = {} # pid => ProcessInfo
       end
 
@@ -115,6 +132,8 @@ module Fluent
             process_info.thread[:_fluentd_plugin_helper_child_process_running] = false
           end
         end
+
+        super
       end
 
       def shutdown
@@ -157,44 +176,50 @@ module Fluent
         super
       end
 
-      def child_process_kill(process_info, force: false)
-        if !process_info || !process_info.alive
-          return
-        end
+      def child_process_kill(pinfo, force: false)
+        return if !pinfo
+        pinfo.killed_at = Time.now unless force
 
-        process_info.killed_at = Time.now unless force
-
-        begin
-          pid, status = Process.waitpid2(process_info.pid, Process::WNOHANG)
-          if pid && status
-            process_info.thread[:_fluentd_plugin_helper_child_process_exit_status] = status
-            process_info.alive = false
+        call_exit_callback = ->(){
+          cb = pinfo.on_exit_callback_mutex.synchronize do
+            cback = pinfo.on_exit_callback
+            pinfo.on_exit_callback = nil
+            cback
           end
-        rescue Errno::ECHILD, Errno::ESRCH, Errno::EPERM
-          process_info.alive = false
-        rescue
-          # ignore
-        end
-        if !process_info.alive
-          return
-        end
+          if cb
+            cb.call(pinfo.exit_status) rescue nil
+          end
+        }
 
+        pid = pinfo.pid
         begin
-          signal = (Fluent.windows? || force) ? :KILL : :TERM
-          Process.kill(signal, process_info.pid)
-          if force
-            process_info.alive = false
+          if child_process_exist?(pid)
+            signal = (Fluent.windows? || force) ? :KILL : :TERM
+            Process.kill(signal, pinfo.pid)
+            if force
+              sleep 0.1 while child_process_exist?(pid)
+            end
           end
         rescue Errno::ECHILD, Errno::ESRCH
-          process_info.alive = false
+          # ignore
+        end
+
+        unless child_process_exist?(pid)
+          call_exit_callback.call
         end
       end
 
-      ProcessInfo = Struct.new(:title, :thread, :pid, :readio, :readio_in_use, :writeio, :writeio_in_use, :stderrio, :stderrio_in_use, :wait_thread, :alive, :killed_at)
+      ProcessInfo = Struct.new(
+        :title,
+        :thread, :pid,
+        :readio, :readio_in_use, :writeio, :writeio_in_use, :stderrio, :stderrio_in_use,
+        :wait_thread, :alive, :killed_at, :exit_status,
+        :on_exit_callback, :on_exit_callback_mutex,
+      )
 
       def child_process_execute_once(
           title, command, arguments, subprocess_name, mode, stderr, env, unsetenv, chdir,
-          internal_encoding, external_encoding, scrub, replace_string, &block
+          internal_encoding, external_encoding, scrub, replace_string, wait_timeout, on_exit_callback, &block
       )
         spawn_args = if arguments || subprocess_name
                        [ env, (subprocess_name ? [command, subprocess_name] : command), *(arguments || []) ]
@@ -227,36 +252,40 @@ module Fluent
           writeio, readio, wait_thread = *Open3.popen2e(*spawn_args, spawn_opts)
         else
           writeio, readio, stderrio, wait_thread = *Open3.popen3(*spawn_args, spawn_opts)
-          if !mode.include?(:stderr) # stderr == :discard
-            stderrio.reopen(IO::NULL)
-          end
         end
 
         if mode.include?(:write)
           writeio.set_encoding(external_encoding, internal_encoding, encoding_options)
           writeio_in_use = true
+        else
+          writeio.reopen(IO::NULL) if writeio
         end
         if mode.include?(:read) || mode.include?(:read_with_stderr)
           readio.set_encoding(external_encoding, internal_encoding, encoding_options)
           readio_in_use = true
+        else
+          readio.reopen(IO::NULL) if readio
         end
         if mode.include?(:stderr)
           stderrio.set_encoding(external_encoding, internal_encoding, encoding_options)
           stderrio_in_use = true
+        else
+          stderrio.reopen(IO::NULL) if stderrio && stderrio == :discard
         end
 
         pid = wait_thread.pid # wait_thread => Process::Waiter
 
         io_objects = []
         mode.each do |m|
-          io_objects << case m
-                        when :read then readio
-                        when :write then writeio
-                        when :read_with_stderr then readio
-                        when :stderr then stderrio
-                        else
-                          raise "BUG: invalid mode must be checked before here: '#{m}'"
-                        end
+          io_obj = case m
+                   when :read then readio
+                   when :write then writeio
+                   when :read_with_stderr then readio
+                   when :stderr then stderrio
+                   else
+                     raise "BUG: invalid mode must be checked before here: '#{m}'"
+                   end
+          io_objects << io_obj
         end
 
         m = Mutex.new
@@ -266,7 +295,16 @@ module Fluent
           m.unlock
           begin
             @_child_process_processes[pid].alive = true
-            block.call(*io_objects)
+            block.call(*io_objects) if block_given?
+            writeio.close if writeio
+            if wait_timeout
+              if wait_thread.join(wait_timeout) # Thread#join returns nil when limit expires
+                # wait_thread successfully exits
+                @_child_process_processes[pid].exit_status = wait_thread.value
+              else
+                log.warn "child process timed out", title: title, pid: pid, command: command, arguments: arguments
+              end
+            end
           rescue EOFError => e
             log.debug "Process exit and I/O closed", title: title, pid: pid, command: command, arguments: arguments
           rescue IOError => e
@@ -275,19 +313,24 @@ module Fluent
             else
               log.error "Unexpected I/O error for child process", title: title, pid: pid, command: command, arguments: arguments, error: e
             end
+          rescue Errno::EPIPE => e
+            log.debug "Broken pipe, child process unexpectedly exits", title: title, pid: pid, command: command, arguments: arguments
           rescue => e
             log.warn "Unexpected error while processing I/O for child process", title: title, pid: pid, command: command, error: e
           end
-          process_info = @_child_process_mutex.synchronize do
-            process_info = @_child_process_processes[pid]
-            @_child_process_processes.delete(pid)
-            process_info
+          process_info = @_child_process_mutex.synchronize{ @_child_process_processes.delete(pid) }
+          if process_info
+            child_process_kill(process_info, force: true)
           end
-          child_process_kill(process_info, force: true) if process_info && process_info.alive && ::Thread.current[:_fluentd_plugin_helper_child_process_running]
         end
         thread[:_fluentd_plugin_helper_child_process_running] = true
         thread[:_fluentd_plugin_helper_child_process_pid] = pid
-        pinfo = ProcessInfo.new(title, thread, pid, readio, readio_in_use, writeio, writeio_in_use, stderrio, stderrio_in_use, wait_thread, false, nil)
+        pinfo = ProcessInfo.new(
+          title, thread, pid,
+          readio, readio_in_use, writeio, writeio_in_use, stderrio, stderrio_in_use,
+          wait_thread, false, nil, nil, on_exit_callback, Mutex.new
+        )
+
         @_child_process_mutex.synchronize do
           @_child_process_processes[pid] = pinfo
         end

--- a/lib/fluent/plugin_helper/child_process.rb
+++ b/lib/fluent/plugin_helper/child_process.rb
@@ -122,7 +122,7 @@ module Fluent
         @_child_process_kill_timeout = CHILD_PROCESS_DEFAULT_KILL_TIMEOUT
         @_child_process_mutex = Mutex.new
         @_child_process_processes = {} # pid => ProcessInfo
-        @_child_process_clock_id = Process::CLOCK_MONOTONIC rescue Process::CLOCK_MONOTONIC_RAW
+        @_child_process_clock_id = Process::CLOCK_MONOTONIC_RAW rescue Process::CLOCK_MONOTONIC
       end
 
       def stop

--- a/lib/fluent/plugin_helper/child_process.rb
+++ b/lib/fluent/plugin_helper/child_process.rb
@@ -298,7 +298,7 @@ module Fluent
           rescue EOFError => e
             log.debug "Process exit and I/O closed", title: title, pid: pid, command: command, arguments: arguments
           rescue IOError => e
-            if e.message == 'stream closed'
+            if e.message == 'stream closed' || e.message == 'closed stream' # "closed stream" is of ruby 2.1
               log.debug "Process I/O stream closed", title: title, pid: pid, command: command, arguments: arguments
             else
               log.error "Unexpected I/O error for child process", title: title, pid: pid, command: command, arguments: arguments, error: e

--- a/lib/fluent/plugin_helper/child_process.rb
+++ b/lib/fluent/plugin_helper/child_process.rb
@@ -58,6 +58,9 @@ module Fluent
         true
       end
 
+      # on_exit_callback = ->(status){ ... }
+      # status is an instance of Process::Status
+      # On Windows, exitstatus=0 and termsig=nil even when child process was killed.
       def child_process_execute(
           title, command,
           arguments: nil, subprocess_name: nil, interval: nil, immediate: false, parallel: false,

--- a/lib/fluent/plugin_helper/compat_parameters.rb
+++ b/lib/fluent/plugin_helper/compat_parameters.rb
@@ -70,9 +70,9 @@ module Fluent
 
       INJECT_PARAMS = {
         "include_time_key" => nil,
-        "time_key"      => "time_key",
-        "time_format"   => "time_format",
-        "timezone"      => "timezone",
+        "time_key"    => "time_key",
+        "time_format" => "time_format",
+        "timezone"    => "timezone",
         "include_tag_key" => nil,
         "tag_key" => "tag_key",
         "localtime" => nil,
@@ -80,9 +80,9 @@ module Fluent
       }
 
       EXTRACT_PARAMS = {
-        "time_key"      => "time_key",
-        "time_format"   => "time_format",
-        "timezone"      => "timezone",
+        "time_key"    => "time_key",
+        "time_format" => "time_format",
+        "timezone"    => "timezone",
         "tag_key" => "tag_key",
         "localtime" => nil,
         "utc" => nil,

--- a/lib/fluent/plugin_helper/inject.rb
+++ b/lib/fluent/plugin_helper/inject.rb
@@ -113,6 +113,10 @@ module Fluent
                                         localtime = @inject_config.localtime && !@inject_config.utc
                                         Fluent::TimeFormatter.new(@inject_config.time_format, localtime, @inject_config.timezone)
                                       end
+          else
+            if @inject_config.time_format
+              log.warn "'time_format' specified without 'time_key', will be ignored"
+            end
           end
 
           @_inject_enabled = @_inject_hostname_key || @_inject_tag_key || @_inject_time_key

--- a/lib/fluent/test/driver/base.rb
+++ b/lib/fluent/test/driver/base.rb
@@ -149,11 +149,15 @@ module Fluent
 
         def run_actual(timeout: DEFAULT_TIMEOUT, &block)
           if @instance.respond_to?(:_threads)
-            sleep 0.01 until @instance._threads.values.all?(&:alive?)
+            sleep 0.1 until @instance._threads.values.all?(&:alive?)
           end
 
           if @instance.respond_to?(:event_loop_running?)
-            sleep 0.01 until @instance.event_loop_running?
+            sleep 0.1 until @instance.event_loop_running?
+          end
+
+          if @instance.respond_to?(:_child_process_processes)
+            sleep 0.1 until @instance._child_process_processes.values.all?{|pinfo| pinfo.alive }
           end
 
           return_value = nil

--- a/test/plugin/test_in_exec.rb
+++ b/test/plugin/test_in_exec.rb
@@ -4,130 +4,94 @@ require 'fluent/plugin/in_exec'
 require 'net/http'
 
 class ExecInputTest < Test::Unit::TestCase
+  SCRIPT_PATH = File.expand_path(File.join(File.dirname(__FILE__), '..', 'scripts', 'exec_script.rb'))
+  TEST_TIME = "2011-01-02 13:14:15"
+  TEST_UNIX_TIME = Time.parse(TEST_TIME)
+
   def setup
     Fluent::Test.setup
-    @test_time = event_time("2011-01-02 13:14:15")
-    @script = File.expand_path(File.join(File.dirname(__FILE__), '..', 'scripts', 'exec_script.rb'))
+    @test_time = event_time()
   end
 
-  def create_driver(conf = tsv_config)
+  def create_driver(conf = TSV_CONFIG)
     Fluent::Test::Driver::Input.new(Fluent::Plugin::ExecInput).configure(conf)
   end
 
-  def tsv_config
-    %[
-      command ruby #{@script} "2011-01-02 13:14:15" 0
+  TSV_CONFIG = %[
+      command ruby #{SCRIPT_PATH} "#{TEST_TIME}" 0
       keys time,tag,k1
       time_key time
       tag_key tag
       time_format %Y-%m-%d %H:%M:%S
       run_interval 1s
-    ]
-  end
+  ]
 
-  def json_config
-    %[
-      command ruby #{@script} #{@test_time} 1
+  JSON_CONFIG = %[
+      command ruby #{SCRIPT_PATH} #{TEST_UNIX_TIME.to_i} 1
       format json
       tag_key tag
       time_key time
       run_interval 1s
-    ]
-  end
+  ]
 
-  def msgpack_config
-    %[
-      command ruby #{@script} #{@test_time} 2
+  MSGPACK_CONFIG = %[
+      command ruby #{SCRIPT_PATH} #{TEST_UNIX_TIME.to_i} 2
       format msgpack
       tag_key tagger
       time_key datetime
       run_interval 1s
-    ]
-  end
+  ]
 
-  def regexp_config
-    %[
-      command ruby #{@script} "2011-01-02 13:14:15" 3
+  REGEXP_CONFIG = %[
+      command ruby #{SCRIPT_PATH} "#{TEST_TIME}" 3
       format /(?<time>[^\\\]]*) (?<message>[^ ]*)/
       tag regex_tag
       run_interval 1s
-    ]
-  end
+  ]
+  #      time_format %Y-%m-%d %H:%M:%S
 
   def test_configure
     d = create_driver
-    assert_equal 'tsv', d.instance.format
-    assert_equal ["time","tag","k1"], d.instance.keys
-    assert_equal "tag", d.instance.tag_key
-    assert_equal "time", d.instance.time_key
-    assert_equal "%Y-%m-%d %H:%M:%S", d.instance.time_format
+    assert{ d.instance.parser.is_a? Fluent::Plugin::TSVParser }
+    assert_equal ["time","tag","k1"], d.instance.parser.keys
+    assert_equal "tag", d.instance.extract_config.tag_key
+    assert_equal "time", d.instance.extract_config.time_key
+    assert_equal "%Y-%m-%d %H:%M:%S", d.instance.extract_config.time_format
   end
 
   def test_configure_with_json
-    d = create_driver json_config
-    assert_equal 'json', d.instance.format
-    assert_equal [], d.instance.keys
+    d = create_driver JSON_CONFIG
+    assert{ d.instance.parser.is_a? Fluent::Plugin::JSONParser }
   end
 
   def test_configure_with_msgpack
-    d = create_driver msgpack_config
-    assert_equal 'msgpack', d.instance.format
-    assert_equal [], d.instance.keys
+    d = create_driver MSGPACK_CONFIG
+    assert{ d.instance.parser.is_a? Fluent::Plugin::MessagePackParser }
   end
 
   def test_configure_with_regexp
-    d = create_driver regexp_config
-    assert_equal '/(?<time>[^\]]*) (?<message>[^ ]*)/', d.instance.format
+    d = create_driver REGEXP_CONFIG
+    assert{ d.instance.parser.is_a? Fluent::Plugin::RegexpParser }
+    assert_equal '(?<time>[^\]]*) (?<message>[^ ]*)', d.instance.parser.expression
     assert_equal 'regex_tag', d.instance.tag
   end
 
-  # TODO: Merge following tests into one case with parameters
+  data(
+    'default' => [TSV_CONFIG,     "tag1", event_time("2011-01-02 13:14:15"), {"k1"=>"ok"}],
+    'json'    => [JSON_CONFIG,    "tag1", event_time("2011-01-02 13:14:15"), {"k1"=>"ok"}],
+    'msgpack' => [MSGPACK_CONFIG, "tag1", event_time("2011-01-02 13:14:15"), {"k1"=>"ok"}],
+    'regexp'  => [REGEXP_CONFIG,  "regex_tag", event_time("2011-01-02 13:14:15"), {"message"=>"hello"}],
+  )
+  test 'emit with formats' do |data|
+    config, tag, time, record = data
+    d = create_driver(config)
 
-  def test_emit
-    d = create_driver
+    d.run(expect_emits: 2, timeout: 10)
 
-    d.run(expect_emits: 2)
-
-    assert_equal true, d.events.length > 0
+    assert{ d.events.length > 0 }
     d.events.each_with_index {|event, i|
-      assert_equal ["tag1", @test_time, {"k1"=>"ok"}], event
-      assert_equal_event_time(@test_time, event[1])
-    }
-  end
-
-  def test_emit_json
-    d = create_driver json_config
-
-    d.run(expect_emits: 2)
-
-    assert_equal true, d.events.length > 0
-    d.events.each_with_index {|event, i|
-      assert_equal ["tag1", @test_time, {"k1"=>"ok"}], event
-      assert_equal_event_time(@test_time, event[1])
-    }
-  end
-
-  def test_emit_msgpack
-    d = create_driver msgpack_config
-
-    d.run(expect_emits: 2)
-
-    assert_equal true, d.events.length > 0
-    d.events.each_with_index {|event, i|
-      assert_equal ["tag1", @test_time, {"k1"=>"ok"}], event
-      assert_equal_event_time(@test_time, event[1])
-    }
-  end
-
-  def test_emit_regexp
-    d = create_driver regexp_config
-
-    d.run(expect_emits: 2)
-
-    assert_equal true, d.events.length > 0
-    d.events.each_with_index {|event, i|
-      assert_equal ["regex_tag", @test_time, {"message"=>"hello"}], event
-      assert_equal_event_time(@test_time, event[1])
+      assert_equal_event_time(time, event[1])
+      assert_equal [tag, time, record], event
     }
   end
 end

--- a/test/plugin/test_in_exec.rb
+++ b/test/plugin/test_in_exec.rb
@@ -1,7 +1,7 @@
 require_relative '../helper'
 require 'fluent/test/driver/input'
 require 'fluent/plugin/in_exec'
-require 'net/http'
+require 'timecop'
 
 class ExecInputTest < Test::Unit::TestCase
   SCRIPT_PATH = File.expand_path(File.join(File.dirname(__FILE__), '..', 'scripts', 'exec_script.rb'))
@@ -13,11 +13,133 @@ class ExecInputTest < Test::Unit::TestCase
     @test_time = event_time()
   end
 
-  def create_driver(conf = TSV_CONFIG)
+  def create_driver(conf)
     Fluent::Test::Driver::Input.new(Fluent::Plugin::ExecInput).configure(conf)
   end
 
+  DEFAULT_CONFIG_ONLY_WITH_KEYS = %[
+    command ruby #{SCRIPT_PATH} "#{TEST_TIME}" 0
+    run_interval 1s
+    tag "my.test.data"
+    <parse>
+      keys ["k1", "k2", "k3"]
+    </parse>
+  ]
+
   TSV_CONFIG = %[
+    command ruby #{SCRIPT_PATH} "#{TEST_TIME}" 0
+    run_interval 1s
+    <parse>
+      @type tsv
+      keys time, tag, k1
+    </parse>
+    <extract>
+      tag_key tag
+      time_key time
+      time_type string
+      time_format %Y-%m-%d %H:%M:%S
+    </extract>
+  ]
+
+  JSON_CONFIG = %[
+    command ruby #{SCRIPT_PATH} #{TEST_UNIX_TIME.to_i} 1
+    run_interval 1s
+    <parse>
+      @type json
+    </parse>
+    <extract>
+      tag_key tag
+      time_key time
+      time_type unixtime
+    </extract>
+  ]
+
+  MSGPACK_CONFIG = %[
+    command ruby #{SCRIPT_PATH} #{TEST_UNIX_TIME.to_i} 2
+    run_interval 1s
+    <parse>
+      @type msgpack
+    </parse>
+    <extract>
+      tag_key tagger
+      time_key datetime
+      time_type unixtime
+    </extract>
+  ]
+
+  # here document for not de-quoting backslashes
+  REGEXP_CONFIG = %[
+    command ruby #{SCRIPT_PATH} "#{TEST_TIME}" 3
+    run_interval 1s
+    tag regex_tag
+] + <<'EOC'
+    <parse>
+      @type regexp
+      expression "(?<time>[^\\]]*) (?<message>[^ ]*)"
+      time_key time
+      time_type string
+      time_format %Y-%m-%d %H:%M:%S
+    </parse>
+EOC
+
+  sub_test_case 'with configuration with sections' do
+    test 'configure with default tsv format without extract' do
+      d = create_driver DEFAULT_CONFIG_ONLY_WITH_KEYS
+      assert{ d.instance.parser.is_a? Fluent::Plugin::TSVParser }
+      assert_equal "my.test.data", d.instance.tag
+      assert_equal ["k1", "k2", "k3"], d.instance.parser.keys
+    end
+
+    test 'configure raises error if both of tag and extract.tag_key are missing' do
+      assert_raise Fluent::ConfigError.new("'tag' or 'tag_key' option is required on exec input") do
+        create_driver %[
+          command ruby -e 'puts "yay"'
+          <parse>
+            keys y1
+          </parse>
+        ]
+      end
+    end
+
+    test 'configure for tsv' do
+      d = create_driver TSV_CONFIG
+      assert{ d.instance.parser.is_a? Fluent::Plugin::TSVParser }
+      assert_equal ["time", "tag", "k1"], d.instance.parser.keys
+      assert_equal "tag", d.instance.extract_config.tag_key
+      assert_equal "time", d.instance.extract_config.time_key
+      assert_equal :string, d.instance.extract_config.time_type
+      assert_equal "%Y-%m-%d %H:%M:%S", d.instance.extract_config.time_format
+    end
+
+    test 'configure for json' do
+      d = create_driver JSON_CONFIG
+      assert{ d.instance.parser.is_a? Fluent::Plugin::JSONParser }
+      assert_equal "tag", d.instance.extract_config.tag_key
+      assert_equal "time", d.instance.extract_config.time_key
+      assert_equal :unixtime, d.instance.extract_config.time_type
+    end
+
+    test 'configure for msgpack' do
+      d = create_driver MSGPACK_CONFIG
+      assert{ d.instance.parser.is_a? Fluent::Plugin::MessagePackParser }
+      assert_equal "tagger", d.instance.extract_config.tag_key
+      assert_equal "datetime", d.instance.extract_config.time_key
+      assert_equal :unixtime, d.instance.extract_config.time_type
+    end
+
+    test 'configure for regexp' do
+      d = create_driver REGEXP_CONFIG
+      assert{ d.instance.parser.is_a? Fluent::Plugin::RegexpParser }
+      assert_equal "regex_tag", d.instance.tag
+      expression = <<'EXP'.chomp
+(?<time>[^\]]*) (?<message>[^ ]*)
+EXP
+      assert_equal expression, d.instance.parser.expression
+      assert_nil d.instance.extract_config
+    end
+  end
+
+  TSV_CONFIG_COMPAT = %[
       command ruby #{SCRIPT_PATH} "#{TEST_TIME}" 0
       keys time,tag,k1
       time_key time
@@ -26,7 +148,7 @@ class ExecInputTest < Test::Unit::TestCase
       run_interval 1s
   ]
 
-  JSON_CONFIG = %[
+  JSON_CONFIG_COMPAT = %[
       command ruby #{SCRIPT_PATH} #{TEST_UNIX_TIME.to_i} 1
       format json
       tag_key tag
@@ -34,7 +156,7 @@ class ExecInputTest < Test::Unit::TestCase
       run_interval 1s
   ]
 
-  MSGPACK_CONFIG = %[
+  MSGPACK_CONFIG_COMPAT = %[
       command ruby #{SCRIPT_PATH} #{TEST_UNIX_TIME.to_i} 2
       format msgpack
       tag_key tagger
@@ -42,38 +164,60 @@ class ExecInputTest < Test::Unit::TestCase
       run_interval 1s
   ]
 
-  REGEXP_CONFIG = %[
+  REGEXP_CONFIG_COMPAT = %[
       command ruby #{SCRIPT_PATH} "#{TEST_TIME}" 3
       format /(?<time>[^\\\]]*) (?<message>[^ ]*)/
       tag regex_tag
       run_interval 1s
   ]
-  #      time_format %Y-%m-%d %H:%M:%S
 
-  def test_configure
-    d = create_driver
-    assert{ d.instance.parser.is_a? Fluent::Plugin::TSVParser }
-    assert_equal ["time","tag","k1"], d.instance.parser.keys
-    assert_equal "tag", d.instance.extract_config.tag_key
-    assert_equal "time", d.instance.extract_config.time_key
-    assert_equal "%Y-%m-%d %H:%M:%S", d.instance.extract_config.time_format
+  sub_test_case 'with traditional configuration' do
+    test 'configure' do
+      d = create_driver TSV_CONFIG_COMPAT
+      assert{ d.instance.parser.is_a? Fluent::Plugin::TSVParser }
+      assert_equal ["time","tag","k1"], d.instance.parser.keys
+      assert_equal "tag", d.instance.extract_config.tag_key
+      assert_equal "time", d.instance.extract_config.time_key
+      assert_equal "%Y-%m-%d %H:%M:%S", d.instance.extract_config.time_format
+    end
+
+    test 'configure_with_json' do
+      d = create_driver JSON_CONFIG_COMPAT
+      assert{ d.instance.parser.is_a? Fluent::Plugin::JSONParser }
+    end
+
+    test 'configure_with_msgpack' do
+      d = create_driver MSGPACK_CONFIG_COMPAT
+      assert{ d.instance.parser.is_a? Fluent::Plugin::MessagePackParser }
+    end
+
+    test 'configure_with_regexp' do
+      d = create_driver REGEXP_CONFIG_COMPAT
+      assert{ d.instance.parser.is_a? Fluent::Plugin::RegexpParser }
+      assert_equal '(?<time>[^\]]*) (?<message>[^ ]*)', d.instance.parser.expression
+      assert_equal 'regex_tag', d.instance.tag
+    end
   end
 
-  def test_configure_with_json
-    d = create_driver JSON_CONFIG
-    assert{ d.instance.parser.is_a? Fluent::Plugin::JSONParser }
-  end
+  sub_test_case 'with default configuration' do
+    setup do
+      @current_event_time = event_time('2016-10-31 20:01:30.123 -0700')
+      Timecop.freeze(Time.at(@current_event_time))
+    end
 
-  def test_configure_with_msgpack
-    d = create_driver MSGPACK_CONFIG
-    assert{ d.instance.parser.is_a? Fluent::Plugin::MessagePackParser }
-  end
+    teardown do
+      Timecop.return
+    end
 
-  def test_configure_with_regexp
-    d = create_driver REGEXP_CONFIG
-    assert{ d.instance.parser.is_a? Fluent::Plugin::RegexpParser }
-    assert_equal '(?<time>[^\]]*) (?<message>[^ ]*)', d.instance.parser.expression
-    assert_equal 'regex_tag', d.instance.tag
+    test 'emits events with current timestamp if time key is not specified' do
+      d = create_driver DEFAULT_CONFIG_ONLY_WITH_KEYS
+      d.run(expect_records: 2, timeout: 10)
+
+      assert{ d.events.length > 0 }
+      d.events.each do |event|
+        assert_equal ["my.test.data", @current_event_time, {"k1"=>"2011-01-02 13:14:15", "k2"=>"tag1", "k3"=>"ok"}], event
+      end
+    end
   end
 
   data(
@@ -81,6 +225,10 @@ class ExecInputTest < Test::Unit::TestCase
     'json'    => [JSON_CONFIG,    "tag1", event_time("2011-01-02 13:14:15"), {"k1"=>"ok"}],
     'msgpack' => [MSGPACK_CONFIG, "tag1", event_time("2011-01-02 13:14:15"), {"k1"=>"ok"}],
     'regexp'  => [REGEXP_CONFIG,  "regex_tag", event_time("2011-01-02 13:14:15"), {"message"=>"hello"}],
+    'default_c' => [TSV_CONFIG_COMPAT,     "tag1", event_time("2011-01-02 13:14:15"), {"k1"=>"ok"}],
+    'json_c'    => [JSON_CONFIG_COMPAT,    "tag1", event_time("2011-01-02 13:14:15"), {"k1"=>"ok"}],
+    'msgpack_c' => [MSGPACK_CONFIG_COMPAT, "tag1", event_time("2011-01-02 13:14:15"), {"k1"=>"ok"}],
+    'regexp_c'  => [REGEXP_CONFIG_COMPAT,  "regex_tag", event_time("2011-01-02 13:14:15"), {"message"=>"hello"}],
   )
   test 'emit with formats' do |data|
     config, tag, time, record = data

--- a/test/plugin/test_out_exec.rb
+++ b/test/plugin/test_out_exec.rb
@@ -44,11 +44,11 @@ class ExecOutputTest < Test::Unit::TestCase
   def test_configure
     d = create_driver
 
-    assert_equal ["time","tag","k1"], d.instance.keys
-    assert_equal "tag", d.instance.tag_key
-    assert_equal "time", d.instance.time_key
-    assert_equal "%Y-%m-%d %H:%M:%S", d.instance.time_format
-    assert_equal true, d.instance.localtime
+    assert_equal ["time","tag","k1"], d.instance.formatter.keys
+    assert_equal "tag", d.instance.inject_config.tag_key
+    assert_equal "time", d.instance.inject_config.time_key
+    assert_equal "%Y-%m-%d %H:%M:%S", d.instance.inject_config.time_format
+    assert_equal true, d.instance.inject_config.localtime
   end
 
   def test_configure_with_compat_buffer_parameters

--- a/test/plugin/test_out_exec.rb
+++ b/test/plugin/test_out_exec.rb
@@ -18,31 +18,111 @@ class ExecOutputTest < Test::Unit::TestCase
 
   TMP_DIR = File.dirname(__FILE__) + "/../tmp/out_exec#{ENV['TEST_ENV_NUMBER']}"
 
-  CONFIG = %[
+  def create_driver(config)
+    Fluent::Test::Driver::Output.new(Fluent::Plugin::ExecOutput).configure(config)
+  end
+
+  def create_test_data
+    time = event_time("2011-01-02 13:14:15.123")
+    records = [{"k1"=>"v1","kx"=>"vx"}, {"k1"=>"v2","kx"=>"vx"}]
+    return time, records
+  end
+
+  DEFAULT_CONFIG_ONLY_WITH_KEYS = %[
+    command cat >#{TMP_DIR}/out
+    <format>
+      keys ["k1", "kx"]
+    </format>
+  ]
+
+  test 'configure in default' do
+    d = create_driver DEFAULT_CONFIG_ONLY_WITH_KEYS
+    assert{ d.instance.formatter.is_a? Fluent::Plugin::TSVFormatter }
+    assert_equal ["k1", "kx"], d.instance.formatter.keys
+    assert_nil d.instance.inject_config
+  end
+
+  TSV_CONFIG = %[
+    command cat >#{TMP_DIR}/out
+    <inject>
+      tag_key tag
+      time_key time
+      time_format %Y-%m-%d %H:%M:%S
+      localtime yes
+    </inject>
+    <format>
+      @type tsv
+      keys time, tag, k1
+    </format>
+  ]
+  TSV_CONFIG_WITH_SUBSEC = %[
+    command cat >#{TMP_DIR}/out
+    <inject>
+      tag_key tag
+      time_key time
+      time_format %Y-%m-%d %H:%M:%S.%3N
+      localtime yes
+    </inject>
+    <format>
+      @type tsv
+      keys time, tag, k1
+    </format>
+  ]
+  TSV_CONFIG_WITH_BUFFER = TSV_CONFIG + %[
+    <buffer time>
+      @type memory
+      timekey 3600
+      flush_thread_count 5
+      chunk_limit_size 50m
+      total_limit_size #{50 * 1024 * 1024 * 128}
+      flush_at_shutdown yes
+    </buffer>
+  ]
+  JSON_CONFIG = %[
+    command cat >#{TMP_DIR}/out
+    <format>
+      @type json
+    </format>
+  ]
+  MSGPACK_CONFIG = %[
+    command cat >#{TMP_DIR}/out
+    <format>
+      @type msgpack
+    </format>
+  ]
+
+  CONFIG_COMPAT = %[
     buffer_path #{TMP_DIR}/buffer
     command cat >#{TMP_DIR}/out
     localtime
   ]
-  TSV_CONFIG = %[
+  TSV_CONFIG_COMPAT = %[
     keys "time,tag,k1"
     tag_key "tag"
     time_key "time"
     time_format %Y-%m-%d %H:%M:%S
   ]
+  BUFFER_CONFIG_COMPAT = %[
+    buffer_type memory
+    time_slice_format %Y%m%d%H
+    num_threads 5
+    buffer_chunk_limit 50m
+    buffer_queue_limit 128
+    flush_at_shutdown yes
+  ]
+  TSV_CONFIG_WITH_SUBSEC_COMPAT = %[
+    keys "time,tag,k1"
+    tag_key "tag"
+    time_key "time"
+    time_format %Y-%m-%d %H:%M:%S.%3N
+  ]
 
-  def create_driver(conf = TSV_CONFIG)
-    config = CONFIG + conf
-    Fluent::Test::Driver::Output.new(Fluent::Plugin::ExecOutput).configure(config)
-  end
-
-  def create_test_case
-    time = Time.parse("2011-01-02 13:14:15").to_i
-    tests = [{"k1"=>"v1","kx"=>"vx"}, {"k1"=>"v2","kx"=>"vx"}]
-    return time, tests
-  end
-
-  def test_configure
-    d = create_driver
+  data(
+    'with sections' => TSV_CONFIG,
+    'traditional' => CONFIG_COMPAT + TSV_CONFIG_COMPAT,
+  )
+  test 'configure for tsv' do |conf|
+    d = create_driver(conf)
 
     assert_equal ["time","tag","k1"], d.instance.formatter.keys
     assert_equal "tag", d.instance.inject_config.tag_key
@@ -51,90 +131,99 @@ class ExecOutputTest < Test::Unit::TestCase
     assert_equal true, d.instance.inject_config.localtime
   end
 
-  def test_configure_with_compat_buffer_parameters
-    conf = TSV_CONFIG + %[
-      buffer_type memory
-      time_slice_format %Y%m%d%H
-      num_threads 5
-      buffer_chunk_limit 50m
-      buffer_queue_limit 128
-      flush_at_shutdown yes
-    ]
+  data(
+    'with sections' => TSV_CONFIG_WITH_BUFFER,
+    'traditional' => CONFIG_COMPAT + TSV_CONFIG_COMPAT + BUFFER_CONFIG_COMPAT,
+  )
+  test 'configure_with_compat_buffer_parameters' do |conf|
     d = create_driver(conf)
     assert_equal 3600, d.instance.buffer_config.timekey
     assert_equal 5, d.instance.buffer_config.flush_thread_count
     assert_equal 50*1024*1024, d.instance.buffer.chunk_limit_size
-    assert_equal 128, d.instance.buffer.queue_length_limit
+    # assert_equal 128, d.instance.buffer.queue_length_limit
+    assert_equal 50*1024*1024*128, d.instance.buffer.total_limit_size
     assert d.instance.buffer_config.flush_at_shutdown
   end
 
-  def test_format
-    d = create_driver
-    time, tests = create_test_case
+  data(
+    'with sections' => TSV_CONFIG,
+    'traditional' => CONFIG_COMPAT + TSV_CONFIG_COMPAT,
+  )
+  test 'format' do |conf|
+    d = create_driver(conf)
+    time, records = create_test_data
 
     d.run(default_tag: 'test') do
-      d.feed(time, tests[0])
-      d.feed(time, tests[1])
+      d.feed(time, records[0])
+      d.feed(time, records[1])
     end
 
     assert_equal %[2011-01-02 13:14:15\ttest\tv1\n], d.formatted[0]
     assert_equal %[2011-01-02 13:14:15\ttest\tv2\n], d.formatted[1]
   end
 
-  def test_format_json
-    d = create_driver("format json")
-    time, tests = create_test_case
+  data(
+    'with sections' => JSON_CONFIG,
+    'traditional' => CONFIG_COMPAT + "format json",
+  )
+  test 'format_json' do |conf|
+    d = create_driver(conf)
+    time, records = create_test_data
 
     d.run(default_tag: 'test') do
-      d.feed(time, tests[0])
-      d.feed(time, tests[1])
+      d.feed(time, records[0])
+      d.feed(time, records[1])
     end
 
-    assert_equal Yajl.dump(tests[0]) + "\n", d.formatted[0]
-    assert_equal Yajl.dump(tests[1]) + "\n", d.formatted[1]
+    assert_equal Yajl.dump(records[0]) + "\n", d.formatted[0]
+    assert_equal Yajl.dump(records[1]) + "\n", d.formatted[1]
   end
 
-  def test_format_msgpack
-    d = create_driver("format msgpack")
-    time, tests = create_test_case
+  data(
+    'with sections' => MSGPACK_CONFIG,
+    'traditional' => CONFIG_COMPAT + "format msgpack"
+  )
+  test 'format_msgpack' do |conf|
+    d = create_driver(conf)
+    time, records = create_test_data
 
     d.run(default_tag: 'test') do
-      d.feed(time, tests[0])
-      d.feed(time, tests[1])
+      d.feed(time, records[0])
+      d.feed(time, records[1])
     end
 
-    assert_equal tests[0].to_msgpack, d.formatted[0]
-    assert_equal tests[1].to_msgpack, d.formatted[1]
+    assert_equal records[0].to_msgpack, d.formatted[0]
+    assert_equal records[1].to_msgpack, d.formatted[1]
   end
 
-  def test_format_time
-    config = %[
-      keys "time,tag,k1"
-      tag_key "tag"
-      time_key "time"
-      time_format %Y-%m-%d %H:%M:%S.%3N
-    ]
-    d = create_driver(config)
-
-    time = event_time("2011-01-02 13:14:15.123")
-    tests = [{"k1"=>"v1","kx"=>"vx"}, {"k1"=>"v2","kx"=>"vx"}]
+  data(
+    'with sections' => TSV_CONFIG_WITH_SUBSEC,
+    'traditional' => CONFIG_COMPAT + TSV_CONFIG_WITH_SUBSEC_COMPAT,
+  )
+  test 'format subsecond time' do |conf|
+    d = create_driver(conf)
+    time, records = create_test_data
 
     d.run(default_tag: 'test') do
-      d.feed(time, tests[0])
-      d.feed(time, tests[1])
+      d.feed(time, records[0])
+      d.feed(time, records[1])
     end
 
     assert_equal %[2011-01-02 13:14:15.123\ttest\tv1\n], d.formatted[0]
     assert_equal %[2011-01-02 13:14:15.123\ttest\tv2\n], d.formatted[1]
   end
 
-  def test_write
-    d = create_driver
-    time, tests = create_test_case
+  data(
+    'with sections' => TSV_CONFIG,
+    'traditional' => CONFIG_COMPAT + TSV_CONFIG_COMPAT,
+  )
+  test 'write' do |conf|
+    d = create_driver(conf)
+    time, records = create_test_data
 
     d.run(default_tag: 'test', flush: true) do
-      d.feed(time, tests[0])
-      d.feed(time, tests[1])
+      d.feed(time, records[0])
+      d.feed(time, records[1])
     end
 
     expect_path = "#{TMP_DIR}/out"
@@ -152,4 +241,3 @@ class ExecOutputTest < Test::Unit::TestCase
     assert_equal expect_data, data
   end
 end
-

--- a/test/plugin/test_out_exec.rb
+++ b/test/plugin/test_out_exec.rb
@@ -243,7 +243,7 @@ class ExecOutputTest < Test::Unit::TestCase
   sub_test_case 'when executed process dies unexpectedly' do
     setup do
       @gen_config = ->(num){ <<EOC
-    command ruby -e 'ARGV.first.to_i == 0 ? open(ARGV[1]){|f| STDOUT.write f.read} : (sleep 1 ; exit ARGV.first.to_i)' #{num} >#{TMP_DIR}/fail_out
+    command ruby -e "ARGV.first.to_i == 0 ? open(ARGV[1]){|f| STDOUT.write f.read} : (sleep 1 ; exit ARGV.first.to_i)" #{num} >#{TMP_DIR}/fail_out
     <inject>
       tag_key tag
       time_key time

--- a/test/plugin/test_out_exec_filter.rb
+++ b/test/plugin/test_out_exec_filter.rb
@@ -148,7 +148,7 @@ class ExecFilterOutputTest < Test::Unit::TestCase
   )
   test 'emit events without time format configuration' do |conf|
     d = create_driver(conf)
-    time = event_time("2011-01-02 13:14:15")
+    time = event_time("2011-01-02 13:14:15 +0900")
 
     d.run(default_tag: 'test', expect_emits: 2, timeout: 10) do
       d.feed(time, {"k1"=>1})
@@ -198,7 +198,7 @@ class ExecFilterOutputTest < Test::Unit::TestCase
   )
   test 'emit events through grep command' do |conf|
     d = create_driver(conf)
-    time = event_time("2011-01-02 13:14:15")
+    time = event_time("2011-01-02 13:14:15 +0900")
 
     d.run(default_tag: 'test', expect_emits: 1, timeout: 10) do
       d.feed(time, {"val1"=>"sed-ed value poo"})
@@ -246,7 +246,7 @@ class ExecFilterOutputTest < Test::Unit::TestCase
   )
   test 'emit events through sed command' do |conf|
     d = create_driver(conf)
-    time = event_time("2011-01-02 13:14:15")
+    time = event_time("2011-01-02 13:14:15 +0900")
 
     d.run(default_tag: 'test', expect_emits: 1, timeout: 10) do
       d.feed(time, {"val1"=>"sed-ed value poo"})
@@ -302,7 +302,7 @@ class ExecFilterOutputTest < Test::Unit::TestCase
   test 'emit events with add/remove tag prefix' do |conf|
     d = create_driver(conf)
 
-    time = event_time("2011-01-02 13:14:15")
+    time = event_time("2011-01-02 13:14:15 +0900")
 
     d.run(default_tag: 'input.test', expect_emits: 2, timeout: 10) do
       d.feed(time, {"val1"=>"sed-ed value foo"})
@@ -348,7 +348,7 @@ class ExecFilterOutputTest < Test::Unit::TestCase
   )
   test 'using json format' do |conf|
     d = create_driver(conf)
-    time = event_time("2011-01-02 13:14:15")
+    time = event_time("2011-01-02 13:14:15 +0900")
 
     d.run(default_tag: 'input.test', expect_emits: 1, timeout: 10) do
       i = d.instance
@@ -392,7 +392,7 @@ class ExecFilterOutputTest < Test::Unit::TestCase
   )
   test 'using json format with float time' do |conf|
     d = create_driver(conf)
-    time = event_time("2011-01-02 13:14:15.123")
+    time = event_time("2011-01-02 13:14:15.123 +0900")
 
     d.run(default_tag: 'input.test', expect_emits: 1, timeout: 10) do
       d.feed(time + 10, {"message"=>%[{"time":#{time.sec}.#{time.nsec},"tag":"t1","k1":"v1"}]})

--- a/test/plugin/test_out_exec_filter.rb
+++ b/test/plugin/test_out_exec_filter.rb
@@ -601,7 +601,8 @@ class ExecFilterOutputTest < Test::Unit::TestCase
       pid = event[2]['child_pid']
       pid_list << pid unless pid_list.include?(pid)
     end
-    assert_equal 20, pid_list.size, "the number of pids should be same with number of child processes: #{pid_list.inspect}"
+    # the number of pids should be same with number of child processes
+    assert{ pid_list.size >= 18 }
 
     logs = d.instance.log.out.logs
     assert{ logs.select{|l| l.include?("child process exits with error code") }.size >= 18 } # 20

--- a/test/plugin/test_out_exec_filter.rb
+++ b/test/plugin/test_out_exec_filter.rb
@@ -10,6 +10,29 @@ class ExecFilterOutputTest < Test::Unit::TestCase
 
   CONFIG = %[
     command cat
+    num_children 3
+    <inject>
+      tag_key     tag
+      time_key    time_in
+      time_type   string
+      time_format %Y-%m-%d %H:%M:%S
+    </inject>
+    <format>
+      keys ["time_in", "tag", "k1"]
+    </format>
+    <parse>
+      keys ["time_out", "tag", "k2"]
+    </parse>
+    <extract>
+      tag_key     tag
+      time_key    time_out
+      time_type   string
+      time_format %Y-%m-%d %H:%M:%S
+    </extract>
+  ]
+
+  CONFIG_COMPAT = %[
+    command cat
     in_keys time_in,tag,k1
     out_keys time_out,tag,k2
     tag_key tag
@@ -20,23 +43,22 @@ class ExecFilterOutputTest < Test::Unit::TestCase
     num_children 3
   ]
 
-  def create_driver(conf = CONFIG)
+  def create_driver(conf)
     Fluent::Test::Driver::Output.new(Fluent::Plugin::ExecFilterOutput).configure(conf)
   end
 
-  def sed_unbuffered_support?
-    @sed_unbuffered_support ||= lambda {
-      system("echo xxx | sed --unbuffered -l -e 's/x/y/g' >#{IO::NULL} 2>&1")
-      $?.success?
-    }.call
-  end
+  SED_SUPPORT_UNBUFFERED_OPTION = ->(){
+    system("echo xxx | sed --unbuffered -l -e 's/x/y/g' >#{IO::NULL} 2>&1")
+    $?.success?
+  }.call
+  SED_UNBUFFERED_OPTION = SED_SUPPORT_UNBUFFERED_OPTION ? '--unbuffered' : ''
 
-  def sed_unbuffered_option
-    sed_unbuffered_support? ? '--unbuffered' : ''
-  end
-
-  def test_configure
-    d = create_driver
+  data(
+    'with sections' => CONFIG,
+    'traditional' => CONFIG_COMPAT,
+  )
+  test 'configure' do |conf|
+    d = create_driver(conf)
 
     assert_false d.instance.parser.estimate_current_event
 
@@ -61,7 +83,7 @@ class ExecFilterOutputTest < Test::Unit::TestCase
     ]
     assert_equal "sed -l -e s/foo/bar/", d.instance.command
 
-    d = create_driver(CONFIG + %[
+    d = create_driver(conf + %[
       remove_prefix before
       add_prefix after
     ])
@@ -69,9 +91,12 @@ class ExecFilterOutputTest < Test::Unit::TestCase
     assert_equal "after" , d.instance.add_prefix
   end
 
-  def test_emit_1
-    d = create_driver
-
+  data(
+    'with sections' => CONFIG,
+    'traditional' => CONFIG_COMPAT,
+  )
+  test 'emit events with TSV format' do |conf|
+    d = create_driver(conf)
     time = event_time("2011-01-02 13:14:15")
 
     d.run(default_tag: 'test', expect_emits: 2, timeout: 10) do
@@ -79,6 +104,9 @@ class ExecFilterOutputTest < Test::Unit::TestCase
       d.feed(time, {"k1"=>1})
       d.feed(time, {"k1"=>2})
     end
+
+    assert_equal "2011-01-02 13:14:15\ttest\t1\n", d.formatted[0]
+    assert_equal "2011-01-02 13:14:15\ttest\t2\n", d.formatted[1]
 
     events = d.events
     assert_equal 2, events.length
@@ -88,22 +116,47 @@ class ExecFilterOutputTest < Test::Unit::TestCase
     assert_equal ["test", time, {"k2"=>"2"}], events[1]
   end
 
-  def test_emit_2
-    d = create_driver %[
-      command cat
-      in_keys time,k1
-      out_keys time,k2
-      tag xxx
+  CONFIG_WITHOUT_TIME_FORMAT = %[
+    command cat
+    num_children 3
+    tag xxx
+    <inject>
       time_key time
-      num_children 3
-    ]
+      time_type unixtime
+    </inject>
+    <format>
+      keys time,k1
+    </format>
+    <parse>
+      keys time,k2
+      time_key time
+      time_type unixtime
+    </parse>
+  ]
+  CONFIG_WITHOUT_TIME_FORMAT_COMPAT = %[
+    command cat
+    in_keys time,k1
+    out_keys time,k2
+    tag xxx
+    time_key time
+    num_children 3
+  ]
 
+  data(
+    'with sections' => CONFIG_WITHOUT_TIME_FORMAT,
+    'traditional' => CONFIG_WITHOUT_TIME_FORMAT_COMPAT,
+  )
+  test 'emit events without time format configuration' do |conf|
+    d = create_driver(conf)
     time = event_time("2011-01-02 13:14:15")
 
     d.run(default_tag: 'test', expect_emits: 2, timeout: 10) do
       d.feed(time, {"k1"=>1})
       d.feed(time, {"k1"=>2})
     end
+
+    assert_equal "1293941655\t1\n", d.formatted[0]
+    assert_equal "1293941655\t2\n", d.formatted[1]
 
     events = d.events
     assert_equal 2, events.length
@@ -113,43 +166,95 @@ class ExecFilterOutputTest < Test::Unit::TestCase
     assert_equal ["xxx", time, {"k2"=>"2"}], events[1]
   end
 
-  def test_emit_3
-    d = create_driver %[
-      command grep --line-buffered -v poo
-      in_keys time,val1
-      out_keys time,val2
-      tag xxx
+  CONFIG_TO_DO_GREP = %[
+    command grep --line-buffered -v poo
+    num_children 3
+    tag xxx
+    <inject>
       time_key time
-      num_children 3
-    ]
+      time_type unixtime
+    </inject>
+    <format>
+      keys time, val1
+    </format>
+    <parse>
+      keys time, val2
+      time_key time
+      time_type unixtime
+    </parse>
+  ]
+  CONFIG_TO_DO_GREP_COMPAT = %[
+    command grep --line-buffered -v poo
+    in_keys time,val1
+    out_keys time,val2
+    tag xxx
+    time_key time
+    num_children 3
+  ]
 
+  data(
+    'with sections' => CONFIG_TO_DO_GREP,
+    'traditional' => CONFIG_TO_DO_GREP_COMPAT,
+  )
+  test 'emit events through grep command' do |conf|
+    d = create_driver(conf)
     time = event_time("2011-01-02 13:14:15")
 
     d.run(default_tag: 'test', expect_emits: 1, timeout: 10) do
       d.feed(time, {"val1"=>"sed-ed value poo"})
       d.feed(time, {"val1"=>"sed-ed value foo"})
     end
+
+    assert_equal "1293941655\tsed-ed value poo\n", d.formatted[0]
+    assert_equal "1293941655\tsed-ed value foo\n", d.formatted[1]
 
     events = d.events
     assert_equal 1, events.length
     assert_equal_event_time time, events[0][1]
     assert_equal ["xxx", time, {"val2"=>"sed-ed value foo"}], events[0]
+  end
 
-    d = create_driver %[
-      command sed #{sed_unbuffered_option} -l -e s/foo/bar/
-      in_keys time,val1
-      out_keys time,val2
-      tag xxx
+  CONFIG_TO_DO_SED = %[
+    command sed #{SED_UNBUFFERED_OPTION} -l -e s/foo/bar/
+    num_children 3
+    tag xxx
+    <inject>
       time_key time
-      num_children 3
-    ]
+      time_type unixtime
+    </inject>
+    <format>
+      keys time, val1
+    </format>
+    <parse>
+      keys time, val2
+      time_key time
+      time_type unixtime
+    </parse>
+  ]
+  CONFIG_TO_DO_SED_COMPAT = %[
+    command sed #{SED_UNBUFFERED_OPTION} -l -e s/foo/bar/
+    in_keys time,val1
+    out_keys time,val2
+    tag xxx
+    time_key time
+    num_children 3
+  ]
 
+  data(
+    'with sections' => CONFIG_TO_DO_SED,
+    'traditional' => CONFIG_TO_DO_SED_COMPAT,
+  )
+  test 'emit events through sed command' do |conf|
+    d = create_driver(conf)
     time = event_time("2011-01-02 13:14:15")
 
     d.run(default_tag: 'test', expect_emits: 1, timeout: 10) do
       d.feed(time, {"val1"=>"sed-ed value poo"})
       d.feed(time, {"val1"=>"sed-ed value foo"})
     end
+
+    assert_equal "1293941655\tsed-ed value poo\n", d.formatted[0]
+    assert_equal "1293941655\tsed-ed value foo\n", d.formatted[1]
 
     events = d.events
     assert_equal 2, events.length
@@ -159,17 +264,43 @@ class ExecFilterOutputTest < Test::Unit::TestCase
     assert_equal ["xxx", time, {"val2"=>"sed-ed value bar"}], events[1]
   end
 
-  def test_emit_4
-    d = create_driver(%[
-      command sed #{sed_unbuffered_option} -l -e s/foo/bar/
-      in_keys tag,time,val1
-      remove_prefix input
-      out_keys tag,time,val2
-      add_prefix output
+  CONFIG_TO_DO_SED_WITH_TAG_MODIFY = %[
+    command sed #{SED_UNBUFFERED_OPTION} -l -e s/foo/bar/
+    num_children 3
+    remove_prefix input
+    add_prefix output
+    <inject>
       tag_key tag
       time_key time
-      num_children 3
-    ])
+    </inject>
+    <format>
+      keys tag, time, val1
+    </format>
+    <parse>
+      keys tag, time, val2
+    </parse>
+    <extract>
+      tag_key tag
+      time_key time
+    </extract>
+  ]
+  CONFIG_TO_DO_SED_WITH_TAG_MODIFY_COMPAT = %[
+    command sed #{SED_UNBUFFERED_OPTION} -l -e s/foo/bar/
+    in_keys tag,time,val1
+    remove_prefix input
+    out_keys tag,time,val2
+    add_prefix output
+    tag_key tag
+    time_key time
+    num_children 3
+  ]
+
+  data(
+    'with sections' => CONFIG_TO_DO_SED_WITH_TAG_MODIFY,
+    'traditional' => CONFIG_TO_DO_SED_WITH_TAG_MODIFY_COMPAT,
+  )
+  test 'emit events with add/remove tag prefix' do |conf|
+    d = create_driver(conf)
 
     time = event_time("2011-01-02 13:14:15")
 
@@ -177,6 +308,9 @@ class ExecFilterOutputTest < Test::Unit::TestCase
       d.feed(time, {"val1"=>"sed-ed value foo"})
       d.feed(time, {"val1"=>"sed-ed value poo"})
     end
+
+    assert_equal "test\t1293941655\tsed-ed value foo\n", d.formatted[0]
+    assert_equal "test\t1293941655\tsed-ed value poo\n", d.formatted[1]
 
     events = d.events
     assert_equal 2, events.length
@@ -186,20 +320,43 @@ class ExecFilterOutputTest < Test::Unit::TestCase
     assert_equal ["output.test", time, {"val2"=>"sed-ed value poo"}], events[1]
   end
 
-  def test_json_1
-    d = create_driver(%[
-      command cat
-      in_keys message
-      out_format json
-      time_key time
+  CONFIG_JSON = %[
+    command cat
+    <format>
+      @type tsv
+      keys message
+    </format>
+    <parse>
+      @type json
+    </parse>
+    <extract>
       tag_key tag
-    ])
+      time_key time
+    </extract>
+  ]
+  CONFIG_JSON_COMPAT = %[
+    command cat
+    in_keys message
+    out_format json
+    time_key time
+    tag_key tag
+  ]
 
+  data(
+    'with sections' => CONFIG_JSON,
+    'traditional' => CONFIG_JSON_COMPAT,
+  )
+  test 'using json format' do |conf|
+    d = create_driver(conf)
     time = event_time("2011-01-02 13:14:15")
 
     d.run(default_tag: 'input.test', expect_emits: 1, timeout: 10) do
+      i = d.instance
+      assert{ i.router }
       d.feed(time, {"message"=>%[{"time":#{time},"tag":"t1","k1":"v1"}]})
     end
+
+    assert_equal '{"time":1293941655,"tag":"t1","k1":"v1"}' + "\n", d.formatted[0]
 
     events = d.events
     assert_equal 1, events.length
@@ -207,37 +364,79 @@ class ExecFilterOutputTest < Test::Unit::TestCase
     assert_equal ["t1", time, {"k1"=>"v1"}], events[0]
   end
 
-  def test_json_with_float_time
-    d = create_driver(%[
-      command cat
-      in_keys message
-      out_format json
-      time_key time
+  CONFIG_JSON_WITH_FLOAT_TIME = %[
+    command cat
+    <format>
+      @type tsv
+      keys message
+    </format>
+    <parse>
+      @type json
+    </parse>
+    <extract>
       tag_key tag
-    ])
+      time_key time
+    </extract>
+  ]
+  CONFIG_JSON_WITH_FLOAT_TIME_COMPAT = %[
+    command cat
+    in_keys message
+    out_format json
+    time_key time
+    tag_key tag
+  ]
 
+  data(
+    'with sections' => CONFIG_JSON_WITH_FLOAT_TIME,
+    'traditional' => CONFIG_JSON_WITH_FLOAT_TIME_COMPAT,
+  )
+  test 'using json format with float time' do |conf|
+    d = create_driver(conf)
     time = event_time("2011-01-02 13:14:15.123")
 
     d.run(default_tag: 'input.test', expect_emits: 1, timeout: 10) do
       d.feed(time + 10, {"message"=>%[{"time":#{time.sec}.#{time.nsec},"tag":"t1","k1":"v1"}]})
     end
 
+    assert_equal '{"time":1293941655.123000000,"tag":"t1","k1":"v1"}' + "\n", d.formatted[0]
+
     events = d.events
     assert_equal 1, events.length
     assert_equal_event_time time, events[0][1]
     assert_equal ["t1", time, {"k1"=>"v1"}], events[0]
   end
 
-  def test_json_with_time_format
-    d = create_driver(%[
-      command cat
-      in_keys message
-      out_format json
-      time_key time
-      time_format %d/%b/%Y %H:%M:%S.%N %z
+  CONFIG_JSON_WITH_TIME_FORMAT = %[
+    command cat
+    <format>
+      @type tsv
+      keys message
+    </format>
+    <parse>
+      @type json
+    </parse>
+    <extract>
       tag_key tag
-    ])
+      time_key time
+      time_type string
+      time_format %d/%b/%Y %H:%M:%S.%N %z
+    </extract>
+  ]
+  CONFIG_JSON_WITH_TIME_FORMAT_COMPAT = %[
+    command cat
+    in_keys message
+    out_format json
+    time_key time
+    time_format %d/%b/%Y %H:%M:%S.%N %z
+    tag_key tag
+  ]
 
+  data(
+    'with sections' => CONFIG_JSON_WITH_TIME_FORMAT,
+    'traditional' => CONFIG_JSON_WITH_TIME_FORMAT_COMPAT,
+  )
+  test 'using json format with custom time format' do |conf|
+    d = create_driver(conf)
     time_str = "28/Feb/2013 12:00:00.123456789 +0900"
     time = event_time(time_str, format: "%d/%b/%Y %H:%M:%S.%N %z")
 
@@ -245,10 +444,169 @@ class ExecFilterOutputTest < Test::Unit::TestCase
       d.feed(time + 10, {"message"=>%[{"time":"#{time_str}","tag":"t1","k1":"v1"}]})
     end
 
+    assert_equal '{"time":"28/Feb/2013 12:00:00.123456789 +0900","tag":"t1","k1":"v1"}' + "\n", d.formatted[0]
+
     events = d.events
     assert_equal 1, events.length
     assert_equal_event_time time, events[0][1]
     assert_equal ["t1", time, {"k1"=>"v1"}], events[0]
   end
-end
 
+  CONFIG_ROUND_ROBIN = %[
+    command ruby -e 'STDOUT.sync = true; STDIN.each_line{|line| puts line.chomp + "\t" + Process.pid.to_s }'
+    num_children 3
+    <inject>
+      tag_key     tag
+      time_key    time_in
+      time_type   string
+      time_format %Y-%m-%d %H:%M:%S
+    </inject>
+    <format>
+      keys ["time_in", "tag", "k1"]
+    </format>
+    <parse>
+      keys ["time_out", "tag", "k2", "child_pid"]
+    </parse>
+    <extract>
+      tag_key     tag
+      time_key    time_out
+      time_type   string
+      time_format %Y-%m-%d %H:%M:%S
+    </extract>
+  ]
+  CONFIG_ROUND_ROBIN_COMPAT = %[
+    command ruby -e 'STDOUT.sync = true; STDIN.each_line{|line| puts line.chomp + "\t" + Process.pid.to_s }'
+    in_keys time_in,tag,k1
+    out_keys time_out,tag,k2,child_pid
+    tag_key tag
+    in_time_key time_in
+    out_time_key time_out
+    time_format %Y-%m-%d %H:%M:%S
+    localtime
+    num_children 3
+  ]
+
+  data(
+    'with sections' => CONFIG_ROUND_ROBIN,
+    'traditional' => CONFIG_ROUND_ROBIN_COMPAT,
+  )
+  test 'using child processes by round robin' do |conf|
+    d = create_driver(conf)
+    time = event_time("2011-01-02 13:14:15")
+
+    d.run(default_tag: 'test', expect_emits: 1, timeout: 10, start: true,  shutdown: false){ d.feed(time, {"k1"=>1}) }
+    d.run(default_tag: 'test', expect_emits: 1, timeout: 10, start: false, shutdown: false){ d.feed(time, {"k1"=>2}) }
+    d.run(default_tag: 'test', expect_emits: 1, timeout: 10, start: false, shutdown: false){ d.feed(time, {"k1"=>3}) }
+    d.run(default_tag: 'test', expect_emits: 1, timeout: 10, start: false, shutdown: false){ d.feed(time, {"k1"=>4}) }
+    d.run(default_tag: 'test', expect_emits: 1, timeout: 10, start: false, shutdown: false){ d.feed(time, {"k1"=>5}) }
+    d.run(default_tag: 'test', expect_emits: 1, timeout: 10, start: false, shutdown: false){ d.feed(time, {"k1"=>6}) }
+    d.run(default_tag: 'test', expect_emits: 1, timeout: 10, start: false, shutdown: false){ d.feed(time, {"k1"=>7}) }
+    d.run(default_tag: 'test', expect_emits: 1, timeout: 10, start: false, shutdown: false){ d.feed(time, {"k1"=>8}) }
+    d.run(default_tag: 'test', expect_emits: 1, timeout: 10, start: false, shutdown: true ){ d.feed(time, {"k1"=>9}) }
+
+    assert_equal "2011-01-02 13:14:15\ttest\t1\n", d.formatted[0]
+    assert_equal "2011-01-02 13:14:15\ttest\t2\n", d.formatted[1]
+    assert_equal "2011-01-02 13:14:15\ttest\t3\n", d.formatted[2]
+    assert_equal "2011-01-02 13:14:15\ttest\t4\n", d.formatted[3]
+    assert_equal "2011-01-02 13:14:15\ttest\t5\n", d.formatted[4]
+    assert_equal "2011-01-02 13:14:15\ttest\t6\n", d.formatted[5]
+    assert_equal "2011-01-02 13:14:15\ttest\t7\n", d.formatted[6]
+    assert_equal "2011-01-02 13:14:15\ttest\t8\n", d.formatted[7]
+    assert_equal "2011-01-02 13:14:15\ttest\t9\n", d.formatted[8]
+
+    events = d.events
+    assert_equal 9, events.length
+
+    pid_list = []
+    events.each do |event|
+      pid = event[2]['child_pid']
+      pid_list << pid unless pid_list.include?(pid)
+    end
+    assert_equal 3, pid_list.size, "the number of pids should be same with number of child processes: #{pid_list.inspect}"
+
+    assert_equal pid_list[0], events[0][2]['child_pid']
+    assert_equal pid_list[1], events[1][2]['child_pid']
+    assert_equal pid_list[2], events[2][2]['child_pid']
+    assert_equal pid_list[0], events[3][2]['child_pid']
+    assert_equal pid_list[1], events[4][2]['child_pid']
+    assert_equal pid_list[2], events[5][2]['child_pid']
+    assert_equal pid_list[0], events[6][2]['child_pid']
+    assert_equal pid_list[1], events[7][2]['child_pid']
+    assert_equal pid_list[2], events[8][2]['child_pid']
+  end
+
+  # child process exits per 3 lines
+  CONFIG_RESPAWN = %[
+    command ruby -e 'STDOUT.sync = true; proc = ->(){line = STDIN.readline.chomp; puts line + "\t" + Process.pid.to_s}; proc.call; proc.call; proc.call'
+    num_children 4
+    child_respawn -1
+    <inject>
+      tag_key   tag
+      time_key  time_in
+      time_type unixtime
+    </inject>
+    <format>
+      keys ["time_in", "tag", "k1"]
+    </format>
+    <parse>
+      keys ["time_out", "tag", "k2", "child_pid"]
+    </parse>
+    <extract>
+      tag_key   tag
+      time_key  time_out
+      time_type unixtime
+    </extract>
+  ]
+
+  CONFIG_RESPAWN_COMPAT = %[
+    command ruby -e 'STDOUT.sync = true; proc = ->(){line = STDIN.readline.chomp; puts line + "\t" + Process.pid.to_s}; proc.call; proc.call; proc.call'
+    num_children 4
+    child_respawn -1
+    in_keys time_in,tag,k1
+    out_keys time_out,tag,k2,child_pid
+    tag_key tag
+    in_time_key time_in
+    out_time_key time_out
+#    time_format %Y-%m-%d %H:%M:%S
+#    localtime
+  ]
+
+  data(
+    'with sections' => CONFIG_RESPAWN,
+    'traditional' => CONFIG_RESPAWN_COMPAT,
+  )
+  test 'emit events via child processes which exits sometimes' do |conf|
+    d = create_driver(conf)
+    time = event_time("2011-01-02 13:14:15")
+
+    countup = 0
+
+    d.run(start: true, shutdown: false)
+
+    assert_equal 4, d.instance.instance_eval{ @_child_process_processes.size }
+
+    20.times do
+      d.run(default_tag: 'test', expect_emits: 1, timeout: 10, force_flush_retry: true, start: false, shutdown: false) do
+        d.feed(time, {"k1"=>countup}); countup += 1
+        d.feed(time, {"k1"=>countup}); countup += 1
+        d.feed(time, {"k1"=>countup}); countup += 1
+      end
+    end
+
+    events = d.events
+    assert_equal 60, events.length
+
+    pid_list = []
+    events.each do |event|
+      pid = event[2]['child_pid']
+      pid_list << pid unless pid_list.include?(pid)
+    end
+    assert_equal 20, pid_list.size, "the number of pids should be same with number of child processes: #{pid_list.inspect}"
+
+    logs = d.instance.log.out.logs
+    assert{ logs.select{|l| l.include?("child process exits with error code") }.size >= 18 } # 20
+    assert{ logs.select{|l| l.include?("respawning child process") }.size >= 18 } # 20
+
+    d.run(start: false, shutdown: true)
+  end
+end

--- a/test/plugin_helper/test_child_process.rb
+++ b/test/plugin_helper/test_child_process.rb
@@ -667,6 +667,7 @@ class ChildProcessTest < Test::Unit::TestCase
         @d.child_process_execute(:st1, "ruby", arguments: args, mode: [:read], on_exit_callback: cb) do |readio|
           pid = @d.instance_eval{ child_process_id }
           Process.kill(:QUIT, pid)
+          Process.kill(:QUIT, pid) rescue nil # once more to kill certainly
           str = readio.read.chomp rescue nil # empty string before EOF
           block_exits = true
         end

--- a/test/plugin_helper/test_child_process.rb
+++ b/test/plugin_helper/test_child_process.rb
@@ -655,7 +655,7 @@ class ChildProcessTest < Test::Unit::TestCase
       block_exits = false
       callback_called = false
       exit_status = nil
-      args = ['-e', 'sleep ARGV[0].to_i; puts "yay"; File.unlink ARGV[1]', '10', @temp_path]
+      args = ['-e', 'sleep ARGV[0].to_i; puts "yay"; File.unlink ARGV[1]', '25', @temp_path]
       cb = ->(status){ exit_status = status; callback_called = true }
 
       str = nil
@@ -675,8 +675,7 @@ class ChildProcessTest < Test::Unit::TestCase
       assert callback_called
       assert exit_status
 
-      assert_nil exit_status.exitstatus
-      assert_equal 3, exit_status.termsig # SIGQUIT
+      assert_equal [nil, 3], [exit_status.exitstatus, exit_status.termsig] # SIGQUIT
 
       assert File.exist?(@temp_path)
       assert_equal "", str


### PR DESCRIPTION
This change is to migrate `out_exec_filter` to v0.14 API, and make `in/out_exec` plugins free from `Fluent::ExecUtil::*` classes.

This change includes the changes to:
- make all (built-in or 3rd party) formatter/parser plugins available in exec plugins
- make inject/extract plugin helpers available in exec plugins
- add a method to return parser/formatter type for data handling (binary, text or text-per-line)
- add methods to pass io or partial data to parsers to parse binary or multiline text data in consistent way
- add options of child_process plugin helper to wait process exits and callback for exit status

This change is successor of #1048.
