### PR TITLE
Root directory per worker process

### DIFF
--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -14,10 +14,6 @@
 #    limitations under the License.
 #
 
-require 'socket'
-
-require 'cool.io'
-
 require 'fluent/config'
 require 'fluent/event'
 require 'fluent/event_router'

--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -58,8 +58,6 @@ module Fluent
     def init(system_config)
       @system_config = system_config
 
-      BasicSocket.do_not_reverse_lookup = true
-
       suppress_interval(system_config.emit_error_log_interval) unless system_config.emit_error_log_interval.nil?
       @suppress_config_dump = system_config.suppress_config_dump unless system_config.suppress_config_dump.nil?
       @without_source = system_config.without_source unless system_config.without_source.nil?

--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -166,7 +166,8 @@ module Fluent
 
     def run
       begin
-        $log.info "starting fluentd worker", pid: Process.pid, ppid: Process.ppid # TODO: worker number
+        worker_id = ENV['SERVERENGINE_WORKER_ID']
+        $log.info "starting fluentd worker", pid: Process.pid, ppid: Process.ppid, worker: worker_id
         start
 
         if @event_router.match?($log.tag)

--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -433,11 +433,6 @@ module Fluent
       end
     end
 
-    def start
-      @log.reset
-      super
-    end
-
     def terminate
       super
       @log.reset

--- a/lib/fluent/plugin/base.rb
+++ b/lib/fluent/plugin/base.rb
@@ -39,6 +39,10 @@ module Fluent
         false
       end
 
+      def plugin_root_dir
+        nil # override this in plugin_id.rb
+      end
+
       def configure(conf)
         super
         @_state ||= State.new(false, false, false, false, false, false, false, false, false)

--- a/lib/fluent/plugin/base.rb
+++ b/lib/fluent/plugin/base.rb
@@ -32,6 +32,7 @@ module Fluent
         super
         @_state = State.new(false, false, false, false, false, false, false, false, false)
         @_context_router = nil
+        @_fluentd_worker_id = nil
         @under_plugin_development = false
       end
 
@@ -41,6 +42,12 @@ module Fluent
 
       def plugin_root_dir
         nil # override this in plugin_id.rb
+      end
+
+      def fluentd_worker_id
+        return @_fluentd_worker_id if @_fluentd_worker_id
+        @_fluentd_worker_id = (ENV['SERVERENGINE_WORKER_ID'] || 0).to_i
+        @_fluentd_worker_id
       end
 
       def configure(conf)

--- a/lib/fluent/plugin/buf_file.rb
+++ b/lib/fluent/plugin/buf_file.rb
@@ -42,10 +42,6 @@ module Fluent
       config_param :file_permission, :string, default: nil # '0644'
       config_param :dir_permission,  :string, default: nil # '0755'
 
-      ##TODO: Buffer plugin cannot handle symlinks because new API @stage has many writing buffer chunks
-      ##      re-implement this feature on out_file, w/ enqueue_chunk(or generate_chunk) hook + chunk.path
-      # attr_accessor :symlink_path
-
       @@buffer_paths = {}
 
       def initialize

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -97,6 +97,7 @@ module Fluent::Plugin
         raise Fluent::ConfigError, "tail: 'path' parameter is required on tail input"
       end
 
+      # TODO: Use plugin_root_dir and storage plugin to store positions if available
       unless @pos_file
         $log.warn "'pos_file PATH' parameter is not set to a 'tail' source."
         $log.warn "this parameter is highly recommended to save the position to resume tailing."

--- a/lib/fluent/plugin_id.rb
+++ b/lib/fluent/plugin_id.rb
@@ -30,6 +30,7 @@ module Fluent
         end
         @@configured_ids.add(@id)
       end
+      @_plugin_root_dir = nil
 
       super
     end
@@ -58,6 +59,17 @@ module Fluent
       else
         "object:#{object_id.to_s(16)}"
       end
+    end
+
+    def plugin_root_dir
+      return @_plugin_root_dir if @_plugin_root_dir
+      return nil unless system_config.root_dir
+      return nil unless plugin_id_configured?
+      worker_id = (ENV['SERVERENGINE_WORKER_ID'] || 0).to_i
+      dir = File.join(system_config.root_dir, "worker#{worker_id}", plugin_id)
+      FileUtils.mkdir_p(dir) unless Dir.exist?(dir)
+      @_plugin_root_dir = dir.freeze
+      dir
     end
   end
 end

--- a/lib/fluent/plugin_id.rb
+++ b/lib/fluent/plugin_id.rb
@@ -20,6 +20,11 @@ module Fluent
   module PluginId
     @@configured_ids = Set.new
 
