### PR TITLE
Add slow_flush_log_threshold parameter

### DIFF
--- a/lib/fluent/output.rb
+++ b/lib/fluent/output.rb
@@ -204,7 +204,7 @@ module Fluent
     desc 'The number of threads to flush the buffer.'
     config_param :num_threads, :integer, default: 1
     desc 'The threshold to show slow flush logs'
-    config_param :slow_flush_threshold, :float, default: 5.0
+    config_param :slow_flush_log_threshold, :float, default: 5.0
     desc 'The interval between data flushes for queued chunk.'
     config_param :queued_chunk_flush_interval, :time, default: 1
 
@@ -343,9 +343,9 @@ module Fluent
         end
 
         elapsed_time = Time.now - chunk_write_start
-        if elapsed_time > @slow_flush_threshold
-          $log.warn "buffer flush took longer time than slow_flush_threshold",
-                    plugin_id: plugin_id, elapsed_time: elapsed_time, slow_flush_threshold: @slow_flush_threshold
+        if elapsed_time > @slow_flush_log_threshold
+          $log.warn "buffer flush took longer time than slow_flush_log_threshold",
+                    plugin_id: plugin_id, elapsed_time: elapsed_time, slow_flush_log_threshold: @slow_flush_log_threshold
         end
 
         # success

--- a/lib/fluent/output.rb
+++ b/lib/fluent/output.rb
@@ -203,6 +203,8 @@ module Fluent
     config_param :max_retry_wait, :time, default: nil
     desc 'The number of threads to flush the buffer.'
     config_param :num_threads, :integer, default: 1
+    desc 'The threshold to show slow flush logs'
+    config_param :slow_flush_threshold, :float, default: 5.0
     desc 'The interval between data flushes for queued chunk.'
     config_param :queued_chunk_flush_interval, :time, default: 1
 
@@ -332,10 +334,18 @@ module Fluent
           end
         end
 
+        chunk_write_start = Time.now
+
         if @secondary && !@disable_retry_limit && @num_errors > @retry_limit
           has_next = flush_secondary(@secondary)
         else
           has_next = @buffer.pop(self)
+        end
+
+        elapsed_time = Time.now - chunk_write_start
+        if elapsed_time > @slow_flush_threshold
+          $log.warn "buffer flush took longer time than slow_flush_threshold",
+                    plugin_id: plugin_id, elapsed_time: elapsed_time, slow_flush_threshold: @slow_flush_threshold
         end
 
         # success

--- a/lib/fluent/output.rb
+++ b/lib/fluent/output.rb
@@ -204,7 +204,7 @@ module Fluent
     desc 'The number of threads to flush the buffer.'
     config_param :num_threads, :integer, default: 1
     desc 'The threshold to show slow flush logs'
-    config_param :slow_flush_log_threshold, :float, default: 5.0
+    config_param :slow_flush_log_threshold, :float, default: 20.0
     desc 'The interval between data flushes for queued chunk.'
     config_param :queued_chunk_flush_interval, :time, default: 1
 
@@ -510,6 +510,7 @@ module Fluent
     config_set_default :buffer_type, 'file'  # overwrite default buffer_type
     config_set_default :buffer_chunk_limit, 256*1024*1024  # overwrite default buffer_chunk_limit
     config_set_default :flush_interval, nil
+    config_set_default :slow_flush_log_threshold, 40.0
 
     attr_accessor :localtime
     attr_reader :time_slicer # for test

--- a/lib/fluent/output.rb
+++ b/lib/fluent/output.rb
@@ -344,7 +344,7 @@ module Fluent
 
         elapsed_time = Time.now - chunk_write_start
         if elapsed_time > @slow_flush_log_threshold
-          $log.warn "buffer flush took longer time than slow_flush_log_threshold",
+          $log.warn "buffer flush took longer time than slow_flush_log_threshold:",
                     plugin_id: plugin_id, elapsed_time: elapsed_time, slow_flush_log_threshold: @slow_flush_log_threshold
         end
 

--- a/test/test_output.rb
+++ b/test/test_output.rb
@@ -47,6 +47,7 @@ module FluentOutputTest
       assert_equal nil, d.instance.max_retry_wait
       assert_equal 1.0, d.instance.retry_wait
       assert_equal 1, d.instance.num_threads
+      assert_equal 20.0, d.instance.slow_flush_log_threshold
       assert_equal 1, d.instance.queued_chunk_flush_interval
 
       # max_retry_wait

--- a/test/test_output.rb
+++ b/test/test_output.rb
@@ -201,6 +201,68 @@ module FluentOutputTest
         10.times { sleep 0.05 }
       end
     end
