### PR TITLE
Clock api for incremental second unit counter

### DIFF
--- a/lib/fluent/clock.rb
+++ b/lib/fluent/clock.rb
@@ -1,0 +1,62 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+module Fluent
+  module Clock
+    CLOCK_ID = Process::CLOCK_MONOTONIC_RAW rescue Process::CLOCK_MONOTONIC
+
+    @@block_level = 0
+    @@frozen_clock = nil
+
+    def self.now
+      @@frozen_clock || now_raw
+    end
+
+    def self.freeze(dst = nil, &block)
+      return freeze_block(dst, &block) if block_given?
+
+      dst = dst_clock_from_time(dst) if dst.is_a?(Time)
+      @@frozen_clock = dst || now_raw
+    end
+
+    def self.return
+      raise "invalid return while running code in blocks" if @@block_level > 0
+      @@frozen_clock = nil
+    end
+
+    # internal use
+
+    def self.now_raw
+      Process.clock_gettime(CLOCK_ID)
+    end
+
+    def self.dst_clock_from_time(time)
+      diff_sec = Time.now - time
+      now_raw - diff_sec
+    end
+
+    def self.freeze_block(dst)
+      dst = dst_clock_from_time(dst) if dst.is_a?(Time)
+      pre_frozen_clock = @@frozen_clock
+      @@frozen_clock = dst || now_raw
+      @@block_level += 1
+      yield
+    ensure
+      @@block_level -= 1
+      @@frozen_clock = pre_frozen_clock
+    end
+  end
+end

--- a/lib/fluent/plugin_helper/event_loop.rb
+++ b/lib/fluent/plugin_helper/event_loop.rb
@@ -16,6 +16,7 @@
 
 require 'cool.io'
 require 'fluent/plugin_helper/thread'
+require 'fluent/clock'
 
 module Fluent
   module PluginHelper
@@ -31,7 +32,6 @@ module Fluent
 
       EVENT_LOOP_RUN_DEFAULT_TIMEOUT = 0.5
       EVENT_LOOP_SHUTDOWN_TIMEOUT = 5
-      EVENT_LOOP_CLOCK_ID = Process::CLOCK_MONOTONIC_RAW rescue Process::CLOCK_MONOTONIC
 
       attr_reader :_event_loop # for tests
 
@@ -89,9 +89,9 @@ module Fluent
             end
           end
         end
-        timeout_at = Process.clock_gettime(EVENT_LOOP_CLOCK_ID) + EVENT_LOOP_SHUTDOWN_TIMEOUT
+        timeout_at = Fluent::Clock.now + EVENT_LOOP_SHUTDOWN_TIMEOUT
         while @_event_loop_running
-          if Process.clock_gettime(EVENT_LOOP_CLOCK_ID) >= timeout_at
+          if Fluent::Clock.now >= timeout_at
             log.warn "event loop does NOT exit until hard timeout."
             raise "event loop does NOT exit until hard timeout." if @under_plugin_development
             break

--- a/lib/fluent/test/driver/base.rb
+++ b/lib/fluent/test/driver/base.rb
@@ -17,6 +17,7 @@
 require 'fluent/config'
 require 'fluent/config/element'
 require 'fluent/log'
+require 'fluent/clock'
 
 require 'serverengine/socket_manager'
 require 'fileutils'
@@ -48,8 +49,6 @@ module Fluent
 
           @logs = []
 
-          @test_clock_id = Process::CLOCK_MONOTONIC_RAW rescue Process::CLOCK_MONOTONIC
-
           @run_post_conditions = []
           @run_breaking_conditions = []
           @broken = false
@@ -77,8 +76,8 @@ module Fluent
           instance_start if start
 
           timeout ||= DEFAULT_TIMEOUT
-          stop_at = Process.clock_gettime(@test_clock_id) + timeout
-          @run_breaking_conditions << ->(){ Process.clock_gettime(@test_clock_id) >= stop_at }
+          stop_at = Fluent::Clock.now + timeout
+          @run_breaking_conditions << ->(){ Fluent::Clock.now >= stop_at }
 
           if !block_given? && @run_post_conditions.empty? && @run_breaking_conditions.empty?
             raise ArgumentError, "no stop conditions nor block specified"

