### PR TITLE
Fix Input and Output deadlock when buffer is full during startup

### DIFF
--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -136,8 +136,9 @@ module Fluent
     def start
       lifecycle(desc: true) do |i| # instance
         i.start unless i.started?
-      end
-      lifecycle(desc: true) do |i|
+        # Input#start emits lots of evetns with in_tail/`read_from_head true` case and
+        # it causes deadlock for small buffer/queue output. To avoid such problem,
+        # buffer related output threads should be run before `Input#start`.
         i.after_start unless i.after_started?
       end
     end

--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -136,9 +136,12 @@ module Fluent
     def start
       lifecycle(desc: true) do |i| # instance
         i.start unless i.started?
-        # Input#start emits lots of evetns with in_tail/`read_from_head true` case and
-        # it causes deadlock for small buffer/queue output. To avoid such problem,
+        # Input#start sometimes emits lots of evetns with in_tail/`read_from_head true` case
+        # and it causes deadlock for small buffer/queue output. To avoid such problem,
         # buffer related output threads should be run before `Input#start`.
+        # This is why after_start should be called immediately after start call.
+        # This depends on `desc: true` because calling plugin order of `desc: true` is
+        # Output, Filter, Label, Output with Router, then Input.
         i.after_start unless i.after_started?
       end
     end

--- a/test/test_plugin_classes.rb
+++ b/test/test_plugin_classes.rb
@@ -21,6 +21,28 @@ module FluentTest
     end
   end
 
+  class FluentTestGenInput < ::Fluent::Plugin::Input
+    ::Fluent::Plugin.register_input('test_in_gen', self)
+
+    attr_reader :started
+
+    config_param :num, :integer, default: 10000
+
+    def start
+      super
+      @started = true
+
+      @num.times { |i|
+        router.emit("test.evet", Fluent::EventTime.now, {'message' => 'Hello!', 'key' => "value#{i}", 'num' => i})
+      }
+    end
+
+    def shutdown
+      @started = false
+      super
+    end
+  end
+
   class FluentTestOutput < ::Fluent::Plugin::Output
     ::Fluent::Plugin.register_output('test_out', self)
 
@@ -112,6 +134,19 @@ module FluentTest
 
   class FluentTestBufferedOutput < ::Fluent::Plugin::Output
     ::Fluent::Plugin.register_output('test_out_buffered', self)
+
+    attr_reader :started
+
+    def start
+      super
+      @started = true
+    end
+
+    def shutdown
+      @started = false
+      super
+    end
+
     def write(chunk)
       # drop everything
     end

--- a/test/test_root_agent.rb
+++ b/test/test_root_agent.rb
@@ -224,7 +224,7 @@ EOC
   </buffer>
 </match>
 EOC
-      ra.start
+      waiting(5) { ra.start }
       assert_true ra.inputs.first.started
       assert_true ra.outputs.first.started
 


### PR DESCRIPTION
Output threads need calling `after_start` to run but
`after_start` is sometimes not called when Input#start is blocked.
This happens when in_tail with `read_from_head true` and
output with `overflow_action block`.
This fixes the problem by checking `after_start` immediately after start.

This may be related with #1485 