### PR TITLE
fix to change process name for supervisor process

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -502,6 +502,7 @@ module Fluent
     end
 
     def supervise
+      Process.setproctitle("supervisor:#{@process_name}") if @process_name
       $log.info "starting fluentd-#{Fluent::VERSION}", pid: Process.pid
 
       rubyopt = ENV["RUBYOPT"]


### PR DESCRIPTION
`process_name` parameter doesn't work. This code has been deleted at https://github.com/fluent/fluentd/commit/c1170cc0b83ec6c7875ee24abfe0b2dac46442f7.

before:
```
$ ps aux | grep fluentd
qwiggy    15870  1.0  0.4 251696 33664 pts/5    Sl+  02:17   0:01 ruby /home/qwiggy/work/fluentd/fluentd/vendor/bundle/ruby/2.1.0/bin/fluentd -c test.conf
qwiggy    15904  0.6  0.4 116404 33448 pts/5    Sl+  02:17   0:00 worker:fluentd1                                                            
```

after:
``` 
$ ps aux | grep fluentd
qwiggy    16248 21.3  0.4 251736 33656 pts/5    Sl+  02:20   0:01 supervisor:fluentd1                                                        
qwiggy    16282 16.0  0.4 116452 33436 pts/5    Sl+  02:20   0:00 worker:fluentd1                                                            
```