### PR TITLE
Rename parameter names with the rule of other params

### DIFF
--- a/lib/fluent/plugin/buffer.rb
+++ b/lib/fluent/plugin/buffer.rb
@@ -47,10 +47,10 @@ module Fluent
 
       # If user specify this value and (chunk_size * queue_length) is smaller than total_size,
       # then total_size is automatically configured to that value
-      config_param :queue_length_limit, :integer, default: nil
+      config_param :queue_limit_length, :integer, default: nil
 
       # optional new limitations
-      config_param :chunk_records_limit, :integer, default: nil
+      config_param :chunk_limit_records, :integer, default: nil
 
       # if chunk size (or records) is 95% or more after #write, then that chunk will be enqueued
       config_param :chunk_full_threshold, :float, default: DEFAULT_CHUNK_FULL_THRESHOLD
@@ -73,8 +73,8 @@ module Fluent
 
         @chunk_limit_size = nil
         @total_limit_size = nil
-        @queue_length_limit = nil
-        @chunk_records_limit = nil
+        @queue_limit_length = nil
+        @chunk_limit_records = nil
 
         @stage = {}    #=> Hash (metadata -> chunk) : not flushed yet
         @queue = []    #=> Array (chunks)           : already flushed (not written)
@@ -92,8 +92,8 @@ module Fluent
       def configure(conf)
         super
 
-        unless @queue_length_limit.nil?
-          @total_limit_size = @chunk_limit_size * @queue_length_limit
+        unless @queue_limit_length.nil?
+          @total_limit_size = @chunk_limit_size * @queue_limit_length
         end
       end
 
@@ -142,7 +142,7 @@ module Fluent
 
       ## TODO: for back pressure feature
       # def used?(ratio)
-      #   @total_size_limit * ratio > @stage_size + @queue_size
+      #   @total_limit_size * ratio > @stage_size + @queue_size
       # end
 
       def resume
@@ -433,11 +433,11 @@ module Fluent
       end
 
       def chunk_size_over?(chunk)
-        chunk.bytesize > @chunk_limit_size || (@chunk_records_limit && chunk.size > @chunk_records_limit)
+        chunk.bytesize > @chunk_limit_size || (@chunk_limit_records && chunk.size > @chunk_limit_records)
       end
 
       def chunk_size_full?(chunk)
-        chunk.bytesize >= @chunk_limit_size * @chunk_full_threshold || (@chunk_records_limit && chunk.size >= @chunk_records_limit * @chunk_full_threshold)
+        chunk.bytesize >= @chunk_limit_size * @chunk_full_threshold || (@chunk_limit_records && chunk.size >= @chunk_limit_records * @chunk_full_threshold)
       end
 
       class ShouldRetry < StandardError; end

--- a/lib/fluent/plugin_helper/compat_parameters.rb
+++ b/lib/fluent/plugin_helper/compat_parameters.rb
@@ -36,7 +36,7 @@ module Fluent
         "retry_limit"         => "retry_max_times",
         "max_retry_wait"      => "retry_max_interval",
         "buffer_chunk_limit"  => "chunk_limit_size",
-        "buffer_queue_limit"  => "queue_length_limit",
+        "buffer_queue_limit"  => "queue_limit_length",
         "buffer_queue_full_action" => "overflow_action",
         "flush_at_shutdown" => "flush_at_shutdown",
       }

--- a/test/plugin/test_buffer.rb
+++ b/test/plugin/test_buffer.rb
@@ -138,7 +138,7 @@ class BufferTest < Test::Unit::TestCase
     end
 
     test 'chunk records limit is ignored in default' do
-      assert_nil @p.chunk_records_limit
+      assert_nil @p.chunk_limit_records
     end
 
     test '#storable? checks total size of staged and enqueued(includes dequeued chunks) against total_limit_size' do
@@ -1113,9 +1113,9 @@ class BufferTest < Test::Unit::TestCase
     end
   end
 
-  sub_test_case 'with configuration includes chunk_records_limit' do
+  sub_test_case 'with configuration includes chunk_limit_records' do
     setup do
