### PR TITLE
introduce unrecoverable error type, and logs to show Fluentd process/worker started

### DIFF
--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -172,6 +172,7 @@ module Fluent
 
     def run
       begin
+        $log.info "starting fluentd worker", pid: Process.pid, ppid: Process.ppid # TODO: worker number
         start
 
         if @event_router.match?($log.tag)
@@ -179,6 +180,7 @@ module Fluent
           @log_emit_thread = Thread.new(&method(:log_event_loop))
         end
 
+        $log.info "fluentd worker is now running" # TODO: worker number
         sleep MAINLOOP_SLEEP_INTERVAL until @engine_stopped
 
       rescue Exception => e
@@ -187,7 +189,7 @@ module Fluent
         raise
       end
 
-      $log.info "shutting down fluentd"
+      $log.info "shutting down fluentd worker" # TODO: worker number
       shutdown
       if @log_emit_thread
         @log_event_loop_stop = true

--- a/lib/fluent/error.rb
+++ b/lib/fluent/error.rb
@@ -1,0 +1,30 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+module Fluent
+  class UnrecoverableError < StandardError
+    def initialize(error_message = nil)
+      @message = error_message || "an unrecoverable error occurs in Fluentd process"
+    end
+
+    def to_s
+      @message
+    end
+  end
+
+  class InvalidRootDirectory < UnrecoverableError
+  end
+end

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -636,31 +636,31 @@ module Fluent
 
       begin
         block.call
-      rescue Fluent::ConfigError
+      rescue Fluent::ConfigError => e
         logging_with_console_output do |log|
-          log.error "config error", file: @config_path, error: $!
+          log.error "config error", file: @config_path, error: e
           log.debug_backtrace
         end
         unrecoverable_error = true
-      rescue Fluent::UnrecoverableError
+      rescue Fluent::UnrecoverableError => e
         logging_with_console_output do |log|
-          log.error $!.message, error: $!
+          log.error e.message, error: e
           log.error_backtrace
         end
         unrecoverable_error = true
-      rescue ScriptError # LoadError, NotImplementedError, SyntaxError
+      rescue ScriptError => e # LoadError, NotImplementedError, SyntaxError
         logging_with_console_output do |log|
-          if $!.respond_to?(:path)
-            log.error $!.message, path: $!.path, error: $!
+          if e.respond_to?(:path)
+            log.error e.message, path: e.path, error: e
           else
-            log.error $!.message, error: $!
+            log.error e.message, error: e
           end
           log.error_backtrace
         end
         unrecoverable_error = true
-      rescue
+      rescue => e
         logging_with_console_output do |log|
-          log.error "unexpected error", error: $!
+          log.error "unexpected error", error: e
           log.error_backtrace
         end
       end

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -445,7 +445,7 @@ module Fluent
 
       install_main_process_signal_handlers
 
-      $log.info "starting fluentd-#{Fluent::VERSION} without supervision"
+      $log.info "starting fluentd-#{Fluent::VERSION} without supervision", pid: Process.pid
 
       main_process do
         create_socket_manager if @standalone_worker
@@ -502,7 +502,7 @@ module Fluent
     end
 
     def supervise
-      $log.info "starting fluentd-#{Fluent::VERSION}"
+      $log.info "starting fluentd-#{Fluent::VERSION}", pid: Process.pid
 
       rubyopt = ENV["RUBYOPT"]
       fluentd_spawn_cmd = [ServerEngine.ruby_bin_path, "-Eascii-8bit:ascii-8bit"]

