### PR TITLE
Fix warnings

### DIFF
--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -299,8 +299,6 @@ module Fluent
       @out.reset if @out.respond_to?(:reset)
     end
 
-    private
-
     def dump_stacktrace(backtrace, level)
       return if @level > level
 

--- a/test/plugin/test_out_file.rb
+++ b/test/plugin/test_out_file.rb
@@ -136,7 +136,6 @@ class FileOutputTest < Test::Unit::TestCase
 
     test 'configured as secondary with primary using chunk_key_tag and not using chunk_key_time' do
       require 'fluent/plugin/out_null'
-      port = unused_port
       conf = config_element('match', '**', {
         }, [
           config_element('buffer', 'tag', {


### PR DESCRIPTION
Since ruby 2.4, `forwardable` checks the method visibility and it shows the warnings.
This patch simply removes private for targets methods.
