### PR TITLE
record_transformer: remove_keys processing should be last

### DIFF
--- a/lib/fluent/plugin/filter_record_transformer.rb
+++ b/lib/fluent/plugin/filter_record_transformer.rb
@@ -101,6 +101,8 @@ module Fluent::Plugin
           if @renew_time_key && new_record.has_key?(@renew_time_key)
             time = Fluent::EventTime.from_time(Time.at(new_record[@renew_time_key].to_f))
           end
+          @remove_keys.each {|k| new_record.delete(k) } if @remove_keys
+
           new_es.add(time, new_record)
         rescue => e
           router.emit_error_event(tag, time, record, e)
@@ -129,7 +131,6 @@ module Fluent::Plugin
       new_record = @renew_record ? {} : record.dup
       @keep_keys.each {|k| new_record[k] = record[k]} if @keep_keys and @renew_record
       new_record.merge!(expand_placeholders(@map, placeholders))
-      @remove_keys.each {|k| new_record.delete(k) } if @remove_keys
 
       new_record
     end

--- a/test/plugin/test_filter_record_transformer.rb
+++ b/test/plugin/test_filter_record_transformer.rb
@@ -104,6 +104,26 @@ class RecordTransformerFilterTest < Test::Unit::TestCase
       filtered.each_with_index do |(time, _record), i|
         assert_equal(times[i].to_i, time)
         assert(time.is_a?(Fluent::EventTime))
+        assert_true(_record.has_key?('message'))
+      end
+    end
+
+    test 'renew_time_key and remove_keys' do
+      config = %[
+                 renew_time_key event_time_key
+                 remove_keys event_time_key
+                 auto_typecast true
+                 <record>
+                   event_time_key ${record["message"]}
+                 </record>
+               ]
+      times = [Time.local(2, 2, 3, 4, 5, 2010, nil, nil, nil, nil), Time.local(3, 2, 3, 4, 5, 2010, nil, nil, nil, nil)]
+      msgs = times.map { |t| t.to_f.to_s }
+      filtered = filter(config, msgs)
+      filtered.each_with_index do |(time, _record), i|
+        assert_equal(times[i].to_i, time)
+        assert(time.is_a?(Fluent::EventTime))
+        assert_false(_record.has_key?('event_time_key'))
       end
     end
 


### PR DESCRIPTION
Currently, `remove_keys` doesn't work with `renew_time_key` parameter, so
user needs one more filter to remove `renew_time_key` field from the record.

```aconf
<filter pattern>
  @type record_transformer
  renew_time_key event_time
  auto_typecast true
  <record>
    event_time ${Convert record["time_str"] into unixtime or float type}
  </record>
</filter>

<filter pattern>
  @type record_transformer
  remove_keys event_time
</filter>
```

This is verbose and not good performance. `remove_keys` should remove `renew_time_key`.

```aconf
<filter pattern>
  @type record_transformer
  renew_time_key event_time
  remove_keys event_time
  auto_typecast true
  <record>
    event_time ${Convert record["time_str"] into unixtime or float type}
  </record>
</filter>
```