### PR TITLE
fix to raise error if injected hostname_key is also specified in buffer chunk key

### DIFF
--- a/lib/fluent/plugin_helper/inject.rb
+++ b/lib/fluent/plugin_helper/inject.rb
@@ -97,6 +97,17 @@ module Fluent
         if @inject_config
           @_inject_hostname_key = @inject_config.hostname_key
           if @_inject_hostname_key
+            if self.respond_to?(:buffer_config)
+              # Output plugin cannot use "hostname"(specified by @hostname_key),
+              # injected by this plugin helper, in chunk keys.
+              # This plugin helper works in `#format` (in many cases), but modified record
+              # don't have any side effect in chunking of output plugin.
+              if self.buffer_config.chunk_keys.include?(@_inject_hostname_key)
+                log.error "Use filters to inject hostname to use it in buffer chunking."
+                raise Fluent::ConfigError, "the key specified by 'hostname_key' in <inject> cannot be used in buffering chunk key."
+              end
+            end
+
             @_inject_hostname =  @inject_config.hostname
             unless @_inject_hostname
               @_inject_hostname = Socket.gethostname


### PR DESCRIPTION
Inject plugin helper does record.dup, so that Output plugin code cannot find any
side effect of inject plugin helper. It means output cannnot do chunking with injected values.

On the other hand, there is just few good use cases about chunking with injected hostname.

* chunking hostname (just after injected) is to route events with hostname... and hostname is unique on a host
* just one good use-case, to extract hostname into ${hostname} in configured values
  * but it can be done by ruby code eval

This fixes #1353.