+    def initialize
+      super
+      @_plugin_root_dir = nil
+    end
+
     def configure(conf)
       @id = conf['@id']
       @_id_configured = !!@id # plugin id is explicitly configured by users (or not)
@@ -30,7 +35,6 @@ module Fluent
         end
         @@configured_ids.add(@id)
       end
-      @_plugin_root_dir = nil
 
       super
     end

--- a/lib/fluent/plugin_id.rb
+++ b/lib/fluent/plugin_id.rb
@@ -65,8 +65,9 @@ module Fluent
       return @_plugin_root_dir if @_plugin_root_dir
       return nil unless system_config.root_dir
       return nil unless plugin_id_configured?
-      worker_id = (ENV['SERVERENGINE_WORKER_ID'] || 0).to_i
-      dir = File.join(system_config.root_dir, "worker#{worker_id}", plugin_id)
+
+      # Fluent::Plugin::Base#fluentd_worker_id
+      dir = File.join(system_config.root_dir, "worker#{fluentd_worker_id}", plugin_id)
       FileUtils.mkdir_p(dir) unless Dir.exist?(dir)
       @_plugin_root_dir = dir.freeze
       dir

--- a/test/config/test_system_config.rb
+++ b/test/config/test_system_config.rb
@@ -55,41 +55,43 @@ module Fluent::Config
       assert_nil(s.instance_variable_get(:@dir_permission))
     end
 
-    {'log_level' => 'error',
-     'suppress_repeated_stacktrace' => true,
-     'emit_error_log_interval' => 60,
-     'suppress_config_dump' => true,
-     'without_source' => true,
-    }.each { |k, v|
-      test "accepts #{k} parameter" do
-        conf = parse_text(<<-EOS)
+    data(
+      'log_level' => ['log_level', 'error'],
+      'suppress_repeated_stacktrace' => ['suppress_repeated_stacktrace', true],
+      'emit_error_log_interval' => ['emit_error_log_interval', 60],
+      'suppress_config_dump' => ['suppress_config_dump', true],
+      'without_source' => ['without_source', true],
+    )
+    test "accepts #{k} parameter" do |k, v|
+      conf = parse_text(<<-EOS)
           <system>
             #{k} #{v}
           </system>
-        EOS
-        s = FakeSupervisor.new
-        sc = Fluent::SystemConfig.new(conf)
-        sc.apply(s)
-        assert_not_nil(sc.instance_variable_get("@#{k}"))
-        key = (k == 'emit_error_log_interval' ? 'suppress_interval' : k)
-        assert_not_nil(s.instance_variable_get("@#{key}"))
-      end
-    }
+      EOS
+      s = FakeSupervisor.new
+      sc = Fluent::SystemConfig.new(conf)
+      sc.apply(s)
+      assert_not_nil(sc.instance_variable_get("@#{k}"))
+      key = (k == 'emit_error_log_interval' ? 'suppress_interval' : k)
+      assert_not_nil(s.instance_variable_get("@#{key}"))
+    end
 
-    {'foo' => 'bar', 'hoge' => 'fuga'}.each { |k, v|
-      test "should not affect settable parameters with unknown #{k} parameter" do
-        s = FakeSupervisor.new
-        sc = Fluent::SystemConfig.new({k => v})
-        sc.apply(s)
-        assert_nil(s.instance_variable_get(:@log_level))
-        assert_nil(s.instance_variable_get(:@suppress_repeated_stacktrace))
-        assert_nil(s.instance_variable_get(:@emit_error_log_interval))
-        assert_nil(s.instance_variable_get(:@suppress_config_dump))
-        assert_nil(s.instance_variable_get(:@without_source))
-        assert_nil(s.instance_variable_get(:@file_permission))
-        assert_nil(s.instance_variable_get(:@dir_permission))
-      end
-    }
+    data(
+      'foo' => ['foo', 'bar'],
+      'hoge' => ['hoge', 'fuga'],
+    )
+    test "should not affect settable parameters with unknown #{k} parameter" do |k, v|
+      s = FakeSupervisor.new
+      sc = Fluent::SystemConfig.new({k => v})
+      sc.apply(s)
+      assert_nil(s.instance_variable_get(:@log_level))
+      assert_nil(s.instance_variable_get(:@suppress_repeated_stacktrace))
+      assert_nil(s.instance_variable_get(:@emit_error_log_interval))
+      assert_nil(s.instance_variable_get(:@suppress_config_dump))
+      assert_nil(s.instance_variable_get(:@without_source))
+      assert_nil(s.instance_variable_get(:@file_permission))
+      assert_nil(s.instance_variable_get(:@dir_permission))
+    end
 
     test 'log_level' do
       conf = parse_text(<<-EOS)

