### PR TITLE
Support TLS by socket/server plugin helper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 cache: bundler
 
-# script: bundle exec rake test TESTOPTS=-v
+script: bundle exec rake test TESTOPTS=-v
 
 # http://rubies.travis-ci.org/
 # See here for osx_image -> OSX versions: https://docs.travis-ci.com/user/languages/objective-c

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ branches:
     - v0.14
 
 sudo: false
+dist: trusty # for TLSv1.2 support
 
 addons:
   apt:

--- a/example/in_forward_tls.conf
+++ b/example/in_forward_tls.conf
@@ -1,0 +1,14 @@
+<source>
+  @type forward
+  port 24224
+  <transport tls>
+    insecure true
+  </transport>
+</source>
+
+<match test>
+  @type stdout
+  # <buffer>
+  #   flush_interval 10s
+  # </buffer>
+</match>

--- a/example/out_forward_tls.conf
+++ b/example/out_forward_tls.conf
@@ -1,0 +1,18 @@
+<source>
+  @type dummy
+  tag test
+</source>
+
+<match test>
+  @type forward
+  transport tls
+  tls_insecure_mode true
+  <server>
+    # first server
+    host 127.0.0.1
+    port 24224
+  </server>
+  <buffer>
+    flush_interval 0
+  </buffer>
+</match>

--- a/lib/fluent/config/section.rb
+++ b/lib/fluent/config/section.rb
@@ -75,6 +75,10 @@ module Fluent
         @params[key.to_sym]
       end
 
+      def []=(key, value)
+        @params[key.to_sym] = value
+      end
+
       def respond_to?(symbol, include_all=false)
         case symbol
         when :inspect, :nil?, :to_h, :+, :instance_of?, :kind_of?, :[], :respond_to?, :respond_to_missing?

--- a/lib/fluent/plugin/in_forward.rb
+++ b/lib/fluent/plugin/in_forward.rb
@@ -154,7 +154,7 @@ module Fluent::Plugin
 
       shared_socket = system_config.workers > 1
 
