### PR TITLE
Add null check for `logger`

### DIFF
--- a/lib/fluent/config/section.rb
+++ b/lib/fluent/config/section.rb
@@ -147,7 +147,7 @@ module Fluent
             #             because they are expected to be removed entirely sometime in the future.
             # Obsoleted: These obsolete features have been entirely removed from JavaScript and can no longer be used.
             if opts[:deprecated]
-              logger.warn "'#{name}' parameter is deprecated: #{opts[:deprecated]}"
+              logger.warn "'#{name}' parameter is deprecated: #{opts[:deprecated]}" if logger
             end
             if opts[:obsoleted]
               logger.error "config error in:\n#{conf}" if logger

--- a/test/config/test_configurable.rb
+++ b/test/config/test_configurable.rb
@@ -1307,7 +1307,7 @@ module Fluent::Config
           assert_nil(obj.log)
         end
 
-        test 'nothing raised if obsoleted parameter is configured' do
+        test 'NoMethodError is not raised if obsoleted parameter is configured' do
           obj = ConfigurableSpec::UnRecommended.new
           obj.log = nil
           assert_raise Fluent::ObsoletedParameterError.new("'key2' parameter is already removed: key2 has been removed.") do

--- a/test/config/test_configurable.rb
+++ b/test/config/test_configurable.rb
@@ -1298,6 +1298,24 @@ module Fluent::Config
         first_log = obj.log.logs.first
         assert{ first_log && first_log.include?("[error]") && first_log.include?("'key2' parameter is already removed: key2 has been removed.") }
       end
+
+      sub_test_case 'logger is nil' do
+        test 'nothing raised if deprecated parameter is configured' do
+          obj = ConfigurableSpec::UnRecommended.new
+          obj.log = nil
+          obj.configure(config_element('ROOT', '', {'key1' => 'yay'}, []))
+          assert_nil(obj.log)
+        end
+
+        test 'nothing raised if obsoleted parameter is configured' do
+          obj = ConfigurableSpec::UnRecommended.new
+          obj.log = nil
+          assert_raise Fluent::ObsoletedParameterError.new("'key2' parameter is already removed: key2 has been removed.") do
+            obj.configure(config_element('ROOT', '', {'key2' => 'yay'}, []))
+          end
+          assert_nil(obj.log)
+        end
+      end
     end
 
     sub_test_case '#config_param without default values cause error if section is configured as init:true' do

--- a/test/config/test_configurable.rb
+++ b/test/config/test_configurable.rb
@@ -1295,6 +1295,8 @@ module Fluent::Config
         assert_raise Fluent::ObsoletedParameterError.new("'key2' parameter is already removed: key2 has been removed.") do
           obj.configure(config_element('ROOT', '', {'key2' => 'yay'}, []))
         end
+        first_log = obj.log.logs.first
+        assert{ first_log && first_log.include?("[error]") && first_log.include?("'key2' parameter is already removed: key2 has been removed.") }
       end
     end
 

--- a/test/config/test_configurable.rb
+++ b/test/config/test_configurable.rb
@@ -1296,7 +1296,7 @@ module Fluent::Config
           obj.configure(config_element('ROOT', '', {'key2' => 'yay'}, []))
         end
         first_log = obj.log.logs.first
-        assert{ first_log && first_log.include?("[error]") && first_log.include?("'key2' parameter is already removed: key2 has been removed.") }
+        assert{ first_log && first_log.include?("[error]") && first_log.include?("config error in:\n<ROOT>\n  key2 yay\n</ROOT>") }
       end
 
       sub_test_case 'logger is nil' do


### PR DESCRIPTION
If plugin uses `config_param :name, :string, deprecated: "This is
deprecated"` then we cannot use the plugin with plugins using v0.12
compatible layer.