### PR TITLE
Fix bug to ignore some command line options

### DIFF
--- a/example/suppress_config_dump.conf
+++ b/example/suppress_config_dump.conf
@@ -1,0 +1,7 @@
+<system>
+  suppress_config_dump false
+</system>
+
+<match data.*>
+  @type stdout
+</match>

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -374,7 +374,7 @@ module Fluent
         root_dir: nil,
         suppress_interval: 0,
         suppress_repeated_stacktrace: true,
-        without_source: false,
+        without_source: nil,
         use_v1_config: true,
         supervise: true,
         standalone_worker: false,

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -695,6 +695,7 @@ module Fluent
 
     def set_system_config
       @system_config = SystemConfig.create(@conf) # @conf is set in read_config
+      @system_config.attach(self)
       @system_config.apply(self)
     end
 

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -82,6 +82,26 @@ module Fluent
       s
     end
 
+    def attach(supervisor)
+      system = self
+      supervisor.instance_eval {
+        SYSTEM_CONFIG_PARAMETERS.each do |param|
+          case param
+          when :rpc_endpoint, :enable_get_dump, :process_name, :file_permission, :dir_permission
+            next # doesn't exist in command line options
+          when :emit_error_log_interval
+            system.emit_error_log_interval = @suppress_interval if @suppress_interval
+          else
+            next unless instance_variable_defined?("@#{param}")
+            supervisor_value = instance_variable_get("@#{param}")
+            next if supervisor_value.nil? # it's not configured by command line options
+
+            system.send("#{param}=", supervisor_value)
+          end
+        end
+      }
+    end
+
     def apply(supervisor)
       system = self
       supervisor.instance_eval {


### PR DESCRIPTION
Currently, supervisor overwrites values from command line options by system config values (even if no parameters are configured in `<system>` sections).
This makes a bug to ignore some command line options, which can be configured via both of command line options and system config section (For example, `--suppress-config-dump`).

This change makes command line options prior than system config parameters.
It's just standard way in all daemon software.