--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -1,0 +1,276 @@
+require_relative '../helper'
+
+# require 'fluent/command/fluentd'
+# don't require it... it runs immediately
+
+require 'fileutils'
+require 'timeout'
+
+class TestFluentdCommand < ::Test::Unit::TestCase
+  TMP_DIR = File.expand_path(File.dirname(__FILE__) + "/../tmp/command/fluentd#{ENV['TEST_ENV_NUMBER']}")
+
+  setup do
+    FileUtils.rm_rf(TMP_DIR)
+    FileUtils.mkdir_p(TMP_DIR)
+    @pid = nil
+    @worker_pids = []
+  end
+
+  teardown do
+    if @pid
+      Process.kill(:KILL, @pid) rescue nil
+      @worker_pids.each do |pid|
+        Process.kill(:KILL, pid) rescue nil
+      end
+      Timeout.timeout(10){ sleep 0.1 while process_exist?(@pid) }
+    end
+  end
+
+  def process_exist?(pid)
+    begin
+      r = Process.waitpid(pid, Process::WNOHANG)
+      return true if r.nil?
+      false
+    rescue SystemCallError
+      false
+    end
+  end
+
+  def create_conf_file(name, content)
+    conf_path = File.join(TMP_DIR, name)
+    File.open(conf_path, 'w') do |file|
+      file.write content
+    end
+    conf_path
+  end
+
+  def create_plugin_file(name, content)
+    file_path = File.join(TMP_DIR, 'plugin', name)
+    FileUtils.mkdir_p(File.dirname(file_path))
+    File.open(file_path, 'w') do |file|
+      file.write content
+    end
+    file_path
+  end
+
+  def create_cmdline(conf_path, *fluentd_options)
+    cmd_path = File.expand_path(File.dirname(__FILE__) + "../../../bin/fluentd")
+    ["bundle", "exec", cmd_path, "-c", conf_path, *fluentd_options]
+  end
+
+  def execute_command(cmdline, chdir=TMP_DIR)
+    gemfile_path = File.expand_path(File.dirname(__FILE__) + "../../../Gemfile")
+
+    rstdio, wstdio = IO.pipe
+    env = {
+      "BUNDLE_GEMFILE" => gemfile_path,
+    }
+    pid = spawn(env, *cmdline, chdir: chdir, out: wstdio, err: [:child, :out])
+    wstdio.close
+    yield pid, rstdio
+  end
+
+  def assert_log_matches(cmdline, *pattern_list, timeout: 10)
+    matched = false
+    assert_error_msg = "matched correctly"
+    stdio_buf = ""
+    begin
+      execute_command(cmdline) do |pid, stdout|
+        @pid = pid
+        waiting(timeout) do
+          while process_exist?(@pid) && !matched
+            readables, _, _ = IO.select([stdout], nil, nil, 1)
+            next unless readables
+            buf = readables.first.readpartial(1024)
+            if buf =~ /starting fluentd worker pid=(\d+) /m
+              @worker_pids << $1.to_i
+            end
+            stdio_buf << buf
+            lines = stdio_buf.split("\n")
+            if pattern_list.all?{|ptn| lines.any?{|line| ptn.is_a?(Regexp) ? ptn.match(line) : line.include?(ptn) } }
+              matched = true
+            end
+          end
+        end
+      end
+    rescue Timeout::Error
+      assert_error_msg = "execution timeout with command out:\n" + stdio_buf
+    rescue => e
+      assert_error_msg = "unexpected error in launching fluentd: #{e.inspect}\n" + stdio_buf
+    end
+    assert matched, assert_error_msg
+  end
+
+  def assert_fluentd_fails_to_start(cmdline, *pattern_list, timeout: 10)
+    # empty_list.all?{ ... } is always true
+    matched = false
+    running = false
+    assert_error_msg = "failed to start correctly"
+    stdio_buf = ""
+    begin
+      execute_command(cmdline) do |pid, stdout|
+        @pid = pid
+        waiting(timeout) do
+          while process_exist?(@pid) && !running
+            readables, _, _ = IO.select([stdout], nil, nil, 1)
+            next unless readables
+            next if readables.first.eof?
+
+            buf = readables.first.readpartial(1024)
+            if buf =~ /starting fluentd worker pid=(\d+) /m
+              @worker_pids << $1.to_i
+            end
+            stdio_buf << buf
+            lines = stdio_buf.split("\n")
+            if lines.any?{|line| line.include?("fluentd worker is now running") }
+              running = true
+            end
+            if pattern_list.all?{|ptn| lines.any?{|line| ptn.is_a?(Regexp) ? ptn.match(line) : line.include?(ptn) } }
+              matched = true
+            end
+          end
+        end
+      end
+    rescue Timeout::Error
+      assert_error_msg = "execution timeout with command out:\n" + stdio_buf
+    rescue => e
+      assert_error_msg = "unexpected error in launching fluentd: #{e.inspect}\n" + stdio_buf
+      assert false, assert_error_msg
+    end
+    assert !running, "fluentd started to run incorrectly:\n" + stdio_buf
+    unless matched
+      assert_error_msg = "fluentd failed to start, without specified regular expressions:\n" + stdio_buf
+    end
+    assert matched, assert_error_msg
+  end
+
+  sub_test_case 'with valid configuration' do
+    test 'runs successfully' do
+      conf = <<CONF
+<source>
+  @type dummy
+  @id dummy
+  @label @dummydata
+  tag dummy
+  dummy {"message": "yay!"}
+</source>
+<label @dummydata>
+  <match dummy>
+    @type null
+    @id   blackhole
+  </match>
+</label>
+CONF
+      conf_path = create_conf_file('valid.conf', conf)
+      assert File.exist?(conf_path)
+
+      assert_log_matches(create_cmdline(conf_path), "fluentd worker is now running")
+      assert process_exist?(@pid)
+    end
+  end
+
+  sub_test_case 'configuration with wrong plugin type' do
+    test 'failed to start' do
+      conf = <<CONF
+<source>
+  @type
+  @id dummy
+  @label @dummydata
+  tag dummy
+  dummy {"message": "yay!"}
+</source>
+<label @dummydata>
+  <match dummy>
+    @type null
+    @id   blackhole
+  </match>
+</label>
+CONF
+      conf_path = create_conf_file('type_missing.conf', conf)
+      assert File.exist?(conf_path)
+
+      assert_fluentd_fails_to_start(
+        create_cmdline(conf_path),
+        "config error",
+        "error=\"Unknown input plugin ''. Run 'gem search -rd fluent-plugin' to find plugins",
+      )
+      assert !process_exist?(@pid)
+    end
+  end
+
+  sub_test_case 'configuration to load plugin file with syntax error' do
+    test 'failed to start' do
+      script =  "require 'fluent/plugin/input'\n"
+      script << "module Fluent::Plugin\n"
+      script << "  class BuggyInput < Input\n"
+      script << "    Fluent::Plugin.register_input('buggy', self)\n"
+      script << "  end\n"
+      plugin_path = create_plugin_file('in_buggy.rb', script)
+
+      conf = <<CONF
+<source>
+  @type buggy
+  @id dummy
+  @label @dummydata
+  tag dummy
+  dummy {"message": "yay!"}
+</source>
+<label @dummydata>
+  <match dummy>
+    @type null
+    @id   blackhole
+  </match>
+</label>
+CONF
+      conf_path = create_conf_file('buggy_plugin.conf', conf)
+      assert File.exist?(conf_path)
+
+      assert_fluentd_fails_to_start(
+        create_cmdline(conf_path, "-p", File.dirname(plugin_path)),
+        "error_class=SyntaxError",
+        "in_buggy.rb:5: syntax error, unexpected end-of-input, expecting keyword_end",
+      )
+      assert !process_exist?(@pid)
+    end
+  end
+
+  sub_test_case 'configuration to load plugin which raises unrecoverable error in #start' do
+    test 'failed to start' do
+      script =  "require 'fluent/plugin/input'\n"
+      script << "require 'fluent/error'\n"
+      script << "module Fluent::Plugin\n"
+      script << "  class CrashingInput < Input\n"
+      script << "    Fluent::Plugin.register_input('crashing', self)\n"
+      script << "    def start\n"
+      script << "      raise Fluent::UnrecoverableError"
+      script << "    end\n"
+      script << "  end\n"
+      script << "end\n"
+      plugin_path = create_plugin_file('in_crashing.rb', script)
+
+      conf = <<CONF
+<source>
+  @type crashing
+  @id dummy
+  @label @dummydata
+  tag dummy
+  dummy {"message": "yay!"}
+</source>
+<label @dummydata>
+  <match dummy>
+    @type null
+    @id   blackhole
+  </match>
+</label>
+CONF
+      conf_path = create_conf_file('crashing_plugin.conf', conf)
+      assert File.exist?(conf_path)
+
+      assert_fluentd_fails_to_start(
+        create_cmdline(conf_path, "-p", File.dirname(plugin_path)),
+        'unexpected error error_class=Fluent::UnrecoverableError error="an unrecoverable error occurs in Fluentd process"',
+      )
+      assert !process_exist?(@pid)
+    end
+  end
+end

