### PR TITLE
Capture unmatched lines

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -362,7 +362,7 @@ module Fluent::Plugin
             if @enable_catch_all
               record = {'parse_fail' => line}
               record[@path_key] ||= tail_watcher.path unless @path_key.nil?
-              es.add(Fluent::EventTime.now, record)
+              es.add(Time.now.to_i, record)
             end
             log.warn "pattern not match: #{line.inspect}"
           end

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -65,8 +65,8 @@ module Fluent::Plugin
     config_param :read_lines_limit, :integer, default: 1000
     desc 'The interval of flushing the buffer for multiline format'
     config_param :multiline_flush_interval, :time, default: nil
-    desc 'Enable the option to capture unmatched lines.'
-    config_param :enable_catch_all, :bool, default: false
+    desc 'Enable the option to emit unmatched lines.'
+    config_param :emit_unmatched_lines, :bool, default: false
     desc 'Enable the additional watch timer.'
     config_param :enable_watch_timer, :bool, default: true
     desc 'The encoding after conversion of the input.'
@@ -359,8 +359,8 @@ module Fluent::Plugin
             record[@path_key] ||= tail_watcher.path unless @path_key.nil?
             es.add(time, record)
           else
-            if @enable_catch_all
-              record = {'parse_fail' => line}
+            if @emit_unmatched_lines
+              record = {'unmatched_line' => line}
               record[@path_key] ||= tail_watcher.path unless @path_key.nil?
               es.add(Time.now.to_i, record)
             end
@@ -394,7 +394,7 @@ module Fluent::Plugin
             lb = line
           else
             if lb.nil?
-              if @enable_catch_all
+              if @emit_unmatched_lines
                 convert_line_to_event(line, es, tail_watcher)
               end
               log.warn "got incomplete line before first line from #{tail_watcher.path}: #{line.inspect}"

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -362,7 +362,7 @@ module Fluent::Plugin
             if @emit_unmatched_lines
               record = {'unmatched_line' => line}
               record[@path_key] ||= tail_watcher.path unless @path_key.nil?
-              es.add(Time.now.to_i, record)
+              es.add(Fluent::EventTime.now, record)
             end
             log.warn "pattern not match: #{line.inspect}"
           end


### PR DESCRIPTION
Essentially all unmatched lines will be placed inside the parse_fail attribute, i.e.
```
{  
   "parse_fail":"unmatched line....rest of the line",
   "server":"myserver",
   "stack":"my-app-dev-01",
   "application":"my-app",
   "log_type":"apache.access",
   "time":"2017-01-16T23:06:49Z"
}
```

This will enable our analytics tools to pick up any pattern matching regexp issues.