### PR TITLE
Fix timezone for compat timesliced output plugins

### DIFF
--- a/lib/fluent/compat/output.rb
+++ b/lib/fluent/compat/output.rb
@@ -617,17 +617,16 @@ module Fluent
           end
 
           if conf['timezone']
-            @timezone = conf['timezone']
-            Fluent::Timezone.validate!(@timezone)
+            Fluent::Timezone.validate!(conf['timezone'])
           elsif conf['utc']
-            @timezone = "+0000"
-            @localtime = false
+            conf['timezone'] = "+0000"
+            conf['localtime'] = "false"
           elsif conf['localtime']
-            @timezone = Time.now.strftime('%z')
-            @localtime = true
+            conf['timezone'] = Time.now.strftime('%z')
+            conf['localtime'] = "true"
           else
-            @timezone = "+0000" # v0.12 assumes UTC without any configuration
-            @localtime = false
+            conf['timezone'] = "+0000" # v0.12 assumes UTC without any configuration
+            conf['localtime'] = "false"
           end
 
           @_timekey = case conf['time_slice_format']


### PR DESCRIPTION
This change fixes #1300.

Instance variables defined via `config_param` are initialized with nil (if specified so) after change #1296.
TimeSlicedOutput plugin compat layer wrongly sets instance variable before calling `super`, and the values of these instance variable are overwritten by `super`.

I fixed that problem, and wrote a test for it.