### PR TITLE
Introduce server plugin helpers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 cache: bundler
 
-script: bundle exec rake test TESTOPTS=-v
+# script: bundle exec rake test TESTOPTS=-v
 
 # http://rubies.travis-ci.org/
 # See here for osx_image -> OSX versions: https://docs.travis-ci.com/user/languages/objective-c

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 cache: bundler
 
+script: bundle exec rake test TESTOPTS=-v
+
 # http://rubies.travis-ci.org/
 # See here for osx_image -> OSX versions: https://docs.travis-ci.com/user/languages/objective-c
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ install:
   - bundle install
 build: off
 test_script:
-  - bundle exec rake test
+  - bundle exec rake test TESTOPTS=-v
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,8 @@ install:
   - bundle install
 build: off
 test_script:
-  - bundle exec rake test TESTOPTS=-v
+  - bundle exec rake test
+#  - bundle exec rake test TESTOPTS=-v
 
 branches:
   only:

--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("msgpack", [">= 0.7.0", "< 2.0.0"])
   gem.add_runtime_dependency("yajl-ruby", ["~> 1.0"])
   gem.add_runtime_dependency("cool.io", ["~> 1.4.5"])
-  gem.add_runtime_dependency("serverengine", [">= 2.0.3", "< 3.0.0"])
+  gem.add_runtime_dependency("serverengine", [">= 2.0.4", "< 3.0.0"])
   gem.add_runtime_dependency("http_parser.rb", [">= 0.5.1", "< 0.7.0"])
   gem.add_runtime_dependency("sigdump", ["~> 0.2.2"])
   gem.add_runtime_dependency("tzinfo", ["~> 1.0"])

--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("msgpack", [">= 0.7.0", "< 2.0.0"])
   gem.add_runtime_dependency("yajl-ruby", ["~> 1.0"])
   gem.add_runtime_dependency("cool.io", ["~> 1.4.5"])
-  gem.add_runtime_dependency("serverengine", ["~> 2.0"])
+  gem.add_runtime_dependency("serverengine", [">= 2.0.3", "< 3.0.0"])
   gem.add_runtime_dependency("http_parser.rb", [">= 0.5.1", "< 0.7.0"])
   gem.add_runtime_dependency("sigdump", ["~> 0.2.2"])
   gem.add_runtime_dependency("tzinfo", ["~> 1.0"])

--- a/lib/fluent/plugin/in_forward.rb
+++ b/lib/fluent/plugin/in_forward.rb
@@ -322,8 +322,6 @@ module Fluent::Plugin
 
       # return option for response
       option
-    ensure
-      p(here: "ensure of on_message", error: $!) if $!
     end
 
     def invalid_event?(tag, time, record)

--- a/lib/fluent/plugin/in_tcp.rb
+++ b/lib/fluent/plugin/in_tcp.rb
@@ -43,6 +43,8 @@ module Fluent::Plugin
       compat_parameters_convert(conf, :parser)
       super
       @_event_loop_blocking_timeout = @blocking_timeout
+      @source_hostname_key ||= @source_host_key if @source_host_key
+
       @parser = parser_create
     end
 
@@ -67,7 +69,7 @@ module Fluent::Plugin
               tag = extract_tag_from_record(record)
               tag ||= @tag
               time ||= extract_time_from_record(record) || Fluent::EventTime.now
-              record[@source_host_key] = conn.remote_host if @source_host_key
+              record[@source_hostname_key] = conn.remote_host if @source_hostname_key
               router.emit(tag, time, record)
             end
           end

--- a/lib/fluent/plugin/in_udp.rb
+++ b/lib/fluent/plugin/in_udp.rb
@@ -14,24 +14,58 @@
 #    limitations under the License.
 #
 
-require 'fluent/plugin/socket_util'
+require 'fluent/plugin/input'
 
-module Fluent
-  class UdpInput < SocketUtil::BaseInput
-    Plugin.register_input('udp', self)
+module Fluent::Plugin
+  class UdpInput < Input
+    Fluent::Plugin.register_input('udp', self)
 
-    config_set_default :port, 5160
+    helpers :server, :parser, :extract, :compat_parameters
+
+    desc 'Tag of output events.'
+    config_param :tag, :string
+    desc 'The port to listen to.'
+    config_param :port, :integer, default: 5160
+    desc 'The bind address to listen to.'
+    config_param :bind, :string, default: '0.0.0.0'
+
+    desc "The field name of the client's hostname."
+    config_param :source_host_key, :string, default: nil, deprecated: "use source_hostname_key instead."
+    desc "The field name of the client's hostname."
+    config_param :source_hostname_key, :string, default: nil
+
     config_param :body_size_limit, :size, default: 4096
 
-    def listen(callback)
-      log.info "listening udp socket on #{@bind}:#{@port}"
-      socket_manager_path = ENV['SERVERENGINE_SOCKETMANAGER_PATH']
-      if Fluent.windows?
-        socket_manager_path = socket_manager_path.to_i
+    config_param :blocking_timeout, :time, default: 0.5
+
+    def configure(conf)
+      compat_parameters_convert(conf, :parser)
+      super
+      @_event_loop_blocking_timeout = @blocking_timeout
+      @parser = parser_create
+    end
+
+    def start
+      super
+
+      log.info "listening udp socket", bind: @bind, port: @port
+      server_create(:in_udp_server, @port, proto: :udp, bind: @bind, max_bytes: @body_size_limit) do |data, sock|
+        data.chomp!
+        begin
+          @parser.parse(data) do |time, record|
+            unless time && record
+              log.warn "pattern not match", data: data
+              next
+            end
+
+            tag = extract_tag_from_record(record)
+            tag ||= @tag
+            time ||= extract_time_from_record(record) || Fluent::EventTime.now
+            record[@source_host_key] = sock.remote_host if @source_host_key
+            router.emit(tag, time, record)
+          end
+        end
       end
-      client = ServerEngine::SocketManager::Client.new(socket_manager_path)
-      @usock = client.listen_udp(@bind, @port)
-      SocketUtil::UdpHandler.new(@usock, log, @body_size_limit, callback)
     end
   end
 end

--- a/lib/fluent/plugin/in_udp.rb
+++ b/lib/fluent/plugin/in_udp.rb
@@ -42,6 +42,8 @@ module Fluent::Plugin
       compat_parameters_convert(conf, :parser)
       super
       @_event_loop_blocking_timeout = @blocking_timeout
+      @source_hostname_key ||= @source_host_key if @source_host_key
+
       @parser = parser_create
     end
 
@@ -61,7 +63,7 @@ module Fluent::Plugin
             tag = extract_tag_from_record(record)
             tag ||= @tag
             time ||= extract_time_from_record(record) || Fluent::EventTime.now
-            record[@source_host_key] = sock.remote_host if @source_host_key
+            record[@source_hostname_key] = sock.remote_host if @source_hostname_key
             router.emit(tag, time, record)
           end
         end

--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -317,7 +317,7 @@ module Fluent::Plugin
       def on_readable
         begin
           msg, addr = @io.recvfrom(1024)
-        rescue Errno::EAGAIN, Errno::EWOULDBLOCK, Errno::EINTR
+        rescue Errno::EAGAIN, Errno::EWOULDBLOCK, Errno::EINTR, Errno::ECONNRESET
           return
         end
         host = addr[3]

--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -1176,7 +1176,7 @@ module Fluent
         flush_thread_interval = @buffer_config.flush_thread_interval
 
         # If the given clock_id is not supported, Errno::EINVAL is raised.
-        clock_id = Process::CLOCK_MONOTONIC rescue Process::CLOCK_MONOTONIC_RAW
+        clock_id = Process::CLOCK_MONOTONIC_RAW rescue Process::CLOCK_MONOTONIC
         state.next_time = Process.clock_gettime(clock_id) + flush_thread_interval
 
         while !self.after_started? && !self.stopped?

--- a/lib/fluent/plugin_helper.rb
+++ b/lib/fluent/plugin_helper.rb
@@ -24,6 +24,8 @@ require 'fluent/plugin_helper/parser'
 require 'fluent/plugin_helper/formatter'
 require 'fluent/plugin_helper/inject'
 require 'fluent/plugin_helper/extract'
+# require 'fluent/plugin_helper/socket'
+require 'fluent/plugin_helper/server'
 require 'fluent/plugin_helper/retry_state'
 require 'fluent/plugin_helper/compat_parameters'
 

--- a/lib/fluent/plugin_helper/event_loop.rb
+++ b/lib/fluent/plugin_helper/event_loop.rb
@@ -65,11 +65,14 @@ module Fluent
 
         # event loop does not run here, so mutex lock is not required
         thread_create :event_loop do
-          default_watcher = DefaultWatcher.new
-          @_event_loop.attach(default_watcher)
-          @_event_loop_running = true
-          @_event_loop.run(@_event_loop_run_timeout) # this method blocks
-          @_event_loop_running = false
+          begin
+            default_watcher = DefaultWatcher.new
+            @_event_loop.attach(default_watcher)
+            @_event_loop_running = true
+            @_event_loop.run(@_event_loop_run_timeout) # this method blocks
+          ensure
+            @_event_loop_running = false
+          end
         end
       end
 

