### PR TITLE
Test driver fixes for error handling

### DIFF
--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -1005,10 +1005,6 @@ module Fluent
           end
           @buffer.takeback_chunk(chunk.unique_id)
 
-          if @under_plugin_development && !@retry_for_error_chunk
-            raise
-          end
-
           @retry_mutex.synchronize do
             if @retry
               @counters_monitor.synchronize{ @num_errors += 1 }
@@ -1036,6 +1032,8 @@ module Fluent
               log.warn_backtrace e.backtrace
             end
           end
+
+          raise if @under_plugin_development && !@retry_for_error_chunk
         end
       end
 

--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -151,8 +151,8 @@ module Fluent
       # for tests
       attr_reader :buffer, :retry, :secondary, :chunk_keys, :chunk_key_time, :chunk_key_tag
       attr_accessor :output_enqueue_thread_waiting, :dequeued_chunks, :dequeued_chunks_mutex
-
       # output_enqueue_thread_waiting: for test of output.rb itself
+      attr_accessor :retry_for_error_chunk # if true, error flush will be retried even if under_plugin_development is true
 
       def initialize
         super
@@ -194,6 +194,8 @@ module Fluent
         @chunk_keys = @chunk_key_time = @chunk_key_tag = nil
         @flush_mode = nil
         @timekey_zone = nil
+
+        @retry_for_error_chunk = false
       end
 
       def acts_as_secondary(primary)
@@ -1003,7 +1005,7 @@ module Fluent
           end
           @buffer.takeback_chunk(chunk.unique_id)
 
-          if @under_plugin_development
+          if @under_plugin_development && !@retry_for_error_chunk
             raise
           end
 

--- a/lib/fluent/plugin_helper/thread.rb
+++ b/lib/fluent/plugin_helper/thread.rb
@@ -66,12 +66,6 @@ module Fluent
             yield
             thread_exit = true
           rescue Exception => e
-            if @under_plugin_development
-              STDERR.puts "\nError raised in thread from #thread_create, #{e.class}:#{e.message}"
-              e.backtrace.each do |msg|
-                STDERR.puts [" ", msg].join
-              end
-            end
             log.warn "thread exited by unexpected error", plugin: self.class, title: title, error: e
             thread_exit = true
             raise

--- a/lib/fluent/test/driver/base.rb
+++ b/lib/fluent/test/driver/base.rb
@@ -138,8 +138,9 @@ module Fluent
           end
 
           timeout ||= DEFAULT_TIMEOUT
-          stop_at = Time.now + timeout
-          @run_breaking_conditions << ->(){ Time.now >= stop_at }
+          clock_id = Process::CLOCK_MONOTONIC rescue Process::CLOCK_MONOTONIC_RAW
+          stop_at = Process.clock_gettime(clock_id) + timeout
+          @run_breaking_conditions << ->(){ Process.clock_gettime(clock_id) >= stop_at }
 
           if !block_given? && @run_post_conditions.empty? && @run_breaking_conditions.empty?
             raise ArgumentError, "no stop conditions nor block specified"

--- a/lib/fluent/test/driver/base.rb
+++ b/lib/fluent/test/driver/base.rb
@@ -130,15 +130,11 @@ module Fluent
 
         def run_actual(timeout: nil, &block)
           if @instance.respond_to?(:_threads)
-            until @instance._threads.values.all?(&:alive?)
-              sleep 0.01
-            end
+            sleep 0.01 until @instance._threads.values.all?(&:alive?)
           end
 
           if @instance.respond_to?(:event_loop_running?)
-            until @instance.event_loop_running?
-              sleep 0.01
-            end
+            sleep 0.01 until @instance.event_loop_running?
           end
 
           timeout ||= DEFAULT_TIMEOUT

--- a/lib/fluent/test/driver/base.rb
+++ b/lib/fluent/test/driver/base.rb
@@ -165,7 +165,7 @@ module Fluent
 
         def stop?
           # Should stop running if post conditions are not registered.
-          return true unless @run_post_conditions
+          return true unless @run_post_conditions || @run_post_conditions.empty?
 
           # Should stop running if all of the post conditions are true.
           return true if @run_post_conditions.all? {|proc| proc.call }

--- a/lib/fluent/test/driver/base.rb
+++ b/lib/fluent/test/driver/base.rb
@@ -89,18 +89,25 @@ module Fluent
         def instance_start
           unless @instance.started?
             @instance.start
