### PR TITLE
parser_syslog: Polish implementation

### DIFF
--- a/lib/fluent/plugin/parser_syslog.rb
+++ b/lib/fluent/plugin/parser_syslog.rb
@@ -54,6 +54,7 @@ module Fluent
                     class << self
                       alias_method :parse, :parse_plain
                     end
+                    @time_format = @rfc5424_time_format unless conf.has_key?('time_format')
                     REGEXP_RFC5424
                   when :auto
                     class << self

--- a/lib/fluent/plugin/parser_syslog.rb
+++ b/lib/fluent/plugin/parser_syslog.rb
@@ -75,14 +75,12 @@ module Fluent
       end
 
       def parse_auto(text, &block)
-        if @message_format == :auto
-          if REGEXP_DETECT_RFC5424.match(text)
-            @regexp = REGEXP_RFC5424
-            @time_parser = @time_parser_rfc5424
-          else
-            @regexp = @with_priority ? REGEXP_WITH_PRI : REGEXP
-            @time_parser = @time_parser_rfc3164
-          end
+        if REGEXP_DETECT_RFC5424.match(text)
+          @regexp = REGEXP_RFC5424
+          @time_parser = @time_parser_rfc5424
+        else
+          @regexp = @with_priority ? REGEXP_WITH_PRI : REGEXP
+          @time_parser = @time_parser_rfc3164
         end
         parse_plain(text, &block)
       end

--- a/test/plugin/test_parser_syslog.rb
+++ b/test/plugin/test_parser_syslog.rb
@@ -80,6 +80,20 @@ class SyslogParserTest < ::Test::Unit::TestCase
       end
     end
 
+    def test_parse_with_rfc5424_message_without_time_format
+      @parser.configure(
+                        'message_format' => 'rfc5424',
+                        )
+      text = '<16>1 2017-02-06T13:14:15.003Z 192.168.0.1 fluentd - - - Hi, from Fluentd!'
+      @parser.instance.parse(text) do |time, record|
+        assert_equal(event_time("2017-02-06T13:14:15.003Z", format: '%Y-%m-%dT%H:%M:%S.%L%z'), time)
+        assert_equal "-", record["pid"]
+        assert_equal "-", record["msgid"]
+        assert_equal "-", record["extradata"]
+        assert_equal "Hi, from Fluentd!", record["message"]
+      end
+    end
+
     def test_parse_with_rfc5424_structured_message
       @parser.configure(
                         'time_format' => '%Y-%m-%dT%H:%M:%S.%L%z',


### PR DESCRIPTION
`@message_format` is always :auto in #parse_auto.

This is pointed out in https://github.com/fluent/fluentd/pull/1495#discussion_r105095256.