### PR TITLE
Add Fluent::Test::Helpers module for easy to write tests

### DIFF
--- a/lib/fluent/test/helpers.rb
+++ b/lib/fluent/test/helpers.rb
@@ -1,0 +1,86 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'fluent/config/element'
+require 'time'
+require 'fluent/time'
+
+module Fluent
+  module Test
+    module Helpers
+      # See "Example Custom Assertion: http://test-unit.github.io/test-unit/en/Test/Unit/Assertions.html
+      def assert_equal_event_time(expected, actual, message = nil)
+        expected_s = "#{expected}"
+        actual_s   = "#{actual}"
+        message = build_message(message, <<EOT, expected_s, actual_s)
+<?> time expected but was
+<?>.
+EOT
+        assert_block(message) do
+          expected.is_a?(Integer) && actual.is_a?(Integer) && expected == actual
+        end
+      end
+
+      def config_element(name = 'test', argument = '', params = {}, elements = [])
+        Fluent::Config::Element.new(name, argument, params, elements)
+      end
+
+      def event_time(str = nil, format: nil)
+        if str
+          if format
+            Time.strptime(str, format).to_i
+          else
+            Time.parse(str).to_i
+          end
+        else
+          Time.now.to_i
+        end
+      end
+
+      def with_timezone(tz)
+        oldtz, ENV['TZ'] = ENV['TZ'], tz
+        yield
+      ensure
+        ENV['TZ'] = oldtz
+      end
+
+      def time2str(time, localtime: false, format: nil)
+        if format
+          if localtime
+            Time.at(time).strftime(format)
+          else
+            Time.at(time).utc.strftime(format)
+          end
+        else
+          if localtime
+            Time.at(time).iso8601
+          else
+            Time.at(time).utc.iso8601
+          end
+        end
+      end
+
+      def capture_log(driver)
+        tmp = driver.instance.log.out
+        driver.instance.log.out = StringIO.new
+        yield
+        return driver.instance.log.out.string
+      ensure
+        driver.instance.log.out = tmp
+      end
+    end
+  end
+end

--- a/test/config/test_configurable.rb
+++ b/test/config/test_configurable.rb
@@ -296,7 +296,7 @@ module Fluent::Config
         def e(name, arg = '', attrs = {}, elements = [])
           attrs_str_keys = {}
           attrs.each{|key, value| attrs_str_keys[key.to_s] = value }
-          Fluent::Config::Element.new(name, arg, attrs_str_keys, elements)
+          config_element(name, arg, attrs_str_keys, elements)
         end
 
         BASE_ATTRS = {
@@ -577,7 +577,7 @@ module Fluent::Config
         def e(name, arg = '', attrs = {}, elements = [])
           attrs_str_keys = {}
           attrs.each{|key, value| attrs_str_keys[key.to_s] = value }
-          Fluent::Config::Element.new(name, arg, attrs_str_keys, elements)
+          config_element(name, arg, attrs_str_keys, elements)
         end
 
         test 'subclass configuration spec can overwrite superclass specs' do
@@ -682,7 +682,7 @@ module Fluent::Config
         def e(name, arg = '', attrs = {}, elements = [])
           attrs_str_keys = {}
           attrs.each{|key, value| attrs_str_keys[key.to_s] = value }
-          Fluent::Config::Element.new(name, arg, attrs_str_keys, elements)
+          config_element(name, arg, attrs_str_keys, elements)
         end
 
         test 'provides accessible data for alias attribute keys' do
@@ -701,7 +701,7 @@ module Fluent::Config
       def e(name, arg = '', attrs = {}, elements = [])
         attrs_str_keys = {}
         attrs.each { |key, value| attrs_str_keys[key.to_s] = value }
-        Fluent::Config::Element.new(name, arg, attrs_str_keys, elements)
+        config_element(name, arg, attrs_str_keys, elements)
       end
 
       setup do
@@ -813,7 +813,7 @@ module Fluent::Config
       test 'warned if deprecated parameter is configured' do
         obj = ConfigurableSpec::UnRecommended.new
         obj.log = Fluent::Test::TestLogger.new
-        obj.configure(Fluent::Config::Element.new('ROOT', '', {'key1' => 'yay'}, []))
+        obj.configure(config_element('ROOT', '', {'key1' => 'yay'}, []))
 
         assert_equal 'yay', obj.key1
         first_log = obj.log.logs.first
@@ -825,7 +825,7 @@ module Fluent::Config
         obj.log = Fluent::Test::TestLogger.new
 
         assert_raise Fluent::ObsoletedParameterError.new("'key2' parameter is already removed: key2 has been removed.") do
-          obj.configure(Fluent::Config::Element.new('ROOT', '', {'key2' => 'yay'}, []))
+          obj.configure(config_element('ROOT', '', {'key2' => 'yay'}, []))
         end
       end
     end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -41,11 +41,14 @@ require 'test/unit/rr'
 require 'fileutils'
 require 'fluent/log'
 require 'fluent/test'
+require 'fluent/test/helpers'
 
 unless defined?(Test::Unit::AssertionFailedError)
   class Test::Unit::AssertionFailedError < StandardError
   end
 end
+
+include Fluent::Test::Helpers
 
 def unused_port
   s = TCPServer.open(0)


### PR DESCRIPTION
From v0.14 `fluent/test/helpers`.
Reduce if conditions for v0.12 and v0.14 in tests.