### PR TITLE
Improve flush_interval handling

### DIFF
--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -310,6 +310,10 @@ module Fluent
             log.warn "'flush_at_shutdown' is false, and buffer plugin '#{buf_type}' is not persistent buffer."
             log.warn "your configuration will lose buffered data at shutdown. please confirm your configuration again."
           end
+
+          if @flush_mode != :interval && buffer_conf.has_key?('flush_interval')
+            log.warn "'flush_interval' is ignored because 'flush_mode' is not 'interval': '#{@flush_mode}'"
+          end
         end
 
         if @secondary_config

--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -229,6 +229,7 @@ module Fluent
         end
 
         has_buffer_section = (conf.elements(name: 'buffer').size > 0)
+        has_flush_interval = conf.has_key?('flush_interval')
 
         super
 
@@ -290,7 +291,12 @@ module Fluent
 
           @flush_mode = @buffer_config.flush_mode
           if @flush_mode == :default
-            @flush_mode = (@chunk_key_time ? :lazy : :interval)
+            if has_flush_interval
+              log.info "'flush_interval' is configured at out side of <buffer>. 'flush_mode' is set to 'interval' to keep existing behaviour"
+              @flush_mode = :interval
+            else
+              @flush_mode = (@chunk_key_time ? :lazy : :interval)
+            end
           end
 
           buffer_type = @buffer_config[:@type]
@@ -311,8 +317,12 @@ module Fluent
             log.warn "your configuration will lose buffered data at shutdown. please confirm your configuration again."
           end
 
-          if @flush_mode != :interval && buffer_conf.has_key?('flush_interval')
-            log.warn "'flush_interval' is ignored because 'flush_mode' is not 'interval': '#{@flush_mode}'"
+          if (@flush_mode != :interval) && buffer_conf.has_key?('flush_interval')
+            if buffer_conf.has_key?('flush_mode')
+              raise Fluent::ConfigError, "'flush_interval' can't be specified when 'flush_mode' is not 'interval' explicitly: '#{@flush_mode}'"
+            else
+              log.warn "'flush_interval' is ignored because default 'flush_mode' is not 'interval': '#{@flush_mode}'"
+            end
           end
         end
 

--- a/lib/fluent/plugin_helper/compat_parameters.rb
+++ b/lib/fluent/plugin_helper/compat_parameters.rb
@@ -169,9 +169,6 @@ module Fluent
             hash['timekey'] = 86400 # TimeSliceOutput.time_slice_format default value is '%Y%m%d'
           end
         end
-        if conf.has_key?('flush_interval')
-          hash['flush_mode'] = 'interval'
-        end
 
         e = Fluent::Config::Element.new('buffer', chunk_key, hash, [])
         conf.elements << e

--- a/lib/fluent/plugin_helper/compat_parameters.rb
+++ b/lib/fluent/plugin_helper/compat_parameters.rb
@@ -169,6 +169,9 @@ module Fluent
             hash['timekey'] = 86400 # TimeSliceOutput.time_slice_format default value is '%Y%m%d'
           end
         end
+        if conf.has_key?('flush_interval')
+          hash['flush_mode'] = 'interval'
+        end
 
         e = Fluent::Config::Element.new('buffer', chunk_key, hash, [])
         conf.elements << e

--- a/test/plugin/test_output.rb
+++ b/test/plugin/test_output.rb
@@ -707,8 +707,21 @@ class OutputTest < Test::Unit::TestCase
     end
 
     test 'flush_interval is ignored when flush_mode is not interval' do
-      mock(@i.log).warn("'flush_interval' is ignored because 'flush_mode' is not 'interval': 'lazy'")
+      mock(@i.log).warn("'flush_interval' is ignored because default 'flush_mode' is not 'interval': 'lazy'")
       @i.configure(config_element('ROOT', '', {}, [config_element('buffer', 'time', {'timekey' => 60*30, 'flush_interval' => 10})]))
