### PR TITLE
formatter_csv: Change fields parameter to required

### DIFF
--- a/lib/fluent/formatter.rb
+++ b/lib/fluent/formatter.rb
@@ -206,6 +206,7 @@ module Fluent
       def configure(conf)
         super
         @fields = fields.select { |f| !f.empty? }
+        raise ConfigError, "empty value is specified in fields parameter" if @fields.empty?
       end
 
       def format(tag, time, record)

--- a/lib/fluent/formatter.rb
+++ b/lib/fluent/formatter.rb
@@ -207,6 +207,8 @@ module Fluent
         super
         @fields = fields.select { |f| !f.empty? }
         raise ConfigError, "empty value is specified in fields parameter" if @fields.empty?
+
+        @generate_opts = {col_sep: @delimiter, force_quotes: @force_quotes}
       end
 
       def format(tag, time, record)
@@ -215,8 +217,7 @@ module Fluent
             memo << record[key]
             memo
         end
-        CSV.generate_line(row, col_sep: @delimiter,
-                          force_quotes: @force_quotes)
+        CSV.generate_line(row, @generate_opts)
       end
     end
 

--- a/lib/fluent/formatter.rb
+++ b/lib/fluent/formatter.rb
@@ -196,16 +196,16 @@ module Fluent
         ['\t', 'TAB'].include?(val) ? "\t" : val
       end
       config_param :force_quotes, :bool, default: true
-      config_param :fields, default: [] do |val|
-        val.split(',').map do |f|
-          f.strip!
-          f.size > 0 ? f : nil
-        end.compact
-      end
+      config_param :fields, :array, value_type: :string
 
       def initialize
         super
         require 'csv'
+      end
+
+      def configure(conf)
+        super
+        @fields = fields.select { |f| !f.empty? }
       end
 
       def format(tag, time, record)

--- a/test/test_formatter.rb
+++ b/test/test_formatter.rb
@@ -292,6 +292,14 @@ module FormatterTest
       assert_nil @formatter.fields
     end
 
+    data('empty array' => [],
+         'array including empty string' => ['', ''])
+    def test_empty_fields(param)
+      assert_raise ConfigError do
+        @formatter.configure('fields' => param)
+      end
+    end
+
     data(
       'tab_char' => ["\t", '\t'],
       'tab_string' => ["\t", 'TAB'],

--- a/test/test_formatter.rb
+++ b/test/test_formatter.rb
@@ -289,7 +289,7 @@ module FormatterTest
     def test_config_params
       assert_equal ',', @formatter.delimiter
       assert_equal true, @formatter.force_quotes
-      assert_equal [], @formatter.fields
+      assert_nil @formatter.fields
     end
 
     data(
@@ -298,7 +298,7 @@ module FormatterTest
       'pipe' => ['|', '|'])
     def test_config_params_with_customized_delimiters(data)
       expected, target = data
-      @formatter.configure('delimiter' => target)
+      @formatter.configure('fields' => 'f1', 'delimiter' => target)
       assert_equal expected, @formatter.delimiter
     end
 


### PR DESCRIPTION
Empty fields is error prone because it generates empty line.