-      @p = create_buffer({"chunk_limit_size" => 1024, "total_limit_size" => 10240, "chunk_records_limit" => 6})
+      @p = create_buffer({"chunk_limit_size" => 1024, "total_limit_size" => 10240, "chunk_limit_records" => 6})
       @dm0 = dm0 = create_metadata(Time.parse('2016-04-11 16:00:00 +0000').to_i, nil, nil)
       @dm1 = dm1 = create_metadata(Time.parse('2016-04-11 16:10:00 +0000').to_i, nil, nil)
       @dm2 = dm2 = create_metadata(Time.parse('2016-04-11 16:20:00 +0000').to_i, nil, nil)
@@ -1139,7 +1139,7 @@ class BufferTest < Test::Unit::TestCase
     end
 
     test '#chunk_size_over? returns true if too many records exists in a chunk even if its bytes is less than limit' do
-      assert_equal 6, @p.chunk_records_limit
+      assert_equal 6, @p.chunk_limit_records
 
       m = create_metadata(Time.parse('2016-04-11 16:40:00 +0000').to_i)
 
@@ -1155,7 +1155,7 @@ class BufferTest < Test::Unit::TestCase
     end
 
     test '#chunk_size_full? returns true if enough many records exists in a chunk even if its bytes is less than limit' do
-      assert_equal 6, @p.chunk_records_limit
+      assert_equal 6, @p.chunk_limit_records
 
       m = create_metadata(Time.parse('2016-04-11 16:40:00 +0000').to_i)
 
@@ -1171,9 +1171,9 @@ class BufferTest < Test::Unit::TestCase
     end
   end
 
-  sub_test_case 'with configuration includes queue_length_limit' do
+  sub_test_case 'with configuration includes queue_limit_length' do
     setup do
-      @p = create_buffer({"chunk_limit_size" => 1024, "total_limit_size" => 10240, "queue_length_limit" => 5})
+      @p = create_buffer({"chunk_limit_size" => 1024, "total_limit_size" => 10240, "queue_limit_length" => 5})
       @dm0 = dm0 = create_metadata(Time.parse('2016-04-11 16:00:00 +0000').to_i, nil, nil)
       @dm1 = dm1 = create_metadata(Time.parse('2016-04-11 16:10:00 +0000').to_i, nil, nil)
       @dm2 = dm2 = create_metadata(Time.parse('2016-04-11 16:20:00 +0000').to_i, nil, nil)
@@ -1196,9 +1196,9 @@ class BufferTest < Test::Unit::TestCase
       @p.start
     end
 
-    test '#configure will overwrite standard configuration if queue_length_limit' do
+    test '#configure will overwrite standard configuration if queue_limit_length' do
       assert_equal 1024, @p.chunk_limit_size
-      assert_equal 5, @p.queue_length_limit
+      assert_equal 5, @p.queue_limit_length
       assert_equal (1024*5), @p.total_limit_size
     end
   end

--- a/test/plugin_helper/test_compat_parameters.rb
+++ b/test/plugin_helper/test_compat_parameters.rb
@@ -109,7 +109,7 @@ class CompatParameterTest < Test::Unit::TestCase
       assert @i.buffer_config.flush_at_shutdown
 
       assert_equal 8*1024*1024, @i.buffer.chunk_limit_size
-      assert_equal 1024, @i.buffer.queue_length_limit
+      assert_equal 1024, @i.buffer.queue_limit_length
     end
   end
 


### PR DESCRIPTION
This change is to rename two buffer parameters:
* `chunk_records_limit` -> `chunk_limit_records`
* `queue_length_limit` -> `queue_limit_length`

These new names are named under the same rule with other parameters:
* `chunk_limit_size`
* `total_limit_size`

Once (in very early era in v0.14) these parameters were renamed from `chunk_size_limit` and `total_size_limit` with consultation of some English native speakers, but some others were unchanged at that time.
But I think these should be named under the same rule for consistency.

These parameters are still undocumented, so I believe we can do it now, only right now.