### PR TITLE
Fix issue #1451. The in_tail plugin tries to tail directories when th…

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -184,7 +184,7 @@ module Fluent::Plugin
         path = date.strftime(path)
         if path.include?('*')
           paths += Dir.glob(path).select { |p|
-            if File.readable?(p)
+            if File.readable?(p) && !File.directory?(p)
               true
             else
               log.warn "#{p} unreadable. It is excluded and would be examined next time."

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -847,6 +847,25 @@ class TailInputTest < Test::Unit::TestCase
       plugin = create_driver(exclude_config, false).instance
       assert_equal EX_PATHS - [EX_PATHS.last], plugin.expand_paths.sort
     end
+
+    def test_log_file_without_extension
+      expected_files = [
+        'test/plugin/data/log/bar',
+        'test/plugin/data/log/foo/bar.log',
+        'test/plugin/data/log/foo/bar2',
+        'test/plugin/data/log/test.log'
+      ]
+
+      config = config_element("", "", {
+        "tag" => "tail",
+        "path" => "test/plugin/data/log/**/*",
+        "format" => "none",
+        "pos_file" => "#{TMP_DIR}/tail.pos"
+      })
+
+      plugin = create_driver(config, false).instance
+      assert_equal expected_files, plugin.expand_paths.sort
+    end
   end
 
   def test_z_refresh_watchers


### PR DESCRIPTION
**Original issue:** #1451.

**Issue:**
the in_tail plugin tries to tail directories when the /**/* file path is used.

**Description:**
There is a directory which contains subdirectories. These subdirectories can contain log files without extension. The goal is to let fluentd tail all files that it can find in the subdirectories.
The best way to do it is to set the path plugin parameter = /**/*, but the plugin doesn't distinguish files from directories and tries to tails directories that causes an io exception.

**Fix description:**
This fix includes removing all the directories from the list of file objects that fluentd finds according to the given path parameter.