### PR TITLE
Update log events and its handling

### DIFF
--- a/example/logevents.conf
+++ b/example/logevents.conf
@@ -1,0 +1,25 @@
+<source>
+  @type dummy
+  @label @dummylog
+  tag "data"
+  dummy {"message":"yay"}
+</source>
+<label @dummylog>
+  <match **>
+    @type stdout
+  </match>
+</label>
+<label @FLUENT_LOG>
+  <match fluent.debug fluent.info fluent.warn fluent.error fluent.fatal>
+    @type stdout
+    <inject>
+      hostname_key "host"
+    </inject>
+  </match>
+  # <match fluent.{info,warn,error,fatal}>
+  #   @type stdout
+  #   <inject>
+  #     hostname_key "host"
+  #   </inject>
+  # </match>
+</label> 

--- a/lib/fluent/agent.rb
+++ b/lib/fluent/agent.rb
@@ -17,6 +17,7 @@
 require 'fluent/configurable'
 require 'fluent/plugin'
 require 'fluent/output'
+require 'fluent/match'
 
 module Fluent
   #
@@ -157,36 +158,6 @@ module Fluent
     end
 
     def handle_emits_error(tag, es, error)
-    end
-
-    class NoMatchMatch
-      def initialize(log)
-        @log = log
-        @count = 0
-      end
-
-      def emit_events(tag, es)
-        # TODO use time instead of num of records
-        c = (@count += 1)
-        if c < 512
-          if Math.log(c) / Math.log(2) % 1.0 == 0
-            @log.warn "no patterns matched", tag: tag
-            return
-          end
-        else
-          if c % 512 == 0
-            @log.warn "no patterns matched", tag: tag
-            return
-          end
-        end
-        @log.on_trace { @log.trace "no patterns matched", tag: tag }
-      end
-
-      def start
-      end
-
-      def shutdown
-      end
     end
   end
 end

--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -98,6 +98,10 @@ op.on('--log-rotate-size BYTES', 'sets the byte size to rotate log files') {|s|
   opts[:log_rotate_size] = s.to_i
 }
 
+op.on('--log-event-verbose', 'enable log events during process startup/shutdown') {|b|
+  opts[:log_event_verbose] = b
+}
+
 op.on('-i', '--inline-config CONFIG_STRING', "inline config which is appended to the config file on-the-fly") {|s|
   opts[:inline_config] = s
 }

--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -29,13 +29,15 @@ module Fluent
 
     def initialize
       @root_agent = nil
-      @event_router = nil
       @default_loop = nil
       @engine_stopped = false
 
+      @log_event_router = nil
       @log_emit_thread = nil
       @log_event_loop_stop = false
+      @log_event_loop_graceful_stop = false
       @log_event_queue = []
+      @log_event_verbose = false
 
       @suppress_config_dump = false
 
@@ -57,6 +59,8 @@ module Fluent
       suppress_interval(system_config.emit_error_log_interval) unless system_config.emit_error_log_interval.nil?
       @suppress_config_dump = system_config.suppress_config_dump unless system_config.suppress_config_dump.nil?
       @without_source = system_config.without_source unless system_config.without_source.nil?
+
+      @log_event_verbose = system_config.log_event_verbose unless system_config.log_event_verbose.nil?
 
       @root_agent = RootAgent.new(log: log, system_config: @system_config)
 
@@ -111,7 +115,30 @@ module Fluent
       end
 
       @root_agent.configure(conf)
-      @event_router = @root_agent.event_router
+
+      begin
+        log_event_agent = @root_agent.find_label(Fluent::Log::LOG_EVENT_LABEL)
+        log_event_router = log_event_agent.event_router
+
+        # suppress mismatched tags only for <label @FLUENT_LOG> label.
+        # it's not suppressed in default event router for non-log-event events
+        log_event_router.suppress_missing_match!
+
+      rescue ArgumentError # ArgumentError "#{label_name} label not found"
+        # use default event router if <label @FLUENT_LOG> is missing in configuration
+        log_event_router = @root_agent.event_router
+      end
+
+      if Fluent::Log.event_tags.any?{|t| log_event_router.match?(t) }
+        @log_event_router = log_event_router
+
+        unmatched_tags = Fluent::Log.event_tags.select{|t| !@log_event_router.match?(t) }
+        unless unmatched_tags.empty?
+          $log.warn "match for some tags of log events are not defined (to be ignored)", tags: unmatched_tags
+        end
+      end
+
+      $log.enable_event(true) if @log_event_router
 
       unless @suppress_config_dump
         $log.info "using configuration file: #{conf.to_s.rstrip}"