--- a/lib/fluent/plugin_helper/server.rb
+++ b/lib/fluent/plugin_helper/server.rb
@@ -1,0 +1,411 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'fluent/plugin_helper/event_loop'
+
+require 'serverengine/socket_manager'
+require 'cool.io'
+require 'socket'
+require 'ipaddr'
+require 'fcntl'
+
+module Fluent
+  module PluginHelper
+    module Server
+      include Fluent::PluginHelper::EventLoop
+
+      # This plugin helper doesn't support these things for now:
+      # * SSL/TLS (TBD)
+      # * IPv6
+      # * TCP/TLS keepalive
+
+      # stop     : [-]
+      # shutdown : detach server event handler from event loop (event_loop)
+      # close    : close listening sockets
+      # terminate: remote all server instances
+
+      attr_reader :_servers # for tests
+
+      def server_wait_until_start
+        # event_loop_wait_until_start works well for this
+      end
+
+      def server_wait_until_stop
+        sleep 0.1 while @_servers.any?{|si| si.server.attached? }
+        @_servers.each{|si| si.server.close rescue nil }
+      end
+
+      PROTOCOLS = [:tcp, :udp, :tls, :unix]
+      CONNECTION_PROTOCOLS = [:tcp, :tls, :unix]
+
+      # server_create_connection(:title, @port) do |conn|
+      #   # on connection
+      #   source_addr = conn.remote_host
+      #   source_port = conn.remote_port
+      #   conn.data do |data|
+      #     # on data
+      #     conn.write resp # ...
+      #     conn.close
+      #   end
+      # end
+      def server_create_connection(title, port, proto: :tcp, bind: '0.0.0.0', shared: true, certopts: nil, resolve_name: false, linger_timeout: 0, backlog: nil, &block)
+        raise ArgumentError, "BUG: title must be a symbol" unless title.is_a? Symbol
+        raise ArgumentError, "BUG: cannot create connection for UDP" unless CONNECTION_PROTOCOLS.include?(proto)
+        raise ArgumentError, "BUG: block not specified which handles connection" unless block_given?
+        raise ArgumentError, "BUG: block must have just one argument" unless block.arity == 1
+
+        case proto
+        when :tcp
+          server = server_create_for_tcp_connection(shared, bind, port, resolve_name, linger_timeout, backlog, &block)
+        when :tls
+          raise ArgumentError, "BUG: certopts (certificate options) not specified for TLS" unless certopts
+          # server_certopts_validate!(certopts)
+          # sock = server_create_tls_socket(shared, bind, port)
+          # server = nil # ...
+          raise "not implemented yet"
+        when :unix
+          raise "not implemented yet"
+        else
+          raise "unknown protocol #{proto}"
+        end
+
+        server_attach(title, port, bind, shared, server)
+      end
+
+      # server_create(:title, @port) do |data|
+      #   # ...
+      # end
+      # server_create(:title, @port) do |data, conn|
+      #   # ...
+      # end
+      # server_create(:title, @port, proto: :udp, max_bytes: 2048) do |data, sock|
+      #   sock.remote_host
+      #   sock.remote_port
+      #   # ...
+      # end
+      def server_create(title, port, proto: :tcp, bind: '0.0.0.0', shared: true, certopts: nil, resolve_name: false, linger_timeout: 0, backlog: nil, max_bytes: nil, flags: 0, &callback)
+        raise ArgumentError, "BUG: title must be a symbol" unless title.is_a? Symbol
+        raise ArgumentError, "BUG: invalid protocol name" unless PROTOCOLS.include?(proto)
+
+        raise ArgumentError, "BUG: block not specified which handles received data" unless block_given?
+        raise ArgumentError, "BUG: block must have 1 or 2 arguments" unless callback.arity == 1 || callback.arity == 2
+
+        case proto
+        when :tcp
+          server = server_create_for_tcp_connection(shared, bind, port, resolve_name, linger_timeout, backlog) do |conn|
+            conn.data(&callback)
+          end
+        when :tls
+          raise ArgumentError, "BUG: certopts (certificate options) not specified for TLS" unless certopts
+          server_certopts_validate!(certopts)
+          raise "not implemented yet"
+        when :udp
+          raise ArgumentError, "BUG: max_bytes must be specified for UDP" unless max_bytes
+          sock = server_create_udp_socket(shared, bind, port)
+          sock.do_not_reverse_lookup = !resolve_name
+          server = EventHandler::UDPServer.new(sock, resolve_name, max_bytes, flags, @log, @under_plugin_development, &callback)
+        when :unix
+          raise "not implemented yet"
+        else
+          raise "BUG: unknown protocol #{proto}"
+        end
+
+        server_attach(title, port, bind, shared, server)
+      end
+
+      def server_create_tcp(title, port, **kwargs, &callback)
+        server_create(title, port, proto: :tcp, **kwargs, &callback)
+      end
+
+      def server_create_udp(title, port, **kwargs, &callback)
+        server_create(title, port, proto: :udp, **kwargs, &callback)
+      end
+
+      ServerInfo = Struct.new(:title, :port, :bind, :shared, :server)
+
+      def server_attach(title, port, bind, shared, server)
+        @_servers << ServerInfo.new(title, port, bind, shared, server)
+        event_loop_attach(server)
+      end
+
+      def server_create_for_tcp_connection(shared, bind, port, resolve_name, linger_timeout, backlog, &block)
+        sock = server_create_tcp_socket(shared, bind, port)
+        server = Coolio::TCPServer.new(sock, nil, EventHandler::TCPServer, resolve_name, linger_timeout, @log, @under_plugin_development, block)
+        server.listen(backlog) if backlog
+        server
+      end
+
+      def initialize
+        super
+        @_servers = []
+      end
+
+      def close
+        @_servers.each do |si|
+          si.server.close rescue nil
+        end
+
+        super
+      end
+
+      def terminate
+        @_servers = []
+        super
+      end
+
+      def server_certopts_validate!(certopts)
+        raise "not implemented yet"
+      end
+
+      def server_socket_manager_client
+        socket_manager_path = ENV['SERVERENGINE_SOCKETMANAGER_PATH']
+        if Fluent.windows?
+          socket_manager_path = socket_manager_path.to_i
+        end
+        ServerEngine::SocketManager::Client.new(socket_manager_path)
+      end
+
+      def server_create_tcp_socket(shared, bind, port)
+        sock = if shared
+                 server_socket_manager_client.listen_tcp(bind, port)
+               else
+                 TCPServer.new(bind, port) # this method call can create sockets for AF_INET6
+               end
+        sock.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC) # close-on-exec
+        sock.fcntl(Fcntl::F_SETFL, Fcntl::O_NONBLOCK) # nonblock
+        sock
+      end
+
+      def server_create_udp_socket(shared, bind, port)
+        sock = if shared
+                 server_socket_manager_client.listen_udp(bind, port)
+               else
+                 family = IPAddr.new(IPSocket.getaddress(bind)).ipv4? ? ::Socket::AF_INET : ::Socket::AF_INET6
+                 usock = UDPSocket.new(family)
+                 usock.bind(bind, port)
+                 usock
+               end
+        sock.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC) # close-on-exec
+        sock.fcntl(Fcntl::F_SETFL, Fcntl::O_NONBLOCK) # nonblock
+        sock
+      end
+
+      def server_create_tls_socket(shared, bind, port)
+        raise "not implemented yet"
+      end
+
+      class CallbackSocket
+        def initialize(server_type, sock, enabled_events = [])
+          @server_type = server_type
+          @sock = sock
+          @enabled_events = enabled_events
+        end
+
+        def remote_addr
+          @sock.peeraddr[3]
+        end
+
+        def remote_host
+          @sock.peeraddr[2]
+        end
+
+        def remote_port
+          @sock.peeraddr[1]
+        end
+
+        def send(data, flag)
+          @sock.send(data, flag)
+        end
+
+        def write(data)
+          @sock.write(data)
+        end
+
+        def close
+          @sock.close
+        end
+
+        def data(&callback)
+          on(:data, &callback)
+        end
+
+        def on(event, &callback)
+          raise "BUG: this event is disabled for #{@server_type}" unless @enabled_events.include?(event)
+          case event
+          when :data
+            @sock.data(&callback)
+          when :write_complete
+            @sock.on_write_complete(&callback)
+          when :before_close
+            @sock.before_close(&callback)
+          when :close
+            @sock.on_close(&callback)
+          else
+            raise "BUG: unknown event: #{event}"
+          end
+        end
+      end
+
+      class TCPCallbackSocket < CallbackSocket
+        def initialize(sock)
+          super("tcp", sock, [:data, :write_complete, :before_close, :close])
+        end
+      end
+
+      class UDPCallbackSocket < CallbackSocket
+        def initialize(sock)
+          super("udp", sock, [:write_complete])
+        end
+
+        def write(data)
+          self.send(data, 0)
+        end
+      end
+
+      module EventHandler
+        class UDPServer < Coolio::IO
+          def initialize(sock, resolve_name, max_bytes, flags, log, under_plugin_development, &callback)
+            raise ArgumentError, "socket must be a UDPSocket: sock = #{sock}" unless sock.is_a?(UDPSocket)
+
+            super(sock)
+
+            @sock = sock
+            @resolve_name = resolve_name
+            @max_bytes = max_bytes
+            @flags = flags
+            @log = log
+            @under_plugin_development = under_plugin_development
+            @callback = callback
+
+            @sock.do_not_reverse_lookup = !resolve_name
+            on_readable_impl = case @callback.arity
+                               when 1 then :on_readable_without_sock
+                               when 2 then :on_readable_with_sock
+                               else
+                                 raise "BUG: callback block must have 1 or 2 arguments"
+                               end
+            self.define_singleton_method(:on_readable, method(on_readable_impl))
+          end
+
+          def on_readable_without_sock
+            begin
+              data = @sock.recv(@max_bytes, @flags)
+            rescue Errno::EAGAIN, Errno::EWOULDBLOCK, Errno::EINTR
+              return
+            end
+            @callback.call(data)
+          rescue => e
+            @log.error "unexpected error in processing UDP data", error: e
+            @log.error_backtrace
+            raise if @under_plugin_development
+          end
+
+          def on_readable_with_sock
+            begin
+              data, addr = @sock.recvfrom(@max_bytes)
+            rescue Errno::EAGAIN, Errno::EWOULDBLOCK, Errno::EINTR
+              return
+            end
+            sock = UDPSocket.new(addr[0]) # Address family: "AF_INET", "AF_INET6"
+            sock.do_not_reverse_lookup = !@resolve_name
+            sock.connect(addr[3], addr[1])
+            @callback.call(data, UDPCallbackSocket.new(sock))
+          rescue => e
+            @log.error "unexpected error in processing UDP data", error: e
+            @log.error_backtrace
+            raise if @under_plugin_development
+          end
+        end
+
+        class TCPServer < Coolio::TCPSocket
+          SOCK_OPT_FORMAT = 'I!I!' # { int l_onoff; int l_linger; }
+
+          def initialize(sock, resolve_name, linger_timeout, log, under_plugin_development, connect_callback)
+            raise ArgumentError, "socket must be a TCPSocket" unless sock.is_a?(TCPSocket)
+
+            super(sock)
+
+            sock_opt = [1, linger_timeout].pack(SOCK_OPT_FORMAT)
+            sock.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_LINGER, sock_opt)
+
+            @resolve_name = resolve_name
+            @log = log
+            @connect_callback = connect_callback
+
+            @under_plugin_development = under_plugin_development
+
+            @data_callback = nil
+            @closing = false
+            @mutex = Mutex.new # to serialize #write and #close
+          end
+
+          def data(&callback)
+            @data_callback = callback
+            on_read_impl = case callback.arity
+                           when 1 then :on_read_without_connection
+                           when 2 then :on_read_with_connection
+                           else
+                             raise "BUG: callback block must have 1 or 2 arguments"
+                           end
+            self.define_singleton_method(:on_read, method(on_read_impl))
+          end
+
+          def write(data)
+            raise IOError, "server TCP connection is already going to be closed" if @closing
+            @mutex.synchronize do
+              super
+            end
+          end
+
+          def on_connect
+            conn = TCPCallbackSocket.new(self)
+            @connect_callback.call(conn)
+            unless @data_callback
+              raise "connection callback must call #data to set data callback"
+            end
+          end
+
+          def on_read_without_connection(data)
+            @data_callback.call(data)
+          rescue => e
+            @log.error "unexpected error on reading data", host: remote_host, port: remote_port, error: e
+            @log.error_backtrace
+            close(true) rescue nil
+            raise if @under_plugin_development
+          end
+
+          def on_read_with_connection(data)
+            @data_callback.call(data, self)
+          rescue => e
+            @log.error "unexpected error on reading data", host: remote_host, port: remote_port, error: e
+            @log.error_backtrace
+            close(true) rescue nil
+            raise if @under_plugin_development
+          end
+
+          def close(force = false)
+            @closing = true
+            if force
+              super()
+            else
+              @mutex.synchronize{ super() }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fluent/plugin_helper/server.rb
+++ b/lib/fluent/plugin_helper/server.rb
@@ -184,9 +184,7 @@ module Fluent
                else
                  TCPServer.new(bind, port) # this method call can create sockets for AF_INET6
                end
