### PR TITLE
Use BasicObject for cleanroom

### DIFF
--- a/lib/fluent/plugin/filter_record_transformer.rb
+++ b/lib/fluent/plugin/filter_record_transformer.rb
@@ -307,13 +307,9 @@ module Fluent::Plugin
         raise "failed to expand `#{str}` : error = #{e}"
       end
 
-      class CleanroomExpander
+      class CleanroomExpander < BasicObject
         def expand(__str_to_eval__, tag, time, record, tag_parts, tag_prefix, tag_suffix, hostname)
           instance_eval(__str_to_eval__)
-        end
-
-        (Object.instance_methods).each do |m|
-          undef_method m unless m.to_s =~ /^__|respond_to_missing\?|object_id|public_methods|instance_eval|method_missing|define_singleton_method|respond_to\?|new_ostruct_member/
         end
       end
     end


### PR DESCRIPTION
BasicObject has following methods:

    >> BasicObject.instance_methods
    => [:!, :==, :!=, :__send__, :equal?, :instance_eval, :instance_exec, :__id__]