--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -8,22 +8,14 @@ require 'timeout'
 
 class TestFluentdCommand < ::Test::Unit::TestCase
   TMP_DIR = File.expand_path(File.dirname(__FILE__) + "/../tmp/command/fluentd#{ENV['TEST_ENV_NUMBER']}")
+  SUPERVISOR_PID_PATTERN = /starting fluentd-[.0-9]+ pid=(\d+)/
+  WORKER_PID_PATTERN = /starting fluentd worker pid=(\d+) /
 
   setup do
     FileUtils.rm_rf(TMP_DIR)
     FileUtils.mkdir_p(TMP_DIR)
-    @pid = nil
+    @supervisor_pid = nil
     @worker_pids = []
-  end
-
-  teardown do
-    if @pid
-      Process.kill(:KILL, @pid) rescue nil
-      @worker_pids.each do |pid|
-        Process.kill(:KILL, pid) rescue nil
-      end
-      Timeout.timeout(10){ sleep 0.1 while process_exist?(@pid) }
-    end
   end
 
   def process_exist?(pid)
@@ -55,19 +47,38 @@ class TestFluentdCommand < ::Test::Unit::TestCase
 
   def create_cmdline(conf_path, *fluentd_options)
     cmd_path = File.expand_path(File.dirname(__FILE__) + "../../../bin/fluentd")
