### PR TITLE
Fix cleanup resource

### DIFF
--- a/lib/fluent/env.rb
+++ b/lib/fluent/env.rb
@@ -14,15 +14,15 @@
 #    limitations under the License.
 #
 
+require 'serverengine/utils'
+
 module Fluent
   DEFAULT_CONFIG_PATH = ENV['FLUENT_CONF'] || '/etc/fluent/fluent.conf'
   DEFAULT_PLUGIN_DIR = ENV['FLUENT_PLUGIN'] || '/etc/fluent/plugin'
   DEFAULT_SOCKET_PATH = ENV['FLUENT_SOCKET'] || '/var/run/fluent/fluent.sock'
   DEFAULT_OJ_OPTIONS = {bigdecimal_load: :float, mode: :compat, use_to_json: true}
-  IS_WINDOWS = /mswin|mingw/ === RUBY_PLATFORM
-  private_constant :IS_WINDOWS
 
   def self.windows?
-    IS_WINDOWS
+    ServerEngine.windows?
   end
 end

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -61,6 +61,7 @@ module Fluent
 
     def after_run
       stop_rpc_server if @rpc_endpoint
+      Fluent::Supervisor.cleanup_resources
     end
 
     def run_rpc_server
@@ -387,6 +388,14 @@ module Fluent
       }
     end
 
+    def self.cleanup_resources
+      unless Fluent.windows?
+        if ENV.has_key?('SERVERENGINE_SOCKETMANAGER_PATH')
+          FileUtils.rm_f(ENV['SERVERENGINE_SOCKETMANAGER_PATH'])
+        end
+      end
+    end
+
     def initialize(opt)
       @daemonize = opt[:daemonize]
       @supervise = opt[:supervise]
@@ -493,6 +502,7 @@ module Fluent
         init_engine
         run_configure
         run_engine
+        self.class.cleanup_resources
         exit 0
       end
     end

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -502,7 +502,7 @@ module Fluent
         init_engine
         run_configure
         run_engine
-        self.class.cleanup_resources
+        self.class.cleanup_resources if @standalone_worker
         exit 0
       end
     end


### PR DESCRIPTION
I noticed fluentd doesn't remove SocketManager's socket file.
It remains lots of garbage files under `/tmp`.

I added `cleanup_resources` function to handle such case.