### PR TITLE
Add placeholder validation target to error message

### DIFF
--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -589,13 +589,13 @@ module Fluent
           example = @argument[:example]
           timekey = @argument[:timekey]
           if !sec && timekey
-            raise Fluent::ConfigError, "Parameter '#{name}' doesn't have timestamp placeholders for timekey #{timekey.to_i}"
+            raise Fluent::ConfigError, "Parameter '#{name}: #{string}' doesn't have timestamp placeholders for timekey #{timekey.to_i}"
           end
           if sec && !timekey
-            raise Fluent::ConfigError, "Parameter '#{name}' has timestamp placeholders, but chunk key 'time' is not configured"
+            raise Fluent::ConfigError, "Parameter '#{name}: #{string}' has timestamp placeholders, but chunk key 'time' is not configured"
           end
           if sec && timekey && timekey < sec
-            raise Fluent::ConfigError, "Parameter '#{@name}' doesn't have timestamp placeholder for #{title}('#{example}') for timekey #{timekey.to_i}"
+            raise Fluent::ConfigError, "Parameter '#{name}: #{string}' doesn't have timestamp placeholder for #{title}('#{example}') for timekey #{timekey.to_i}"
           end
         end
 
@@ -603,10 +603,10 @@ module Fluent
           parts = @argument[:parts]
           tagkey = @argument[:tagkey]
           if tagkey && parts.empty?
-            raise Fluent::ConfigError, "Parameter '#{@name}' doesn't have tag placeholder"
+            raise Fluent::ConfigError, "Parameter '#{name}: #{string}' doesn't have tag placeholder"
           end
           if !tagkey && !parts.empty?
-            raise Fluent::ConfigError, "Parameter '#{@name}' has tag placeholders, but chunk key 'tag' is not configured"
+            raise Fluent::ConfigError, "Parameter '#{name}: #{string}' has tag placeholders, but chunk key 'tag' is not configured"
           end
         end
 
@@ -615,11 +615,11 @@ module Fluent
           chunk_keys = @argument[:chunkkeys]
           if (chunk_keys - keys).size > 0
             not_specified = (chunk_keys - keys).sort
-            raise Fluent::ConfigError, "Parameter '#{@name}' doesn't have enough placeholders for keys #{not_specified.join(',')}"
+            raise Fluent::ConfigError, "Parameter '#{name}: #{string}' doesn't have enough placeholders for keys #{not_specified.join(',')}"
           end
           if (keys - chunk_keys).size > 0
             not_satisfied = (keys - chunk_keys).sort
-            raise Fluent::ConfigError, "Parameter '#{@name}' has placeholders, but chunk keys doesn't have keys #{not_satisfied.join(',')}"
+            raise Fluent::ConfigError, "Parameter '#{name}: #{string}' has placeholders, but chunk keys doesn't have keys #{not_satisfied.join(',')}"
           end
         end
       end

--- a/test/plugin/test_output.rb
+++ b/test/plugin/test_output.rb
@@ -315,7 +315,7 @@ class OutputTest < Test::Unit::TestCase
         validators = @i.placeholder_validators(:path, "/my/path/file.%Y-%m-%d.log")
         assert_equal 1, validators.size
         assert_equal 1, validators.select(&:time?).size
-        assert_raise Fluent::ConfigError.new("Parameter 'path' has timestamp placeholders, but chunk key 'time' is not configured") do
+        assert_raise Fluent::ConfigError.new("Parameter 'path: /my/path/file.%Y-%m-%d.log' has timestamp placeholders, but chunk key 'time' is not configured") do
           validators.first.validate!
         end
       end
@@ -325,7 +325,7 @@ class OutputTest < Test::Unit::TestCase
         validators = @i.placeholder_validators(:path, "/my/path/to/file.log")
         assert_equal 1, validators.size
         assert_equal 1, validators.select(&:time?).size
-        assert_raise Fluent::ConfigError.new("Parameter 'path' doesn't have timestamp placeholders for timekey 30") do
+        assert_raise Fluent::ConfigError.new("Parameter 'path: /my/path/to/file.log' doesn't have timestamp placeholders for timekey 30") do
           validators.first.validate!
         end
       end
