### PR TITLE
Keep Fluent::BufferQueueLimitError for exsting plugins

### DIFF
--- a/lib/fluent/plugin/buffer.rb
+++ b/lib/fluent/plugin/buffer.rb
@@ -614,4 +614,7 @@ module Fluent
       end
     end
   end
+
+  # Some input plugins refer BufferQueueLimitError for throttling
+  BufferQueueLimitError = ::Fluent::Plugin::Buffer::BufferOverflowError
 end

--- a/test/plugin/test_buffer.rb
+++ b/test/plugin/test_buffer.rb
@@ -1217,4 +1217,8 @@ class BufferTest < Test::Unit::TestCase
       assert chunk.singleton_class.ancestors.include?(Fluent::Plugin::Buffer::Chunk::Decompressable)
     end
   end
+
+  test 'BufferQueueLimitError compatibility' do
+    assert_equal Fluent::Plugin::Buffer::BufferOverflowError, Fluent::BufferQueueLimitError
+  end
 end


### PR DESCRIPTION
This is for v0.12 based plugins.
Plugin should be moved to BufferOverflowError after v0.14 migration.
But fluentd should keep API compatibility for now.