-      log.info "listening a tcp port", port: @port, bind: @bind
+      log.info "listening port", port: @port, bind: @bind
       server_create_connection(
         :in_forward_server, @port,
         bind: @bind,

--- a/lib/fluent/plugin/in_tcp.rb
+++ b/lib/fluent/plugin/in_tcp.rb
@@ -56,7 +56,7 @@ module Fluent::Plugin
       super
 
       @buffer = ''
-      server_create(:in_tcp_server, @port, proto: :tcp, bind: @bind) do |data, conn|
+      server_create(:in_tcp_server, @port, bind: @bind) do |data, conn|
         @buffer << data
         begin
           pos = 0

--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -43,7 +43,7 @@ module Fluent::Plugin
     # TODO: add linger_timeout, recv_timeout
 
     desc 'The protocol to use for heartbeats (default is the same with "transport").'
-    config_param :heartbeat_type, :enum, list: [:transport, :udp, :none], default: :transport
+    config_param :heartbeat_type, :enum, list: [:transport, :tcp, :udp, :none], default: :transport
     desc 'The interval of the heartbeat packer.'
     config_param :heartbeat_interval, :time, default: 1
     desc 'The wait time before accepting a server fault recovery.'
@@ -153,6 +153,11 @@ module Fluent::Plugin
 
       @read_interval = @read_interval_msec / 1000.0
       @recover_sample_size = @recover_wait / @heartbeat_interval
+
+      if @heartbeat_type == :tcp
+        log.warn "'heartbeat_type tcp' is deprecated. use 'transport' instead."
+        @heartbeat_type = :transport
+      end
 
       if @dns_round_robin
         if @heartbeat_type == :udp

--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -33,12 +33,17 @@ module Fluent::Plugin
 
     LISTEN_PORT = 24224
 
+    desc 'The transport protocol.'
+    config_param :transport, :enum, list: [:tcp, :tls], default: :tcp
+    # TODO: TLS session cache/tickets
+    # TODO: Connection keepalive
+
     desc 'The timeout time when sending event logs.'
     config_param :send_timeout, :time, default: 60
     # TODO: add linger_timeout, recv_timeout
 
-    desc 'The transport protocol to use for heartbeats.(udp,tcp,none)'
-    config_param :heartbeat_type, :enum, list: [:tcp, :udp, :none], default: :tcp
+    desc 'The protocol to use for heartbeats (default is the same with "transport").'
+    config_param :heartbeat_type, :enum, list: [:transport, :udp, :none], default: :transport
     desc 'The interval of the heartbeat packer.'
     config_param :heartbeat_interval, :time, default: 1
     desc 'The wait time before accepting a server fault recovery.'
@@ -75,6 +80,19 @@ module Fluent::Plugin
     desc 'Compress buffered data.'
     config_param :compress, :enum, list: [:text, :gzip], default: :text
 
+    desc 'The default version of TLS transport.'
+    config_param :tls_version, :enum, list: Fluent::PluginHelper::Socket::TLS_SUPPORTED_VERSIONS, default: Fluent::PluginHelper::Socket::TLS_DEFAULT_VERSION
+    desc 'The cipher configuration of TLS transport.'
+    config_param :tls_ciphers, :string, default: Fluent::PluginHelper::Socket::CIPHERS_DEFAULT
+    desc 'Skip all verification of certificates or not.'
+    config_param :tls_insecure_mode, :bool, default: false
+    desc 'Allow self signed certificates or not.'
+    config_param :tls_allow_self_signed_cert, :bool, default: false
+    desc 'Verify hostname of servers and certificates or not in TLS transport.'
+    config_param :tls_verify_hostname, :bool, default: true
+    desc 'The additional CA certificate path for TLS.'
+    config_param :tls_cert_path, :array, value_type: :string, default: nil
+
     config_section :security, required: false, multi: false do
       desc 'The hostname'
       config_param :self_hostname, :string
@@ -85,7 +103,7 @@ module Fluent::Plugin
     config_section :server, param_name: :servers do
       desc "The IP address or host name of the server."
       config_param :host, :string
-      desc "The name of the server. Used in log messages."
+      desc "The name of the server. Used for logging and certificate verification in TLS transport (when host is address)."
       config_param :name, :string, default: nil
       desc "The port number of the host."
       config_param :port, :integer, default: LISTEN_PORT
@@ -138,7 +156,22 @@ module Fluent::Plugin
 
       if @dns_round_robin
         if @heartbeat_type == :udp
-          raise Fluent::ConfigError, "forward output heartbeat type must be 'tcp' or 'none' to use dns_round_robin option"
+          raise Fluent::ConfigError, "forward output heartbeat type must be 'transport' or 'none' to use dns_round_robin option"
+        end
+      end
+
+      if @transport == :tls
+        if @tls_cert_path && !@tls_cert_path.empty?
+          @tls_cert_path.each do |path|
+            raise Fluent::ConfigError, "specified cert path does not exist:#{path}" unless File.exist?(path)
+            raise Fluent::ConfigError, "specified cert path is not readable:#{path}" unless File.exist?(path)
+          end
+        end
+
+        if @tls_insecure_mode
+          log.warn "TLS transport is configured in insecure way"
+          @tls_verify_hostname = false
+          @tls_allow_self_signed_cert = true
         end
       end
 
@@ -275,14 +308,34 @@ module Fluent::Plugin
       raise NoNodesAvailable, "no nodes are available"
     end
 
-    def create_transfer_socket(host, port, &block)
-      socket_create_tcp(
-        host, port,
-        linger_timeout: @send_timeout,
-        send_timeout: @send_timeout,
-        recv_timeout: @ack_response_timeout,
-        &block
-      )
+    def create_transfer_socket(host, port, hostname, &block)
+      case @transport
+      when :tls
+        socket_create_tls(
+          host, port,
+          version: @tls_version,
+          ciphers: @tls_ciphers,
+          insecure: @tls_insecure_mode,
+          verify_fqdn: @tls_verify_hostname,
+          fqdn: hostname,
+          allow_self_signed_cert: @tls_allow_self_signed_cert,
+          cert_paths: @tls_cert_path,
+          linger_timeout: @send_timeout,
+          send_timeout: @send_timeout,
+          recv_timeout: @ack_response_timeout,
+          &block
+        )
+      when :tcp
+        socket_create_tcp(
+          host, port,
+          linger_timeout: @send_timeout,
+          send_timeout: @send_timeout,
+          recv_timeout: @ack_response_timeout,
+          &block
+        )
+      else
+        raise "BUG: unknown transport protocol #{@transport}"
+      end
     end
 
     # MessagePack FixArray length is 3
@@ -458,6 +511,14 @@ module Fluent::Plugin
         @available = true
         @state = nil
 
+        # @hostname is used for certificate verification & TLS SNI
+        host_is_hostname = !(IPAddr.new(@host) rescue false)
+        @hostname = case
+                    when host_is_hostname then @host
+                    when @name then @name
+                    else nil
+                    end
+
         @usock = nil
 
         @username = server.username
@@ -557,7 +618,7 @@ module Fluent::Plugin
       end
 
       def send_data(tag, chunk)
-        sock = @sender.create_transfer_socket(resolved_host, port)
+        sock = @sender.create_transfer_socket(resolved_host, port, @hostname)
         begin
           send_data_actual(sock, tag, chunk)
         rescue
@@ -589,8 +650,8 @@ module Fluent::Plugin
         end
 
         case @sender.heartbeat_type
-        when :tcp
-          @sender.create_transfer_socket(dest_addr, port) do |sock|
+        when :transport
+          @sender.create_transfer_socket(dest_addr, port, @hostname) do |sock|
             ## don't send any data to not cause a compatibility problem
             # sock.write FORWARD_TCP_HEARTBEAT_DATA
 

--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -169,7 +169,7 @@ module Fluent::Plugin
         if @tls_cert_path && !@tls_cert_path.empty?
           @tls_cert_path.each do |path|
             raise Fluent::ConfigError, "specified cert path does not exist:#{path}" unless File.exist?(path)
-            raise Fluent::ConfigError, "specified cert path is not readable:#{path}" unless File.exist?(path)
+            raise Fluent::ConfigError, "specified cert path is not readable:#{path}" unless File.readable?(path)
           end
         end
 

--- a/lib/fluent/plugin_helper/cert_option.rb
+++ b/lib/fluent/plugin_helper/cert_option.rb
@@ -1,0 +1,142 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'openssl'
+require 'socket'
+
+# this module is only for Socket/Server plugin helpers
+module Fluent
+  module PluginHelper
+    module CertOption
+      def cert_option_create_context(version, insecure, ciphers, conf)
+        cert, key, extra_chain_certs = cert_option_server_validate!(conf)
+
+        ctx = OpenSSL::SSL::SSLContext.new(version)
+        unless insecure
+          # inject OpenSSL::SSL::SSLContext::DEFAULT_PARAMS
+          # https://bugs.ruby-lang.org/issues/9424
+          ctx.set_params({})
+
+          ctx.ciphers = ciphers
+        end
+
+        ctx.cert = cert
+        ctx.key = key
+        if extra_chain_certs
+          ctx.extra_chain_cert = extra_chain_certs
+        end
+
+        ctx
+      end
+
+      def cert_option_server_validate!(conf)
+        case
+        when conf.cert_path
+          raise Fluent::ConfigError, "private_key_path is required when cert_path is specified" unless conf.private_key_path
+          raise Fluent::ConfigError, "private_key_passphrase is required when cert_path is specified" unless conf.private_key_passphrase
+          cert_option_load(conf.cert_path, conf.private_key_path, conf.private_key_passphrase)
+
+        when conf.ca_cert_path
+          raise Fluent::ConfigError, "ca_private_key_path is required when ca_cert_path is specified" unless conf.ca_private_key_path
+          raise Fluent::ConfigError, "ca_private_key_passphrase is required when ca_cert_path is specified" unless conf.ca_private_key_passphrase
+          generate_opts = cert_option_cert_generation_opts_from_conf(conf)
+          cert_option_generate_server_pair_by_ca(
+            conf.ca_cert_path,
+            conf.ca_private_key_path,
+            conf.private_key_passphrase,
+            generate_opts
+          )
+
+        when conf.insecure
+          log.warn "insecure TLS communication server is configured (using 'insecure' mode)"
+          generate_opts = cert_option_cert_generation_opts_from_conf(conf)
+          cert_option_generate_server_pair_self_signed(generate_opts)
+
+        else
+          raise Fluent::ConfigError, "no valid cert options configured. specify either 'cert_path', 'ca_cert_path' or 'insecure'"
+        end
+      end
+
+      def cert_option_load(cert_path, private_key_path, private_key_passphrase)
+        key = OpenSSL::PKey::RSA.new(File.read(private_key_path), private_key_passphrase)
+        certs = cert_option_certificates_from_file(cert_path)
+        cert = certs.shift
+        extra_chain_certs = certs
+        return cert, key, extra_chain_certs
+      end
+
+      def cert_option_cert_generation_opts_from_conf(conf)
+        {
+          private_key_length: conf.generate_private_key_length,
+          country: conf.generate_cert_country,
+          state: conf.generate_cert_state,
+          locality: conf.generate_cert_locality,
+          common_name: conf.generate_cert_common_name || ::Socket.gethostname,
+          expiration: conf.generate_cert_expiration,
+          digest: conf.generate_cert_digest,
+        }
+      end
+
+      def cert_option_generate_server_pair(opts, issuer = nil)
+        key = OpenSSL::PKey::RSA.generate(opts[:private_key_length])
+
+        subject = OpenSSL::X509::Name.new
+        subject.add_entry('C', opts[:country])
+        subject.add_entry('ST', opts[:state])
+        subject.add_entry('L', opts[:locality])
+        subject.add_entry('CN', opts[:common_name])
+
+        issuer ||= subject
+
+        cert = OpenSSL::X509::Certificate.new
+        cert.not_before = Time.at(0)
+        cert.not_after = Time.now + opts[:expiration]
+        cert.public_key = key
+        cert.serial = 1
+        cert.issuer = issuer
+        cert.subject  = subject
+
+        # basicConstraints: this cert is for CA or not
+        cert.add_extension OpenSSL::X509::Extension.new('basicConstraints', OpenSSL::ASN1.Sequence([OpenSSL::ASN1::Boolean(false)]))
+        cert.add_extension OpenSSL::X509::Extension.new('nsCertType', 'server')
+
+        return cert, key
+      end
+
+      def cert_option_generate_server_pair_by_ca(ca_cert_path, ca_key_path, ca_key_passphrase, generate_opts)
+        ca_key = OpenSSL::PKey::RSA.new(File.read(ca_key_path), ca_key_passphrase)
+        ca_cert = OpenSSL::X509::Certificate.new(File.read(ca_cert_path))
+        cert, key = cert_option_generate_server_pair(generate_opts, ca_cert.issuer)
+        cert.sign(ca_key, generate_opts[:digest].to_s)
+        return cert, key, nil
+      end
+
+      def cert_option_generate_server_pair_self_signed(generate_opts)
+        cert, key = cert_option_generate_server_pair(generate_opts)
+        cert.sign(key, generate_opts[:digest].to_s)
+        return cert, key, nil
+      end
+
+      def cert_option_certificates_from_file(path)
+        data = File.read(path)
+        pattern = Regexp.compile('-+BEGIN CERTIFICATE-+\n(?:[^-]*\n)+-+END CERTIFICATE-+\n', Regexp::MULTILINE)
+        list = []
+        data.scan(pattern){|match| list << OpenSSL::X509::Certificate.new(match) }
+        list
+      end
+    end
+  end
+end

--- a/lib/fluent/plugin_helper/cert_option.rb
+++ b/lib/fluent/plugin_helper/cert_option.rb
@@ -120,12 +120,14 @@ module Fluent
         ca_key = OpenSSL::PKey::RSA.new(File.read(ca_key_path), ca_key_passphrase)
         ca_cert = OpenSSL::X509::Certificate.new(File.read(ca_cert_path))
         cert, key = cert_option_generate_server_pair(generate_opts, ca_cert.issuer)
+        raise "BUG: certificate digest algorithm not set" unless generate_opts[:digest]
         cert.sign(ca_key, generate_opts[:digest].to_s)
         return cert, key, nil
       end
 
       def cert_option_generate_server_pair_self_signed(generate_opts)
         cert, key = cert_option_generate_server_pair(generate_opts)
+        raise "BUG: certificate digest algorithm not set" unless generate_opts[:digest]
         cert.sign(key, generate_opts[:digest].to_s)
         return cert, key, nil
       end

--- a/lib/fluent/plugin_helper/server.rb
+++ b/lib/fluent/plugin_helper/server.rb
@@ -35,6 +35,7 @@ module Fluent
 
       # This plugin helper doesn't support these things for now:
       # * TCP/TLS keepalive
+      # * TLS session cache/tickets
       # * unix domain sockets
 
       # stop     : [-]

--- a/lib/fluent/plugin_helper/server.rb
+++ b/lib/fluent/plugin_helper/server.rb
@@ -21,18 +21,21 @@ require 'cool.io'
 require 'socket'
 require 'ipaddr'
 require 'fcntl'
+require 'openssl'
 
 require_relative 'socket_option'
+require_relative 'cert_option'
 
 module Fluent
   module PluginHelper
     module Server
       include Fluent::PluginHelper::EventLoop
       include Fluent::PluginHelper::SocketOption
+      include Fluent::PluginHelper::CertOption
 
       # This plugin helper doesn't support these things for now:
-      # * SSL/TLS (TBD)
       # * TCP/TLS keepalive
+      # * unix domain sockets
 
       # stop     : [-]
       # shutdown : detach server event handler from event loop (event_loop)
@@ -63,11 +66,15 @@ module Fluent
       #     conn.close
       #   end
       # end
-      def server_create_connection(title, port, proto: :tcp, bind: '0.0.0.0', shared: true, backlog: nil, **socket_options, &block)
+      def server_create_connection(title, port, proto: nil, bind: '0.0.0.0', shared: true, backlog: nil, tls_options: nil, **socket_options, &block)
+        proto ||= (@transport_config && @transport_config.protocol == :tls) ? :tls : :tcp
+
         raise ArgumentError, "BUG: title must be a symbol" unless title && title.is_a?(Symbol)
         raise ArgumentError, "BUG: port must be an integer" unless port && port.is_a?(Integer)
         raise ArgumentError, "BUG: invalid protocol name" unless PROTOCOLS.include?(proto)
         raise ArgumentError, "BUG: cannot create connection for UDP" unless CONNECTION_PROTOCOLS.include?(proto)
+
+        raise ArgumentError, "BUG: tls_options is available only for tls" if tls_options && proto != :tls
 
         raise ArgumentError, "BUG: block not specified which handles connection" unless block_given?
         raise ArgumentError, "BUG: block must have just one argument" unless block.arity == 1
@@ -83,11 +90,14 @@ module Fluent
         when :tcp
           server = server_create_for_tcp_connection(shared, bind, port, backlog, socket_option_setter, &block)
         when :tls
-          raise ArgumentError, "BUG: certopts (certificate options) not specified for TLS" unless certopts
-          # server_certopts_validate!(certopts)
-          # sock = server_create_tls_socket(shared, bind, port)
-          # server = nil # ...
-          raise "not implemented yet"
+          transport_config = if tls_options
+                               server_create_transport_section_object(tls_options)
+                             elsif @transport_config && @transport_config.protocol == :tls
+                               @transport_config
+                             else
+                               raise ArgumentError, "BUG: TLS transport specified, but certification options are not specified"
+                             end
+          server = server_create_for_tls_connection(shared, bind, port, transport_config, backlog, socket_option_setter, &block)
         when :unix
           raise "not implemented yet"
         else
@@ -108,12 +118,15 @@ module Fluent
       #   sock.remote_port
       #   # ...
       # end
-      def server_create(title, port, proto: :tcp, bind: '0.0.0.0', shared: true, socket: nil, backlog: nil, max_bytes: nil, flags: 0, **socket_options, &callback)
+      def server_create(title, port, proto: nil, bind: '0.0.0.0', shared: true, socket: nil, backlog: nil, tls_options: nil, max_bytes: nil, flags: 0, **socket_options, &callback)
+        proto ||= (@transport_config && @transport_config.protocol == :tls) ? :tls : :tcp
+
         raise ArgumentError, "BUG: title must be a symbol" unless title && title.is_a?(Symbol)
         raise ArgumentError, "BUG: port must be an integer" unless port && port.is_a?(Integer)
         raise ArgumentError, "BUG: invalid protocol name" unless PROTOCOLS.include?(proto)
 
         raise ArgumentError, "BUG: socket option is available only for udp" if socket && proto != :udp
+        raise ArgumentError, "BUG: tls_options is available only for tls" if tls_options && proto != :tls
 
         raise ArgumentError, "BUG: block not specified which handles received data" unless block_given?
         raise ArgumentError, "BUG: block must have 1 or 2 arguments" unless callback.arity == 1 || callback.arity == 2
@@ -141,7 +154,16 @@ module Fluent
             conn.data(&callback)
           end
         when :tls
-          raise "not implemented yet"
+          transport_config = if tls_options
+                               server_create_transport_section_object(tls_options)
+                             elsif @transport_config && @transport_config.protocol == :tls
+                               @transport_config
+                             else
+                               raise ArgumentError, "BUG: TLS transport specified, but certification options are not specified"
+                             end
+          server = server_create_for_tls_connection(shared, bind, port, transport_config, backlog, socket_option_setter) do |conn|
+            conn.data(&callback)
+          end
         when :udp
           raise ArgumentError, "BUG: max_bytes must be specified for UDP" unless max_bytes
           if socket
@@ -198,11 +220,95 @@ module Fluent
         server
       end
 
+      def server_create_for_tls_connection(shared, bind, port, conf, backlog, socket_option_setter, &block)
+        context = cert_option_create_context(conf.version, conf.insecure, conf.ciphers, conf)
+        sock = server_create_tcp_socket(shared, bind, port)
+        socket_option_setter.call(sock)
+        close_callback = ->(conn){ @_server_mutex.synchronize{ @_server_connections.delete(conn) } }
+        server = Coolio::TCPServer.new(sock, nil, EventHandler::TLSServer, context, socket_option_setter, close_callback, @log, @under_plugin_development, block) do |conn|
+          @_server_mutex.synchronize do
+            @_server_connections << conn
+          end
+        end
+        server.listen(backlog) if backlog
+        server
+      end
+
+      SERVER_TRANSPORT_PARAMS = [
+        :protocol, :version, :ciphers, :insecure,
+        :cert_path, :private_key_path, :private_key_passphrase,
+        :ca_cert_path, :ca_private_key_path, :ca_private_key_passphrase,
+        :generate_private_key_length,
+        :generate_cert_country, :generate_cert_state, :generate_cert_state,
+        :generate_cert_locality, :generate_cert_common_name,
+        :generate_cert_expiration, :generate_cert_digest,
+      ]
+
+      def server_create_transport_section_object(opts)
+        transport_section = configured_section_create(:transport)
+        SERVER_TRANSPORT_PARAMS.each do |param|
+          if opts.has_key?(param)
+            transport_section[param] = opts[param]
+          end
+        end
+        transport_section
+      end
+
+      module ServerTransportParams
+        TLS_DEFAULT_VERSION = :'TLSv1_2'
+        TLS_SUPPORTED_VERSIONS = [:'TLSv1_1', :'TLSv1_2']
+        ### follow httpclient configuration by nahi
+        # OpenSSL 0.9.8 default: "ALL:!ADH:!LOW:!EXP:!MD5:+SSLv2:@STRENGTH"
+        CIPHERS_DEFAULT = "ALL:!aNULL:!eNULL:!SSLv2" # OpenSSL >1.0.0 default
+
+        include Fluent::Configurable
+        config_section :transport, required: false, multi: false, init: true, param_name: :transport_config do
+          config_argument :protocol, :enum, list: [:tcp, :tls], default: :tcp
+          config_param :version, :enum, list: TLS_SUPPORTED_VERSIONS, default: TLS_DEFAULT_VERSION
+
+          config_param :ciphers, :string, default: CIPHERS_DEFAULT
+          config_param :insecure, :bool, default: false
+
+          # Cert signed by public CA
+          config_param :cert_path, :string, default: nil
+          config_param :private_key_path, :string, default: nil
+          config_param :private_key_passphrase, :string, default: nil, secret: true
+
+          # Cert generated and signed by private CA Certificate
+          config_param :ca_cert_path, :string, default: nil
+          config_param :ca_private_key_path, :string, default: nil
+          config_param :ca_private_key_passphrase, :string, default: nil, secret: true
+
+          # Options for generating certs by private CA certs or self-signed
+          config_param :generate_private_key_length, :integer, default: 2048
+          config_param :generate_cert_country, :string, default: 'US'
+          config_param :generate_cert_state, :string, default: 'CA'
+          config_param :generate_cert_locality, :string, default: 'Mountain View'
+          config_param :generate_cert_common_name, :string, default: nil
+          config_param :generate_cert_expiration, :time, default: 10 * 365 * 86400 # 10years later
+          config_param :generate_cert_digest, :enum, list: [:sha1, :sha256, :sha384, :sha512], default: :sha256
+        end
+      end
+
+      def self.included(mod)
+        mod.include ServerTransportParams
+      end
+
       def initialize
         super
         @_servers = []
         @_server_connections = []
         @_server_mutex = Mutex.new
+      end
+
+      def configure(conf)
+        super
+
+        if @transport_config
+          if @transport_config.protocol == :tls
+            cert_option_server_validate!(@transport_config)
+          end
+        end
       end
 
       def stop
@@ -228,10 +334,6 @@ module Fluent
       def terminate
         @_servers = []
         super
-      end
-
-      def server_certopts_validate!(certopts)
-        raise "not implemented yet"
       end
 
       def server_socket_manager_client
@@ -267,28 +369,25 @@ module Fluent
         sock
       end
 
-      def server_create_tls_socket(shared, bind, port)
-        raise "not implemented yet"
-      end
-
       class CallbackSocket
         def initialize(server_type, sock, enabled_events = [], close_socket: true)
           @server_type = server_type
           @sock = sock
+          @peeraddr = nil
           @enabled_events = enabled_events
           @close_socket = close_socket
         end
 
         def remote_addr
-          @sock.peeraddr[3]
+          @peeraddr[3]
         end
 
         def remote_host
-          @sock.peeraddr[2]
+          @peeraddr[2]
         end
 
         def remote_port
-          @sock.peeraddr[1]
+          @peeraddr[1]
         end
 
         def send(data, flags = 0)
@@ -327,6 +426,18 @@ module Fluent
       class TCPCallbackSocket < CallbackSocket
         def initialize(sock)
           super("tcp", sock, [:data, :write_complete, :close])
+          @peeraddr = @sock.peeraddr
+        end
+
+        def write(data)
+          @sock.write(data)
+        end
+      end
+
+      class TLSCallbackSocket < CallbackSocket
+        def initialize(sock)
+          super("tls", sock, [:data, :write_complete, :close])
+          @peeraddr = @sock.to_io.peeraddr
         end
 
         def write(data)
@@ -430,6 +541,10 @@ module Fluent
             @mutex = Mutex.new # to serialize #write and #close
           end
 
+          def to_io
+            @_handler_socket
+          end
+
           def data(&callback)
             raise "data callback can be registered just once, but registered twice" if self.singleton_methods.include?(:on_read)
             @data_callback = callback
@@ -459,7 +574,7 @@ module Fluent
           def on_read_without_connection(data)
             @data_callback.call(data)
           rescue => e
-            @log.error "unexpected error on reading data", host: remote_host, port: remote_port, error: e
+            @log.error "unexpected error on reading data", host: @callback_connection.remote_host, port: @callback_connection.remote_port, error: e
             @log.error_backtrace
             close(true) rescue nil
             raise if @under_plugin_development
@@ -468,7 +583,135 @@ module Fluent
           def on_read_with_connection(data)
             @data_callback.call(data, @callback_connection)
           rescue => e
-            @log.error "unexpected error on reading data", host: remote_host, port: remote_port, error: e
+            @log.error "unexpected error on reading data", host: @callback_connection.remote_host, port: @callback_connection.remote_port, error: e
+            @log.error_backtrace
+            close(true) rescue nil
+            raise if @under_plugin_development
+          end
+
+          def close
+            @mutex.synchronize do
+              return if @closing
+              @closing = true
+              @close_callback.call(self)
+              super
+            end
+          end
+        end
+
+        class TLSServer < Coolio::Socket
+          # It can't use Coolio::TCPSocket, because Coolio::TCPSocket checks that underlying socket (1st argument of super) is TCPSocket.
+          def initialize(sock, context, socket_option_setter, close_callback, log, under_plugin_development, connect_callback)
+            raise ArgumentError, "socket must be a TCPSocket: sock=#{sock}" unless sock.is_a?(TCPSocket)
+
+            socket_option_setter.call(sock)
+            @_handler_socket = OpenSSL::SSL::SSLSocket.new(sock, context)
+            @_handler_write_buffer = ''.force_encoding('ascii-8bit')
+            @_handler_accepted = false
+            super(@_handler_socket)
+
+            @log = log
+            @under_plugin_development = under_plugin_development
+
+            @connect_callback = connect_callback
+            @data_callback = nil
+            @close_callback = close_callback
+
+            @callback_connection = nil
+            @closing = false
+
+            @mutex = Mutex.new # to serialize #write and #close
+          end
+
+          def to_io
+            @_handler_socket.to_io
+          end
+
+          def data(&callback)
+            raise "data callback can be registered just once, but registered twice" if self.singleton_methods.include?(:on_read)
+            @data_callback = callback
+            on_read_impl = case callback.arity
+                           when 1 then :on_read_without_connection
+                           when 2 then :on_read_with_connection
+                           else
+                             raise "BUG: callback block must have 1 or 2 arguments"
+                           end
+            self.define_singleton_method(:on_read, method(on_read_impl))
+          end
+
+          def write(data)
+            @mutex.synchronize do
+              @_handler_write_buffer << data
+              schedule_write
+              data.bytesize
+            end
+          end
+
+          def try_tls_accept
+            return if @_handler_accepted
+
+            begin
+              @_handler_socket.accept_nonblock # this method call actually try to do handshake via TLS
+              @_handler_accepted = true
+
+              @callback_connection = TLSCallbackSocket.new(self)
+              @connect_callback.call(@callback_connection)
+              unless @data_callback
+                raise "connection callback must call #data to set data callback"
+              end
+            rescue IO::WaitReadable, IO::WaitWritable
+              # retry accept_nonblock: there aren't enough data in underlying socket buffer
+            rescue OpenSSL::SSL::SSLError => e
+              @log.trace "unexpected error before accepting TLS connection", error: e
+              close rescue nil
+            end
+          end
+
+          def on_connect
+            try_tls_accept
+          end
+
+          def on_readable
+            if @_handler_accepted
+              super
+            else
+              try_tls_accept
+            end
+          end
+
+          def on_writable
+            begin
+              @mutex.synchronize do
+                written_bytes = @_handler_socket.write_nonblock(@_handler_write_buffer)
+                @_handler_write_buffer.slice!(0, written_bytes)
+                super
+              end
+            rescue IO::WaitWritable, IO::WaitReadable
+              return
+            rescue Errno::EINTR
+              return
+            rescue SystemCallError, IOError, SocketError
+              # SystemCallError catches Errno::EPIPE & Errno::ECONNRESET amongst others.
+              close rescue nil
+              return
+            rescue OpenSSL::SSL::SSLError => e
+              @log.debug "unexpected SSLError while writing data into socket connected via TLS", error: e
+            end
+          end
+
+          def on_read_without_connection(data)
+            @data_callback.call(data)
+          rescue => e
+            @log.error "unexpected error on reading data", host: @callback_connection.remote_host, port: @callback_connection.remote_port, error: e
+            @log.error_backtrace
+            close(true) rescue nil
+            raise if @under_plugin_development
+          end
+
+          def on_read_with_connection(data)
+            @data_callback.call(data, @callback_connection)
+          rescue => e
+            @log.error "unexpected error on reading data", host: @callback_connection.remote_host, port: @callback_connection.remote_port, error: e
             @log.error_backtrace
             close(true) rescue nil
             raise if @under_plugin_development

--- a/lib/fluent/plugin_helper/socket.rb
+++ b/lib/fluent/plugin_helper/socket.rb
@@ -16,6 +16,7 @@
 
 require 'socket'
 require 'ipaddr'
+require 'openssl'
 
 require_relative 'socket_option'
 
@@ -28,6 +29,12 @@ module Fluent
       # terminate: [-]
 
       include Fluent::PluginHelper::SocketOption
+
+      TLS_DEFAULT_VERSION = :'TLSv1_2'
+      TLS_SUPPORTED_VERSIONS = [:'TLSv1_1', :'TLSv1_2']
+      ### follow httpclient configuration by nahi
+      # OpenSSL 0.9.8 default: "ALL:!ADH:!LOW:!EXP:!MD5:+SSLv2:@STRENGTH"
+      CIPHERS_DEFAULT = "ALL:!aNULL:!eNULL:!SSLv2" # OpenSSL >1.0.0 default
 
       attr_reader :_sockets # for tests
 
@@ -49,7 +56,7 @@ module Fluent
       end
 
       def socket_create_tcp(host, port, resolve_name: false, **kwargs, &block)
-        sock = TCPSocket.new(host, port)
+        sock = WrappedSocket::TCP.new(host, port)
         socket_option_set(sock, resolve_name: resolve_name, **kwargs)
         if block
           begin
@@ -65,7 +72,7 @@ module Fluent
 
       def socket_create_udp(host, port, resolve_name: false, connect: false, **kwargs, &block)
         family = IPAddr.new(IPSocket.getaddress(host)).ipv4? ? ::Socket::AF_INET : ::Socket::AF_INET6
-        sock = UDPSocket.new(family)
+        sock = WrappedSocket::UDP.new(family)
         socket_option_set(sock, resolve_name: resolve_name, **kwargs)
         sock.connect(host, port) if connect
         if block
@@ -79,11 +86,140 @@ module Fluent
         end
       end
 
-      def socket_create_tls(host, port, resolve_name: false, certopts: {}, &block)
-        raise "not implemented yet"
+      def socket_create_tls(
+          host, port,
+          version: TLS_DEFAULT_VERSION, ciphers: CIPHERS_DEFAULT, insecure: false, verify_fqdn: true, fqdn: nil,
+          enable_system_cert_store: true, allow_self_signed_cert: false, cert_path: nil, **kwargs, &block)
+
+        host_is_ipaddress = IPAddr.new(host) rescue false
+        fqdn ||= host unless host_is_ipaddress
+
+        context = OpenSSL::SSL::SSLContext.new(version)
+
+        if insecure
+          log.trace "setting TLS verify_mode NONE"
+          context.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        else
+          cert_store = OpenSSL::X509::Store.new
+          if allow_self_signed_cert && OpenSSL::X509.const_defined?('V_FLAG_CHECK_SS_SIGNATURE')
+            cert_store.flags = OpenSSL::X509::V_FLAG_CHECK_SS_SIGNATURE
+          end
+          begin
+            if enable_system_cert_store
+              log.trace "loading system default certificate store"
+              cert_store.set_default_paths
+            end
+          rescue OpenSSL::X509::StoreError
+            log.warn "failed to load system default certificate store", error: e
+          end
+          if ca_cert_path
+            log.trace "adding CA cert", path: ca_cert_path
+            cert_store.add_file(ca_cert_path)
+          end
+          if server_cert_dir
+            log.trace "adding server cert directory", path: server_cert_dir
+            cert_store.add_path(server_cert_dir)
+          end
+
+          log.trace "setting TLS context", mode: "peer", ciphers: ciphers
+          context.set_params({})
+          context.ciphers = ciphers
+          context.verify_mode = OpenSSL::SSL::VERIFY_PEER
+          context.cert_store = cert_store
+          context.verify_hostname = true if verify_fqdn && fqdn && context.respond_to?(:verify_hostname=)
+        end
+
+        tcpsock = socket_create_tcp(host, port, **kwargs)
+        sock = WrappedSocket::TLS.new(tcpsock, context)
+        sock.sync_close = true
+        sock.hostname = fqdn if verify_fqdn && fqdn && sock.respond_to?(:hostname=)
+
+        log.trace "entering TLS handshake"
+        sock.connect
+
+        begin
+          if verify_fqdn
+            log.trace "checking peer's certificate", subject: sock.peer_cert.subject
+            sock.post_connection_check(fqdn)
+            verify = sock.verify_result
+            if verify != OpenSSL::X509::V_OK
+              err_name = Socket.tls_verify_result_name(verify)
+              log.warn "BUG: failed to verify certification while connecting (but not raised, why?)", host: host, fqdn: fqdn, error: err_name
+              raise RuntimeError, "BUG: failed to verify certification and to handle it correctly while connecting host #{host} as #{fqdn}"
+            end
+          end
+        rescue OpenSSL::SSL::SSLError => e
+          log.warn "failed to verify certification while connecting tls session", host: host, fqdn: fqdn, error: e
+          raise
+        end
+
+        if block
+          begin
+            block.call(sock)
+          ensure
+            sock.close rescue nil
+          end
+        else
+          sock
+        end
+      end
+
+      def self.tls_verify_result_name(code)
+        case code
+        when OpenSSL::X509::V_OK then 'V_OK'
+        when OpenSSL::X509::V_ERR_AKID_SKID_MISMATCH then 'V_ERR_AKID_SKID_MISMATCH'
+        when OpenSSL::X509::V_ERR_APPLICATION_VERIFICATION then 'V_ERR_APPLICATION_VERIFICATION'
+        when OpenSSL::X509::V_ERR_CERT_CHAIN_TOO_LONG then 'V_ERR_CERT_CHAIN_TOO_LONG'
+        when OpenSSL::X509::V_ERR_CERT_HAS_EXPIRED then 'V_ERR_CERT_HAS_EXPIRED'
+        when OpenSSL::X509::V_ERR_CERT_NOT_YET_VALID then 'V_ERR_CERT_NOT_YET_VALID'
+        when OpenSSL::X509::V_ERR_CERT_REJECTED then 'V_ERR_CERT_REJECTED'
+        when OpenSSL::X509::V_ERR_CERT_REVOKED then 'V_ERR_CERT_REVOKED'
+        when OpenSSL::X509::V_ERR_CERT_SIGNATURE_FAILURE then 'V_ERR_CERT_SIGNATURE_FAILURE'
+        when OpenSSL::X509::V_ERR_CERT_UNTRUSTED then 'V_ERR_CERT_UNTRUSTED'
+        when OpenSSL::X509::V_ERR_CRL_HAS_EXPIRED then 'V_ERR_CRL_HAS_EXPIRED'
+        when OpenSSL::X509::V_ERR_CRL_NOT_YET_VALID then 'V_ERR_CRL_NOT_YET_VALID'
+        when OpenSSL::X509::V_ERR_CRL_SIGNATURE_FAILURE then 'V_ERR_CRL_SIGNATURE_FAILURE'
+        when OpenSSL::X509::V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT then 'V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT'
+        when OpenSSL::X509::V_ERR_ERROR_IN_CERT_NOT_AFTER_FIELD then 'V_ERR_ERROR_IN_CERT_NOT_AFTER_FIELD'
+        when OpenSSL::X509::V_ERR_ERROR_IN_CERT_NOT_BEFORE_FIELD then 'V_ERR_ERROR_IN_CERT_NOT_BEFORE_FIELD'
+        when OpenSSL::X509::V_ERR_ERROR_IN_CRL_LAST_UPDATE_FIELD then 'V_ERR_ERROR_IN_CRL_LAST_UPDATE_FIELD'
+        when OpenSSL::X509::V_ERR_ERROR_IN_CRL_NEXT_UPDATE_FIELD then 'V_ERR_ERROR_IN_CRL_NEXT_UPDATE_FIELD'
+        when OpenSSL::X509::V_ERR_INVALID_CA then 'V_ERR_INVALID_CA'
+        when OpenSSL::X509::V_ERR_INVALID_PURPOSE then 'V_ERR_INVALID_PURPOSE'
+        when OpenSSL::X509::V_ERR_KEYUSAGE_NO_CERTSIGN then 'V_ERR_KEYUSAGE_NO_CERTSIGN'
+        when OpenSSL::X509::V_ERR_OUT_OF_MEM then 'V_ERR_OUT_OF_MEM'
+        when OpenSSL::X509::V_ERR_PATH_LENGTH_EXCEEDED then 'V_ERR_PATH_LENGTH_EXCEEDED'
+        when OpenSSL::X509::V_ERR_SELF_SIGNED_CERT_IN_CHAIN then 'V_ERR_SELF_SIGNED_CERT_IN_CHAIN'
+        when OpenSSL::X509::V_ERR_SUBJECT_ISSUER_MISMATCH then 'V_ERR_SUBJECT_ISSUER_MISMATCH'
+        when OpenSSL::X509::V_ERR_UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY then 'V_ERR_UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY'
+        when OpenSSL::X509::V_ERR_UNABLE_TO_DECRYPT_CERT_SIGNATURE then 'V_ERR_UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY'
+        when OpenSSL::X509::V_ERR_UNABLE_TO_DECRYPT_CRL_SIGNATURE then 'V_ERR_UNABLE_TO_DECRYPT_CRL_SIGNATURE'
+        when OpenSSL::X509::V_ERR_UNABLE_TO_GET_CRL then 'V_ERR_UNABLE_TO_GET_CRL'
+        when OpenSSL::X509::V_ERR_UNABLE_TO_GET_ISSUER_CERT then 'V_ERR_UNABLE_TO_GET_ISSUER_CERT'
+        when OpenSSL::X509::V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY then 'V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY'
+        when OpenSSL::X509::V_ERR_UNABLE_TO_VERIFY_LEAF_SIGNATURE then 'V_ERR_UNABLE_TO_VERIFY_LEAF_SIGNATURE'
+        end
       end
 
       # socket_create_socks ?
+
+      module WrappedSocket
+        class TCP < ::TCPSocket
+          def remote_addr; peeraddr[3]; end
+          def remote_host; peeraddr[2]; end
+          def remote_port; peeraddr[1]; end
+        end
+        class UDP < ::UDPSocket
+          def remote_addr; peeraddr[3]; end
+          def remote_host; peeraddr[2]; end
+          def remote_port; peeraddr[1]; end
+        end
+        class TLS < OpenSSL::SSL::SSLSocket
+          def remote_addr; peeraddr[3]; end
+          def remote_host; peeraddr[2]; end
+          def remote_port; peeraddr[1]; end
+        end
+      end
 
       def initialize
         super

--- a/lib/fluent/plugin_helper/socket_option.rb
+++ b/lib/fluent/plugin_helper/socket_option.rb
@@ -24,7 +24,7 @@ module Fluent
       FORMAT_STRUCT_LINGER  = 'I!I!' # { int l_onoff; int l_linger; }
       FORMAT_STRUCT_TIMEVAL = 'L!L!' # { time_t tv_sec; suseconds_t tv_usec; }
 
-      def socket_option_validate!(protocol, resolve_name: nil, linger_timeout: nil, recv_timeout: nil, send_timeout: nil, certopts: nil)
+      def socket_option_validate!(protocol, resolve_name: nil, linger_timeout: nil, recv_timeout: nil, send_timeout: nil)
         unless resolve_name.nil?
           if protocol != :tcp && protocol != :udp && protocol != :tls
             raise ArgumentError, "BUG: resolve_name in available for tcp/udp/tls"
@@ -35,23 +35,9 @@ module Fluent
             raise ArgumentError, "BUG: linger_timeout is available for tcp/tls"
           end
         end
-        if certopts
-          if protocol != :tls
-            raise ArgumentError, "BUG: certopts is available only for tls"
-          end
-        else
-          if protocol == :tls
-            raise ArgumentError, "BUG: certopts (certificate options) not specified for TLS"
-            socket_option_certopts_validate!(certopts)
-          end
-        end
       end
 
-      def socket_option_certopts_validate!(certopts)
-        raise "not implemented yet"
-      end
-
-      def socket_option_set(sock, resolve_name: nil, nonblock: false, linger_timeout: nil, recv_timeout: nil, send_timeout: nil, certopts: nil)
+      def socket_option_set(sock, resolve_name: nil, nonblock: false, linger_timeout: nil, recv_timeout: nil, send_timeout: nil)
         unless resolve_name.nil?
           sock.do_not_reverse_lookup = !resolve_name
         end
@@ -70,7 +56,6 @@ module Fluent
           optval = [send_timeout.to_i, 0].pack(FORMAT_STRUCT_TIMEVAL)
           socket_option_set_one(sock, :SO_SNDTIMEO, optval)
         end
-        # TODO: certopts for TLS
         sock
       end
 

--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -72,7 +72,7 @@ class ForwardOutputTest < Test::Unit::TestCase
     ])
     nodes = d.instance.nodes
     assert_equal 60, d.instance.send_timeout
