### PR TITLE
Remove 'utc' field from TimeSlicedOutput conf to prevent ConfigError in plugin helpers

### DIFF
--- a/lib/fluent/compat/output.rb
+++ b/lib/fluent/compat/output.rb
@@ -81,7 +81,7 @@ module Fluent
       end
 
       def assume_timekey!
-        @_formatter = Fluent::Timezone.formatter(@_timezone, @_time_slice_format)
+        @_formatter = Fluent::TimeFormatter.new(@_time_slice_format, nil, @_timezone)
 
         return if self.metadata.timekey
         if self.respond_to?(:path) && self.path =~ /\.(\d+)\.(?:b|q)(?:[a-z0-9]+)/

--- a/lib/fluent/compat/output.rb
+++ b/lib/fluent/compat/output.rb
@@ -621,6 +621,7 @@ module Fluent
           elsif conf['utc']
             conf['timezone'] = "+0000"
             conf['localtime'] = "false"
+            conf.delete('utc')
           elsif conf['localtime']
             conf['timezone'] = Time.now.strftime('%z')
             conf['localtime'] = "true"

--- a/lib/fluent/compat/output.rb
+++ b/lib/fluent/compat/output.rb
@@ -619,14 +619,16 @@ module Fluent
           if conf['timezone']
             Fluent::Timezone.validate!(conf['timezone'])
           elsif conf['utc']
-            conf['timezone'] = "+0000"
+            # v0.12 assumes UTC without any configuration
+            # 'localtime=false && no timezone key' means UTC
             conf['localtime'] = "false"
             conf.delete('utc')
           elsif conf['localtime']
             conf['timezone'] = Time.now.strftime('%z')
             conf['localtime'] = "true"
           else
-            conf['timezone'] = "+0000" # v0.12 assumes UTC without any configuration
+            # v0.12 assumes UTC without any configuration
+            # 'localtime=false && no timezone key' means UTC
             conf['localtime'] = "false"
           end
 

--- a/test/test_output.rb
+++ b/test/test_output.rb
@@ -203,6 +203,16 @@ module FluentOutputTest
       Fluent::Test::TimeSlicedOutputTestDriver.new(TimeSlicedOutputTestPlugin).configure(conf, true)
     end
 
+    data(:none => '',
+         :utc => "utc",
+         :localtime => 'localtime',
+         :timezone => 'timezone +0000')
+    test 'configure with timezone related parameters' do |param|
+      assert_nothing_raised {
+        create_driver(CONFIG + param)
+      }
+    end
+
     sub_test_case "test emit" do
       setup do
         @time = Time.parse("2011-01-02 13:14:15 UTC")


### PR DESCRIPTION
Helpers/Compat utils  can't judge user specifies both localtime/utc or converted result.
This changes conf dumpped result but it seems acceptable.

Without this change, v0.12 TimeSlicedOutput plugins with `utc` parameter don't work.