### PR TITLE
fix not to check tag and variable placeholders when configured as secondary

### DIFF
--- a/test/plugin/test_out_file.rb
+++ b/test/plugin/test_out_file.rb
@@ -133,6 +133,23 @@ class FileOutputTest < Test::Unit::TestCase
         create_driver(conf)
       end
     end
+
+    test 'configured as secondary with primary using chunk_key_tag and not using chunk_key_time' do
+      require 'fluent/plugin/out_null'
+      port = unused_port
+      conf = config_element('match', '**', {
+        }, [
+          config_element('buffer', 'tag', {
+          }),
+          config_element('secondary', '', {
+              '@type' => 'file',
+              'path' => "#{TMP_DIR}/testing_to_dump_by_out_file",
+          }),
+      ])
+      assert_nothing_raised do
+        Fluent::Test::Driver::Output.new(Fluent::Plugin::NullOutput).configure(conf)
+      end
+    end
   end
 
   sub_test_case 'fully configured output' do


### PR DESCRIPTION
out_file has been used as plugin to dump data in secondary for a long time, and
that configuration looses consistency about chunk keys (even in v0.12).
But increment placeholder of out_file can create another file name (by just numbering) for such cases.

This change makes v0.14 to work with such configuration...

This fixes #1330.