-    assert_equal :tcp, d.instance.heartbeat_type
+    assert_equal :transport, d.instance.heartbeat_type
     assert_equal 1, nodes.length
     node = nodes.first
     assert_equal "test", node.name
@@ -119,8 +119,8 @@ EOL
     end
   end
 
-  test 'configure_dns_round_robin tcp' do
-    @d = d = create_driver(CONFIG + "\nheartbeat_type tcp\ndns_round_robin true")
+  test 'configure_dns_round_robin transport' do
+    @d = d = create_driver(CONFIG + "\nheartbeat_type transport\ndns_round_robin true")
     assert_equal true, d.instance.dns_round_robin
   end
 
@@ -655,7 +655,8 @@ EOL
     usock = d.instance.instance_variable_get(:@usock)
     servers = d.instance.instance_variable_get(:@_servers)
     timers = d.instance.instance_variable_get(:@_timers)
-    assert_equal UDPSocket, usock.class
+    assert_equal Fluent::PluginHelper::Socket::WrappedSocket::UDP, usock.class
+    assert_kind_of UDPSocket, usock
     assert servers.find{|s| s.title == :out_forward_heartbeat_receiver }
     assert timers.include?(:out_forward_heartbeat_request)
 

--- a/test/plugin_helper/test_server.rb
+++ b/test/plugin_helper/test_server.rb
@@ -469,7 +469,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
       end
       waiting(10){ sleep 0.1 until received.bytesize == 4 || errors.size == 1 }
       assert_equal "foo\n", received
