### PR TITLE
Make sure to specify use_to_json option

### DIFF
--- a/lib/fluent/env.rb
+++ b/lib/fluent/env.rb
@@ -18,7 +18,7 @@ module Fluent
   DEFAULT_CONFIG_PATH = ENV['FLUENT_CONF'] || '/etc/fluent/fluent.conf'
   DEFAULT_PLUGIN_DIR = ENV['FLUENT_PLUGIN'] || '/etc/fluent/plugin'
   DEFAULT_SOCKET_PATH = ENV['FLUENT_SOCKET'] || '/var/run/fluent/fluent.sock'
-  DEFAULT_OJ_OPTIONS = {bigdecimal_load: :float, mode: :compat}
+  DEFAULT_OJ_OPTIONS = {bigdecimal_load: :float, mode: :compat, use_to_json: true}
   IS_WINDOWS = /mswin|mingw/ === RUBY_PLATFORM
   private_constant :IS_WINDOWS
 

--- a/test/test_event_time.rb
+++ b/test/test_event_time.rb
@@ -51,7 +51,9 @@ class EventTimeTest < Test::Unit::TestCase
 
   test 'Oj.dump' do
     time = Fluent::EventTime.new(100)
-    assert_equal('{"time":100}', Oj.dump({'time' => time}, mode: :compat))
+    require 'fluent/env'
+    Oj.default_options = Fluent::DEFAULT_OJ_OPTIONS
+    assert_equal('{"time":100}', Oj.dump({'time' => time}))
     assert_equal('["tag",100,{"key":"value"}]', Oj.dump(["tag", time, {"key" => "value"}], mode: :compat))
   end
 


### PR DESCRIPTION
For the behavior change of Oj 2.18.0.
CI tasks newly kicked are now failing with Oj 2.18.0. This change fixes it.