@@ -335,7 +335,7 @@ class OutputTest < Test::Unit::TestCase
         validators = @i.placeholder_validators(:path, "/my/path/${tag}/file.log")
         assert_equal 1, validators.size
         assert_equal 1, validators.select(&:tag?).size
-        assert_raise Fluent::ConfigError.new("Parameter 'path' has tag placeholders, but chunk key 'tag' is not configured") do
+        assert_raise Fluent::ConfigError.new("Parameter 'path: /my/path/${tag}/file.log' has tag placeholders, but chunk key 'tag' is not configured") do
           validators.first.validate!
         end
       end
@@ -345,7 +345,7 @@ class OutputTest < Test::Unit::TestCase
         validators = @i.placeholder_validators(:path, "/my/path/file.log")
         assert_equal 1, validators.size
         assert_equal 1, validators.select(&:tag?).size
-        assert_raise Fluent::ConfigError.new("Parameter 'path' doesn't have tag placeholder") do
+        assert_raise Fluent::ConfigError.new("Parameter 'path: /my/path/file.log' doesn't have tag placeholder") do
           validators.first.validate!
         end
       end
@@ -355,7 +355,7 @@ class OutputTest < Test::Unit::TestCase
         validators = @i.placeholder_validators(:path, "/my/path/${username}/file.${group}.log")
         assert_equal 1, validators.size
         assert_equal 1, validators.select(&:keys?).size
-        assert_raise Fluent::ConfigError.new("Parameter 'path' has placeholders, but chunk keys doesn't have keys group,username") do
+        assert_raise Fluent::ConfigError.new("Parameter 'path: /my/path/${username}/file.${group}.log' has placeholders, but chunk keys doesn't have keys group,username") do
           validators.first.validate!
         end
       end
@@ -365,7 +365,7 @@ class OutputTest < Test::Unit::TestCase
         validators = @i.placeholder_validators(:path, "/my/path/file.log")
         assert_equal 1, validators.size
         assert_equal 1, validators.select(&:keys?).size
-        assert_raise Fluent::ConfigError.new("Parameter 'path' doesn't have enough placeholders for keys group,username") do
+        assert_raise Fluent::ConfigError.new("Parameter 'path: /my/path/file.log' doesn't have enough placeholders for keys group,username") do
           validators.first.validate!
         end
       end
@@ -374,14 +374,14 @@ class OutputTest < Test::Unit::TestCase
     sub_test_case '#placeholder_validate!' do
       test 'raises configuration error for a templace when timestamp placeholders exist but time key is missing' do
         @i.configure(config_element('ROOT', '', {}, [config_element('buffer', '')]))
-        assert_raise Fluent::ConfigError.new("Parameter 'path' has timestamp placeholders, but chunk key 'time' is not configured") do
+        assert_raise Fluent::ConfigError.new("Parameter 'path: /path/without/timestamp/file.%Y%m%d-%H%M.log' has timestamp placeholders, but chunk key 'time' is not configured") do
           @i.placeholder_validate!(:path, "/path/without/timestamp/file.%Y%m%d-%H%M.log")
         end
       end
 
       test 'raises configuration error for a template without timestamp placeholders when timekey is configured' do
         @i.configure(config_element('ROOT', '', {}, [config_element('buffer', 'time', {"timekey" => 180})]))
-        assert_raise Fluent::ConfigError.new("Parameter 'path' doesn't have timestamp placeholders for timekey 180") do
+        assert_raise Fluent::ConfigError.new("Parameter 'path: /my/path/file.log' doesn't have timestamp placeholders for timekey 180") do
           @i.placeholder_validate!(:path, "/my/path/file.log")
         end
         assert_nothing_raised do
@@ -391,7 +391,7 @@ class OutputTest < Test::Unit::TestCase
 
       test 'raises configuration error for a template with timestamp placeholders when plugin is configured more fine timekey' do
         @i.configure(config_element('ROOT', '', {}, [config_element('buffer', 'time', {"timekey" => 180})]))
-        assert_raise Fluent::ConfigError.new("Parameter 'path' doesn't have timestamp placeholder for hour('%H') for timekey 180") do
+        assert_raise Fluent::ConfigError.new("Parameter 'path: /my/path/file.%Y%m%d_%H.log' doesn't have timestamp placeholder for hour('%H') for timekey 180") do
           @i.placeholder_validate!(:path, "/my/path/file.%Y%m%d_%H.log")
         end
         assert_nothing_raised do