@@ -148,6 +175,7 @@ module Fluent
 
       while sleep(LOG_EMIT_INTERVAL)
         break if @log_event_loop_stop
+        break if @log_event_loop_graceful_stop && @log_event_queue.empty?
         next if @log_event_queue.empty?
 
         # NOTE: thead-safe of slice! depends on GVL
@@ -156,8 +184,9 @@ module Fluent
 
         events.each {|tag,time,record|
           begin
-            @event_router.emit(tag, time, record)
+            @log_event_router.emit(tag, time, record)
           rescue => e
+            # This $log.error doesn't emit log events, because of `$log.disable_events(Thread.current)` above
             $log.error "failed to emit fluentd's log event", tag: tag, event: record, error: e
           end
         }
@@ -170,13 +199,14 @@ module Fluent
         $log.info "starting fluentd worker", pid: Process.pid, ppid: Process.ppid, worker: worker_id
         start
 
-        if @event_router.match?($log.tag)
-          $log.enable_event
+        if @log_event_router
+          $log.enable_event(true)
           @log_emit_thread = Thread.new(&method(:log_event_loop))
         end
 
         $log.info "fluentd worker is now running" # TODO: worker number
         sleep MAINLOOP_SLEEP_INTERVAL until @engine_stopped
+        $log.info "fluentd worker is now stopping" # TODO: worker number
 
       rescue Exception => e
         $log.error "unexpected error", error: e
@@ -184,6 +214,15 @@ module Fluent
         raise
       end
 
+      unless @log_event_verbose
+        $log.enable_event(false)
+        if @log_emit_thread
+          # to make sure to emit all log events into router, before shutting down
+          @log_event_loop_graceful_stop = true
+          @log_emit_thread.join
+          @log_emit_thread = nil
+        end
+      end
       $log.info "shutting down fluentd worker" # TODO: worker number
       shutdown
       if @log_emit_thread

--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -124,17 +124,23 @@ module Fluent
         # it's not suppressed in default event router for non-log-event events
         log_event_router.suppress_missing_match!
 
-      rescue ArgumentError # ArgumentError "#{label_name} label not found"
-        # use default event router if <label @FLUENT_LOG> is missing in configuration
-        log_event_router = @root_agent.event_router
-      end
-
-      if Fluent::Log.event_tags.any?{|t| log_event_router.match?(t) }
         @log_event_router = log_event_router
 
         unmatched_tags = Fluent::Log.event_tags.select{|t| !@log_event_router.match?(t) }
         unless unmatched_tags.empty?
           $log.warn "match for some tags of log events are not defined (to be ignored)", tags: unmatched_tags
+        end
+      rescue ArgumentError # ArgumentError "#{label_name} label not found"
+        # use default event router if <label @FLUENT_LOG> is missing in configuration
+        log_event_router = @root_agent.event_router
+
+        if Fluent::Log.event_tags.any?{|t| log_event_router.match?(t) }
+          @log_event_router = log_event_router
+
+          unmatched_tags = Fluent::Log.event_tags.select{|t| !@log_event_router.match?(t) }
+          unless unmatched_tags.empty?
+            $log.warn "match for some tags of log events are not defined (to be ignored)", tags: unmatched_tags
+          end
         end
       end
 

--- a/lib/fluent/event_router.rb
+++ b/lib/fluent/event_router.rb
@@ -71,6 +71,12 @@ module Fluent
       attr_reader :pattern_str
     end
 
+    def suppress_missing_match!
+      if @default_collector.respond_to?(:suppress_missing_match!)
+        @default_collector.suppress_missing_match!
+      end
+    end
+
     # called by Agent to add new match pattern and collector
     def add_rule(pattern, collector)
       @match_rules << Rule.new(pattern, collector)

--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -138,6 +138,13 @@ module Fluent
       self
     end
 
+    # If you want to suppress event emitting in specific thread, please use this method.
+    # Events in passed thread are never emitted.
+    def disable_events(thread)
+      # this method is not symmetric with #enable_event.
+      @threads_exclude_events.push(thread) unless @threads_exclude_events.include?(thread)
+    end
+
     def enable_color?
       !@color_reset.empty?
     end
@@ -161,12 +168,6 @@ module Fluent
         @color_reset = ''
       end
       self
-    end
-
-    # If you want to suppress event emitting in specific thread, please use this method.
-    # Events in passed thread are never emitted.
-    def disable_events(thread)
-      @threads_exclude_events.push(thread) unless @threads_exclude_events.include?(thread)
     end
 
     def on_trace(&block)

--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -351,7 +351,7 @@ module Fluent
           record[key] = record[key].inspect unless record[key].respond_to?(:to_msgpack)
         }
         record['message'] = message.dup
