### PR TITLE
in_exec: Ensure to sleep for prevending fork bomb

### DIFF
--- a/lib/fluent/plugin/in_exec.rb
+++ b/lib/fluent/plugin/in_exec.rb
@@ -140,10 +140,11 @@ module Fluent
           io = IO.popen(@command, "r")
           @parser.call(io)
           Process.waitpid(io.pid)
-          sleep @run_interval
         rescue
           log.error "exec failed to run or shutdown child process", error: $!.to_s, error_class: $!.class.to_s
           log.warn_backtrace $!.backtrace
+        ensure
+          sleep @run_interval
         end
       end
     end

--- a/test/plugin/test_in_exec.rb
+++ b/test/plugin/test_in_exec.rb
@@ -7,11 +7,6 @@ class ExecInputTest < Test::Unit::TestCase
     Fluent::Test.setup
     @test_time = Time.parse("2011-01-02 13:14:15").to_i
     @script = File.expand_path(File.join(File.dirname(__FILE__), '..', 'scripts', 'exec_script.rb'))
-    @count_file = File.expand_path(File.join(File.dirname(__FILE__), '..', 'scripts', 'count.txt'))
-  end
-
-  def teardown
-    FileUtils.rm_f(@count_file)
   end
 
   def create_driver(conf = tsv_config)
@@ -61,7 +56,7 @@ class ExecInputTest < Test::Unit::TestCase
   def invalid_json_config
     # For counting command execution, redirect stderr to file
     %[
-      command ruby #{@script} #{@test_time} 4 2>>#{@count_file}
+      command ruby #{@script} #{@test_time} 4
       format json
       tag_key tag
       time_key time
@@ -155,6 +150,7 @@ class ExecInputTest < Test::Unit::TestCase
     end
 
     assert_equal true, d.emits.empty?
-    assert_equal true, File.read(@count_file).length.between?(1, 4)
+    logs = d.instance.log.logs
+    assert_equal true, logs.count { |line| line =~ /exec failed to run or shutdown child process/ }.between?(1, 4)
   end
 end

--- a/test/scripts/exec_script.rb
+++ b/test/scripts/exec_script.rb
@@ -18,7 +18,6 @@ def gen_raw_string(time)
 end
 
 def gen_invalid_json(time)
-  $stderr.print '*' # For counting command exections
   %({"tag": "tag1", "time": #{time}, "k1": "ok", })
 end
 

--- a/test/scripts/exec_script.rb
+++ b/test/scripts/exec_script.rb
@@ -17,6 +17,11 @@ def gen_raw_string(time)
   "#{time} hello"
 end
 
+def gen_invalid_json(time)
+  $stderr.print '*' # For counting command exections
+  %({"tag": "tag1", "time": #{time}, "k1": "ok", })
+end
+
 time = ARGV.first
 time = Integer(time) rescue time
 
@@ -29,4 +34,6 @@ when 2
   print gen_msgpack(time)
 when 3
   print gen_raw_string(time)
+when 4
+  print gen_invalid_json(time)
 end


### PR DESCRIPTION
Since 0.12.18,  `in_exec` dose not sleep `run_interval` when command or output parsing failed.
This causes the fork bomb.
This is prevended by moving `sleep @run_interval` to `ensure` clause.

(Sorry, the added test case may not be good...)