-        unless Fluent.windows?
-          sock.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC) # close-on-exec
-        end
+        # close-on-exec is set by default in Ruby 2.0 or later (, and it's unavailable on Windows)
         sock.fcntl(Fcntl::F_SETFL, Fcntl::O_NONBLOCK) # nonblock
         sock
       end
@@ -200,9 +198,7 @@ module Fluent
                  usock.bind(bind, port)
                  usock
                end
-        unless Fluent.windows?
-          sock.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC) # close-on-exec
-        end
+        # close-on-exec is set by default in Ruby 2.0 or later (, and it's unavailable on Windows)
         sock.fcntl(Fcntl::F_SETFL, Fcntl::O_NONBLOCK) # nonblock
         sock
       end

--- a/lib/fluent/plugin_helper/server.rb
+++ b/lib/fluent/plugin_helper/server.rb
@@ -184,7 +184,9 @@ module Fluent
                else
                  TCPServer.new(bind, port) # this method call can create sockets for AF_INET6
                end
-        sock.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC) # close-on-exec
+        unless Fluent.windows?
+          sock.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC) # close-on-exec
+        end
         sock.fcntl(Fcntl::F_SETFL, Fcntl::O_NONBLOCK) # nonblock
         sock
       end
@@ -198,7 +200,9 @@ module Fluent
                  usock.bind(bind, port)
                  usock
                end
-        sock.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC) # close-on-exec
+        unless Fluent.windows?
+          sock.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC) # close-on-exec
+        end
         sock.fcntl(Fcntl::F_SETFL, Fcntl::O_NONBLOCK) # nonblock
         sock
       end

--- a/lib/fluent/plugin_helper/server.rb
+++ b/lib/fluent/plugin_helper/server.rb
@@ -92,7 +92,7 @@ module Fluent
           raise "unknown protocol #{proto}"
         end
 
-        server_attach(title, port, bind, shared, server)
+        server_attach(title, proto, port, bind, shared, server)
       end
 
       # server_create(:title, @port) do |data|
@@ -148,7 +148,7 @@ module Fluent
           raise "BUG: unknown protocol #{proto}"
         end
 
-        server_attach(title, port, bind, shared, server)
+        server_attach(title, proto, port, bind, shared, server)
       end
 
       def server_create_tcp(title, port, **kwargs, &callback)
@@ -159,10 +159,18 @@ module Fluent
         server_create(title, port, proto: :udp, **kwargs, &callback)
       end
 
-      ServerInfo = Struct.new(:title, :port, :bind, :shared, :server)
+      def server_create_tls(title, port, **kwargs, &callback)
+        server_create(title, port, proto: :tls, **kwargs, &callback)
+      end
 
-      def server_attach(title, port, bind, shared, server)
-        @_servers << ServerInfo.new(title, port, bind, shared, server)
+      def server_create_unix(title, port, **kwargs, &callback)
+        server_create(title, port, proto: :unix, **kwargs, &callback)
+      end
+
+      ServerInfo = Struct.new(:title, :proto, :port, :bind, :shared, :server)
+
+      def server_attach(title, proto, port, bind, shared, server)
+        @_servers << ServerInfo.new(title, proto, port, bind, shared, server)
         event_loop_attach(server)
       end
 

--- a/lib/fluent/plugin_helper/server.rb
+++ b/lib/fluent/plugin_helper/server.rb
@@ -311,9 +311,7 @@ module Fluent
           when :data
             @sock.data(&callback)
           when :write_complete
-            cb = ->(){
-              callback.call(self)
-            }
+            cb = ->(){ callback.call(self) }
             @sock.on_write_complete(&cb)
           when :close
             cb = ->(){ callback.call(self) }
@@ -413,7 +411,7 @@ module Fluent
           SOCK_OPT_FORMAT = 'I!I!' # { int l_onoff; int l_linger; }
 
           def initialize(sock, close_callback, resolve_name, linger_timeout, log, under_plugin_development, connect_callback)
-            raise ArgumentError, "socket must be a TCPSocket" unless sock.is_a?(TCPSocket)
+            raise ArgumentError, "socket must be a TCPSocket: sock=#{sock}" unless sock.is_a?(TCPSocket)
 
             sock_opt = [1, linger_timeout].pack(SOCK_OPT_FORMAT)
             sock.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_LINGER, sock_opt)

--- a/lib/fluent/plugin_helper/server.rb
+++ b/lib/fluent/plugin_helper/server.rb
@@ -143,6 +143,7 @@ module Fluent
 
       def server_create_for_tcp_connection(shared, bind, port, resolve_name, linger_timeout, backlog, &block)
         sock = server_create_tcp_socket(shared, bind, port)
+        sock.do_not_reverse_lookup = !resolve_name
         server = Coolio::TCPServer.new(sock, nil, EventHandler::TCPServer, resolve_name, linger_timeout, @log, @under_plugin_development, block)
         server.listen(backlog) if backlog
         server
@@ -340,8 +341,8 @@ module Fluent
 
             sock_opt = [1, linger_timeout].pack(SOCK_OPT_FORMAT)
             sock.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_LINGER, sock_opt)
+            sock.do_not_reverse_lookup = !resolve_name
 
-            @resolve_name = resolve_name
             @log = log
             @connect_callback = connect_callback
 

--- a/lib/fluent/plugin_helper/server.rb
+++ b/lib/fluent/plugin_helper/server.rb
@@ -16,7 +16,7 @@
 
 require 'fluent/plugin_helper/event_loop'
 
-require 'serverengine/socket_manager'
+require 'serverengine'
 require 'cool.io'
 require 'socket'
 require 'ipaddr'

--- a/lib/fluent/plugin_helper/socket_option.rb
+++ b/lib/fluent/plugin_helper/socket_option.rb
@@ -1,0 +1,80 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'socket'
+
+# this module is only for Socket/Server plugin helpers
+module Fluent
+  module PluginHelper
+    module SocketOption
+      FORMAT_STRUCT_LINGER  = 'I!I!' # { int l_onoff; int l_linger; }
+      FORMAT_STRUCT_TIMEVAL = 'L!L!' # { time_t tv_sec; suseconds_t tv_usec; }
+
+      def socket_option_validate!(protocol, resolve_name: nil, linger_timeout: nil, recv_timeout: nil, send_timeout: nil, certopts: nil)
+        unless resolve_name.nil?
+          if protocol != :tcp && protocol != :udp && protocol != :tls
+            raise ArgumentError, "BUG: resolve_name in available for tcp/udp/tls"
+          end
+        end
+        if linger_timeout
+          if protocol != :tcp && protocol != :tls
+            raise ArgumentError, "BUG: linger_timeout is available for tcp/tls"
+          end
+        end
+        if certopts
+          if protocol != :tls
+            raise ArgumentError, "BUG: certopts is available only for tls"
+          end
+        else
+          if protocol == :tls
+            raise ArgumentError, "BUG: certopts (certificate options) not specified for TLS"
+            socket_option_certopts_validate!(certopts)
+          end
+        end
+      end
+
+      def socket_option_certopts_validate!(certopts)
+        raise "not implemented yet"
+      end
+
+      def socket_option_set(sock, resolve_name: nil, linger_timeout: nil, recv_timeout: nil, send_timeout: nil, certopts: nil)
+        unless resolve_name.nil?
+          sock.do_not_reverse_lookup = !resolve_name
+        end
+        if linger_timeout
+          optval = [1, linger_timeout.to_i].pack(FORMAT_STRUCT_LINGER)
+          socket_option_set_one(sock, :SO_LINGER, optval)
+        end
+        if recv_timeout
+          optval = [recv_timeout.to_i, 0].pack(FORMAT_STRUCT_TIMEVAL)
+          socket_option_set_one(sock, :SO_RCVTIMEO, optval)
+        end
+        if send_timeout
+          optval = [send_timeout.to_i, 0].pack(FORMAT_STRUCT_TIMEVAL)
+          socket_option_set_one(sock, :SO_SNDTIMEO, optval)
+        end
+        # TODO: certopts for TLS
+        sock
+      end
+
+      def socket_option_set_one(sock, option, value)
+        sock.setsockopt(Socket::SOL_SOCKET, option, value)
+      rescue => e
+        log.warn "failed to set socket option", sock: sock.class, option: option, value: value, error: e
+      end
+    end
+  end
+end

