### PR TITLE
migrating in_http to v0.14 API

### DIFF
--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -17,7 +17,6 @@
 require 'fluent/plugin/input'
 require 'fluent/plugin/parser'
 require 'fluent/event'
-require 'fluent/process'
 
 require 'http/parser'
 require 'webrick/httputils'
@@ -37,7 +36,6 @@ module Fluent::Plugin
   class HttpInput < Input
     Fluent::Plugin.register_input('http', self)
 
-    # include DetachMultiProcessMixin
     helpers :parser, :compat_parameters, :event_loop
 
     EMPTY_GIF_IMAGE = "GIF89a\u0001\u0000\u0001\u0000\x80\xFF\u0000\xFF\xFF\xFF\u0000\u0000\u0000,\u0000\u0000\u0000\u0000\u0001\u0000\u0001\u0000\u0000\u0002\u0002D\u0001\u0000;".force_encoding("UTF-8")
@@ -138,21 +136,6 @@ module Fluent::Plugin
       event_loop_attach(@lsock)
 
       @float_time_parser = Fluent::NumericTimeParser.new(:float)
-
-      # detach_multi_process do
-      #   super
-      #   @km = KeepaliveManager.new(@keepalive_timeout)
-      #   @lsock = Coolio::TCPServer.new(lsock, nil, Handler, @km, method(:on_request),
-      #                                  @body_size_limit, @format, log,
-      #                                  @cors_allow_origins)
-      #   @lsock.listen(@backlog) unless @backlog.nil?
-
-      #   @loop = Coolio::Loop.new
-      #   @loop.attach(@km)
-      #   @loop.attach(@lsock)
-
-      #   @thread = Thread.new(&method(:run))
-      # end
     end
 
     def close

--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -137,6 +137,8 @@ module Fluent::Plugin
       event_loop_attach(@km)
       event_loop_attach(@lsock)
 
+      @float_time_parser = Fluent::NumericTimeParser.new(:float)
+
       # detach_multi_process do
       #   super
       #   @km = KeepaliveManager.new(@keepalive_timeout)
@@ -187,7 +189,7 @@ module Fluent::Plugin
         end
         time = if param_time = params['time']
                  param_time = param_time.to_f
-                 param_time.zero? ? Fluent::Engine.now : Fluent::EventTime.from_time(Time.at(param_time))
+                 param_time.zero? ? Fluent::Engine.now : @float_time_parser.parse(param_time)
                else
                  record_time.nil? ? Fluent::Engine.now : record_time
                end

--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -71,9 +71,9 @@ module Fluent::Plugin
       super
 
       m = if @parser_configs.first['@type'] == 'in_http'
-            @parser_msgpack = parser_create(type: 'msgpack')
+            @parser_msgpack = parser_create(usage: 'parser_in_http_msgpack', type: 'msgpack')
             @parser_msgpack.estimate_current_event = false
-            @parser_json = parser_create(type: 'json')
+            @parser_json = parser_create(usage: 'parser_in_http_json', type: 'json')
             @parser_json.estimate_current_event = false
             @format_name = 'default'
             method(:parse_params_default)

--- a/lib/fluent/plugin/parser.rb
+++ b/lib/fluent/plugin/parser.rb
@@ -96,7 +96,7 @@ module Fluent
       end
 
       def parse_time(record)
-        if @time_key && record.has_key?(@time_key)
+        if @time_key && record.respond_to?(:has_key?) && record.has_key?(@time_key)
           src = if @keep_time_key
                   record[@time_key]
                 else

