### PR TITLE
…

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -65,6 +65,8 @@ module Fluent::Plugin
     config_param :read_lines_limit, :integer, default: 1000
     desc 'The interval of flushing the buffer for multiline format'
     config_param :multiline_flush_interval, :time, default: nil
+    desc 'Enable the option to capture unmatched multiline events.'
+    config_param :enable_multiline_catch_all, :bool, default: false
     desc 'Enable the additional watch timer.'
     config_param :enable_watch_timer, :bool, default: true
     desc 'The encoding after conversion of the input.'
@@ -387,6 +389,9 @@ module Fluent::Plugin
             lb = line
           else
             if lb.nil?
+              if @enable_multiline_catch_all
+                lb = line
+              end
               log.warn "got incomplete line before first line from #{tail_watcher.path}: #{line.inspect}"
             else
               lb << line


### PR DESCRIPTION
For multiline events, if the first line doesn't match the prescribed pattern, we should still store the unmatched lines in the line buffer so that plugins such as fluent-plugin-grok-parser can report the log event as a grok parse error, see: https://github.com/fluent/fluent-plugin-grok-parser/issues/25

Example:
input:
```
abcd efgh
asdfadsasda
```

output:
```
{"message":"abcd efgh\nasdfadsasda","grokfailure":"No grok pattern matched","server":"tranj-fluentd-s3b","stack":"my-app-pdev-01","application":"my-app","log_type":"filter.test","time":"2017-01-11T04:19:56Z"}
```