@@ -401,14 +401,14 @@ class OutputTest < Test::Unit::TestCase
 
       test 'raises configuration error for a template when tag placeholders exist but tag key is missing' do
         @i.configure(config_element('ROOT', '', {}, [config_element('buffer', '')]))
-        assert_raise Fluent::ConfigError.new("Parameter 'path' has tag placeholders, but chunk key 'tag' is not configured") do
+        assert_raise Fluent::ConfigError.new("Parameter 'path: /my/path/${tag}/file.${tag[2]}.log' has tag placeholders, but chunk key 'tag' is not configured") do
           @i.placeholder_validate!(:path, "/my/path/${tag}/file.${tag[2]}.log")
         end
       end
 
       test 'raises configuration error for a template without tag placeholders when tagkey is configured' do
         @i.configure(config_element('ROOT', '', {}, [config_element('buffer', 'tag')]))
-        assert_raise Fluent::ConfigError.new("Parameter 'path' doesn't have tag placeholder") do
+        assert_raise Fluent::ConfigError.new("Parameter 'path: /my/path/file.log' doesn't have tag placeholder") do
           @i.placeholder_validate!(:path, "/my/path/file.log")
         end
         assert_nothing_raised do
@@ -418,14 +418,14 @@ class OutputTest < Test::Unit::TestCase
 
       test 'raises configuration error for a template when variable key placeholders exist but chunk keys are missing' do
         @i.configure(config_element('ROOT', '', {}, [config_element('buffer', '')]))
-        assert_raise Fluent::ConfigError.new("Parameter 'path' has placeholders, but chunk keys doesn't have keys service,username") do
+        assert_raise Fluent::ConfigError.new("Parameter 'path: /my/path/${service}/file.${username}.log' has placeholders, but chunk keys doesn't have keys service,username") do
           @i.placeholder_validate!(:path, "/my/path/${service}/file.${username}.log")
         end
       end
 
       test 'raises configuration error for a template without variable key placeholders when chunk keys are configured' do
         @i.configure(config_element('ROOT', '', {}, [config_element('buffer', 'username,service')]))
-        assert_raise Fluent::ConfigError.new("Parameter 'path' doesn't have enough placeholders for keys service,username") do
+        assert_raise Fluent::ConfigError.new("Parameter 'path: /my/path/file.log' doesn't have enough placeholders for keys service,username") do
           @i.placeholder_validate!(:path, "/my/path/file.log")
         end
         assert_nothing_raised do
@@ -435,10 +435,10 @@ class OutputTest < Test::Unit::TestCase
 
       test 'raise configuration error for a template and configuration with keys mismatch' do
         @i.configure(config_element('ROOT', '', {}, [config_element('buffer', 'username,service')]))
-        assert_raise Fluent::ConfigError.new("Parameter 'path' doesn't have enough placeholders for keys service") do
+        assert_raise Fluent::ConfigError.new("Parameter 'path: /my/path/file.${username}.log' doesn't have enough placeholders for keys service") do
           @i.placeholder_validate!(:path, "/my/path/file.${username}.log")
         end
-        assert_raise Fluent::ConfigError.new("Parameter 'path' doesn't have enough placeholders for keys username") do
+        assert_raise Fluent::ConfigError.new("Parameter 'path: /my/path/${service}/file.log' doesn't have enough placeholders for keys username") do
           @i.placeholder_validate!(:path, "/my/path/${service}/file.log")
         end
         assert_nothing_raised do


### PR DESCRIPTION
In some case, `placeholder_validate!` checks composited value.
For example, https://github.com/kaizenplatform/fluent-plugin-bigquery/pull/115.

this patch enable user to can find wrong config easily by error message even if In the case.

## Output Example