--- a/lib/fluent/plugin_helper/timer.rb
+++ b/lib/fluent/plugin_helper/timer.rb
@@ -36,6 +36,7 @@ module Fluent
         timer = TimerWatcher.new(title, interval, repeat, log, checker, &block)
         @_timers << title
         event_loop_attach(timer)
+        timer
       end
 
       def timer_running?

--- a/lib/fluent/test/driver/base.rb
+++ b/lib/fluent/test/driver/base.rb
@@ -107,7 +107,9 @@ module Fluent
         def instance_start
           if @instance.respond_to?(:server_wait_until_start)
             @socket_manager_path = ServerEngine::SocketManager::Server.generate_path
-            FileUtils.rm_f @socket_manager_path if File.exist?(@socket_manager_path)
+            if @socket_manager_path.is_a?(String) && File.exist?(@socket_manager_path)
+              FileUtils.rm_f @socket_manager_path
+            end
             @socket_manager_server = ServerEngine::SocketManager::Server.open(@socket_manager_path)
             ENV['SERVERENGINE_SOCKETMANAGER_PATH'] = @socket_manager_path.to_s
           end
@@ -164,7 +166,9 @@ module Fluent
 
           if @socket_manager_server
             @socket_manager_server.close
-            FileUtils.rm_f @socket_manager_path if File.exist?(@socket_manager_path)
+            if @socket_manager_server.is_a?(String) && File.exist?(@socket_manager_path)
+              FileUtils.rm_f @socket_manager_path
+            end
           end
         end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -69,13 +69,48 @@ end
 
 include Fluent::Test::Helpers
 
-def unused_port(num = 1)
+def unused_port(num = 1, protocol: :tcp, bind: "0.0.0.0")
+  case protocol
+  when :tcp
+    unused_port_tcp(num)
+  when :udp
+    unused_port_udp(num, bind: bind)
+  else
+    raise ArgumentError, "unknown protocol: #{protocol}"
+  end
+end
+
+def unused_port_tcp(num = 1)
   ports = []
   sockets = []
   num.times do
     s = TCPServer.open(0)
     sockets << s
     ports << s.addr[1]
+  end
+  sockets.each{|s| s.close }
+  if num == 1
+    return ports.first
+  else
+    return *ports
+  end
+end
+
+PORT_RANGE_AVAILABLE = (1024...65535)
+
+def unused_port_udp(num = 1, bind: "0.0.0.0")
+  family = IPAddr.new(IPSocket.getaddress(bind)).ipv4? ? ::Socket::AF_INET : ::Socket::AF_INET6
+  ports = []
+  sockets = []
+  while ports.size < num
+    port = rand(PORT_RANGE_AVAILABLE)
+    u = UDPSocket.new(family)
+    if (u.bind(bind, port) rescue nil)
+      ports << port
+      sockets << u
+    else
+      u.close
+    end
   end
   sockets.each{|s| s.close }
   if num == 1

--- a/test/plugin/test_in_tcp.rb
+++ b/test/plugin/test_in_tcp.rb
@@ -1,20 +1,8 @@
 require_relative '../helper'
-require 'fluent/test'
+require 'fluent/test/driver/input'
 require 'fluent/plugin/in_tcp'
 
 class TcpInputTest < Test::Unit::TestCase
-  class << self
-    def startup
-      socket_manager_path = ServerEngine::SocketManager::Server.generate_path
-      @server = ServerEngine::SocketManager::Server.open(socket_manager_path)
-      ENV['SERVERENGINE_SOCKETMANAGER_PATH'] = socket_manager_path.to_s
-    end
-
-    def shutdown
-      @server.close
-    end
-  end
-
   def setup
     Fluent::Test.setup
   end
@@ -34,69 +22,97 @@ class TcpInputTest < Test::Unit::TestCase
   ]
 
   def create_driver(conf)
-    Fluent::Test::InputTestDriver.new(Fluent::TcpInput).configure(conf)
+    Fluent::Test::Driver::Input.new(Fluent::Plugin::TcpInput).configure(conf)
   end
 
-  def test_configure
-    configs = {'127.0.0.1' => CONFIG}
-    configs.merge!('::1' => IPv6_CONFIG) if ipv6_enabled?
-
-    configs.each_pair { |k, v|
-      d = create_driver(v)
-      assert_equal PORT, d.instance.port
-      assert_equal k, d.instance.bind
-      assert_equal "\n", d.instance.delimiter
-    }
+  def create_tcp_socket(host, port, &block)
+    if block_given?
+      TCPSocket.open(host, port, &block)
+    else
+      TCPSocket.open(host, port)
+    end
   end
 
