### PR TITLE
Fix issue #1451. The in_tail plugin tries to tail directories when th…

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -196,7 +196,11 @@ module Fluent::Plugin
           paths << path
         end
       }
-      paths - excluded
+      remove_directories(paths - excluded)
+    end
+
+    def remove_directories(paths)
+      paths.select { |p| !File.directory?(p) }
     end
 
     # in_tail with '*' path doesn't check rotation file equality at refresh phase.

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -847,6 +847,25 @@ class TailInputTest < Test::Unit::TestCase
       plugin = create_driver(exclude_config, false).instance
       assert_equal EX_PATHS - [EX_PATHS.last], plugin.expand_paths.sort
     end
+
+    def test_log_file_without_extension
+      expected_files = [
+        'test/plugin/data/log/bar',
+        'test/plugin/data/log/foo/bar.log',
+        'test/plugin/data/log/foo/bar2',
+        'test/plugin/data/log/test.log'
+      ]
+
+      config = config_element("", "", {
+        "tag" => "tail",
+        "path" => "test/plugin/data/log/**/*",
+        "format" => "none",
+        "pos_file" => "#{TMP_DIR}/tail.pos"
+      })
+
+      plugin = create_driver(config, false).instance
+      assert_equal expected_files, plugin.expand_paths.sort
+    end
   end
 
   def test_z_refresh_watchers


### PR DESCRIPTION
**Original issue:** https://github.com/fluent/fluentd/issues/1451.

**Issue:**
the in_tail plugin tries to tail directories when the /**/* file path is used.

**Description:**
There is a directory which contains subdirectories. These subdirectories can contain log files without extension.  The goal is to let fluentd tail all files that it can find in the subdirectories. 
The best way to do it is to set the path plugin parameter = /**/*, but the plugin doesn't distinguish files from directories and tries to tails directories that causes an io exception.

**Fix description:**
This fix includes removing all the directories from the list of file objects that fluentd finds according to the given path parameter.