```
% be fluentd -c fluent.conf -v
2017-03-10 23:04:32 +0900 [info]: fluent/supervisor.rb:696:read_config: reading config file path="fluent.conf"
2017-03-10 23:04:32 +0900 [info]: fluent/supervisor.rb:537:supervise: starting fluentd-0.14.13 pid=26713
2017-03-10 23:04:32 +0900 [info]: fluent/supervisor.rb:546:supervise: spawn command to main:  cmdline=["/home/joker/.rbenv/versions/2.3.3/bin/ruby", "-Eascii-8bit:ascii-8bit", "-rbundler/setup", "/home/joker/fluentd_workspace/.bundle/ruby/2.3.0/bin/fluentd", "-c", "fluent.conf", "-v", "--under-supervisor"]
2017-03-10 23:04:32 +0900 [info]: fluent/engine.rb:114:block in configure: gem 'fluentd' version '0.14.13'
2017-03-10 23:04:32 +0900 [info]: fluent/engine.rb:114:block in configure: gem 'fluent-mixin-config-placeholders' version '0.4.0'
2017-03-10 23:04:32 +0900 [info]: fluent/engine.rb:114:block in configure: gem 'fluent-mixin-plaintextformatter' version '0.2.6'
2017-03-10 23:04:32 +0900 [info]: fluent/engine.rb:114:block in configure: gem 'fluent-mixin-rewrite-tag-name' version '0.1.0'
2017-03-10 23:04:32 +0900 [info]: fluent/engine.rb:114:block in configure: gem 'fluent-plugin-bigquery' version '0.5.0.beta'
2017-03-10 23:04:32 +0900 [info]: fluent/engine.rb:114:block in configure: gem 'fluent-plugin-record-modifier' version '0.5.0'
2017-03-10 23:04:32 +0900 [info]: fluent/engine.rb:114:block in configure: gem 'fluent-plugin-remote_syslog' version '0.3.2'
2017-03-10 23:04:32 +0900 [info]: fluent/agent.rb:124:add_match: adding match in @FLUENT_LOG pattern="fluent.info" type="remote_syslog"
2017-03-10 23:04:32 +0900 [error]: #0 fluent/supervisor.rb:665:block in main_process: config error file="fluent.conf" error_class=Fluent::ConfigError error="Parameter 'remote_syslog: host=logs2.papertrailapp.com/host_with_port=/facility=user/severity=${fugafuga}/program=fluentd.repro-local-test' doesn't have tag placeholder"
  2017-03-10 23:04:32 +0900 [debug]: #0 fluent/supervisor.rb:661:main_process: /home/joker/.ghq/github.com/fluent/fluentd/lib/fluent/plugin/output.rb:606:in `validate_tag!'
  2017-03-10 23:04:32 +0900 [debug]: #0 fluent/supervisor.rb:661:main_process: /home/joker/.ghq/github.com/fluent/fluentd/lib/fluent/plugin/output.rb:581:in `validate!'
  2017-03-10 23:04:32 +0900 [debug]: #0 fluent/supervisor.rb:661:main_process: /home/joker/.ghq/github.com/fluent/fluentd/lib/fluent/plugin/output.rb:530:in `block in placeholder_validate!'
  2017-03-10 23:04:32 +0900 [debug]: #0 fluent/supervisor.rb:661:main_process: /home/joker/.ghq/github.com/fluent/fluentd/lib/fluent/plugin/output.rb:529:in `each'
  2017-03-10 23:04:32 +0900 [debug]: #0 fluent/supervisor.rb:661:main_process: /home/joker/.ghq/github.com/fluent/fluentd/lib/fluent/plugin/output.rb:529:in `placeholder_validate!'
  2017-03-10 23:04:32 +0900 [debug]: #0 fluent/supervisor.rb:661:main_process: /home/joker/.ghq/github.com/reproio/fluent-plugin-remote_syslog/lib/fluent/plugin/out_remote_syslog.rb:53:in `configure'
  2017-03-10 23:04:32 +0900 [debug]: #0 fluent/supervisor.rb:661:main_process: /home/joker/.ghq/github.com/fluent/fluentd/lib/fluent/plugin.rb:164:in `configure'
  2017-03-10 23:04:32 +0900 [debug]: #0 fluent/supervisor.rb:661:main_process: /home/joker/.ghq/github.com/fluent/fluentd/lib/fluent/agent.rb:128:in `add_match'
  2017-03-10 23:04:32 +0900 [debug]: #0 fluent/supervisor.rb:661:main_process: /home/joker/.ghq/github.com/fluent/fluentd/lib/fluent/agent.rb:71:in `block in configure'
  2017-03-10 23:04:32 +0900 [debug]: #0 fluent/supervisor.rb:661:main_process: /home/joker/.ghq/github.com/fluent/fluentd/lib/fluent/agent.rb:64:in `each'
  2017-03-10 23:04:32 +0900 [debug]: #0 fluent/supervisor.rb:661:main_process: /home/joker/.ghq/github.com/fluent/fluentd/lib/fluent/agent.rb:64:in `configure'
  2017-03-10 23:04:32 +0900 [debug]: #0 fluent/supervisor.rb:661:main_process: /home/joker/.ghq/github.com/fluent/fluentd/lib/fluent/label.rb:31:in `configure'
  2017-03-10 23:04:32 +0900 [debug]: #0 fluent/supervisor.rb:661:main_process: /home/joker/.ghq/github.com/fluent/fluentd/lib/fluent/root_agent.rb:83:in `block in configure'
  2017-03-10 23:04:32 +0900 [debug]: #0 fluent/supervisor.rb:661:main_process: /home/joker/.ghq/github.com/fluent/fluentd/lib/fluent/root_agent.rb:83:in `each'
  2017-03-10 23:04:32 +0900 [debug]: #0 fluent/supervisor.rb:661:main_process: /home/joker/.ghq/github.com/fluent/fluentd/lib/fluent/root_agent.rb:83:in `configure'
  2017-03-10 23:04:32 +0900 [debug]: #0 fluent/supervisor.rb:661:main_process: /home/joker/.ghq/github.com/fluent/fluentd/lib/fluent/engine.rb:117:in `configure'
  2017-03-10 23:04:32 +0900 [debug]: #0 fluent/supervisor.rb:661:main_process: /home/joker/.ghq/github.com/fluent/fluentd/lib/fluent/engine.rb:91:in `run_configure'
  2017-03-10 23:04:32 +0900 [debug]: #0 fluent/supervisor.rb:661:main_process: /home/joker/.ghq/github.com/fluent/fluentd/lib/fluent/supervisor.rb:734:in `run_configure'
  2017-03-10 23:04:32 +0900 [debug]: #0 fluent/supervisor.rb:661:main_process: /home/joker/.ghq/github.com/fluent/fluentd/lib/fluent/supervisor.rb:503:in `block in run_worker'
  2017-03-10 23:04:32 +0900 [debug]: #0 fluent/supervisor.rb:661:main_process: /home/joker/.ghq/github.com/fluent/fluentd/lib/fluent/supervisor.rb:662:in `main_process'
  2017-03-10 23:04:32 +0900 [debug]: #0 fluent/supervisor.rb:661:main_process: /home/joker/.ghq/github.com/fluent/fluentd/lib/fluent/supervisor.rb:499:in `run_worker'
  2017-03-10 23:04:32 +0900 [debug]: #0 fluent/supervisor.rb:661:main_process: /home/joker/.ghq/github.com/fluent/fluentd/lib/fluent/command/fluentd.rb:300:in `<top (required)>'
  2017-03-10 23:04:32 +0900 [debug]: #0 fluent/supervisor.rb:661:main_process: /home/joker/.ghq/github.com/fluent/fluentd/bin/fluentd:5:in `require'
  2017-03-10 23:04:32 +0900 [debug]: #0 fluent/supervisor.rb:661:main_process: /home/joker/.ghq/github.com/fluent/fluentd/bin/fluentd:5:in `<top (required)>'
  2017-03-10 23:04:32 +0900 [debug]: #0 fluent/supervisor.rb:661:main_process: /home/joker/fluentd_workspace/.bundle/ruby/2.3.0/bin/fluentd:22:in `load'
  2017-03-10 23:04:32 +0900 [debug]: #0 fluent/supervisor.rb:661:main_process: /home/joker/fluentd_workspace/.bundle/ruby/2.3.0/bin/fluentd:22:in `<main>'
2017-03-10 23:04:33 +0900 [info]: serverengine/multi_process_server.rb:136:alive?: Worker 0 finished unexpectedly with status 2
2017-03-10 23:04:33 +0900 [info]: serverengine/server.rb:51:stop: Received graceful stop
```