+    end
+
+    data(:lazy => 'lazy', :immediate => 'immediate')
+    test 'flush_interval and non-interval flush_mode is exclusive ' do |mode|
+      assert_raise Fluent::ConfigError.new("'flush_interval' can't be specified when 'flush_mode' is not 'interval' explicitly: '#{mode}'") do
+        @i.configure(config_element('ROOT', '', {}, [config_element('buffer', '', {'flush_mode' => mode, 'flush_interval' => 10})]))
+      end
+    end
+
+    test 'flush_mode is set to interval when flush_interval with v0.12 configuration is given' do
+      mock(@i.log).info("'flush_interval' is configured at out side of <buffer>. 'flush_mode' is set to 'interval' to keep existing behaviour")
+      @i.configure(config_element('ROOT', '', {'flush_interval' => 60}, []))
+      assert_equal :interval, @i.instance_variable_get(:@flush_mode)
     end
 
     test "Warn if primary type is different from secondary type and either primary or secondary has custom_format" do

--- a/test/plugin/test_output.rb
+++ b/test/plugin/test_output.rb
@@ -706,6 +706,11 @@ class OutputTest < Test::Unit::TestCase
       i.stop; i.before_shutdown; i.shutdown; i.after_shutdown; i.close; i.terminate
     end
 
+    test 'flush_interval is ignored when flush_mode is not interval' do
+      mock(@i.log).warn("'flush_interval' is ignored because 'flush_mode' is not 'interval': 'lazy'")
+      @i.configure(config_element('ROOT', '', {}, [config_element('buffer', 'time', {'timekey' => 60*30, 'flush_interval' => 10})]))
+    end
+
     test "Warn if primary type is different from secondary type and either primary or secondary has custom_format" do
       o = create_output(:buffered)
       mock(o.log).warn("secondary type should be same with primary one",

--- a/test/plugin_helper/test_compat_parameters.rb
+++ b/test/plugin_helper/test_compat_parameters.rb
@@ -106,7 +106,7 @@ class CompatParameterTest < Test::Unit::TestCase
       assert_equal [], @i.buffer_config.chunk_keys
       assert_equal 8, @i.buffer_config.flush_thread_count
       assert_equal 10, @i.buffer_config.flush_interval
-      assert_equal :interval, @i.buffer_config.flush_mode
+      assert_equal :default, @i.buffer_config.flush_mode
       assert @i.buffer_config.flush_at_shutdown
 
       assert_equal 8*1024*1024, @i.buffer.chunk_limit_size

--- a/test/plugin_helper/test_compat_parameters.rb
+++ b/test/plugin_helper/test_compat_parameters.rb
@@ -106,6 +106,7 @@ class CompatParameterTest < Test::Unit::TestCase
       assert_equal [], @i.buffer_config.chunk_keys
       assert_equal 8, @i.buffer_config.flush_thread_count
       assert_equal 10, @i.buffer_config.flush_interval
+      assert_equal :interval, @i.buffer_config.flush_mode
       assert @i.buffer_config.flush_at_shutdown
 
       assert_equal 8*1024*1024, @i.buffer.chunk_limit_size
@@ -131,6 +132,7 @@ class CompatParameterTest < Test::Unit::TestCase
       assert @i.buffer_config.retry_forever
       assert_equal 60*60, @i.buffer_config.retry_max_interval
       assert_equal :block, @i.buffer_config.overflow_action
+      assert_equal :default, @i.buffer_config.flush_mode
 
       assert !@i.chunk_key_tag
       assert_equal [], @i.chunk_keys


### PR DESCRIPTION
This patch improves flush_interval parameter handing.

- Set `flush_mode interval` when v0.12 configuration has `flush_interval`

This avoids a trouble for existing out_file and out_s3 configurations

- Log warning message for flush_interval without `flush_mode interval` in `<buffer>`

Currenlty, `flush_interval` is ignored silently with following configuration. It is hard to debug for users.

```
<buffer time>
  timekey 3600
  flush_interval 30s
</buffer>
```