+
+    sub_test_case "test slow_flush_threshold" do
+      def create_slow_driver(conf, sleep_time)
+        d = Fluent::Test::BufferedOutputTestDriver.new(Fluent::BufferedOutput) do
+          attr_accessor :sleep_time
+
+          def initialize
+            super
+            @_written_check_mutex = Mutex.new
+            @_written_check = false
+          end
+
+          def written_check
+            @_written_check_mutex.synchronize { @_written_check }
+          end
+
+          def write(chunk)
+            sleep @sleep_time
+          end
+
+          def try_flush
+            super
+            @_written_check_mutex.synchronize { @_written_check = true }
+          end
+        end.configure(conf)
+        d.instance.sleep_time = sleep_time
+        d
+      end
+
+      def setup
+        # output#try_flush uses $log, so it should be replaced
+        @orig_log = $log
+        $log = Fluent::Test::TestLogger.new
+      end
+
+      def teardown
+        $log = @orig_log
+      end
+
+      test "flush took longer time than slow_flush_threshold" do
+        d = create_slow_driver(%[
+          slow_flush_threshold 0.5
+        ], 1.5)
+        run_driver(d)
+        assert_equal 1, $log.logs.count { |line| line =~ /buffer flush took longer time than slow_flush_threshold/ }
+      end
+
+      test "flush took lower time than slow_flush_threshold. No logs" do
+        d = create_slow_driver(%[
+          slow_flush_threshold 5.0
+        ], 0)
+        run_driver(d)
+        assert_equal 0, $log.logs.count { |line| line =~ /buffer flush took longer time than slow_flush_threshold/ }
+      end
+
+      def run_driver(d)
+        d.instance.start
+        d.instance.emit('test', OneEventStream.new(@time.to_i, {"message" => "foo"}), NullOutputChain.instance)
+        d.instance.force_flush
+        until d.instance.written_check; end
+      end
+    end
   end
 
   class TimeSlicedOutputTest < ::Test::Unit::TestCase

--- a/test/test_output.rb
+++ b/test/test_output.rb
@@ -246,7 +246,7 @@ module FluentOutputTest
           slow_flush_log_threshold 0.5
         ], 1.5)
         run_driver(d)
-        assert_equal 1, $log.logs.count { |line| line =~ /buffer flush took longer time than slow_flush_log_threshold/ }
+        assert_equal 1, $log.logs.count { |line| line =~ /buffer flush took longer time than slow_flush_log_threshold:/ }
       end
 
       test "flush took lower time than slow_flush_log_threshold. No logs" do
@@ -254,7 +254,7 @@ module FluentOutputTest
           slow_flush_log_threshold 5.0
         ], 0)
         run_driver(d)
-        assert_equal 0, $log.logs.count { |line| line =~ /buffer flush took longer time than slow_flush_log_threshold/ }
+        assert_equal 0, $log.logs.count { |line| line =~ /buffer flush took longer time than slow_flush_log_threshold:/ }
       end
 
       def run_driver(d)

--- a/test/test_output.rb
+++ b/test/test_output.rb
@@ -202,7 +202,7 @@ module FluentOutputTest
       end
     end
 
-    sub_test_case "test slow_flush_threshold" do
+    sub_test_case "test slow_flush_log_threshold" do
       def create_slow_driver(conf, sleep_time)
         d = Fluent::Test::BufferedOutputTestDriver.new(Fluent::BufferedOutput) do
           attr_accessor :sleep_time
@@ -240,20 +240,20 @@ module FluentOutputTest
         $log = @orig_log
       end
 
-      test "flush took longer time than slow_flush_threshold" do
+      test "flush took longer time than slow_flush_log_threshold" do
         d = create_slow_driver(%[
-          slow_flush_threshold 0.5
+          slow_flush_log_threshold 0.5
         ], 1.5)
         run_driver(d)
-        assert_equal 1, $log.logs.count { |line| line =~ /buffer flush took longer time than slow_flush_threshold/ }
+        assert_equal 1, $log.logs.count { |line| line =~ /buffer flush took longer time than slow_flush_log_threshold/ }
       end
 
-      test "flush took lower time than slow_flush_threshold. No logs" do
+      test "flush took lower time than slow_flush_log_threshold. No logs" do
         d = create_slow_driver(%[
-          slow_flush_threshold 5.0
+          slow_flush_log_threshold 5.0
         ], 0)
         run_driver(d)
-        assert_equal 0, $log.logs.count { |line| line =~ /buffer flush took longer time than slow_flush_threshold/ }
+        assert_equal 0, $log.logs.count { |line| line =~ /buffer flush took longer time than slow_flush_log_threshold/ }
       end
 
       def run_driver(d)


### PR DESCRIPTION
This is useful for debugging of buffer flush issue.

I set default value is `5.0`. This is good for local destination but `5.0` seems small for cloud based services.
Should we set large value for default setting?

This patch is for v0.12 but support this feature in v0.14 is also good.