--- a/test/config/test_system_config.rb
+++ b/test/config/test_system_config.rb
@@ -14,6 +14,7 @@ module Fluent::Config
 
   class FakeSupervisor
     def initialize
+      @root_dir = nil
       @log = FakeLoggerInitializer.new
       @log_level = nil
       @suppress_interval = nil
@@ -27,6 +28,7 @@ module Fluent::Config
   end
 
   class TestSystemConfig < ::Test::Unit::TestCase
+    TMP_DIR = File.expand_path(File.dirname(__FILE__) + "/tmp/system_config/#{ENV['TEST_ENV_NUMBER']}")
 
     def parse_text(text)
       basepath = File.expand_path(File.dirname(__FILE__) + '/../../')
@@ -41,11 +43,13 @@ module Fluent::Config
       s = FakeSupervisor.new
       sc = Fluent::SystemConfig.new(conf)
       sc.apply(s)
+      assert_nil(sc.root_dir)
       assert_nil(sc.log_level)
       assert_nil(sc.suppress_repeated_stacktrace)
       assert_nil(sc.emit_error_log_interval)
       assert_nil(sc.suppress_config_dump)
       assert_nil(sc.without_source)
+      assert_nil(s.instance_variable_get(:@root_dir))
       assert_nil(s.instance_variable_get(:@log_level))
       assert_nil(s.instance_variable_get(:@suppress_repeated_stacktrace))
       assert_nil(s.instance_variable_get(:@emit_error_log_interval))
@@ -56,13 +60,14 @@ module Fluent::Config
     end
 
     data(
+      'root_dir' => ['root_dir', File.join(TMP_DIR, 'root')],
       'log_level' => ['log_level', 'error'],
       'suppress_repeated_stacktrace' => ['suppress_repeated_stacktrace', true],
       'emit_error_log_interval' => ['emit_error_log_interval', 60],
       'suppress_config_dump' => ['suppress_config_dump', true],
       'without_source' => ['without_source', true],
     )
-    test "accepts #{k} parameter" do |k, v|
+    test "accepts parameters" do |(k, v)|
       conf = parse_text(<<-EOS)
           <system>
             #{k} #{v}
@@ -80,10 +85,11 @@ module Fluent::Config
       'foo' => ['foo', 'bar'],
       'hoge' => ['hoge', 'fuga'],
     )
-    test "should not affect settable parameters with unknown #{k} parameter" do |k, v|
+    test "should not affect settable parameters with unknown parameters" do |(k, v)|
       s = FakeSupervisor.new
       sc = Fluent::SystemConfig.new({k => v})
       sc.apply(s)
+      assert_nil(s.instance_variable_get(:@root_dir))
       assert_nil(s.instance_variable_get(:@log_level))
       assert_nil(s.instance_variable_get(:@suppress_repeated_stacktrace))
       assert_nil(s.instance_variable_get(:@emit_error_log_interval))

--- a/test/plugin/test_base.rb
+++ b/test/plugin/test_base.rb
@@ -56,6 +56,10 @@ class BaseTest < Test::Unit::TestCase
     assert !@p.has_router?
   end
 
+  test 'does not have root dir in default' do
+    assert_nil @p.plugin_root_dir
+  end
+
   test 'is configurable by config_param and config_section' do
     assert_nothing_raised do
       class FluentPluginBaseTest::DummyPlugin2 < Fluent::Plugin::TestBase

--- a/test/plugin/test_base.rb
+++ b/test/plugin/test_base.rb
@@ -56,6 +56,22 @@ class BaseTest < Test::Unit::TestCase
     assert !@p.has_router?
   end
 
+  sub_test_case '#fluentd_worker_id' do
+    test 'returns 0 in default' do
+      assert_equal 0, @p.fluentd_worker_id
+    end
+
+    test 'returns the value specified via SERVERENGINE_WORKER_ID env variable' do
+      pre_value = ENV['SERVERENGINE_WORKER_ID']
+      begin
+        ENV['SERVERENGINE_WORKER_ID'] = 7.to_s
+        assert_equal 7, @p.fluentd_worker_id
+      ensure
+        ENV['SERVERENGINE_WORKER_ID'] = pre_value
+      end
+    end
+  end
+
   test 'does not have root dir in default' do
     assert_nil @p.plugin_root_dir
   end

--- a/test/plugin/test_in_monitor_agent.rb
+++ b/test/plugin/test_in_monitor_agent.rb
@@ -146,7 +146,8 @@ EOC
         "config_path" => "/etc/fluent/fluent.conf",
         "pid_file"    => nil,
         "plugin_dirs" => ["/etc/fluent/plugin"],
