### PR TITLE
fix to break infinite-loop when shutdown goes on

### DIFF
--- a/example/in_dummy_blocks.conf
+++ b/example/in_dummy_blocks.conf
@@ -1,0 +1,17 @@
+<source>
+  @type dummy
+  tag dummy
+  rate 100
+  dummy {"message":"yaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaay"}
+</source>
+
+<match dummy>
+  @type null
+  never_flush true
+  <buffer>
+    @type memory
+    overflow_action block
+    chunk_limit_size 1k
+    total_limit_size 2k
+  </buffer>
+</match>

--- a/lib/fluent/plugin/out_null.rb
+++ b/lib/fluent/plugin/out_null.rb
@@ -21,6 +21,9 @@ module Fluent::Plugin
     # This plugin is for tests of non-buffered/buffered plugins
     Fluent::Plugin.register_output('null', self)
 
+    desc "The parameter for testing to simulate output plugin which never succeed to flush."
+    config_param :never_flush, :bool, default: false
+
     config_section :buffer do
       config_set_default :chunk_keys, ['tag']
       config_set_default :flush_at_shutdown, true
@@ -44,16 +47,19 @@ module Fluent::Plugin
     end
 
     def process(tag, es)
+      raise "failed to flush" if @never_flush
       # Do nothing
     end
 
     def write(chunk)
+      raise "failed to flush" if @never_flush
       if @feed_proc
         @feed_proc.call(chunk)
       end
     end
 
     def try_write(chunk)
+      raise "failed to flush" if @never_flush
       if @feed_proc
         @feed_proc.call(chunk)
       end


### PR DESCRIPTION
Current Fluentd master:HEAD doesn't run into infinite loop with the configuration file added by this change because thread plugin helper kills all threads (including input plugin thread emitting events).

But this change fixes the problem even with plugins creating threads by plugins themselves.