-        @engine.push_log_event("#{LOG_EVENT_TAG_PREFIX}.#{level}", time.to_i, record)
+        @engine.push_log_event("#{LOG_EVENT_TAG_PREFIX}.#{level}", Fluent::EventTime.from_time(time), record)
       end
 
       return time, message

--- a/lib/fluent/match.rb
+++ b/lib/fluent/match.rb
@@ -138,4 +138,34 @@ module Fluent
       @patterns.any? {|pattern| pattern.match(str) }
     end
   end
+
+  class NoMatchMatch
+    def initialize(log)
+      @log = log
+      @count = 0
+    end
+
+    def emit_events(tag, es)
+      # TODO use time instead of num of records
+      c = (@count += 1)
+      if c < 512
+        if Math.log(c) / Math.log(2) % 1.0 == 0
+          @log.warn "no patterns matched", tag: tag
+          return
+        end
+      else
+        if c % 512 == 0
+          @log.warn "no patterns matched", tag: tag
+          return
+        end
+      end
+      @log.on_trace { @log.trace "no patterns matched", tag: tag }
+    end
+
+    def start
+    end
+
+    def shutdown
+    end
+  end
 end

--- a/lib/fluent/match.rb
+++ b/lib/fluent/match.rb
@@ -143,9 +143,16 @@ module Fluent
     def initialize(log)
       @log = log
       @count = 0
+      @warn_not_matched = true
+    end
+
+    def suppress_missing_match!
+      # for <label @FLUENT_LOG>
+      @warn_not_matched = false
     end
 
     def emit_events(tag, es)
+      return unless @warn_not_matched
       # TODO use time instead of num of records
       c = (@count += 1)
       if c < 512

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -406,6 +406,7 @@ module Fluent
       @log_rotate_size = opt[:log_rotate_size]
       @suppress_interval = opt[:suppress_interval]
       @suppress_config_dump = opt[:suppress_config_dump]
+      @log_event_verbose = opt[:log_event_verbose]
       @without_source = opt[:without_source]
       @signame = opt[:signame]
 

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -24,6 +24,7 @@ module Fluent
     SYSTEM_CONFIG_PARAMETERS = [
       :root_dir, :log_level,
       :suppress_repeated_stacktrace, :emit_error_log_interval, :suppress_config_dump,
+      :log_event_verbose,
       :without_source, :rpc_endpoint, :enable_get_dump, :process_name,
       :file_permission, :dir_permission,
     ]
@@ -35,6 +36,7 @@ module Fluent
     config_param :suppress_repeated_stacktrace, :bool, default: nil
     config_param :emit_error_log_interval, :time, default: nil
     config_param :suppress_config_dump, :bool, default: nil
+    config_param :log_event_verbose, :bool, default: nil
     config_param :without_source, :bool, default: nil
     config_param :rpc_endpoint, :string, default: nil
     config_param :enable_get_dump, :bool, default: nil

--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -289,7 +289,7 @@ CONF
 
     test 'by top level <match> section with warning for missing log levels (and warnings for each log event records)' do
       conf = @basic_conf + <<CONF
-<match fluent.warn fluent.error fluent.fatal>
+<match fluent.info fluent.warn fluent.error fluent.fatal>
   @type stdout
 </match>
 CONF
@@ -298,7 +298,7 @@ CONF
         create_cmdline(conf_path),
         "fluentd worker is now running",
         'fluent.info: {"message":"fluentd worker is now running"}',
-        '[warn]: some tags for log events are not defined (to be ignored) tags=["fluent.trace", "fluent.debug"]',
+        '[warn]: match for some tags of log events are not defined (to be ignored) tags=["fluent.trace", "fluent.debug"]',
       )
     end
 
@@ -315,7 +315,7 @@ CONF
         create_cmdline(conf_path),
         "fluentd worker is now running",
         'fluent.info: {"message":"fluentd worker is now running"}',
-        patterns_not_match: ['[warn]: some tags for log events are not defined (to be ignored) tags=["fluent.trace", "fluent.debug"]'],
+        patterns_not_match: ['[warn]: some tags for log events are not defined (to be ignored)'],
       )
     end
 
@@ -335,7 +335,7 @@ CONF
         create_cmdline(conf_path),
         "fluentd worker is now running",
         'fluent.info: {"message":"fluentd worker is now running"}',
-        '[warn]: some tags for log events are not defined (to be ignored) tags=["fluent.fatal"]',
+        '[warn]: match for some tags of log events are not defined (to be ignored) tags=["fluent.fatal"]',
       )
     end
   end

