### PR TITLE
fix to rescue Errno::ECONNRESET to handle unexpected disconnection

### DIFF
--- a/lib/fluent/plugin_helper/server.rb
+++ b/lib/fluent/plugin_helper/server.rb
@@ -382,7 +382,7 @@ module Fluent
           def on_readable_without_sock
             begin
               data = @sock.recv(@max_bytes, @flags)
-            rescue Errno::EAGAIN, Errno::EWOULDBLOCK, Errno::EINTR
+            rescue Errno::EAGAIN, Errno::EWOULDBLOCK, Errno::EINTR, Errno::ECONNRESET
               return
             end
             @callback.call(data)
@@ -395,7 +395,7 @@ module Fluent
           def on_readable_with_sock
             begin
               data, addr = @sock.recvfrom(@max_bytes)
-            rescue Errno::EAGAIN, Errno::EWOULDBLOCK, Errno::EINTR
+            rescue Errno::EAGAIN, Errno::EWOULDBLOCK, Errno::EINTR, Errno::ECONNRESET
               return
             end
             @callback.call(data, UDPCallbackSocket.new(@sock, addr))


### PR DESCRIPTION
Some tests show that some tests sometimes fail with Errno::ECONNRESET by unexpected disconnection from client.
https://ci.appveyor.com/project/fluent/fluentd/build/1915/job/k4jfxnjp8jxxqtch