-    ["bundle", "exec", cmd_path, "-c", conf_path, *fluentd_options]
+    ["bundle", "exec", "ruby", cmd_path, "-c", conf_path, *fluentd_options]
   end
 
   def execute_command(cmdline, chdir=TMP_DIR)
+    null_stream = File.open(File::NULL, 'w')
     gemfile_path = File.expand_path(File.dirname(__FILE__) + "../../../Gemfile")
 
-    rstdio, wstdio = IO.pipe
     env = {
       "BUNDLE_GEMFILE" => gemfile_path,
     }
-    pid = spawn(env, *cmdline, chdir: chdir, out: wstdio, err: [:child, :out])
-    wstdio.close
-    yield pid, rstdio
+    cmdname = cmdline.shift
+    arg0 = "testing-fluentd"
+    # p(here: "executing process", env: env, cmdname: cmdname, arg0: arg0, args: cmdline)
+    IO.popen(env, [[cmdname, arg0], *cmdline], chdir: chdir, err: [:child, :out]) do |io|
+      pid = io.pid
+      begin
+        yield pid, io
+        # p(here: "execute command", pid: pid, worker_pids: @worker_pids)
+      ensure
+        Process.kill(:KILL, pid) rescue nil
+        if @supervisor_pid
+          Process.kill(:KILL, @supervisor_pid) rescue nil
+        end
+        @worker_pids.each do |cpid|
+          Process.kill(:KILL, cpid) rescue nil
+        end
+        # p(here: "execute command", pid: pid, exist: process_exist?(pid), worker_pids: @worker_pids, exists: @worker_pids.map{|i| process_exist?(i) })
+        Timeout.timeout(10){ sleep 0.1 while process_exist?(pid) }
+      end
+    end
+  ensure
+    null_stream.close rescue nil
   end
 
   def assert_log_matches(cmdline, *pattern_list, timeout: 10)
@@ -76,20 +87,28 @@ class TestFluentdCommand < ::Test::Unit::TestCase
     stdio_buf = ""
     begin
       execute_command(cmdline) do |pid, stdout|
-        @pid = pid
-        waiting(timeout) do
-          while process_exist?(@pid) && !matched
-            readables, _, _ = IO.select([stdout], nil, nil, 1)
-            next unless readables
-            buf = readables.first.readpartial(1024)
-            if buf =~ /starting fluentd worker pid=(\d+) /m
-              @worker_pids << $1.to_i
+        begin
+          waiting(timeout) do
+            while process_exist?(pid) && !matched
+              readables, _, _ = IO.select([stdout], nil, nil, 1)
+              next unless readables
+              break if readables.first.eof?
+
+              buf = readables.first.readpartial(1024)
+              # puts buf
+              stdio_buf << buf
+              lines = stdio_buf.split("\n")
+              if pattern_list.all?{|ptn| lines.any?{|line| ptn.is_a?(Regexp) ? ptn.match(line) : line.include?(ptn) } }
+                matched = true
+              end
             end