-            instance_hook_after_started
           end
           unless @instance.after_started?
             @instance.after_start
           end
+
+          instance_hook_after_started
         end
 
         def instance_hook_after_started
           # insert hooks for tests available after instance.start
         end
 
+        def instance_hook_before_stopped
+          # same with above
+        end
+
         def instance_shutdown
+          instance_hook_before_stopped
+
           @instance.stop            unless @instance.stopped?
           @instance.before_shutdown unless @instance.before_shutdown?
           @instance.shutdown        unless @instance.shutdown?

--- a/lib/fluent/test/driver/base.rb
+++ b/lib/fluent/test/driver/base.rb
@@ -23,6 +23,8 @@ require 'timeout'
 module Fluent
   module Test
     module Driver
+      class TestTimedOut < RuntimeError; end
+
       class Base
         attr_reader :instance, :logs
 
@@ -159,7 +161,7 @@ module Fluent
               proc.call
             end
           rescue Timeout::Error
-            @broken = true
+            raise TestTimedOut, "Test case timed out with hard limit."
           end
           return_value
         end

--- a/lib/fluent/test/driver/base_owner.rb
+++ b/lib/fluent/test/driver/base_owner.rb
@@ -28,7 +28,6 @@ module Fluent
             @instance.system_config_override(opts)
           end
           @instance.log = TestLogger.new
-          @instance.log.under_plugin_development = true
           @logs = @instance.log.out.logs
 
           @event_streams = nil

--- a/lib/fluent/test/driver/output.rb
+++ b/lib/fluent/test/driver/output.rb
@@ -44,8 +44,7 @@ module Fluent
         def run_actual(**kwargs, &block)
           val = super(**kwargs, &block)
           if @flush_buffer_at_cleanup
-            @instance.force_flush
-            Timeout.timeout(10){ sleep 0.1 until !@instance.buffer || @instance.buffer.queue.size == 0 }
+            self.flush
           end
           val
         end

--- a/lib/fluent/test/log.rb
+++ b/lib/fluent/test/log.rb
@@ -41,13 +41,6 @@ module Fluent
         args.each{ |arg| write(arg + "\n") }
       end
 
-      def dump_stderr(&block)
-        @use_stderr = true
-        block.call
-      ensure
-        @use_stderr = false
-      end
-
       def write(message)
         if @use_stderr
           STDERR.write message
@@ -65,48 +58,13 @@ module Fluent
     end
 
     class TestLogger < Fluent::PluginLogger
-      attr_accessor :under_plugin_development
-
       def initialize
         @logdev = DummyLogDevice.new
-        @under_plugin_development = false
         dl_opts = {}
         dl_opts[:log_level] = ServerEngine::DaemonLogger::INFO
         logger = ServerEngine::DaemonLogger.new(@logdev, dl_opts)
         log = Fluent::Log.new(logger)
         super(log)
-      end
-
-      def error(*args, &block)
-        if @under_plugin_development
-          @logdev.dump_stderr{ super }
-        else
-          super
-        end
-      end
-
-      def error_backtrace(backtrace=$!.backtrace)
-        if @under_plugin_development
-          @logdev.dump_stderr{ super }
-        else
-          super
-        end
-      end
-
-      def fatal(*args, &block)
-        if @under_plugin_development
-          @logdev.dump_stderr{ super }
-        else
-          super
-        end
-      end
-
-      def fatal_backtrace(backtrace=$!.backtrace)
-        if @under_plugin_development
-          @logdev.dump_stderr{ super }
-        else
-          super
-        end
       end
 
       def reset


### PR DESCRIPTION
This change follows #1302.
After #1302, I found that any errors in `#write` of output plugins are not raised in test case code like below:
```ruby
assert_raise AnyErrors do
  d.run
    d.feed(events)
  end # events flushed and #write called - "AnyErrors" raised
end
```

Errors are shown on console, but we can't test it.
This change is to check all threads via thread plugin helper, and re-raise errors from these threads at the end of `#run` method. It shows all errors in all threads related with plugins explicitly as test results - so there's no need to show these errors on console.

Some changes are also included:
* add an option to retry for flush errors even in plugin development: to emulate write operations 2 or more times over failures
* use `Process.clock_gettime` instead of `Time` to work well even when `timecop` is used
* raise TestTimedOut error for hard timeout to show problematic test cases clearly
* change to wait post conditions after `#run_actual`, because output plugin test driver flushes and wait for completion of flushing in `#run_actual`