### PR TITLE
Default nginx access log format parse fix

### DIFF
--- a/lib/fluent/plugin/parser_nginx.rb
+++ b/lib/fluent/plugin/parser_nginx.rb
@@ -21,7 +21,7 @@ module Fluent
     class NginxParser < RegexpParser
       Plugin.register_parser("nginx", self)
 
-      config_set_default :expression, %q{/^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$/}
+      config_set_default :expression, %q{/^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?( "(?<ratio>[^\"]*)")?$/}
       config_set_default :time_format, "%d/%b/%Y:%H:%M:%S %z"
     end
   end

--- a/test/plugin/test_parser_nginx.rb
+++ b/test/plugin/test_parser_nginx.rb
@@ -45,4 +45,12 @@ class NginxParserTest < ::Test::Unit::TestCase
       assert_equal(@expected, record)
     }
   end
+
+  def test_parse_with_gzip_ratio
+    d = create_driver
+    d.instance.parse('127.0.0.1 192.168.0.1 - [28/Feb/2013:12:00:00 +0900] "GET /" 200 777 "-" "Opera/12.0" "-"') { |time, record|
+      assert_equal(event_time('28/Feb/2013:12:00:00 +0900', format: '%d/%b/%Y:%H:%M:%S %z'), time)
+      assert_equal(@expected.merge('ratio' => '-'), record)
+    }
+  end
 end


### PR DESCRIPTION
Default nginx access log format (http://nginx.org/en/docs/http/ngx_http_log_module.html) looks like:
```
log_format compression '$remote_addr - $remote_user [$time_local] '
                       '"$request" $status $bytes_sent '
                       '"$http_referer" "$http_user_agent" "$gzip_ratio"';
```

Fluentd parser was missing `"$gzip_ratio"`.

How to reproduce the bug:
```
➜  ~ docker run --name test-nginx -P -d nginx
[…]
➜  ~ docker ps
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                                           NAMES
3b445987ac4d        nginx               "nginx -g 'daemon off"   16 hours ago        Up 2 minutes        0.0.0.0:32769->80/tcp, 0.0.0.0:32768->443/tcp   test-nginx
➜  ~ curl -so /dev/null http://localhost:32769
➜  ~ docker logs 3b445987ac4d
172.17.0.1 - - [01/Nov/2016:01:25:20 +0000] "GET / HTTP/1.1" 200 612 "-" "curl/7.49.1" "-"
```

Fluentd was unable to parse default nginx log format without this patch.

My patch adds missing field and keep backward compatibility.

The issue was reported also here - https://github.com/fluent/fluentd/issues/608