-      assert_equal 1, errors.size
+      assert{ errors.size > 0 } # it might be called twice (or more) when connection was accepted, and then data arrived (or more)
       assert_equal "data callback can be registered just once, but registered twice", errors.first.message
     end
 

--- a/test/plugin_helper/test_server.rb
+++ b/test/plugin_helper/test_server.rb
@@ -1217,7 +1217,8 @@ class ServerPluginHelperTest < Test::Unit::TestCase
         end
       end
       waiting(10){ sleep 0.1 until received.bytesize == 24 }
-      assert_equal "yay\nfoo\nyay\nfoo\nyay\nfoo\n", received
+      assert_equal 3, received.scan("yay\n").size
+      assert_equal 3, received.scan("foo\n").size
     end
 
     test 'creates a tls server to read and write data' do
@@ -1236,7 +1237,8 @@ class ServerPluginHelperTest < Test::Unit::TestCase
         end
       end
       waiting(10){ sleep 0.1 until received.bytesize == 24 }
-      assert_equal "yay\nfoo\nyay\nfoo\nyay\nfoo\n", received
+      assert_equal 3, received.scan("yay\n").size
+      assert_equal 3, received.scan("foo\n").size
       assert_equal ["ack\n","ack\n","ack\n"], responses
     end
 
@@ -1258,7 +1260,8 @@ class ServerPluginHelperTest < Test::Unit::TestCase
         end
       end
       waiting(10){ sleep 0.1 until received.bytesize == 24 }