--- a/test/test_clock.rb
+++ b/test/test_clock.rb
@@ -1,0 +1,162 @@
+require_relative 'helper'
+require 'fluent/clock'
+
+require 'timecop'
+
+class ClockTest < ::Test::Unit::TestCase
+  teardown do
+    Fluent::Clock.return # call it always not to affect other tests
+  end
+
+  sub_test_case 'without any pre-operation' do
+    test 'clock can provides incremental floating point number based on second' do
+      c1 = Fluent::Clock.now
+      assert_kind_of Float, c1
+      sleep 1.1
+      c2 = Fluent::Clock.now
+      assert{ c2 >= c1 + 1.0 && c2 < c1 + 9.0 } # if clock returns deci-second (fantastic!), c2 should be larger than c1 + 10
+    end
+
+    test 'clock value will proceed even if timecop freezes Time' do
+      Timecop.freeze(Time.now) do
+        c1 = Fluent::Clock.now
+        assert_kind_of Float, c1
+        sleep 1.1
+        c2 = Fluent::Clock.now
+        assert{ c2 >= c1 + 1.0 && c2 < c1 + 9.0 }
+      end
+    end
+  end
+
+  sub_test_case 'using #freeze without any arguments' do
+    test 'Clock.freeze without arguments freezes clock with current clock value' do
+      c0 = Fluent::Clock.now
+      Fluent::Clock.freeze
+      c1 = Fluent::Clock.now
+      Fluent::Clock.return
+      c2 = Fluent::Clock.now
+      assert{ c0 <= c1 && c1 <= c2 }
+    end
+
+    test 'Clock.return raises an error if it is called in block' do
+      assert_raise "invalid return while running code in blocks" do
+        Fluent::Clock.freeze do
+          Fluent::Clock.return
+        end
+      end
+    end
+  end
+
+  sub_test_case 'using #freeze with clock value' do
+    test 'Clock.now always returns frozen time until #return called' do
+      c0 = Fluent::Clock.now
+      Fluent::Clock.freeze(c0)
+      assert_equal c0, Fluent::Clock.now
+      sleep 0.5
+      assert_equal c0, Fluent::Clock.now
+      sleep 0.6
+      assert_equal c0, Fluent::Clock.now
+
+      Fluent::Clock.return
+      c1 = Fluent::Clock.now
+      assert{ c1 >= c0 + 1.0 }
+    end
+
+    test 'Clock.now returns frozen time in the block argument of #freeze' do
+      c0 = Fluent::Clock.now
+      Fluent::Clock.freeze(c0) do
+        assert_equal c0, Fluent::Clock.now
+        sleep 0.5
+        assert_equal c0, Fluent::Clock.now
+        sleep 0.6
+        assert_equal c0, Fluent::Clock.now
+      end
+      c1 = Fluent::Clock.now
+      assert{ c1 >= c0 + 1.0 }
+    end
+
+    test 'Clock.now returns unfrozen value after jumping out from block by raising errors' do
+      c0 = Fluent::Clock.now
+      rescued_error = nil
+      begin
+        Fluent::Clock.freeze(c0) do
+          assert_equal c0, Fluent::Clock.now
+          sleep 0.5
+          assert_equal c0, Fluent::Clock.now
+          sleep 0.6
+          assert_equal c0, Fluent::Clock.now
+          raise "bye!"
+        end
+      rescue => e
+        rescued_error = e
+      end
+      assert rescued_error # ensure to rescue an error
+      c1 = Fluent::Clock.now
+      assert{ c1 >= c0 + 1.0 }
+    end
+
+    test 'Clock.return cancels all Clock.freeze effects by just once' do
+      c0 = Fluent::Clock.now
+      sleep 0.1
+      c1 = Fluent::Clock.now
+      sleep 0.1
+      c2 = Fluent::Clock.now
+      Fluent::Clock.freeze(c0)
+      sleep 0.1
+      assert_equal c0, Fluent::Clock.now
+      Fluent::Clock.freeze(c1)
+      sleep 0.1
+      assert_equal c1, Fluent::Clock.now
+      Fluent::Clock.freeze(c2)
+      sleep 0.1
+      assert_equal c2, Fluent::Clock.now
+
+      Fluent::Clock.return
+      assert{ Fluent::Clock.now > c2 }
+    end
+
+    test 'Clock.freeze allows nested blocks by itself' do
+      c0 = Fluent::Clock.now
+      sleep 0.1
+      c1 = Fluent::Clock.now
+      sleep 0.1
+      c2 = Fluent::Clock.now
+      Fluent::Clock.freeze(c0) do
+        sleep 0.1
+        assert_equal c0, Fluent::Clock.now
+        Fluent::Clock.freeze(c1) do
+          sleep 0.1
+          assert_equal c1, Fluent::Clock.now
+          Fluent::Clock.freeze(c2) do
+            sleep 0.1
+            assert_equal c2, Fluent::Clock.now
+          end
+          assert_equal c1, Fluent::Clock.now
+        end
+        assert_equal c0, Fluent::Clock.now
+      end
+      assert{ Fluent::Clock.now > c0 }
+    end
+  end
+
+  sub_test_case 'using #freeze with Time argument' do
+    test 'Clock.freeze returns the clock value which should be produced when the time is at the specified time' do
+      c0 = Fluent::Clock.now
+      t0 = Time.now
+      t1 = t0 - 30
+      assert_kind_of Time, t1
+      t2 = t0 + 30
+      assert_kind_of Time, t2
+
+      Fluent::Clock.freeze(t1) do
+        c1 = Fluent::Clock.now
+        assert{ c1 >= c0 - 30 && c1 <= c0 - 30 + 10 } # +10 is for threading schedule error
+      end
+
+      Fluent::Clock.freeze(t2) do
+        c2 = Fluent::Clock.now
+        assert{ c2 >= c0 + 30 && c2 <= c0 + 30 + 10 } # +10 is for threading schedule error
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently there are many code to use `Time.now` to control flush timing and event invoke timing.
It's basically wrong, because time may move to future or past by time adjustment, or affected by leap seconds (and Timecop).
We can use `Process.clock_gettime` to avoid this problem, but it's a bit troublesome to specify clock type available. It's too much and too raw for almost core code and plugins. Using `Process.clock_gettime` is also not controlled by test code.

So, this change will introduce a new internal API to provide clock value, which can be controlled to be frozen for tests.