--- a/lib/fluent/plugin_helper/compat_parameters.rb
+++ b/lib/fluent/plugin_helper/compat_parameters.rb
@@ -48,7 +48,7 @@ module Fluent
       }
 
       PARSER_PARAMS = {
-        "format" => "@type",
+        "format" => nil,
         "types" => nil,
         "types_delimiter" => nil,
         "types_label_delimiter" => nil,
@@ -252,6 +252,15 @@ module Fluent
 
         # TODO: warn obsolete parameters if these are deprecated
         hash = compat_parameters_copy_to_subsection_attributes(conf, PARSER_PARAMS)
+
+        if conf["format"]
+          if conf["format"].start_with?("/") && conf["format"].end_with?("/")
+            hash["@type"] = "regexp"
+            hash["expression"] = conf["format"]
+          else
+            hash["@type"] = conf["format"]
+          end
+        end
 
         if conf["types"]
           delimiter = conf["types_delimiter"] || ','

--- a/lib/fluent/plugin_helper/compat_parameters.rb
+++ b/lib/fluent/plugin_helper/compat_parameters.rb
@@ -217,7 +217,7 @@ module Fluent
 
       def compat_parameters_extract(conf)
         return unless conf.elements('extract').empty?
-        return if EXTRACT_PARAMS.keys.all?{|k| !conf.has_key?(k) }
+        return if EXTRACT_PARAMS.keys.all?{|k| !conf.has_key?(k) } && !conf.has_key?('format')
 
         # TODO: warn obsolete parameters if these are deprecated
         hash = compat_parameters_copy_to_subsection_attributes(conf, EXTRACT_PARAMS)
@@ -225,6 +225,9 @@ module Fluent
         if conf.has_key?('time_as_epoch') && Fluent::Config.bool_value(conf['time_as_epoch'])
           hash['time_key'] ||= 'time'
           hash['time_type'] = 'unixtime'
+        elsif conf.has_key?('format') && conf["format"].start_with?("/") && conf["format"].end_with?("/") # old-style regexp parser
+          hash['time_key'] ||= 'time'
+          hash['time_type'] ||= 'string'
         end
         if conf.has_key?('localtime') || conf.has_key?('utc')
           if conf.has_key?('localtime') && conf.has_key?('utc')

--- a/lib/fluent/plugin_helper/compat_parameters.rb
+++ b/lib/fluent/plugin_helper/compat_parameters.rb
@@ -259,7 +259,7 @@ module Fluent
         if conf["format"]
           if conf["format"].start_with?("/") && conf["format"].end_with?("/")
             hash["@type"] = "regexp"
-            hash["expression"] = conf["format"]
+            hash["expression"] = conf["format"][1..-2]
           else
             hash["@type"] = conf["format"]
           end

--- a/lib/fluent/time.rb
+++ b/lib/fluent/time.rb
@@ -50,6 +50,10 @@ module Fluent
       @sec
     end
 
+    def to_f
+      @sec + @nsec / 1_000_000_000.0
+    end
+
     # for Time.at
     def to_r
       Rational(@sec * 1_000_000_000 + @nsec, 1_000_000_000)

--- a/test/plugin/test_in_http.rb
+++ b/test/plugin/test_in_http.rb
@@ -190,8 +190,8 @@ class HttpInputTest < Test::Unit::TestCase
     time_i = time.to_i
 
     events = [
-      ["tag1", time, {"REMOTE_ADDR"=>"129.78.138.66", "a"=>1}],
-      ["tag2", time, {"REMOTE_ADDR"=>"129.78.138.66", "a"=>1}],
+      ["tag1", time, {"a"=>1}],
+      ["tag2", time, {"a"=>2}],
     ]
     res_codes = []
 
@@ -202,9 +202,14 @@ class HttpInputTest < Test::Unit::TestCase
       end
     end
     assert_equal ["200", "200"], res_codes
-    assert_equal events, d.events
+
+    assert_equal "tag1", d.events[0][0]
     assert_equal_event_time time, d.events[0][1]
+    assert_equal({"REMOTE_ADDR"=>"129.78.138.66", "a"=>1}, d.events[0][2])
+
+    assert_equal "tag2", d.events[1][0]
     assert_equal_event_time time, d.events[1][1]
+    assert_equal({"REMOTE_ADDR"=>"129.78.138.66", "a"=>2}, d.events[1][2])
   end
 
   def test_multi_json_with_add_remote_addr_given_x_forwarded_for


### PR DESCRIPTION
This change is to migrate `in_http` to v0.14 APIs, without socket/server plugin helpers (like #1306).

Currently, this change disables DetachMultiProcessMixin feature, because `event_loop` plugin helper can't work with it (error below occurs when DetachMultiProcessMixin is mixed in):
```
Assertion failed: (("libev: ev_loop recursion during release detected", loop_done != EVBREAK_RECURSE)), function ev_run, file ./../libev/ev.c, line 3437.
rake aborted!
SignalException: SIGABRT
```