-      assert_equal "yay\nfoo\nyay\nfoo\nyay\nfoo\n", received
+      assert_equal 3, received.scan("yay\n").size
+      assert_equal 3, received.scan("foo\n").size
       assert_equal ["ack\n","ack\n","ack\n"], responses
     end
 
@@ -1276,7 +1279,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
         end
       end
       waiting(10){ sleep 0.1 until received.bytesize == 12 }
-      assert_equal "yay\nyay\nyay\n", received
+      assert_equal 3, received.scan("yay\n").size
       assert{ sources.all?{|s| s == "127.0.0.1" } }
     end
 
@@ -1296,7 +1299,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
         end
       end
       waiting(10){ sleep 0.1 until received.bytesize == 12 }
-      assert_equal "yay\nyay\nyay\n", received
+      assert_equal 3, received.scan("yay\n").size
       assert{ sources.all?{|s| s == hostname } }
     end
 
@@ -1315,7 +1318,6 @@ class ServerPluginHelperTest < Test::Unit::TestCase
           errors << e
         end
       end
-      # open_tls_session('127.0.0.1', PORT, cert_path: @cert_path, hostname: @default_hostname) do |sock|
       open_tls_session('127.0.0.1', PORT, cert_path: @cert_path) do |sock|
         sock.puts "foo"
       end
