### PR TITLE
Add `Fluent::Log#<<`

### DIFF
--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -357,6 +357,7 @@ module Fluent
     def write(data)
       @out.write(data)
     end
+    alias << write
 
     def flush
       @out.flush

--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -357,6 +357,8 @@ module Fluent
     def write(data)
       @out.write(data)
     end
+    # We need `#<<` method to use this logger class with other
+    # libraries such as aws-sdk
     alias << write
 
     def flush

--- a/test/test_log.rb
+++ b/test/test_log.rb
@@ -720,6 +720,10 @@ class PluginLoggerTest < Test::Unit::TestCase
       @log.write("log")
     end
 
+    def test_write_alias
+      assert { @log.respond_to?(:<<) }
+    end
+
     def test_out
       assert_equal(@log.out, @logger.out)
       @log.out = Object.new

--- a/test/test_log.rb
+++ b/test/test_log.rb
@@ -721,7 +721,7 @@ class PluginLoggerTest < Test::Unit::TestCase
     end
 
     def test_write_alias
-      assert { @log.respond_to?(:<<) }
+      assert(@log.respond_to?(:<<))
     end
 
     def test_out


### PR DESCRIPTION
This is useful for AWS related plugins to set Aws::XXX::Client's logger.
AWS logger requires `#<<` method.

See https://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Client.html#initialize-instance_method