--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -256,6 +256,90 @@ CONF
     end
   end
 
+  sub_test_case 'configured to route log events to plugins' do
+    setup do
+      @basic_conf = <<CONF
+<source>
+  @type dummy
+  @id dummy
+  tag dummy
+  dummy {"message": "yay!"}
+</source>
+<match dummy>
+  @type null
+  @id   blackhole
+</match>
+CONF
+    end
+
+    test 'by top level <match fluent.*> section' do
+      conf = @basic_conf + <<CONF
+<match fluent.**>
+  @type stdout
+</match>
+CONF
+      conf_path = create_conf_file('logevent_1.conf', conf)
+      assert_log_matches(
+        create_cmdline(conf_path),
+        "fluentd worker is now running",
+        'fluent.info: {"message":"fluentd worker is now running"}',
+        patterns_not_match: ['[warn]: some tags for log events are not defined (to be ignored) tags=["fluent.trace", "fluent.debug"]'],
+      )
+    end
+
+    test 'by top level <match> section with warning for missing log levels (and warnings for each log event records)' do
+      conf = @basic_conf + <<CONF
+<match fluent.warn fluent.error fluent.fatal>
+  @type stdout
+</match>
+CONF
+      conf_path = create_conf_file('logevent_2.conf', conf)
+      assert_log_matches(
+        create_cmdline(conf_path),
+        "fluentd worker is now running",
+        'fluent.info: {"message":"fluentd worker is now running"}',
+        '[warn]: some tags for log events are not defined (to be ignored) tags=["fluent.trace", "fluent.debug"]',
+      )
+    end
+
+    test 'by <label @FLUENT_LOG> section' do
+      conf = @basic_conf + <<CONF
+<label @FLUENT_LOG>
+  <match **>
+    @type stdout
+  </match>
+</label>
+CONF
+      conf_path = create_conf_file('logevent_3.conf', conf)
+      assert_log_matches(
+        create_cmdline(conf_path),
+        "fluentd worker is now running",
+        'fluent.info: {"message":"fluentd worker is now running"}',
+        patterns_not_match: ['[warn]: some tags for log events are not defined (to be ignored) tags=["fluent.trace", "fluent.debug"]'],
+      )
+    end
+
+    test 'by <label> section with warning for missing log levels' do
+      conf = @basic_conf + <<CONF
+<label @FLUENT_LOG>
+  <match fluent.{trace,debug}>
+    @type null
+  </match>
+  <match fluent.info fluent.warn fluent.error>
+    @type stdout
+  </match>
+</label>
+CONF
+      conf_path = create_conf_file('logevent_4.conf', conf)
+      assert_log_matches(
+        create_cmdline(conf_path),
+        "fluentd worker is now running",
+        'fluent.info: {"message":"fluentd worker is now running"}',
+        '[warn]: some tags for log events are not defined (to be ignored) tags=["fluent.fatal"]',
+      )
+    end
+  end
+
   sub_test_case 'configured to suppress configration dump' do
     setup do
       @basic_conf = <<CONF

--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -289,7 +289,7 @@ CONF
 
     test 'by top level <match> section with warning for missing log levels (and warnings for each log event records)' do
       conf = @basic_conf + <<CONF
-<match fluent.info fluent.warn fluent.error fluent.fatal>
+<match fluent.warn fluent.error fluent.fatal>
   @type stdout
 </match>
 CONF
@@ -297,8 +297,8 @@ CONF
       assert_log_matches(
         create_cmdline(conf_path),
         "fluentd worker is now running",
-        'fluent.info: {"message":"fluentd worker is now running"}',
-        '[warn]: match for some tags of log events are not defined (to be ignored) tags=["fluent.trace", "fluent.debug"]',
+        '[warn]: match for some tags of log events are not defined (to be ignored) tags=["fluent.trace", "fluent.debug", "fluent.info"]',
+        '[warn]: no patterns matched tag="fluent.info"',
       )
     end
 
@@ -325,7 +325,7 @@ CONF
   <match fluent.{trace,debug}>
     @type null
   </match>
-  <match fluent.info fluent.warn fluent.error>
+  <match fluent.warn fluent.error>
     @type stdout
   </match>
 </label>
@@ -334,8 +334,8 @@ CONF
       assert_log_matches(
         create_cmdline(conf_path),
         "fluentd worker is now running",
-        'fluent.info: {"message":"fluentd worker is now running"}',
-        '[warn]: match for some tags of log events are not defined (to be ignored) tags=["fluent.fatal"]',
+        '[warn]: match for some tags of log events are not defined (to be ignored) tags=["fluent.info", "fluent.fatal"]',
+        patterns_not_match: ['[warn]: no patterns matched tag="fluent.info"'],
       )
     end
   end

