### PR TITLE
Show errors on console under plugin development

### DIFF
--- a/lib/fluent/plugin/out_stdout.rb
+++ b/lib/fluent/plugin/out_stdout.rb
@@ -41,17 +41,7 @@ module Fluent::Plugin
       false
     end
 
-    def prefer_delayed_commit
-      @delayed
-    end
-
-    attr_accessor :delayed
     attr_accessor :formatter
-
-    def initialize
-      super
-      @delayed = false
-    end
 
     def configure(conf)
       compat_parameters_convert(conf, :inject, :formatter)
@@ -75,11 +65,6 @@ module Fluent::Plugin
 
     def write(chunk)
       chunk.write_to($log)
-    end
-
-    def try_write(chunk)
-      chunk.write_to($log)
-      commit_write(chunk.unique_id)
     end
   end
 end

--- a/lib/fluent/plugin_helper/thread.rb
+++ b/lib/fluent/plugin_helper/thread.rb
@@ -66,6 +66,12 @@ module Fluent
             yield
             thread_exit = true
           rescue Exception => e
+            if @under_plugin_development
+              STDERR.puts "\nError raised in thread from #thread_create, #{e.class}:#{e.message}"
+              e.backtrace.each do |msg|
+                STDERR.puts [" ", msg].join
+              end
+            end
             log.warn "thread exited by unexpected error", plugin: self.class, title: title, error: e
             thread_exit = true
             raise

--- a/lib/fluent/test/driver/base_owner.rb
+++ b/lib/fluent/test/driver/base_owner.rb
@@ -28,6 +28,7 @@ module Fluent
             @instance.system_config_override(opts)
           end
           @instance.log = TestLogger.new
+          @instance.log.under_plugin_development = true
           @logs = @instance.log.out.logs
 
           @event_streams = nil

--- a/test/plugin/test_in_dummy.rb
+++ b/test/plugin/test_in_dummy.rb
@@ -15,7 +15,7 @@ class DummyTest < Test::Unit::TestCase
   sub_test_case 'configure' do
     test 'required parameters' do
       assert_raise_message("'tag' parameter is required") do
-        create_driver('')
+        Fluent::Plugin::DummyInput.new.configure(config_element('ROOT',''))
       end
     end
 

--- a/test/plugin/test_out_null.rb
+++ b/test/plugin/test_out_null.rb
@@ -80,7 +80,7 @@ class NullOutputTest < Test::Unit::TestCase
       d.instance.delayed = true
 
       t = event_time("2016-05-23 00:22:13 -0800")
-      d.run(default_tag: 'test', flush: true, shutdown: false) do
+      d.run(default_tag: 'test', flush: true, wait_flush_completion: false, shutdown: false) do
         d.feed(t, {"message" => "null null null"})
         d.feed(t, {"message" => "null null"})
         d.feed(t, {"message" => "null"})

--- a/test/plugin/test_out_secondary_file.rb
+++ b/test/plugin/test_out_secondary_file.rb
@@ -97,7 +97,9 @@ class FileOutputSecondaryTest < Test::Unit::TestCase
 
     test 'should be passed directory' do
       assert_raise Fluent::ConfigError do
-        create_driver %[]
+        i = Fluent::Plugin::SecondaryFileOutput.new
+        i.acts_as_secondary(create_primary)
+        i.configure(config_element())
       end
 
       assert_nothing_raised do

--- a/test/plugin/test_out_stdout.rb
+++ b/test/plugin/test_out_stdout.rb
@@ -139,21 +139,6 @@ class StdoutOutputTest < Test::Unit::TestCase
         end
         assert_equal "#{Time.at(time).localtime.strftime(TIME_FORMAT)} test: {\"test\":\"test\"}\n", out
       end
-
-      data('oj' => 'oj', 'yajl' => 'yajl')
-      test '#try_write(asynchronous)' do |data|
-        d = create_driver(config_element("ROOT", "", {"output_type" => "json", "json_parser" => data}, [config_element("buffer")]))
-        time = event_time()
-        d.instance.delayed = true
-
-        out = capture_log do
-          d.run(default_tag: 'test', flush: true, shutdown: false) do
-            d.feed(time, {'test' => 'test'})
-          end
-        end
-
-        assert_equal "#{Time.at(time).localtime.strftime(TIME_FORMAT)} test: {\"test\":\"test\"}\n", out
-      end
     end
 
     sub_test_case 'emit hash' do
@@ -163,20 +148,6 @@ class StdoutOutputTest < Test::Unit::TestCase
 
         out = capture_log do
           d.run(default_tag: 'test', flush: true) do
-            d.feed(time, {'test' => 'test'})
-          end
-        end
-
-        assert_equal "#{Time.at(time).localtime.strftime(TIME_FORMAT)} test: {\"test\"=>\"test\"}\n", out
-      end
-
-      test '#try_write(asynchronous)' do
-        d = create_driver(config_element("ROOT", "", {"output_type" => "hash"}, [config_element("buffer")]))
-        time = event_time()
-        d.instance.delayed = true
-
-        out = capture_log do
-          d.run(default_tag: 'test', flush: true, shutdown: false) do
             d.feed(time, {'test' => 'test'})
           end
         end


### PR DESCRIPTION
This change fixes code to show error/fatal logs in testing console.

Raising errors doesn't help situation because:
* errors raised in threads will be raised in main thread by abort_on_exception=true
* main thread of test-unit will rescues and ignore errors

So we can't find any errors in unit tests without showing these on console.

I found that some `#try_write` method call `#commit_write` in it, and it misses to remove the chunk from `@dequeued_chunks`. It's a kind of bug.

Adding a chunk into `@dequeued_chunks` after calling `#try_write` has thread-unsafe bug. (because plugin may commit the chunk in another threads just after `#try_write` called, and plugin's main thread may have NOT added that chunk into `@dequeued_chunks`.)
So, I fixed it at the same time.