-            stdio_buf << buf
-            lines = stdio_buf.split("\n")
-            if pattern_list.all?{|ptn| lines.any?{|line| ptn.is_a?(Regexp) ? ptn.match(line) : line.include?(ptn) } }
-              matched = true
-            end
+          end
+        ensure
+          if SUPERVISOR_PID_PATTERN =~ stdio_buf
+            @supervisor_pid = $1.to_i
+          end
+          stdio_buf.scan(WORKER_PID_PATTERN) do |worker_pid|
+            @worker_pids << worker_pid.first.to_i
           end
         end
       end
@@ -109,25 +128,29 @@ class TestFluentdCommand < ::Test::Unit::TestCase
     stdio_buf = ""
     begin
       execute_command(cmdline) do |pid, stdout|
-        @pid = pid
-        waiting(timeout) do
-          while process_exist?(@pid) && !running
-            readables, _, _ = IO.select([stdout], nil, nil, 1)
-            next unless readables
-            next if readables.first.eof?
+        begin
+          waiting(timeout) do
+            while process_exist?(pid) && !running
+              readables, _, _ = IO.select([stdout], nil, nil, 1)
+              next unless readables
+              next if readables.first.eof?
 
-            buf = readables.first.readpartial(1024)
-            if buf =~ /starting fluentd worker pid=(\d+) /m
-              @worker_pids << $1.to_i
+              stdio_buf << readables.first.readpartial(1024)
+              lines = stdio_buf.split("\n")
+              if lines.any?{|line| line.include?("fluentd worker is now running") }
+                running = true
+              end
+              if pattern_list.all?{|ptn| lines.any?{|line| ptn.is_a?(Regexp) ? ptn.match(line) : line.include?(ptn) } }
+                matched = true
+              end
             end
-            stdio_buf << buf
-            lines = stdio_buf.split("\n")
-            if lines.any?{|line| line.include?("fluentd worker is now running") }
-              running = true
-            end
-            if pattern_list.all?{|ptn| lines.any?{|line| ptn.is_a?(Regexp) ? ptn.match(line) : line.include?(ptn) } }
-              matched = true
-            end
+          end
+        ensure
+          if SUPERVISOR_PID_PATTERN =~ stdio_buf
+            @supervisor_pid = $1.to_i
+          end
+          stdio_buf.scan(WORKER_PID_PATTERN) do |worker_pid|
+            @worker_pids << worker_pid.first.to_i
           end
         end
       end
@@ -165,7 +188,6 @@ CONF
       assert File.exist?(conf_path)
 
       assert_log_matches(create_cmdline(conf_path), "fluentd worker is now running")
-      assert process_exist?(@pid)
     end
   end
 
@@ -194,7 +216,6 @@ CONF
         "config error",
         "error=\"Unknown input plugin ''. Run 'gem search -rd fluent-plugin' to find plugins",
       )
-      assert !process_exist?(@pid)
     end
   end
 
@@ -230,7 +251,6 @@ CONF
         "error_class=SyntaxError",
         "in_buggy.rb:5: syntax error, unexpected end-of-input, expecting keyword_end",
       )
-      assert !process_exist?(@pid)
     end
   end
 
@@ -270,7 +290,6 @@ CONF
         create_cmdline(conf_path, "-p", File.dirname(plugin_path)),
         'unexpected error error_class=Fluent::UnrecoverableError error="an unrecoverable error occurs in Fluentd process"',
       )
-      assert !process_exist?(@pid)
     end
   end
 end


### PR DESCRIPTION
Currently, unrecoverable errors (which serverengine doesn't try to restart workers about) are only configuration errors.
But some other situation cannot be retried. For example:
* per-worker root directory (will be introduced next) exists but it is a file
* failed to bind an address/port in server plugin helper
* failed to read a file from in_tail by permission error
* or many others

We are using ConfigError for such cases, but it's nonsense in fact.

This change also adds unrecoverable cases for scripting errors while loading plugin files.
Fluentd is now restarting for such cases, but it's just wrong behavior.