--- a/test/config/test_system_config.rb
+++ b/test/config/test_system_config.rb
@@ -20,6 +20,8 @@ module Fluent::Config
       @suppress_interval = nil
       @suppress_config_dump = nil
       @suppress_repeated_stacktrace = nil
+      @log_event_label = nil
+      @log_event_verbose = nil
       @without_source = nil
       @emit_error_log_interval = nil
       @file_permission = nil
@@ -54,6 +56,7 @@ module Fluent::Config
       assert_nil(s.instance_variable_get(:@suppress_repeated_stacktrace))
       assert_nil(s.instance_variable_get(:@emit_error_log_interval))
       assert_nil(s.instance_variable_get(:@suppress_config_dump))
+      assert_nil(s.instance_variable_get(:@log_event_verbose))
       assert_nil(s.instance_variable_get(:@without_source))
       assert_nil(s.instance_variable_get(:@file_permission))
       assert_nil(s.instance_variable_get(:@dir_permission))
@@ -64,6 +67,7 @@ module Fluent::Config
       'log_level' => ['log_level', 'error'],
       'suppress_repeated_stacktrace' => ['suppress_repeated_stacktrace', true],
       'emit_error_log_interval' => ['emit_error_log_interval', 60],
+      'log_event_verbose' => ['log_event_verbose', true],
       'suppress_config_dump' => ['suppress_config_dump', true],
       'without_source' => ['without_source', true],
     )
@@ -94,6 +98,7 @@ module Fluent::Config
       assert_nil(s.instance_variable_get(:@suppress_repeated_stacktrace))
       assert_nil(s.instance_variable_get(:@emit_error_log_interval))
       assert_nil(s.instance_variable_get(:@suppress_config_dump))
+      assert_nil(s.instance_variable_get(:@log_event_verbose))
       assert_nil(s.instance_variable_get(:@without_source))
       assert_nil(s.instance_variable_get(:@file_permission))
       assert_nil(s.instance_variable_get(:@dir_permission))

--- a/test/test_log.rb
+++ b/test/test_log.rb
@@ -374,12 +374,8 @@ class LogTest < Test::Unit::TestCase
     log1 = Fluent::Log.new(logger)
     log2 = log1.dup
     log1.level = Fluent::Log::LEVEL_DEBUG
-    original_tag = log1.tag
-    log1.tag = "changed"
     assert_equal(Fluent::Log::LEVEL_DEBUG, log1.level)
     assert_equal(Fluent::Log::LEVEL_TRACE, log2.level)
-    assert_equal("changed", log1.tag)
-    assert_equal(original_tag, log2.tag)
   end
 
   def test_disable_events
@@ -388,6 +384,7 @@ class LogTest < Test::Unit::TestCase
     logdev = @log_device
     logger = ServerEngine::DaemonLogger.new(logdev, dl_opts)
     log = Fluent::Log.new(logger)
+    log.enable_event(true)
     engine = log.instance_variable_get("@engine")
     mock(engine).push_log_event(anything, anything, anything).once
     log.trace "trace log"
@@ -554,12 +551,6 @@ class PluginLoggerTest < Test::Unit::TestCase
     def test_disable_events
       mock(@logger).disable_events(Thread.current)
       @log.disable_events(Thread.current)
-    end
-
-    def test_tag
-      assert_equal(@log.tag, @logger.tag)
-      @log.tag = "dummy"
-      assert_equal(@log.tag, @logger.tag)
     end
 
     def test_time_format


### PR DESCRIPTION
There are some issues and unexpected behavior about log events (`fluent.**` events).
This change is to fix these problems and add features.

* log events can be routed only by `<match fluent.**>` sections
  * unexpectedly, `<match fluent.info>` section doesn't work #485 
* log events can be matched only by top-level match sections
  * we are recommending label routing for all events #1038 
* log events sometimes occurs unexpected errors in shutting down
  * log events may be routed into plugins already shutdown

Added features and changes:
* logger emits log events into `@FLUENT_LOG` labels if exists
  * In that sections, mis-matched logs will be ignored without warnings (missed tags are warned at startup)
  * This behavior estimates log levels of standard loggers
* Log events will NOT be emitted before completion of startup (including `#configure` and `#start` of each plugiins), and after entering shutdown sequence (`#stop`, `#shutdown`...)
  * `--log-event-verbose` (or `log_event_verbose` in system config) turns log events on even in startup and shutting down
* Fix logger to prohibit changing tag prefix from "fluent"
  * There is no use-case to change that tag prefix

Fixes #485, #1038 