-        "log_path"    => nil
+        "log_path"    => nil,
+        "root_dir"    => nil,
       }
       assert_equal(expected_opts, d.instance.fluentd_opts)
     end

--- a/test/plugin/test_storage_local.rb
+++ b/test/plugin/test_storage_local.rb
@@ -240,6 +240,8 @@ class LocalStorageTest < Test::Unit::TestCase
 
   sub_test_case 'with various configurations' do
     test 'mode and dir_mode controls permissions of stored data' do
+      omit "NTFS doesn't support UNIX like permissions" if Fluent.windows?
+
       storage_path = File.join(TMP_DIR, 'dir', 'my_store.json')
       storage_conf = {
         'path' => storage_path,

--- a/test/plugin/test_storage_local.rb
+++ b/test/plugin/test_storage_local.rb
@@ -1,8 +1,294 @@
 require_relative '../helper'
 require 'fluent/plugin/storage_local'
+require 'fluent/plugin/input'
+require 'fluent/system_config'
+require 'fileutils'
 
 class LocalStorageTest < Test::Unit::TestCase
-  test 'syntax' do
-    assert true
+  TMP_DIR = File.expand_path(File.dirname(__FILE__) + "/tmp/storage_local#{ENV['TEST_ENV_NUMBER']}")
+
+  class MyInput < Fluent::Plugin::Input
+    helpers :storage
+    config_section :storage do
+      config_set_default :@type, 'local'
+    end
+  end
+
+  setup do
+    FileUtils.rm_rf(TMP_DIR)
+    FileUtils.mkdir_p(TMP_DIR)
+    Fluent::Test.setup
+    @d = MyInput.new
+  end
+
+  teardown do
+    @d.stop unless @d.stopped?
+    @d.before_shutdown unless @d.before_shutdown?
+    @d.shutdown unless @d.shutdown?
+    @d.after_shutdown unless @d.after_shutdown?
+    @d.close unless @d.closed?
+    @d.terminate unless @d.terminated?
+  end
+
+  sub_test_case 'without any configuration' do
+    test 'works as on-memory storage' do
+      conf = config_element()
+
+      @d.configure(conf)
+      @d.start
+      @p = @d.storage_create()
+
+      assert_nil @p.path
+      assert @p.store.empty?
+
+      assert_nil @p.get('key1')
+      assert_equal 'EMPTY', @p.fetch('key1', 'EMPTY')
+
+      @p.put('key1', '1')
+      assert_equal '1', @p.get('key1')
+
+      @p.update('key1') do |v|
+        (v.to_i * 2).to_s
+      end
+      assert_equal '2', @p.get('key1')
+
+      @p.save # on-memory storage does nothing...
+
+      @d.stop; @d.before_shutdown; @d.shutdown; @d.after_shutdown; @d.close; @d.terminate
+
+      # re-create to reload storage contents
+      @d = MyInput.new
+      @d.configure(conf)
+      @d.start
+      @p = @d.storage_create()
+
+      assert @p.store.empty?
+    end
+
+    test 'warns about on-memory storage if autosave is true' do
+      @d.configure(config_element())
+      @d.start
+      @p = @d.storage_create()
+
+      logs = @d.log.out.logs
+      assert{ logs.any?{|log| log.include?("[warn]: both of Plugin @id and path for <storage> are not specified. Using on-memory store.") } }
+    end
+
+    test 'show info log about on-memory storage if autosave is false' do
+      @d.configure(config_element('ROOT', '', {}, [config_element('storage', '', {'autosave' => 'false'})]))
+      @d.start
+      @p = @d.storage_create()
+
+      logs = @d.log.out.logs
+      assert{ logs.any?{|log| log.include?("[info]: both of Plugin @id and path for <storage> are not specified. Using on-memory store.") } }
+    end
+  end
+
+  sub_test_case 'configured with path' do
+    test 'works as storage which stores data on disk' do
+      storage_path = File.join(TMP_DIR, 'my_store.json')
+      conf = config_element('ROOT', '', {}, [config_element('storage', '', {'path' => storage_path})])
+      @d.configure(conf)
+      @d.start
+      @p = @d.storage_create()
+
+      assert_equal storage_path, @p.path
+      assert @p.store.empty?
+
+      assert_nil @p.get('key1')
+      assert_equal 'EMPTY', @p.fetch('key1', 'EMPTY')
+
+      @p.put('key1', '1')
+      assert_equal '1', @p.get('key1')
+
+      @p.update('key1') do |v|
+        (v.to_i * 2).to_s
+      end
+      assert_equal '2', @p.get('key1')
+
+      @p.save # stores all data into file
+
+      assert File.exist?(storage_path)
+
+      @p.put('key2', 4)
+
+      @d.stop; @d.before_shutdown; @d.shutdown; @d.after_shutdown; @d.close; @d.terminate
+
+      assert_equal({'key1' => '2', 'key2' => 4}, File.open(storage_path){|f| JSON.parse(f.read) })
+
+      # re-create to reload storage contents
+      @d = MyInput.new
+      @d.configure(conf)
+      @d.start
+      @p = @d.storage_create()
+
+      assert_false @p.store.empty?
+
+      assert_equal '2', @p.get('key1')
+      assert_equal 4, @p.get('key2')
+    end
+  end
+
+  sub_test_case 'configured with root-dir and plugin id' do
+    test 'works as storage which stores data under root dir' do
+      root_dir = File.join(TMP_DIR, 'root')
+      expected_storage_path = File.join(root_dir, 'worker0', 'local_storage_test', 'storage.json')
+      conf = config_element('ROOT', '', {'@id' => 'local_storage_test'})
+      Fluent::SystemConfig.overwrite_system_config('root_dir' => root_dir) do
+        @d.configure(conf)
+      end
+      @d.start
+      @p = @d.storage_create()
+
+      assert_equal expected_storage_path, @p.path
+      assert @p.store.empty?
+
+      assert_nil @p.get('key1')
+      assert_equal 'EMPTY', @p.fetch('key1', 'EMPTY')
+
+      @p.put('key1', '1')
+      assert_equal '1', @p.get('key1')
+
+      @p.update('key1') do |v|
+        (v.to_i * 2).to_s
+      end
+      assert_equal '2', @p.get('key1')
+
+      @p.save # stores all data into file
+
+      assert File.exist?(expected_storage_path)
+
+      @p.put('key2', 4)
+
+      @d.stop; @d.before_shutdown; @d.shutdown; @d.after_shutdown; @d.close; @d.terminate
+
+      assert_equal({'key1' => '2', 'key2' => 4}, File.open(expected_storage_path){|f| JSON.parse(f.read) })
+
+      # re-create to reload storage contents
+      @d = MyInput.new
+      Fluent::SystemConfig.overwrite_system_config('root_dir' => root_dir) do
+        @d.configure(conf)
+      end
+      @d.start
+      @p = @d.storage_create()
+
+      assert_false @p.store.empty?
+
+      assert_equal '2', @p.get('key1')
+      assert_equal 4, @p.get('key2')
+    end
+  end
+
+  sub_test_case 'persistent specified' do
+    test 'works well with path' do
+      omit "It's hard to test on Windows" if Fluent.windows?
+
+      storage_path = File.join(TMP_DIR, 'my_store.json')
+      conf = config_element('ROOT', '', {}, [config_element('storage', '', {'path' => storage_path, 'persistent' => 'true'})])
+      @d.configure(conf)
+      @d.start
+      @p = @d.storage_create()
+
+      assert_equal storage_path, @p.path
+      assert @p.store.empty?
+
+      assert_nil @p.get('key1')
+      assert_equal 'EMPTY', @p.fetch('key1', 'EMPTY')
+
+      @p.put('key1', '1')
+      assert_equal({'key1' => '1'}, File.open(storage_path){|f| JSON.parse(f.read) })
+
+      @p.update('key1') do |v|
+        (v.to_i * 2).to_s
+      end
+      assert_equal({'key1' => '2'}, File.open(storage_path){|f| JSON.parse(f.read) })
+    end
+
+    test 'works well with root-dir and plugin id' do
+      omit "It's hard to test on Windows" if Fluent.windows?
+
+      root_dir = File.join(TMP_DIR, 'root')
+      expected_storage_path = File.join(root_dir, 'worker0', 'local_storage_test', 'storage.json')
+      conf = config_element('ROOT', '', {'@id' => 'local_storage_test'}, [config_element('storage', '', {'persistent' => 'true'})])
+      Fluent::SystemConfig.overwrite_system_config('root_dir' => root_dir) do
+        @d.configure(conf)
+      end
+      @d.start
+      @p = @d.storage_create()
+
+      assert_equal expected_storage_path, @p.path
+      assert @p.store.empty?
+
+      assert_nil @p.get('key1')
+      assert_equal 'EMPTY', @p.fetch('key1', 'EMPTY')
+
+      @p.put('key1', '1')
+      assert_equal({'key1' => '1'}, File.open(expected_storage_path){|f| JSON.parse(f.read) })
+
+      @p.update('key1') do |v|
+        (v.to_i * 2).to_s
+      end
+      assert_equal({'key1' => '2'}, File.open(expected_storage_path){|f| JSON.parse(f.read) })
+    end
+
+    test 'raises error if it is configured to use on-memory storage' do
+      assert_raise Fluent::ConfigError.new("Plugin @id or path for <storage> required when 'persistent' is true") do
+        @d.configure(config_element('ROOT', '', {}, [config_element('storage', '', {'persistent' => 'true'})]))
+      end
+    end
+  end
+
+  sub_test_case 'with various configurations' do
+    test 'mode and dir_mode controls permissions of stored data' do
+      storage_path = File.join(TMP_DIR, 'dir', 'my_store.json')
+      storage_conf = {
+        'path' => storage_path,
+        'mode' => '0600',
+        'dir_mode' => '0777',
+      }
+      conf = config_element('ROOT', '', {}, [config_element('storage', '', storage_conf)])
+      @d.configure(conf)
+      @d.start
+      @p = @d.storage_create()
+
+      assert_equal storage_path, @p.path
+      assert @p.store.empty?
+
+      @p.put('key1', '1')
+      assert_equal '1', @p.get('key1')
+
+      @p.save # stores all data into file
+
+      assert File.exist?(storage_path)
+      assert_equal 0600, (File.stat(storage_path).mode % 01000)
+      assert_equal 0777, (File.stat(File.dirname(storage_path)).mode % 01000)
+    end
+
+    test 'pretty_print controls to write data in files as human-easy-to-read' do
+      storage_path = File.join(TMP_DIR, 'dir', 'my_store.json')
+      storage_conf = {
+        'path' => storage_path,
+        'pretty_print' => 'true',
+      }
+      conf = config_element('ROOT', '', {}, [config_element('storage', '', storage_conf)])
+      @d.configure(conf)
+      @d.start
+      @p = @d.storage_create()
+
+      assert_equal storage_path, @p.path
+      assert @p.store.empty?
+
+      @p.put('key1', '1')
+      assert_equal '1', @p.get('key1')
+
+      @p.save # stores all data into file
+
+      expected_pp_json = <<JSON.chomp
+{
+  "key1": "1"
+}
+JSON
+      assert_equal expected_pp_json, File.read(storage_path)
+    end
   end
 end

--- a/test/plugin_helper/test_child_process.rb
+++ b/test/plugin_helper/test_child_process.rb
@@ -226,55 +226,55 @@ class ChildProcessTest < Test::Unit::TestCase
     end
   end
 
-  unless Fluent.windows?
-    # In windows environment, child_process try KILL at first (because there's no SIGTERM)
-    test 'can execute external command just once, and can terminate it forcedly when shutdown/terminate even if it ignore SIGTERM' do
-      m = Mutex.new
-      ary = []
-      Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
-        ran = false
-        @d.child_process_execute(:t4, "ruby -e 'Signal.trap(:TERM, nil); while sleep #{TEST_WAIT_INTERVAL_FOR_LOOP}; puts 1; STDOUT.flush rescue nil; end'", mode: [:read]) do |io|
-          m.lock
-          ran = true
-          begin
-            while line = io.readline
-              ary << line
-            end
-          rescue
-            # ignore
-          ensure
-            m.unlock
-          end
-        end
-        sleep TEST_WAIT_INTERVAL_FOR_BLOCK_RUNNING until m.locked? || ran
+  # In windows environment, child_process try KILL at first (because there's no SIGTERM)
+  test 'can execute external command just once, and can terminate it forcedly when shutdown/terminate even if it ignore SIGTERM' do
+    omit "SIGTERM is unavailable on Windows" if Fluent.windows?
 
-        assert_equal [], @d.log.out.logs
-
-        @d.stop # nothing occurs
-        sleep TEST_WAIT_INTERVAL_FOR_LOOP * 5
-        lines1 = ary.size
-        assert{ lines1 > 1 }
-
-        pid = @d._child_process_processes.keys.first
-
-        @d.shutdown
-        sleep TEST_WAIT_INTERVAL_FOR_LOOP * 5
-        lines2 = ary.size
-        assert{ lines2 > lines1 }
-
-        @d.close
-
-        assert_nil((Process.waitpid(pid, Process::WNOHANG) rescue nil))
-
-        @d.terminate
-        assert @d._child_process_processes.empty?
+    m = Mutex.new
+    ary = []
+    Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
+      ran = false
+      @d.child_process_execute(:t4, "ruby -e 'Signal.trap(:TERM, nil); while sleep #{TEST_WAIT_INTERVAL_FOR_LOOP}; puts 1; STDOUT.flush rescue nil; end'", mode: [:read]) do |io|
+        m.lock
+        ran = true
         begin
-          Process.waitpid(pid)
-        rescue Errno::ECHILD
+          while line = io.readline
+            ary << line
+          end
+        rescue
+          # ignore
+        ensure
+          m.unlock
         end
-        # Process successfully KILLed if test reaches here
-        assert true
       end
+      sleep TEST_WAIT_INTERVAL_FOR_BLOCK_RUNNING until m.locked? || ran
+
+      assert_equal [], @d.log.out.logs
+
+      @d.stop # nothing occurs
+      sleep TEST_WAIT_INTERVAL_FOR_LOOP * 5
+      lines1 = ary.size
+      assert{ lines1 > 1 }
+
+      pid = @d._child_process_processes.keys.first
+
+      @d.shutdown
+      sleep TEST_WAIT_INTERVAL_FOR_LOOP * 5
+      lines2 = ary.size
+      assert{ lines2 > lines1 }
+
+      @d.close
+
+      assert_nil((Process.waitpid(pid, Process::WNOHANG) rescue nil))
+
+      @d.terminate
+      assert @d._child_process_processes.empty?
+      begin
+        Process.waitpid(pid)
+      rescue Errno::ECHILD
+      end
+      # Process successfully KILLed if test reaches here
+      assert true
     end
   end
 

--- a/test/plugin_helper/test_child_process.rb
+++ b/test/plugin_helper/test_child_process.rb
@@ -23,6 +23,7 @@ class ChildProcessTest < Test::Unit::TestCase
       @d.shutdown  unless @d.shutdown?
       @d.close     unless @d.closed?
       @d.terminate unless @d.terminated?
+      @d.log.reset
     end
   end
 

--- a/test/plugin_helper/test_storage.rb
+++ b/test/plugin_helper/test_storage.rb
@@ -102,7 +102,8 @@ class StorageHelperTest < Test::Unit::TestCase
   test 'can override default configuration parameters, but not overwrite whole definition' do
     d = Dummy.new
     d.configure(config_element())
-    assert_equal [], d.storage_configs
+    assert_equal 1, d.storage_configs.size
+    assert_equal 'local', d.storage_configs.first[:@type]
 
     d = Dummy2.new
     d.configure(config_element('ROOT', '', {}, [config_element('storage', '', {}, [])]))
@@ -130,7 +131,7 @@ class StorageHelperTest < Test::Unit::TestCase
     d = Dummy2.new
     d.configure(config_element())
     assert_raise Fluent::ConfigError.new("@type is required in <storage>") do
-      d.storage_create(conf: config_element('storage', '', {}), default_type: 'ex2')
+      d.storage_create(conf: config_element('storage', 'foo', {}), default_type: 'ex2')
     end
   end
 
@@ -139,7 +140,7 @@ class StorageHelperTest < Test::Unit::TestCase
     assert_nothing_raised do
       d.configure(config_element())
     end
-    assert_equal 0, d._storages.size
+    assert_equal 1, d._storages.size
   end
 
   test 'can be configured with a storage section' do

--- a/test/test_log.rb
+++ b/test/test_log.rb
@@ -643,7 +643,7 @@ class PluginLoggerMixinTest < Test::Unit::TestCase
 
   def test_start
     plugin = DummyPlugin.new
-    mock(plugin.log).reset
+    mock(plugin.log).should_receive(:reset).never
     plugin.start
   end
 

--- a/test/test_plugin_id.rb
+++ b/test/test_plugin_id.rb
@@ -1,5 +1,6 @@
 require_relative 'helper'
 require 'fluent/plugin/base'
+require 'fluent/system_config'
 require 'fileutils'
 
 class PluginIdTest < Test::Unit::TestCase

--- a/test/test_plugin_id.rb
+++ b/test/test_plugin_id.rb
@@ -1,0 +1,100 @@
+require_relative 'helper'
+require 'fluent/plugin/base'
+require 'fileutils'
+
+class PluginIdTest < Test::Unit::TestCase
+  TMP_DIR = File.expand_path(File.dirname(__FILE__) + "/tmp/plugin_id/#{ENV['TEST_ENV_NUMBER']}")
+
+  class MyPlugin < Fluent::Plugin::Base
+    include Fluent::PluginId
+  end
+
+  setup do
+    @p = MyPlugin.new
+  end
+
+  sub_test_case '#plugin_id_for_test?' do
+    test 'returns true always in test files' do
+      assert @p.plugin_id_for_test?
+    end
+
+    test 'returns false always out of test files' do
+      # TODO: no good way to write this test....
+    end
+  end
+
+  sub_test_case 'configured without @id' do
+    setup do
+      @p.configure(config_element())
+    end
+
+    test '#plugin_id_configured? returns false' do
+      assert_false @p.plugin_id_configured?
+    end
+
+    test '#plugin_id returns object_id based string' do
+      assert_kind_of String, @p.plugin_id
+      assert @p.plugin_id =~ /^object:[0-9a-f]+/
+    end
+
+    test '#plugin_root_dir returns nil' do
+      assert_nil @p.plugin_root_dir
+    end
+  end
+
+  sub_test_case 'configured with @id' do
+    setup do
+      FileUtils.rm_rf(TMP_DIR)
+      FileUtils.mkdir_p(TMP_DIR)
+      @p.configure(config_element('ROOT', '', {'@id' => 'testing_plugin_id'}))
+    end
+
+    test '#plugin_id_configured? returns true' do
+      assert @p.plugin_id_configured?
+    end
+
+    test '#plugin_id returns the configured value' do
+      assert_equal 'testing_plugin_id', @p.plugin_id
+    end
+
+    test '#plugin_root_dir returns nil without system root directory configuration' do
+      assert_nil @p.plugin_root_dir
+    end
+
+    test '#plugin_root_dir returns an existing directory path frozen String' do
+      root_dir = Fluent::SystemConfig.overwrite_system_config('root_dir' => File.join(TMP_DIR, "myroot")) do
+        @p.plugin_root_dir
+      end
+      assert_kind_of String, root_dir
+      assert Dir.exist?(root_dir)
+      assert root_dir =~ %r!/worker0/!
+      assert root_dir.frozen?
+    end
+
+    test '#plugin_root_dir returns the same value for 2nd or more call' do
+      root_dir = Fluent::SystemConfig.overwrite_system_config('root_dir' => File.join(TMP_DIR, "myroot")) do
+        @p.plugin_root_dir
+      end
+      twice = Fluent::SystemConfig.overwrite_system_config('root_dir' => File.join(TMP_DIR, "myroot")) do
+        @p.plugin_root_dir
+      end
+      assert_equal root_dir.object_id, twice.object_id
+    end
+
+    test '#plugin_root_dir referres SERVERENGINE_WORKER_ID environment path to create it' do
+      prev_env_val = ENV['SERVERENGINE_WORKER_ID']
+      begin
+        ENV['SERVERENGINE_WORKER_ID'] = '7'
+        root_dir = Fluent::SystemConfig.overwrite_system_config('root_dir' => File.join(TMP_DIR, "myroot")) do
+          @p.plugin_root_dir
+        end
+        assert_kind_of String, root_dir
+        assert Dir.exist?(root_dir)
+        assert root_dir =~ %r!/worker7/!
+        assert root_dir.frozen?
+      ensure
+        ENV['SERVERENGINE_WORKER_ID'] = prev_env_val
+      end
+    end
+  end
+end

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -15,6 +15,7 @@ class SupervisorTest < ::Test::Unit::TestCase
   include WorkerModule
 
   TMP_DIR = File.expand_path(File.dirname(__FILE__) + "/tmp/supervisor#{ENV['TEST_ENV_NUMBER']}")
+  TMP_ROOT_DIR = File.join(TMP_DIR, 'root')
 
   def setup
     FileUtils.rm_rf(TMP_DIR)
@@ -85,6 +86,7 @@ class SupervisorTest < ::Test::Unit::TestCase
   enable_get_dump true
   process_name "process_name"
   log_level info
+  root_dir #{TMP_ROOT_DIR}
 </system>
     EOC
     conf = Fluent::Config.parse(conf_data, "(test)", "(test_dir)", true)
@@ -99,6 +101,7 @@ class SupervisorTest < ::Test::Unit::TestCase
     assert_equal true, sys_conf.enable_get_dump
     assert_equal "process_name", sys_conf.process_name
     assert_equal 2, sys_conf.log_level
+    assert_equal TMP_ROOT_DIR, sys_conf.root_dir
   end
 
   def test_main_process_signal_handlers


### PR DESCRIPTION
This change introduces system-wide "root directory" and root directory per plugins.
It's enabled when:
* `root_dir` specified in `<system>` section
* `@id` configured in each plugin configuration sections

The root directories per plugin instances must be unique in a filesystem (between many workers of fluentd). So it uses `worker_id` provided by supervisor process via environment variable.
The path of directories are: `/system-wide-root/workerN/plugin-id` (generated and provided via `Fluent::Plugin::Base#plugin_root_dir`). Plugins will creates files or directories under that.

This change also adds 2 implementations to use this new feature:
* `buf_file`: configure buffer file `path` automatically
* `storage_local`: configure storage file `path` automatically

I have an additional plan to fix `in_tail` to use storage plugin as replacement of `pos_file`, but it's will be added by another pull-request.