### PR TITLE
Allow escape sequence in Apache access log

### DIFF
--- a/lib/fluent/plugin/parser_apache2.rb
+++ b/lib/fluent/plugin/parser_apache2.rb
@@ -21,7 +21,7 @@ module Fluent
     class Apache2Parser < Parser
       Plugin.register_parser('apache2', self)
 
-      REGEXP = /^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$/
+      REGEXP = /^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>(?:[^\"]|\\.)*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>(?:[^\"]|\\.)*)" "(?<agent>(?:[^\"]|\\.)*)")?$/
       TIME_FORMAT = "%d/%b/%Y:%H:%M:%S %z"
 
       def initialize

--- a/test/plugin/test_parser_apache2.rb
+++ b/test/plugin/test_parser_apache2.rb
@@ -35,4 +35,12 @@ class Apache2ParserTest < ::Test::Unit::TestCase
       assert_equal(@expected, record)
     }
   end
+
+  def test_parse_with_escape_sequence
+    @parser.instance.parse('192.168.0.1 - - [28/Feb/2013:12:00:00 +0900] "GET /\" HTTP/1.1" 200 777 "referer \\\ \"" "user agent \\\ \""') { |_, record|
+      assert_equal('/\"', record['path'])
+      assert_equal('referer \\\ \"', record['referer'])
+      assert_equal('user agent \\\ \"', record['agent'])
+    }
+  end
 end


### PR DESCRIPTION
http://httpd.apache.org/docs/current/mod/mod_log_config.html#format-notes