-  {
-    'none' => [
-      {'msg' => "tcptest1\n", 'expected' => 'tcptest1'},
-      {'msg' => "tcptest2\n", 'expected' => 'tcptest2'},
-    ],
-    'json' => [
-      {'msg' => {'k' => 123, 'message' => 'tcptest1'}.to_json + "\n", 'expected' => 'tcptest1'},
-      {'msg' => {'k' => 'tcptest2', 'message' => 456}.to_json + "\n", 'expected' => 456},
-    ]
-  }.each { |format, test_cases|
-    define_method("test_msg_size_#{format}") do
-      d = create_driver(BASE_CONFIG + "format #{format}")
-      tests = test_cases
 
-      d.run do
-        tests.each {|test|
-          TCPSocket.open('127.0.0.1', PORT) do |s|
-            s.send(test['msg'], 0)
-          end
-        }
-        sleep 1
-      end
+  data(
+    'ipv4' => [CONFIG, '127.0.0.1', :ipv4],
+    'ipv6' => [IPv6_CONFIG, '::1', :ipv6],
+  )
+  test 'configure' do |data|
+    conf, bind, protocol = data
+    omit "IPv6 is not supported on this environment" if protocol == :ipv6 && !ipv6_enabled?
 
-      compare_test_result(d.emits, tests)
-    end
+    d = create_driver(conf)
+    assert_equal PORT, d.instance.port
+    assert_equal bind, d.instance.bind
+    assert_equal "\n", d.instance.delimiter
+  end
 
-    define_method("test_msg_size_with_same_connection_#{format}") do
-      d = create_driver(BASE_CONFIG + "format #{format}")
-      tests = test_cases
-
-      d.run do
-        TCPSocket.open('127.0.0.1', PORT) do |s|
-          tests.each {|test|
-            s.send(test['msg'], 0)
-          }
-        end
-        sleep 1
-      end
-
-      compare_test_result(d.emits, tests)
-    end
+  test_case_data = {
+    'none' => {
+      'format' => 'none',
+      'payloads' => [ "tcptest1\n", "tcptest2\n" ],
+      'expecteds' => [
+        {'message' => 'tcptest1'},
+        {'message' => 'tcptest2'},
+      ],
+    },
+    'json' => {
+      'format' => 'json',
+      'payloads' => [
+        {'k' => 123, 'message' => 'tcptest1'}.to_json + "\n",
+        {'k' => 'tcptest2', 'message' => 456}.to_json + "\n",
+      ],
+      'expecteds' => [
+        {'k' => 123, 'message' => 'tcptest1'},
+        {'k' => 'tcptest2', 'message' => 456}
+      ],
+    },
   }
 
-  def compare_test_result(emits, tests)
-    assert_equal(2, emits.size)
-    emits.each_index {|i|
-      assert_equal(tests[i]['expected'], emits[i][2]['message'])
-      assert(emits[i][1].is_a?(Fluent::EventTime))
-    }
+  data(test_case_data)
+  test 'test_msg_size' do |data|
+    format = data['format']
+    payloads = data['payloads']
+    expecteds = data['expecteds']
+
+    d = create_driver(BASE_CONFIG + "format #{format}")
+    d.run(expect_records: 2) do
+      payloads.each do |payload|
+        create_tcp_socket('127.0.0.1', PORT) do |sock|
+          sock.send(payload, 0)
+        end
+      end
+    end
+
+    assert_equal 2, d.events.size
+    expecteds.each_with_index do |expected_record, i|
+      assert_equal "tcp", d.events[i][0]
+      assert d.events[i][1].is_a?(Fluent::EventTime)
+      assert_equal expected_record, d.events[i][2]
+    end
+  end
+
+  data(test_case_data)
+  test 'test data in a connection' do |data|
+    format = data['format']
+    payloads = data['payloads']
+    expecteds = data['expecteds']
+
+    d = create_driver(BASE_CONFIG + "format #{format}")
+    d.run(expect_records: 2) do
+      create_tcp_socket('127.0.0.1', PORT) do |sock|
+        payloads.each do |payload|
+          sock.send(payload, 0)
+        end
+      end
+    end
+
+    assert_equal 2, d.events.size
+    expecteds.each_with_index do |expected_record, i|
+      assert_equal "tcp", d.events[i][0]
+      assert d.events[i][1].is_a?(Fluent::EventTime)
+      assert_equal expected_record, d.events[i][2]
+    end
   end
 end

--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -264,7 +264,7 @@ class ForwardOutputTest < Test::Unit::TestCase
   end
 
   def test_send_to_a_node_supporting_responses
-    target_input_driver = create_target_input_driver(response_stub: true)
+    target_input_driver = create_target_input_driver
 
     d = create_driver(CONFIG + %[flush_interval 1s])
 

--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -1,6 +1,5 @@
 require_relative '../helper'
 require 'fluent/test/driver/output'
-require 'fluent/test/startup_shutdown'
 require 'fluent/plugin/out_forward'
 require 'flexmock/test_unit'
 
@@ -8,8 +7,6 @@ require 'fluent/test/driver/input'
 require 'fluent/plugin/in_forward'
 
 class ForwardOutputTest < Test::Unit::TestCase
-  extend Fluent::Test::StartupShutdown
-
   def setup
     Fluent::Test.setup
   end

--- a/test/plugin_helper/test_server.rb
+++ b/test/plugin_helper/test_server.rb
@@ -510,7 +510,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
       @d.server_create_udp(:s, PORT, max_bytes: 128) do |data|
         received << data
       end
-      bind_port = unused_port
+      bind_port = unused_port(protocol: :udp, bind: "127.0.0.1")
       3.times do
         sock = UDPSocket.new(Socket::AF_INET)
         sock.bind("127.0.0.1", bind_port)

--- a/test/plugin_helper/test_server.rb
+++ b/test/plugin_helper/test_server.rb
@@ -390,6 +390,8 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     end
 
     test 'does resolve name of client address if resolve_name is true' do
+      hostname = Socket.getnameinfo([nil, nil, nil, "127.0.0.1"])[0]
+
       received = ""
       sources = []
       @d.server_create_tcp(:s, PORT, resolve_name: true) do |data, conn|
@@ -403,7 +405,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
       end
       waiting(10){ sleep 0.1 until received.bytesize == 12 }
       assert_equal "yay\nyay\nyay\n", received
-      assert{ sources.all?{|s| s != "127.0.0.1" && Socket.getaddrinfo(s, PORT, Socket::AF_INET).any?{|i| i[3] == "127.0.0.1"} } }
+      assert{ sources.all?{|s| s == hostname } }
     end
 
     test 'can keep connections alive for tcp if keepalive specified' do
@@ -608,6 +610,8 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     end
 
     test 'does resolve name of client address if resolve_name is true' do
+      hostname = Socket.getnameinfo([nil, nil, nil, "127.0.0.1"])[0]
+
       received = ""
       sources = []
       @d.server_create_udp(:s, PORT, resolve_name: true, max_bytes: 128) do |data, sock|
@@ -622,7 +626,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
       end
       waiting(10){ sleep 0.1 until received.bytesize == 12 }
       assert_equal "yay\nyay\nyay\n", received
-      assert{ sources.all?{|s| s != "127.0.0.1" && Socket.getaddrinfo(s, PORT, Socket::AF_INET).any?{|i| i[3] == "127.0.0.1"} } }
+      assert{ sources.all?{|s| s == hostname } }
     end
 
     test 'raises error if plugin registers data callback for connection object from #server_create' do
@@ -773,9 +777,11 @@ class ServerPluginHelperTest < Test::Unit::TestCase
 
     data(protocols)
     test 'does resolve name of client address if resolve_name is true' do |(proto, kwargs)|
+      hostname = Socket.getnameinfo([nil, nil, nil, "127.0.0.1"])[0]
+
       received = ""
       sources = []
-      @d.server_create_connection(:s, PORT, proto: proto, **kwargs) do |conn|
+      @d.server_create_connection(:s, PORT, proto: proto, resolve_name: true, **kwargs) do |conn|
         sources << conn.remote_host
         conn.data do |d|
           received << d
@@ -788,7 +794,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
       end
       waiting(10){ sleep 0.1 until received.bytesize == 12 }
       assert_equal "yay\nyay\nyay\n", received
-      assert{ sources.all?{|s| s == "127.0.0.1" } }
+      assert{ sources.all?{|s| s == hostname } }
     end
 
     data(protocols)

--- a/test/plugin_helper/test_server.rb
+++ b/test/plugin_helper/test_server.rb
@@ -1,0 +1,890 @@
+require_relative '../helper'
+require 'fluent/plugin_helper/server'
+require 'fluent/plugin/base'
+require 'timeout'
+
+require 'serverengine'
+require 'fileutils'
+
+class ServerPluginHelperTest < Test::Unit::TestCase
+  class Dummy < Fluent::Plugin::TestBase
+    helpers :server
+  end
+
+  PORT = unused_port
+
+  setup do
+    @socket_manager_path = ServerEngine::SocketManager::Server.generate_path
+    if @socket_manager_path.is_a?(String) && File.exist?(@socket_manager_path)
+      FileUtils.rm_f @socket_manager_path
+    end
+    @socket_manager_server = ServerEngine::SocketManager::Server.open(@socket_manager_path)
+    ENV['SERVERENGINE_SOCKETMANAGER_PATH'] = @socket_manager_path.to_s
+
+    @d = Dummy.new
+    @d.start
+    @d.after_start
+  end
+
+  teardown do
+    @d.stopped? || @d.stop
+    @d.before_shutdown? || @d.before_shutdown
+    @d.shutdown? || @d.shutdown
+    @d.after_shutdown? || @d.after_shutdown
+    @d.closed? || @d.close
+    @d.terminated? || @d.terminate
+
+    @socket_manager_server.close
+    if @socket_manager_server.is_a?(String) && File.exist?(@socket_manager_path)
+      FileUtils.rm_f @socket_manager_path
+    end
+  end
+
+  sub_test_case 'plugin instance' do
+    test 'can be instantiated to be able to create threads' do
+      d = Dummy.new
+      assert d.respond_to?(:_servers)
+      assert d._servers.empty?
+
+      assert d.respond_to?(:server_wait_until_start)
+      assert d.respond_to?(:server_wait_until_stop)
+      assert d.respond_to?(:server_create_connection)
+      assert d.respond_to?(:server_create)
+      assert d.respond_to?(:server_create_tcp)
+      assert d.respond_to?(:server_create_udp)
+      assert d.respond_to?(:server_create_tls)
+    end
+
+    test 'can be configured' do
+      d = Dummy.new
+      assert_nothing_raised do
+        d.configure(config_element())
+      end
+      assert d.plugin_id
+      assert d.log
+    end
+  end
+
+  # run tests for tcp, udp, tls and unix
+  sub_test_case '#server_create and #server_create_connection' do
+    methods = {server_create: :server_create, server_create_connection: :server_create_connection}
+
+    data(methods)
+    test 'raise error if title is not specified or not a symbol' do |m|
+      assert_raise(ArgumentError.new("BUG: title must be a symbol")) do
+        @d.__send__(m, nil, PORT){|x| x }
+      end
+      assert_raise(ArgumentError.new("BUG: title must be a symbol")) do
+        @d.__send__(m, "", PORT){|x| x }
+      end
+      assert_raise(ArgumentError.new("BUG: title must be a symbol")) do
+        @d.__send__(m, "title", PORT){|x| x }
+      end
+      assert_nothing_raised do
+        @d.__send__(m, :myserver, PORT){|x| x }
+      end
+    end
+
+    data(methods)
+    test 'raise error if port is not specified or not an integer' do |m|
+      assert_raise(ArgumentError.new("BUG: port must be an integer")) do
+        @d.__send__(m, :myserver, nil){|x| x }
+      end
+      assert_raise(ArgumentError.new("BUG: port must be an integer")) do
+        @d.__send__(m, :myserver, "1"){|x| x }
+      end
+      assert_raise(ArgumentError.new("BUG: port must be an integer")) do
+        @d.__send__(m, :myserver, 1.5){|x| x }
+      end
+      assert_nothing_raised do
+        @d.__send__(m, :myserver, PORT){|x| x }
+      end
+    end
+
+    data(methods)
+    test 'raise error if block is not specified' do |m|
+      assert_raise(ArgumentError) do
+        @d.__send__(m, :myserver, PORT)
+      end
+      assert_nothing_raised do
+        @d.__send__(m, :myserver, PORT){|x| x }
+      end
+    end
+
+    data(methods)
+    test 'creates tcp server, binds 0.0.0.0 in default' do |m|
+      @d.__send__(m, :myserver, PORT){|x| x }
+
+      assert_equal 1, @d._servers.size
+      assert_equal :myserver, @d._servers.first.title
+      assert_equal PORT, @d._servers.first.port
+
+      assert_equal :tcp, @d._servers.first.proto
+      assert_equal "0.0.0.0", @d._servers.first.bind
+
+      assert{ @d._servers.first.server.is_a? Coolio::TCPServer }
+      assert_equal "0.0.0.0", @d._servers.first.server.instance_eval{ @listen_socket }.addr[3]
+    end
+
+    data(methods)
+    test 'creates tcp server if specified in proto' do |m|
+      @d.__send__(m, :myserver, PORT, proto: :tcp){|x| x }
+
+      assert_equal :tcp, @d._servers.first.proto
+      assert{ @d._servers.first.server.is_a? Coolio::TCPServer }
+    end
+
+    # tests about "proto: :udp" is in #server_create
+
+    data(methods)
+    test 'creates tls server if specified in proto' do |m|
+      # pend "not implemented yet"
+    end
+
+    data(methods)
+    test 'creates unix server if specified in proto' do |m|
+      # pend "not implemented yet"
+    end
+
+    data(methods)
+    test 'raise error if unknown protocol specified' do |m|
+      assert_raise(ArgumentError.new("BUG: invalid protocol name")) do
+        @d.__send__(m, :myserver, PORT, proto: :quic){|x| x }
+      end
+    end
+
+    data(
+      'server_create tcp' => [:server_create, :tcp],
+      # 'server_create tls' => [:server_create, :tls],
+      # 'server_create unix' => [:server_create, :unix],
+      'server_create_connection tcp' => [:server_create_connection, :tcp],
+      # 'server_create_connection tcp' => [:server_create_connection, :tls],
+      # 'server_create_connection tcp' => [:server_create_connection, :unix],
+    )
+    test 'raise error if udp options specified for tcp/tls/unix' do |(m, proto)|
+      assert_raise ArgumentError do
+        @d.__send__(m, :myserver, PORT, proto: proto, max_bytes: 128){|x| x }
+      end
+      assert_raise ArgumentError do
+        @d.__send__(m, :myserver, PORT, proto: proto, flags: 1){|x| x }
+      end
+    end
+
+    data(
+      'server_create udp' => [:server_create, :udp],
+    )
+    test 'raise error if tcp/tls options specified for udp' do |(m, proto)|
+      assert_raise(ArgumentError.new("BUG: linger_timeout is available for tcp/tls")) do
+        @d.__send__(m, :myserver, PORT, proto: proto, linger_timeout: 1, max_bytes: 128){|x| x }
+      end
+    end
+
+    data(
+      'server_create udp' => [:server_create, :udp],
+    )
+    test 'raise error if tcp/tls/unix options specified for udp' do |(m, proto)|
+      assert_raise(ArgumentError.new("BUG: backlog is available for tcp/tls")) do
+        @d.__send__(m, :myserver, PORT, proto: proto, backlog: 500){|x| x }
+      end
+    end
+
+    data(
+      'server_create tcp' => [:server_create, :tcp, {}],
+      'server_create udp' => [:server_create, :udp, {max_bytes: 128}],
+      # 'server_create unix' => [:server_create, :unix, {}],
+      'server_create_connection tcp' => [:server_create_connection, :tcp, {}],
+      # 'server_create_connection unix' => [:server_create_connection, :unix, {}],
+    )
+    test 'raise error if tls options specified for tcp/udp/unix' do |(m, proto, kwargs)|
+      assert_raise(ArgumentError.new("BUG: certopts is available only for tls")) do
+        @d.__send__(m, :myserver, PORT, proto: proto, certopts: {}, **kwargs){|x| x }
+      end
+    end
+
+    data(
+      'server_create tcp' => [:server_create, :tcp, {}],
+      'server_create udp' => [:server_create, :udp, {max_bytes: 128}],
+      # 'server_create tls' => [:server_create, :tls, {}],
+      'server_create_connection tcp' => [:server_create_connection, :tcp, {}],
+      # 'server_create_connection tls' => [:server_create_connection, :tls, {}],
+    )
+    test 'can bind specified IPv4 address' do |(m, proto, kwargs)|
+      @d.__send__(m, :myserver, PORT, proto: proto, bind: "127.0.0.1", **kwargs){|x| x }
+      assert_equal "127.0.0.1", @d._servers.first.bind
+      assert_equal "127.0.0.1", @d._servers.first.server.instance_eval{ instance_variable_defined?(:@listen_socket) ? @listen_socket : @_io }.addr[3]
+    end
+
+    data(
+      'server_create tcp' => [:server_create, :tcp, {}],
+      'server_create udp' => [:server_create, :udp, {max_bytes: 128}],
+      # 'server_create tls' => [:server_create, :tls, {}],
+      'server_create_connection tcp' => [:server_create_connection, :tcp, {}],
+      # 'server_create_connection tls' => [:server_create_connection, :tls, {}],
+    )
+    test 'can bind specified IPv6 address' do |(m, proto, kwargs)| # if available
+      omit "IPv6 unavailable here" unless ipv6_enabled?
+      @d.__send__(m, :myserver, PORT, proto: proto, bind: "::1", **kwargs){|x| x }
+      assert_equal "::1", @d._servers.first.bind
+      assert_equal "::1", @d._servers.first.server.instance_eval{ instance_variable_defined?(:@listen_socket) ? @listen_socket : @_io }.addr[3]
+    end
+
+    data(
+      'server_create tcp' => [:server_create, :tcp, {}],
+      'server_create udp' => [:server_create, :udp, {max_bytes: 128}],
+      # 'server_create tls' => [:server_create, :tls, {}],
+      # 'server_create unix' => [:server_create, :unix, {}],
+      'server_create_connection tcp' => [:server_create, :tcp, {}],
+      # 'server_create_connection tls' => [:server_create, :tls, {}],
+      # 'server_create_connection unix' => [:server_create, :unix, {}],
+    )
+    test 'can create 2 or more servers which share same bind address and port if shared option is true' do |(m, proto, kwargs)|
+      begin
+        d2 = Dummy.new; d2.start; d2.after_start
+
+        assert_nothing_raised do
+          @d.__send__(m, :myserver, PORT, proto: proto, **kwargs){|x| x }
+          d2.__send__(m, :myserver, PORT, proto: proto, **kwargs){|x| x }
+        end
+      ensure
+        d2.stop; d2.before_shutdown; d2.shutdown; d2.after_shutdown; d2.close; d2.terminate
+      end
+    end
+
+    data(
+      'server_create tcp' => [:server_create, :tcp, {}],
+      'server_create udp' => [:server_create, :udp, {max_bytes: 128}],
+      # 'server_create tls' => [:server_create, :tls, {}],
+      # 'server_create unix' => [:server_create, :unix, {}],
+      'server_create_connection tcp' => [:server_create, :tcp, {}],
+      # 'server_create_connection tls' => [:server_create, :tls, {}],
+      # 'server_create_connection unix' => [:server_create, :unix, {}],
+    )
+    test 'cannot create 2 or more servers using same bind address and port if shared option is false' do |(m, proto, kwargs)|
+      begin
+        d2 = Dummy.new; d2.start; d2.after_start
+
+        assert_nothing_raised do
+          @d.__send__(m, :myserver, PORT, proto: proto, shared: false, **kwargs){|x| x }
+        end
+        assert_raise(Errno::EADDRINUSE) do
+          d2.__send__(m, :myserver, PORT, proto: proto, **kwargs){|x| x }
+        end
+      ensure
+        d2.stop; d2.before_shutdown; d2.shutdown; d2.after_shutdown; d2.close; d2.terminate
+      end
+    end
+  end
+
+  sub_test_case '#server_create' do
+    data(
+      'tcp' => [:tcp, {}],
+      'udp' => [:udp, {max_bytes: 128}],
+      # 'tls' => [:tls, {}],
+      # 'unix' => [:unix, {}],
+    )
+    test 'raise error if block argument is not specified or too many' do |(proto, kwargs)|
+      assert_raise(ArgumentError.new("BUG: block must have 1 or 2 arguments")) do
+        @d.server_create(:myserver, PORT, proto: proto, **kwargs){ 1 }
+      end
+      assert_raise(ArgumentError.new("BUG: block must have 1 or 2 arguments")) do
+        @d.server_create(:myserver, PORT, proto: proto, **kwargs){|sock, conn, what_is_this| 1 }
+      end
+    end
+
+    test 'creates udp server if specified in proto' do
+      @d.server_create(:myserver, PORT, proto: :udp, max_bytes: 512){|x| x }
+
+      assert_equal :udp, @d._servers.first.proto
+      assert{ @d._servers.first.server.is_a? Fluent::PluginHelper::Server::EventHandler::UDPServer }
+    end
+  end
+
+  sub_test_case '#server_create_tcp' do
+    test 'can accept all keyword arguments valid for tcp server' do
+      assert_nothing_raised do
+        @d.server_create_tcp(:s, PORT, bind: '127.0.0.1', shared: false, resolve_name: true, linger_timeout: 10, backlog: 500) do |data, conn|
+          # ...
+        end
+      end
+    end
+
+    test 'creates a tcp server just to read data' do
+      received = ""
+      @d.server_create_tcp(:s, PORT) do |data|
+        received << data
+      end
+      3.times do
+        sock = TCPSocket.new("127.0.0.1", PORT)
+        sock.puts "yay"
+        sock.puts "foo"
+        sock.close
+      end
+      waiting(10){ sleep 0.1 until received.bytesize == 24 }
+      assert_equal "yay\nfoo\nyay\nfoo\nyay\nfoo\n", received
+    end
+
+    test 'creates a tcp server to read and write data' do
+      received = ""
+      responses = []
+      @d.server_create_tcp(:s, PORT) do |data, conn|
+        received << data
+        conn.write "ack\n"
+      end
+      3.times do
+        TCPSocket.open("127.0.0.1", PORT) do |sock|
+          sock.puts "yay"
+          sock.puts "foo"
+          responses << sock.readline
+        end
+      end
+      waiting(10){ sleep 0.1 until received.bytesize == 24 }
+      assert_equal "yay\nfoo\nyay\nfoo\nyay\nfoo\n", received
+      assert_equal ["ack\n","ack\n","ack\n"], responses
+    end
+
+    test 'creates a tcp server to read and write data using IPv6' do
+      omit "IPv6 unavailable here" unless ipv6_enabled?
+
+      received = ""
+      responses = []
+      @d.server_create_tcp(:s, PORT, bind: "::1") do |data, conn|
+        received << data
+        conn.write "ack\n"
+      end
+      3.times do
+        TCPSocket.open("::1", PORT) do |sock|
+          sock.puts "yay"
+          sock.puts "foo"
+          responses << sock.readline
+        end
+      end
+      waiting(10){ sleep 0.1 until received.bytesize == 24 }
+      assert_equal "yay\nfoo\nyay\nfoo\nyay\nfoo\n", received
+      assert_equal ["ack\n","ack\n","ack\n"], responses
+    end
+
+    test 'does not resolve name of client address in default' do
+      received = ""
+      sources = []
+      @d.server_create_tcp(:s, PORT) do |data, conn|
+        received << data
+        sources << conn.remote_host
+      end
+      3.times do
+        TCPSocket.open("127.0.0.1", PORT) do |sock|
+          sock.puts "yay"
+        end
+      end
+      waiting(10){ sleep 0.1 until received.bytesize == 12 }
+      assert_equal "yay\nyay\nyay\n", received
+      assert{ sources.all?{|s| s == "127.0.0.1" } }
+    end
+
+    test 'does resolve name of client address if resolve_name is true' do
+      received = ""
+      sources = []
+      @d.server_create_tcp(:s, PORT, resolve_name: true) do |data, conn|
+        received << data
+        sources << conn.remote_host
+      end
+      3.times do
+        TCPSocket.open("127.0.0.1", PORT) do |sock|
+          sock.puts "yay"
+        end
+      end
+      waiting(10){ sleep 0.1 until received.bytesize == 12 }
+      assert_equal "yay\nyay\nyay\n", received
+      assert{ sources.all?{|s| s != "127.0.0.1" && Socket.getaddrinfo(s, PORT, Socket::AF_INET).any?{|i| i[3] == "127.0.0.1"} } }
+    end
+
+    test 'can keep connections alive for tcp if keepalive specified' do
+      # pend "not implemented yet"
+    end
+
+    test 'raises error if plugin registers data callback for connection object from #server_create' do
+      received = ""
+      errors = []
+      @d.server_create_tcp(:s, PORT) do |data, conn|
+        received << data
+        begin
+          conn.data{|d| received << d.upcase }
+        rescue => e
+          errors << e
+        end
+      end
+      TCPSocket.open("127.0.0.1", PORT) do |sock|
+        sock.puts "foo"
+      end
+      waiting(10){ sleep 0.1 until received.bytesize == 4 || errors.size == 1 }
+      assert_equal "foo\n", received
+      assert_equal 1, errors.size
+      assert_equal "data callback can be registered just once, but registered twice", errors.first.message
+    end
+
+    test 'can call write_complete callback if registered' do
+      buffer = ""
+      lines = []
+      responses = []
+      response_completes = []
+      @d.server_create_tcp(:s, PORT) do |data, conn|
+        conn.on(:write_complete){|c| response_completes << true }
+        buffer << data
+        if idx = buffer.index("\n")
+          lines << buffer.slice!(0,idx+1)
+          conn.write "ack\n"
+        end
+      end
+      3.times do
+        TCPSocket.open("127.0.0.1", PORT) do |sock|
+          sock.write "yay"
+          sock.write "foo\n"
+          begin
+            responses << sock.readline
+          rescue EOFError, IOError, Errno::ECONNRESET
+            # ignore
+          end
+          sock.close
+        end
+      end
+      waiting(10){ sleep 0.1 until lines.size == 3 && response_completes.size == 3 }
+      assert_equal ["yayfoo\n", "yayfoo\n", "yayfoo\n"], lines
+      assert_equal ["ack\n","ack\n","ack\n"], responses
+      assert_equal [true, true, true], response_completes
+    end
+
+    test 'can call close callback if registered' do
+      buffer = ""
+      lines = []
+      callback_results = []
+      @d.server_create_tcp(:s, PORT) do |data, conn|
+        conn.on(:close){|c| callback_results << "closed" }
+        buffer << data
+        if idx = buffer.index("\n")
+          lines << buffer.slice!(0,idx+1)
+          conn.write "ack\n"
+        end
+      end
+      3.times do
+        TCPSocket.open("127.0.0.1", PORT) do |sock|
+          sock.write "yay"
+          sock.write "foo\n"
+          begin
+            while line = sock.readline
+              if line == "ack\n"
+                sock.close
+              end
+            end
+          rescue EOFError, IOError, Errno::ECONNRESET
+            # ignore
+          end
+        end
+      end
+      waiting(10){ sleep 0.1 until lines.size == 3 && callback_results.size == 3 }
+      assert_equal ["yayfoo\n", "yayfoo\n", "yayfoo\n"], lines
+      assert_equal ["closed", "closed", "closed"], callback_results
+    end
+  end
+
+  sub_test_case '#server_create_udp' do
+    test 'can accept all keyword arguments valid for udp server' do
+      assert_nothing_raised do
+        @d.server_create_udp(:s, PORT, bind: '127.0.0.1', shared: false, resolve_name: true, max_bytes: 100, flags: 1) do |data, conn|
+          # ...
+        end
+      end
+    end
+
+    test 'creates a udp server just to read data' do
+      received = ""
+      @d.server_create_udp(:s, PORT, max_bytes: 128) do |data|
+        received << data
+      end
+      bind_port = unused_port
+      3.times do
+        sock = UDPSocket.new(Socket::AF_INET)
+        sock.bind("127.0.0.1", bind_port)
+        sock.connect("127.0.0.1", PORT)
+        sock.puts "yay"
+        sock.puts "foo"
+        sock.close
+      end
+      waiting(10){ sleep 0.1 until received.bytesize == 24 }
+      assert_equal "yay\nfoo\nyay\nfoo\nyay\nfoo\n", received
+    end
+
+    test 'creates a udp server to read and write data' do
+      received = ""
+      responses = []
+      @d.server_create_udp(:s, PORT, max_bytes: 128) do |data, sock|
+        received << data
+        sock.write "ack\n"
+      end
+      bind_port = unused_port
+      3.times do
+        begin
+          sock = UDPSocket.new(Socket::AF_INET)
+          sock.bind("127.0.0.1", bind_port)
+          sock.connect("127.0.0.1", PORT)
+          th = Thread.new do
+            while true
+              begin
+                in_data, _addr = sock.recvfrom_nonblock(16)
+                if in_data
+                  responses << in_data
+                  break
+                end
+              rescue IO::WaitReadable
+                IO.select([sock])
+              end
+            end
+            true
+          end
+          sock.write "yay\nfoo\n"
+          th.join(5)
+        ensure
+          sock.close
+        end
+      end
+      waiting(10){ sleep 0.1 until received.bytesize == 24 }
+      assert_equal "yay\nfoo\nyay\nfoo\nyay\nfoo\n", received
+      assert_equal ["ack\n","ack\n","ack\n"], responses
+    end
+
+    test 'creates a udp server to read and write data using IPv6' do
+      omit "IPv6 unavailable here" unless ipv6_enabled?
+
+      received = ""
+      responses = []
+      @d.server_create_udp(:s, PORT, bind: "::1", max_bytes: 128) do |data, sock|
+        received << data
+        sock.write "ack\n"
+      end
+      bind_port = unused_port
+      3.times do
+        begin
+          sock = UDPSocket.new(Socket::AF_INET6)
+          sock.bind("::1", bind_port)
+          th = Thread.new do
+            responses << sock.recv(16)
+            true
+          end
+          sock.connect("::1", PORT)
+          sock.write "yay\nfoo\n"
+          th.join(5)
+        ensure
+          sock.close
+        end
+      end
+      waiting(10){ sleep 0.1 until received.bytesize == 24 }
+      assert_equal "yay\nfoo\nyay\nfoo\nyay\nfoo\n", received
+      assert_equal ["ack\n","ack\n","ack\n"], responses
+    end
+
+    test 'does not resolve name of client address in default' do
+      received = ""
+      sources = []
+      @d.server_create_udp(:s, PORT, max_bytes: 128) do |data, sock|
+        received << data
+        sources << sock.remote_host
+      end
+      3.times do
+        sock = UDPSocket.new(Socket::AF_INET)
+        sock.connect("127.0.0.1", PORT)
+        sock.puts "yay"
+        sock.close
+      end
+      waiting(10){ sleep 0.1 until received.bytesize == 12 }
+      assert_equal "yay\nyay\nyay\n", received
+      assert{ sources.all?{|s| s == "127.0.0.1" } }
+    end
+
+    test 'does resolve name of client address if resolve_name is true' do
+      received = ""
+      sources = []
+      @d.server_create_udp(:s, PORT, resolve_name: true, max_bytes: 128) do |data, sock|
+        received << data
+        sources << sock.remote_host
+      end
+      3.times do
+        sock = UDPSocket.new(Socket::AF_INET)
+        sock.connect("127.0.0.1", PORT)
+        sock.puts "yay"
+        sock.close
+      end
+      waiting(10){ sleep 0.1 until received.bytesize == 12 }
+      assert_equal "yay\nyay\nyay\n", received
+      assert{ sources.all?{|s| s != "127.0.0.1" && Socket.getaddrinfo(s, PORT, Socket::AF_INET).any?{|i| i[3] == "127.0.0.1"} } }
+    end
+
+    test 'raises error if plugin registers data callback for connection object from #server_create' do
+      received = ""
+      errors = []
+      @d.server_create_udp(:s, PORT, max_bytes: 128) do |data, sock|
+        received << data
+        begin
+          sock.data{|d| received << d.upcase }
+        rescue => e
+          errors << e
+        end
+      end
+      sock = UDPSocket.new(Socket::AF_INET)
+      sock.connect("127.0.0.1", PORT)
+      sock.write "foo\n"
+      sock.close
+
+      waiting(10){ sleep 0.1 until received.bytesize == 4 || errors.size == 1 }
+      assert_equal "foo\n", received
+      assert_equal 1, errors.size
+      assert_equal "BUG: this event is disabled for udp: data", errors.first.message
+    end
+
+    test 'raise error if plugin registers write_complete callback for udp' do
+      received = ""
+      errors = []
+      @d.server_create_udp(:s, PORT, max_bytes: 128) do |data, sock|
+        received << data
+        begin
+          sock.on(:write_complete){|conn| "" }
+        rescue => e
+          errors << e
+        end
+      end
+      sock = UDPSocket.new(Socket::AF_INET)
+      sock.connect("127.0.0.1", PORT)
+      sock.write "foo\n"
+      sock.close
+
+      waiting(10){ sleep 0.1 until received.bytesize == 4 || errors.size == 1 }
+      assert_equal "foo\n", received
+      assert_equal 1, errors.size
+      assert_equal "BUG: this event is disabled for udp: write_complete", errors.first.message
+    end
+
+    test 'raises error if plugin registers close callback for udp' do
+      received = ""
+      errors = []
+      @d.server_create_udp(:s, PORT, max_bytes: 128) do |data, sock|
+        received << data
+        begin
+          sock.on(:close){|d| "" }
+        rescue => e
+          errors << e
+        end
+      end
+      sock = UDPSocket.new(Socket::AF_INET)
+      sock.connect("127.0.0.1", PORT)
+      sock.write "foo\n"
+      sock.close
+
+      waiting(10){ sleep 0.1 until received.bytesize == 4 || errors.size == 1 }
+      assert_equal "foo\n", received
+      assert_equal 1, errors.size
+      assert_equal "BUG: this event is disabled for udp: close", errors.first.message
+    end
+  end
+
+  sub_test_case '#server_create_tls' do
+    # not implemented yet
+
+    # test 'can accept all keyword arguments valid for tcp/tls server'
+    # test 'creates a tls server just to read data'
+    # test 'creates a tls server to read and write data'
+    # test 'creates a tls server to read and write data using IPv6'
+
+    # many tests about certops
+
+    # test 'does not resolve name of client address in default'
+    # test 'does resolve name of client address if resolve_name is true'
+    # test 'can keep connections alive for tls if keepalive specified' do
+    #   pend "not implemented yet"
+    # end
+
+    # test 'raises error if plugin registers data callback for connection object from #server_create'
+    # test 'can call write_complete callback if registered'
+    # test 'can call close callback if registered'
+  end
+
+  sub_test_case '#server_create_unix' do
+    # not implemented yet
+
+    # test 'can accept all keyword arguments valid for unix server'
+    # test 'creates a unix server just to read data'
+    # test 'creates a unix server to read and write data'
+
+    # test 'raises error if plugin registers data callback for connection object from #server_create'
+    # test 'can call write_complete callback if registered'
+    # test 'can call close callback if registered'
+  end
+
+  # run tests for tcp, tls and unix
+  sub_test_case '#server_create_connection' do
+    test 'raise error if udp is specified in proto' do
+      assert_raise(ArgumentError.new("BUG: cannot create connection for UDP")) do
+        @d.server_create_connection(:myserver, PORT, proto: :udp){|c| c }
+      end
+    end
+
+    # def server_create_connection(title, port, proto: :tcp, bind: '0.0.0.0', shared: true, certopts: nil, resolve_name: false, linger_timeout: 0, backlog: nil, &block)
+    protocols = {
+      'tcp' => [:tcp, {}],
+      # 'tls' => [:tls, {certopts: {}}],
+      # 'unix' => [:unix, {path: ""}],
+    }
+
+    data(protocols)
+    test 'raise error if block argument is not specified or too many' do |(proto, kwargs)|
+      empty_block = ->(){}
+      assert_raise(ArgumentError.new("BUG: block must have just one argument")) do
+        @d.server_create_connection(:myserver, PORT, proto: proto, **kwargs, &empty_block)
+      end
+      assert_raise(ArgumentError.new("BUG: block must have just one argument")) do
+        @d.server_create_connection(:myserver, PORT, proto: proto, **kwargs){|conn, what_is_this| [conn, what_is_this] }
+      end
+    end
+
+    data(protocols)
+    test 'does not resolve name of client address in default' do |(proto, kwargs)|
+      received = ""
+      sources = []
+      @d.server_create_connection(:s, PORT, proto: proto, **kwargs) do |conn|
+        sources << conn.remote_host
+        conn.data do |d|
+          received << d
+        end
+      end
+      3.times do
+        TCPSocket.open("127.0.0.1", PORT) do |sock|
+          sock.puts "yay"
+        end
+      end
+      waiting(10){ sleep 0.1 until received.bytesize == 12 }
+      assert_equal "yay\nyay\nyay\n", received
+      assert{ sources.all?{|s| s == "127.0.0.1" } }
+    end
+
+    data(protocols)
+    test 'does resolve name of client address if resolve_name is true' do |(proto, kwargs)|
+      received = ""
+      sources = []
+      @d.server_create_connection(:s, PORT, proto: proto, **kwargs) do |conn|
+        sources << conn.remote_host
+        conn.data do |d|
+          received << d
+        end
+      end
+      3.times do
+        TCPSocket.open("127.0.0.1", PORT) do |sock|
+          sock.puts "yay"
+        end
+      end
+      waiting(10){ sleep 0.1 until received.bytesize == 12 }
+      assert_equal "yay\nyay\nyay\n", received
+      assert{ sources.all?{|s| s == "127.0.0.1" } }
+    end
+
+    data(protocols)
+    test 'creates a server to provide connection, which can read, write and close' do |(proto, kwargs)|
+      lines = []
+      buffer = ""
+      @d.server_create_connection(:s, PORT, proto: proto, **kwargs) do |conn|
+        conn.data do |d|
+          buffer << d
+          if buffer == "x"
+            buffer.slice!(0, 1)
+            conn.close
+          end
+          if idx = buffer.index("\n")
+            lines << buffer.slice!(0, idx + 1)
+            conn.write "foo!\n"
+          end
+        end
+      end
+      replied = []
+      disconnecteds = []
+      3.times do
+        TCPSocket.open("127.0.0.1", PORT) do |sock|
+          sock.puts "yay"
+          while line = sock.readline
+            replied << line
+            break
+          end
+          sock.write "x"
+          begin
+            sock.read
+          rescue => e
+            if e.is_a?(Errno::ECONNRESET)
+              disconnecteds << e.class
+            end
+          end
+        end
+      end
+      waiting(10){ sleep 0.1 until lines.size == 3 }
+      waiting(10){ sleep 0.1 until replied.size == 3 }
+      waiting(10){ sleep 0.1 until disconnecteds.size == 3 }
+      assert_equal ["yay\n", "yay\n", "yay\n"], lines
+      assert_equal ["foo!\n", "foo!\n", "foo!\n"], replied
+      assert_equal [Errno::ECONNRESET, Errno::ECONNRESET, Errno::ECONNRESET], disconnecteds
+    end
+
+    data(protocols)
+    test 'creates a server to provide connection, which accepts callbacks for data, write_complete, and close' do |(proto, kwargs)|
+      lines = []
+      buffer = ""
+      written = 0
+      closed = 0
+      @d.server_create_connection(:s, PORT, proto: proto, **kwargs) do |conn|
+        conn.on(:write_complete){|_conn| written += 1 }
+        conn.on(:close){|_conn| closed += 1 }
+        conn.on(:data) do |d|
+          buffer << d
+          if idx = buffer.index("\n")
+            lines << buffer.slice!(0, idx + 1)
+            conn.write "foo!\n"
+          end
+        end
+      end
+      replied = []
+      3.times do
+        TCPSocket.open("127.0.0.1", PORT) do |sock|
+          sock.puts "yay"
+          while line = sock.readline
+            replied << line
+            break
+          end
+        end # TCP socket is closed here
+      end
+      waiting(10){ sleep 0.1 until lines.size == 3 }
+      waiting(10){ sleep 0.1 until replied.size == 3 }
+      waiting(10){ sleep 0.1 until closed == 3 }
+      assert_equal ["yay\n", "yay\n", "yay\n"], lines
+      assert_equal 3, written
+      assert_equal 3, closed
+      assert_equal ["foo!\n", "foo!\n", "foo!\n"], replied
+    end
+
+    data(protocols)
+    test 'creates a server, and does not leak connections' do |(proto, kwargs)|
+      buffer = ""
+      closed = 0
+      @d.server_create_connection(:s, PORT, proto: proto, **kwargs) do |conn|
+        conn.on(:close){|_c| closed += 1 }
+        conn.on(:data) do |d|
+          buffer << d
+        end
+      end
+      3.times do
+        TCPSocket.open("127.0.0.1", PORT) do |sock|
+          sock.puts "yay"
+        end
+      end
+      waiting(10){ sleep 0.1 until buffer.bytesize == 12 }
+      waiting(10){ sleep 0.1 until closed == 3 }
+      assert_equal 0, @d.instance_eval{ @_server_connections.size }
+    end
+
+    test 'can keep connections alive for tcp/tls if keepalive specified' do
+      # pend "not implemented yet"
+    end
+  end
+
+end

--- a/test/plugin_helper/test_server.rb
+++ b/test/plugin_helper/test_server.rb
@@ -116,22 +116,29 @@ class ServerPluginHelperTest < Test::Unit::TestCase
       @d.__send__(m, :myserver, PORT){|x| x }
 
       assert_equal 1, @d._servers.size
-      assert_equal :myserver, @d._servers.first.title
-      assert_equal PORT, @d._servers.first.port
 
-      assert_equal :tcp, @d._servers.first.proto
-      assert_equal "0.0.0.0", @d._servers.first.bind
+      created_server_info = @d._servers.first
 
-      assert{ @d._servers.first.server.is_a? Coolio::TCPServer }
-      assert_equal "0.0.0.0", @d._servers.first.server.instance_eval{ @listen_socket }.addr[3]
+      assert_equal :myserver, created_server_info.title
+      assert_equal PORT, created_server_info.port
+
+      assert_equal :tcp, created_server_info.proto
+      assert_equal "0.0.0.0", created_server_info.bind
+
+      created_server = created_server_info.server
+
+      assert created_server.is_a?(Coolio::TCPServer)
+      assert_equal "0.0.0.0", created_server.instance_eval{ @listen_socket }.addr[3]
     end
 
     data(methods)
     test 'creates tcp server if specified in proto' do |m|
       @d.__send__(m, :myserver, PORT, proto: :tcp){|x| x }
 
-      assert_equal :tcp, @d._servers.first.proto
-      assert{ @d._servers.first.server.is_a? Coolio::TCPServer }
+      created_server_info = @d._servers.first
+      assert_equal :tcp, created_server_info.proto
+      created_server = created_server_info.server
+      assert created_server.is_a?(Coolio::TCPServer)
     end
 
     # tests about "proto: :udp" is in #server_create
@@ -294,8 +301,10 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     test 'creates udp server if specified in proto' do
       @d.server_create(:myserver, PORT, proto: :udp, max_bytes: 512){|x| x }
 
-      assert_equal :udp, @d._servers.first.proto
-      assert{ @d._servers.first.server.is_a? Fluent::PluginHelper::Server::EventHandler::UDPServer }
+      created_server_info = @d._servers.first
+      assert_equal :udp, created_server_info.proto
+      created_server = created_server_info.server
+      assert created_server.is_a?(Fluent::PluginHelper::Server::EventHandler::UDPServer)
     end
   end
 


### PR DESCRIPTION
Server plugin helpers are to make plugin authors to write network servers very easily.
These make authors free from writing code to create sockets, handle event loops or threads.

The key features are:
* callback-based network daemon execution (plugin helper style)
* test driver support to wait startup/shutdown servers before actual test code running
* creating sockets via socket manager in default for coming multi-process configuration support

The full features of socket/server plugin helpers and TBDs are:
* TCP, UDP and TLS support (TLS will be implemented in future change)
* TCP/TLS keepalive (in future)
* IPv6 support

I committed all changes for this pull-request
* server plugin helper: TCP/UDP implementation complete
* tcp/udp input plugin: migrated to v0.14 APIs with server plugin helper
* forward input plugin: updated with server plugin helper
* tests of server plugin helper

To reduce the size of diff, keepalive support and socket plugin helper support will be implemented in following pull requests.
* socket plugin helper and its tests
* update of output plugins using sockets (including out_forward)
* http input plugin update (in future with keepalive support)
