### PR TITLE
Create code-of-conduct.md

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,3 @@
+## Fluentd Community Code of Conduct
+
+Fluentd follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).


### PR DESCRIPTION
CNCF would like fluentd to adopt the CNCF code of conduct, if you don't have any concerns about it.

History is at https://github.com/cncf/foundation/issues/2

Note that it will be required to move graduate under the draft graduation guidelines: https://docs.google.com/document/d/1l6e-hW7C3S6xJjGn47hUKKxeFBxiamAK7kn5efSryxY/edit

Cc @caniszczyk @monadic