### PR TITLE
close listening socket in #stop not to accept new connections anymore

### DIFF
--- a/lib/fluent/plugin/in_forward.rb
+++ b/lib/fluent/plugin/in_forward.rb
@@ -147,17 +147,19 @@ module Fluent::Plugin
     def start
       super
 
+      shared_socket = false
+
       server_create_connection(
         :in_forward_server, @port,
         bind: @bind,
-        shared: false,
+        shared: shared_socket,
         resolve_name: @resolve_hostname,
         linger_timeout: @linger_timeout,
         backlog: @backlog,
         &method(:handle_connection)
       )
 
-      server_create(:in_forward_server_udp_heartbeat, @port, shared: false, proto: :udp, bind: @bind, resolve_name: @resolve_hostname, max_bytes: 128) do |data, sock|
+      server_create(:in_forward_server_udp_heartbeat, @port, shared: shared_socket, proto: :udp, bind: @bind, resolve_name: @resolve_hostname, max_bytes: 128) do |data, sock|
         log.trace "heartbeat udp data arrived", host: sock.remote_host, port: sock.remote_port, data: data
         begin
           sock.write HEARTBEAT_UDP_PAYLOAD

--- a/lib/fluent/plugin_helper/server.rb
+++ b/lib/fluent/plugin_helper/server.rb
@@ -205,28 +205,23 @@ module Fluent
         @_server_mutex = Mutex.new
       end
 
-      def shutdown
-        @_server_connections.each do |conn|
-          conn.close rescue nil
-        end
+      def stop
         @_server_mutex.synchronize do
           @_servers.each do |si|
             si.server.detach if si.server.attached?
+            # to refuse more connections: (connected sockets are still alive here)
+            si.server.close rescue nil
           end
         end
 
         super
       end
 
-      def close
+      def shutdown
         @_server_connections.each do |conn|
           conn.close rescue nil
         end
-        @_server_mutex.synchronize do
-          @_servers.each do |si|
-            si.server.close rescue nil
-          end
-        end
+
         super
       end
 


### PR DESCRIPTION
This change is revival of #861, to close listening connections in #stop, not to accept connections to tell clients that this node denies incoming data now.

When `shared: true`, SocketManager in ServerEngine accepts connections. So plugin side cannot control it (this change doesn't affect to SM's behavior).
But it's correct, because other workers may be able to handle connections newly coming.