### PR TITLE
Encode utf8 for configuration string values

### DIFF
--- a/lib/fluent/config/configure_proxy.rb
+++ b/lib/fluent/config/configure_proxy.rb
@@ -126,7 +126,7 @@ module Fluent
         merged.configured_in_section = self.configured_in_section || other.configured_in_section
 
         merged.argument = other.argument || self.argument
-        merged.params = other.params.merge(self.params)
+        merged.params = self.params.merge(other.params)
         merged.defaults = self.defaults.merge(other.defaults)
         merged.sections = {}
         (self.sections.keys + other.sections.keys).uniq.each do |section_key|

--- a/lib/fluent/config/types.rb
+++ b/lib/fluent/config/types.rb
@@ -64,7 +64,7 @@ module Fluent
       end
     end
 
-    STRING_TYPE = Proc.new { |val, opts| val }
+    STRING_TYPE = Proc.new { |val, opts| val.to_s.encode(Encoding::UTF_8) }
     ENUM_TYPE = Proc.new { |val, opts|
       s = val.to_sym
       list = opts[:list]
@@ -85,7 +85,7 @@ module Fluent
         value
       else
         case type
-        when :string  then value.to_s
+        when :string  then value.to_s.encode(Encoding::UTF_8)
         when :integer then value.to_i
         when :float   then value.to_f
         when :size then Config.size_value(value)

--- a/lib/fluent/plugin/buf_file.rb
+++ b/lib/fluent/plugin/buf_file.rb
@@ -89,7 +89,9 @@ module Fluent
           end
         end
 
-        unless @dir_permission
+        if @dir_permission
+          @dir_permission = @dir_permission.to_i(8) if @dir_permission.is_a?(String)
+        else
           @dir_permission = system_config.dir_permission || DIR_PERMISSION
         end
       end

--- a/lib/fluent/plugin/buffer/file_chunk.rb
+++ b/lib/fluent/plugin/buffer/file_chunk.rb
@@ -42,12 +42,12 @@ module Fluent
 
         def initialize(metadata, path, mode, perm: system_config.file_permission || FILE_PERMISSION, compress: :text)
           super(metadata, compress: compress)
-          @permission = perm
+          @permission = perm.is_a?(String) ? perm.to_i(8) : perm
           @bytesize = @size = @adding_bytes = @adding_size = 0
           @meta = nil
 
           case mode
-          when :create then create_new_chunk(path, perm)
+          when :create then create_new_chunk(path, @permission)
           when :staged then load_existing_staged_chunk(path)
           when :queued then load_existing_enqueued_chunk(path)
           else

--- a/test/config/test_types.rb
+++ b/test/config/test_types.rb
@@ -66,6 +66,7 @@ class TestConfigTypes < ::Test::Unit::TestCase
       assert_equal 'test', Config::STRING_TYPE.call('test', {})
       assert_equal '1', Config::STRING_TYPE.call('1', {})
       assert_equal '   ', Config::STRING_TYPE.call('   ', {})
+      assert_equal Encoding::UTF_8, Config::STRING_TYPE.call('test', {}).encoding
     end
 
     test 'enum' do

--- a/test/plugin/test_buf_file.rb
+++ b/test/plugin/test_buf_file.rb
@@ -141,7 +141,7 @@ class FileBufferTest < Test::Unit::TestCase
       FileUtils.rm_r bufdir if File.exist?(bufdir)
       assert !File.exist?(bufdir)
 
-      plugin.configure(config_element('buffer', '', {'path' => bufpath, 'dir_permission' => 0700}))
+      plugin.configure(config_element('buffer', '', {'path' => bufpath, 'dir_permission' => '0700'}))
       assert !File.exist?(bufdir)
 
       plugin.start
@@ -215,7 +215,7 @@ class FileBufferTest < Test::Unit::TestCase
       FileUtils.rm_r bufdir if File.exist?(bufdir)
       assert !File.exist?(bufdir)
 
-      plugin.configure(config_element('buffer', '', {'path' => bufpath, 'file_permission' => 0600}))
+      plugin.configure(config_element('buffer', '', {'path' => bufpath, 'file_permission' => '0600'}))
       assert !File.exist?(bufdir)
       plugin.start
 


### PR DESCRIPTION
The parameters defined as `config_param :name, :string` may produce ASCII-8BIT String values, but it's unexpected values for most plugin authors and users (these values will be packed into `bin` in msgpack).
This change encodes string values in utf8.