@@ -1339,7 +1341,6 @@ class ServerPluginHelperTest < Test::Unit::TestCase
         end
       end
       3.times do
-        # open_tls_session('127.0.0.1', PORT, cert_path: @cert_path, hostname: @default_hostname) do |sock|
         open_tls_session('127.0.0.1', PORT, cert_path: @cert_path) do |sock|
           sock.write "yay"
           sock.write "foo\n"
@@ -1370,7 +1371,6 @@ class ServerPluginHelperTest < Test::Unit::TestCase
         end
       end
       3.times do
-        # open_tls_session('127.0.0.1', PORT, cert_path: @cert_path, hostname: @default_hostname) do |sock|
         open_tls_session('127.0.0.1', PORT, cert_path: @cert_path) do |sock|
           sock.write "yay"
           sock.write "foo\n"


### PR DESCRIPTION
This change is to add a functionality to support TLS, mainly for in/out forward plugins.

The server plugin helper's TLS support is:
* plugins can use `tls_options` hash argument to specify various options about TLS options and certifications in programatic way
* plugins can load configurations about TLS via `<transport tls>` section of configuration transparently to control them by users directly (not to write any code in plugins)

This feature supports these certificate management:
* load a server certificate (signed by public/private CA)
* load a private CA certificate and private key, and generate server certificates dynamically
* generate self-signed server certificate dynamically

With this feature, v0.14 forward input/output plugins are compatible with 3rd party secure-forward plugin.