### PR TITLE
Add <worker n> section to set a configuration for a specific worker

### DIFF
--- a/example/worker_section.conf
+++ b/example/worker_section.conf
@@ -1,5 +1,5 @@
 <system>
-  workers 8
+  workers 4
   root_dir /path/fluentd/root
 </system>
 
@@ -8,7 +8,7 @@
   port 24224
 </source>
 
-<match all> # this section works on all workers too
+<match all> # this sections also works on all workers in parallel
   @type stdout
   <inject>
     worker_id_key worker_id
@@ -16,7 +16,18 @@
 </match>
 
 <worker 0> # this section works only on first worker process
-  <match worker0>
+  <source>
+    @type tail
+    format none
+    path /var/log/fluentd_test.log
+    pos_file /var/log/fluentd_test.pos
+    tag tail
+    rotate_wait 5
+    read_from_head true
+    refresh_interval 60
+  </source>
+
+  <match tail>
     @type stdout
     <inject>
       worker_id_key worker_id

--- a/example/worker_section.conf
+++ b/example/worker_section.conf
@@ -1,0 +1,25 @@
+<system>
+  workers 8
+  root_dir /path/fluentd/root
+</system>
+
+<source> # top-level sections works on all workers in parallel
+  @type forward
+  port 24224
+</source>
+
+<match all> # this section works on all workers too
+  @type stdout
+  <inject>
+    worker_id_key worker_id
+  </inject>
+</match>
+
+<worker 0> # this section works only on first worker process
+  <match worker0>
+    @type stdout
+    <inject>
+      worker_id_key worker_id
+    </inject>
+  </match>
+</worker>

--- a/lib/fluent/agent.rb
+++ b/lib/fluent/agent.rb
@@ -62,7 +62,7 @@ module Fluent
 
       # initialize <match> and <filter> elements
       conf.elements('filter', 'match').each { |e|
-        next if e.has_target? && e.target_worker_id != Fluent::Engine.worker_id
+        next if e.has_target_worker_id? && e.target_worker_id != Fluent::Engine.worker_id
         pattern = e.arg.empty? ? '**' : e.arg
         type = e['@type']
         raise ConfigError, "Missing '@type' parameter on <#{e.name}> directive" unless type

--- a/lib/fluent/agent.rb
+++ b/lib/fluent/agent.rb
@@ -62,6 +62,7 @@ module Fluent
 
       # initialize <match> and <filter> elements
       conf.elements('filter', 'match').each { |e|
+        next if e.has_target? && e.target_worker_id != Fluent::Engine.worker_id
         pattern = e.arg.empty? ? '**' : e.arg
         type = e['@type']
         raise ConfigError, "Missing '@type' parameter on <#{e.name}> directive" unless type
@@ -121,7 +122,8 @@ module Fluent
     end
 
     def add_match(type, pattern, conf)
-      log.info :worker0, "adding match#{@context.nil? ? '' : " in #{@context}"}", pattern: pattern, type: type
+      log_type = conf.target_worker_id == Fluent::Engine.worker_id ? :default : :worker0
+      log.info log_type, "adding match#{@context.nil? ? '' : " in #{@context}"}", pattern: pattern, type: type
 
       output = Plugin.new_output(type)
       output.context_router = @event_router
@@ -142,7 +144,8 @@ module Fluent
     end
 
     def add_filter(type, pattern, conf)
-      log.info :worker0, "adding filter#{@context.nil? ? '' : " in #{@context}"}", pattern: pattern, type: type
+      log_type = conf.target_worker_id == Fluent::Engine.worker_id ? :default : :worker0
+      log.info log_type, "adding filter#{@context.nil? ? '' : " in #{@context}"}", pattern: pattern, type: type
 
       filter = Plugin.new_filter(type)
       filter.context_router = @event_router

--- a/lib/fluent/agent.rb
+++ b/lib/fluent/agent.rb
@@ -62,7 +62,7 @@ module Fluent
 
       # initialize <match> and <filter> elements
       conf.elements('filter', 'match').each { |e|
-        next if e.has_target_worker_id? && e.target_worker_id != Fluent::Engine.worker_id
+        next if e.for_another_worker?
         pattern = e.arg.empty? ? '**' : e.arg
         type = e['@type']
         raise ConfigError, "Missing '@type' parameter on <#{e.name}> directive" unless type
@@ -122,7 +122,7 @@ module Fluent
     end
 
     def add_match(type, pattern, conf)
-      log_type = conf.target_worker_id == Fluent::Engine.worker_id ? :default : :worker0
+      log_type = conf.for_this_worker? ? :default : :worker0
       log.info log_type, "adding match#{@context.nil? ? '' : " in #{@context}"}", pattern: pattern, type: type
 
       output = Plugin.new_output(type)
@@ -144,7 +144,7 @@ module Fluent
     end
 
     def add_filter(type, pattern, conf)
-      log_type = conf.target_worker_id == Fluent::Engine.worker_id ? :default : :worker0
+      log_type = conf.for_this_worker? ? :default : :worker0
       log.info log_type, "adding filter#{@context.nil? ? '' : " in #{@context}"}", pattern: pattern, type: type
 
       filter = Plugin.new_filter(type)

--- a/lib/fluent/config/element.rb
+++ b/lib/fluent/config/element.rb
@@ -35,10 +35,13 @@ module Fluent
 
         # it's global logger, not plugin logger: deprecated message should be global warning, not plugin level.
         @logger = defined?($log) ? $log : nil
+
+        @target_worker_id = nil
       end
 
       attr_accessor :name, :arg, :unused, :v1_config, :corresponding_proxies, :unused_in
       attr_writer :elements
+      attr_reader :target_worker_id
 
       RESERVED_PARAMETERS_COMPAT = {
         '@type' => 'type',
@@ -212,6 +215,17 @@ module Fluent
         result = ''
         v.each_char { |c| result << LiteralParser.unescape_char(c) }
         result
+      end
+
+      def set_target_worker_id(worker_id)
+        @target_worker_id = worker_id
+        @elements.each { |e|
+          e.set_target_worker_id(worker_id)
+        }
+      end
+
+      def has_target?
+        !!@target_worker_id
       end
     end
   end

--- a/lib/fluent/config/element.rb
+++ b/lib/fluent/config/element.rb
@@ -224,8 +224,16 @@ module Fluent
         }
       end
 
-      def has_target_worker_id?
-        !!@target_worker_id
+      def for_every_workers?
+        @target_worker_id == nil
+      end
+
+      def for_this_worker?
+        @target_worker_id == Fluent::Engine.worker_id
+      end
+
+      def for_another_worker?
+        @target_worker_id != nil && @target_worker_id != Fluent::Engine.worker_id
       end
     end
   end

--- a/lib/fluent/config/element.rb
+++ b/lib/fluent/config/element.rb
@@ -224,7 +224,7 @@ module Fluent
         }
       end
 
-      def has_target?
+      def has_target_worker_id?
         !!@target_worker_id
       end
     end

--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -98,9 +98,9 @@ module Fluent
                     else
                       "section <#{e.name}> is not used in <#{parent_name}>"
                     end
-          if !e.has_target_worker_id?
+          if e.for_every_workers?
             $log.warn :worker0, message
-          elsif e.target_worker_id == worker_id
+          elsif e.for_this_worker?
             $log.warn message
           end
           next
@@ -108,9 +108,9 @@ module Fluent
         unless e.name == 'system'
           unless @without_source && e.name == 'source'
             message = "parameter '#{key}' in #{e.to_s.strip} is not used."
-            if !e.has_target_worker_id?
+            if e.for_every_workers?
               $log.warn :worker0, message
-            elsif e.target_worker_id == worker_id
+            elsif e.for_this_worker?
               $log.warn message
             end
           end

--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -259,6 +259,8 @@ module Fluent
 
     def worker_id
       return @_worker_id if @_worker_id
+      # if ENV doesn't have SERVERENGINE_WORKER_ID, it is a worker under --no-supervisor or in tests
+      # so it's (almost) a single worker, worker_id=0
       @_worker_id = (ENV['SERVERENGINE_WORKER_ID'] || 0).to_i
       @_worker_id
     end

--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -98,7 +98,7 @@ module Fluent
                     else
                       "section <#{e.name}> is not used in <#{parent_name}>"
                     end
-          if !e.has_target?
+          if !e.has_target_worker_id?
             $log.warn :worker0, message
           elsif e.target_worker_id == worker_id
             $log.warn message
@@ -108,7 +108,7 @@ module Fluent
         unless e.name == 'system'
           unless @without_source && e.name == 'source'
             message = "parameter '#{key}' in #{e.to_s.strip} is not used."
-            if !e.has_target?
+            if !e.has_target_worker_id?
               $log.warn :worker0, message
             elsif e.target_worker_id == worker_id
               $log.warn message

--- a/lib/fluent/plugin/base.rb
+++ b/lib/fluent/plugin/base.rb
@@ -51,6 +51,9 @@ module Fluent
       end
 
       def configure(conf)
+        if conf.respond_to?(:target_worker_id) && conf.target_worker_id == Fluent::Engine.worker_id
+          system_config_override(workers: 1)
+        end
         super
         @_state ||= State.new(false, false, false, false, false, false, false, false, false)
         @_state.configure = true

--- a/lib/fluent/plugin/base.rb
+++ b/lib/fluent/plugin/base.rb
@@ -51,7 +51,7 @@ module Fluent
       end
 
       def configure(conf)
-        if conf.respond_to?(:target_worker_id) && conf.target_worker_id == Fluent::Engine.worker_id
+        if conf.respond_to?(:for_this_worker?) && conf.for_this_worker?
           system_config_override(workers: 1)
         end
         super

--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -91,7 +91,7 @@ module Fluent
       # initialize <label> elements before configuring all plugins to avoid 'label not found' in input, filter and output.
       label_configs = {}
       conf.elements(name: 'label').each { |e|
-        next if e.has_target? && e.target_worker_id != Fluent::Engine.worker_id
+        next if e.has_target_worker_id? && e.target_worker_id != Fluent::Engine.worker_id
         name = e.arg
         raise ConfigError, "Missing symbol argument on <label> directive" if name.empty?
 
@@ -113,7 +113,7 @@ module Fluent
         log.info :worker0, "'--without-source' is applied. Ignore <source> sections"
       else
         conf.elements(name: 'source').each { |e|
-          next if e.has_target? && e.target_worker_id != Fluent::Engine.worker_id
+          next if e.has_target_worker_id? && e.target_worker_id != Fluent::Engine.worker_id
           type = e['@type']
           raise ConfigError, "Missing '@type' parameter on <source> directive" unless type
           add_source(type, e)

--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -73,7 +73,7 @@ module Fluent
 
         target_worker_id = target_worker_id_str.to_i
         if target_worker_id < 0 || target_worker_id > (Fluent::Engine.system_config.workers - 1)
-          raise ConfigError, "worker#{target_worker_id} specified by <worker> directive doesn't exist. Specify id between 0 and #{(Fluent::Engine.system_config.workers - 1)}"
+          raise ConfigError, "worker id #{target_worker_id} specified by <worker> directive is not allowed. Available worker id is between 0 and #{(Fluent::Engine.system_config.workers - 1)}"
         end
 
         e.elements.each do |elem|

--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -91,7 +91,7 @@ module Fluent
       # initialize <label> elements before configuring all plugins to avoid 'label not found' in input, filter and output.
       label_configs = {}
       conf.elements(name: 'label').each { |e|
-        next if e.has_target_worker_id? && e.target_worker_id != Fluent::Engine.worker_id
+        next if e.for_another_worker?
         name = e.arg
         raise ConfigError, "Missing symbol argument on <label> directive" if name.empty?
 
@@ -113,7 +113,7 @@ module Fluent
         log.info :worker0, "'--without-source' is applied. Ignore <source> sections"
       else
         conf.elements(name: 'source').each { |e|
-          next if e.has_target_worker_id? && e.target_worker_id != Fluent::Engine.worker_id
+          next if e.for_another_worker?
           type = e['@type']
           raise ConfigError, "Missing '@type' parameter on <source> directive" unless type
           add_source(type, e)
@@ -259,7 +259,7 @@ module Fluent
     end
 
     def add_source(type, conf)
-      log_type = conf.target_worker_id == Fluent::Engine.worker_id ? :default : :worker0
+      log_type = conf.for_this_worker? ? :default : :worker0
       log.info log_type, "adding source", type: type
 
       input = Plugin.new_input(type)

--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -616,17 +616,19 @@ CONF
     end
 
     test 'failed to start workers when configured plugins as chidren of MultiOutput do not support multi worker configuration' do
-      script =  "require 'fluent/plugin/output'\n"
-      script << "module Fluent::Plugin\n"
-      script << "  class SingleOutput < Output\n"
-      script << "    Fluent::Plugin.register_output('single', self)\n"
-      script << "    def multi_workers_ready?\n"
-      script << "      false\n"
-      script << "    end\n"
-      script << "    def write(chunk)\n"
-      script << "    end\n"
-      script << "  end\n"
-      script << "end\n"
+      script = <<-EOC
+require 'fluent/plugin/output'
+module Fluent::Plugin
+  class SingleOutput < Output
+    Fluent::Plugin.register_output('single', self)
+    def multi_workers_ready?
+      false
+    end
+    def write(chunk)
+    end
+  end
+end
+EOC
       plugin_path = create_plugin_file('out_single.rb', script)
 
       conf = <<CONF
@@ -699,15 +701,17 @@ CONF
     end
 
     test 'success to start workers when configured plugins only for specific worker do not support multi worker configuration' do
-      script =  "require 'fluent/plugin/input'\n"
-      script << "module Fluent::Plugin\n"
-      script << "  class SingleInput < Input\n"
-      script << "    Fluent::Plugin.register_input('single', self)\n"
-      script << "    def multi_workers_ready?\n"
-      script << "      false\n"
-      script << "    end\n"
-      script << "  end\n"
-      script << "end\n"
+      script =  <<-EOC
+require 'fluent/plugin/input'
+module Fluent::Plugin
+  class SingleInput < Input
+    Fluent::Plugin.register_input('single', self)
+    def multi_workers_ready?
+      false
+    end
+  end
+end
+EOC
       plugin_path = create_plugin_file('in_single.rb', script)
 
       conf = <<CONF
@@ -771,17 +775,19 @@ CONF
     end
 
     test 'success to start workers when configured plugins as a chidren of MultiOutput only for specific worker do not support multi worker configuration' do
-      script =  "require 'fluent/plugin/output'\n"
-      script << "module Fluent::Plugin\n"
-      script << "  class SingleOutput < Output\n"
-      script << "    Fluent::Plugin.register_output('single', self)\n"
-      script << "    def multi_workers_ready?\n"
-      script << "      false\n"
-      script << "    end\n"
-      script << "    def write(chunk)\n"
-      script << "    end\n"
-      script << "  end\n"
-      script << "end\n"
+      script = <<-EOC
+require 'fluent/plugin/output'
+module Fluent::Plugin
+  class SingleOutput < Output
+    Fluent::Plugin.register_output('single', self)
+    def multi_workers_ready?
+      false
+    end
+    def write(chunk)
+    end
+  end
+end
+EOC
       plugin_path = create_plugin_file('out_single.rb', script)
 
       conf = <<CONF

--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -297,7 +297,7 @@ CONF
       assert_log_matches(
         create_cmdline(conf_path),
         "fluentd worker is now running",
-        '[warn]: match for some tags of log events are not defined (to be ignored) tags=["fluent.trace", "fluent.debug", "fluent.info"]',
+        '[warn]: #0 match for some tags of log events are not defined (to be ignored) tags=["fluent.trace", "fluent.debug", "fluent.info"]',
         '[warn]: #0 no patterns matched tag="fluent.info"',
       )
     end
@@ -334,7 +334,7 @@ CONF
       assert_log_matches(
         create_cmdline(conf_path),
         "fluentd worker is now running",
-        '[warn]: match for some tags of log events are not defined (to be ignored) tags=["fluent.info", "fluent.fatal"]',
+        '[warn]: #0 match for some tags of log events are not defined (to be ignored) tags=["fluent.info", "fluent.fatal"]',
         patterns_not_match: ['[warn]: no patterns matched tag="fluent.info"'],
       )
     end
@@ -612,6 +612,206 @@ CONF
         create_cmdline(conf_path),
         "[blackhole] file buffer with multi workers should be configured to use directory 'path', or system root_dir and plugin id",
         "config error file=\"#{conf_path}\" error_class=Fluent::ConfigError error=\"Plugin 'file' does not support multi workers configuration (Fluent::Plugin::FileBuffer)\"",
+      )
+    end
+
+    test 'failed to start workers when configured plugins as chidren of MultiOutput do not support multi worker configuration' do
+      script =  "require 'fluent/plugin/output'\n"
+      script << "module Fluent::Plugin\n"
+      script << "  class SingleOutput < Output\n"
+      script << "    Fluent::Plugin.register_output('single', self)\n"
+      script << "    def multi_workers_ready?\n"
+      script << "      false\n"
+      script << "    end\n"
+      script << "    def write(chunk)\n"
+      script << "    end\n"
+      script << "  end\n"
+      script << "end\n"
+      plugin_path = create_plugin_file('out_single.rb', script)
+
+      conf = <<CONF
+<system>
+  workers 2
+</system>
+<source>
+  @type single
+  @id single
+  @label @dummydata
+</source>
+<label @dummydata>
+  <match dummy>
+    @type copy
+    <store>
+      @type single
+    </store>
+    <store>
+      @type single
+    </store>
+  </match>
+</label>
+CONF
+      conf_path = create_conf_file('workers_invalid3.conf', conf)
+      assert_fluentd_fails_to_start(
+        create_cmdline(conf_path, "-p", File.dirname(plugin_path)),
+        "Plugin 'single' does not support multi workers configuration (Fluent::Plugin::SingleOutput)",
+      )
+    end
+
+    test 'success to start a worker with worker specific configuration' do
+      conf = <<CONF
+<system>
+  workers 2
+  root_dir #{@root_path}
+</system>
+<source>
+  @type dummy
+  @id dummy
+  @label @dummydata
+  tag dummy
+  dummy {"message": "yay!"}
+</source>
+<worker 1>
+  <source>
+    @type dummy
+    @id dummy_in_worker
+    @label @dummydata
+    tag dummy
+    dummy {"message": "yay!"}
+  </source>
+</worker>
+<label @dummydata>
+  <match dummy>
+    @type null
+    @id   blackhole
+  </match>
+</label>
+CONF
+      conf_path = create_conf_file('worker_section0.conf', conf)
+      assert Dir.exist?(@root_path)
+
+      assert_log_matches(
+        create_cmdline(conf_path),
+        "#0 fluentd worker is now running worker=0",
+        "#1 fluentd worker is now running worker=1",
+        /(?!#\d) adding source type="dummy"/,
+        '#1 adding source type="dummy"'
+      )
+    end
+
+    test 'success to start workers when configured plugins only for specific worker do not support multi worker configuration' do
+      script =  "require 'fluent/plugin/input'\n"
+      script << "module Fluent::Plugin\n"
+      script << "  class SingleInput < Input\n"
+      script << "    Fluent::Plugin.register_input('single', self)\n"
+      script << "    def multi_workers_ready?\n"
+      script << "      false\n"
+      script << "    end\n"
+      script << "  end\n"
+      script << "end\n"
+      plugin_path = create_plugin_file('in_single.rb', script)
+
+      conf = <<CONF
+<system>
+  workers 2
+</system>
+<worker 1>
+  <source>
+    @type single
+    @id single
+    @label @dummydata
+  </source>
+</worker>
+<label @dummydata>
+  <match dummy>
+    @type null
+    @id   blackhole
+  </match>
+</label>
+CONF
+      conf_path = create_conf_file('worker_section1.conf', conf)
+      assert Dir.exist?(@root_path)
+
+      assert_log_matches(
+        create_cmdline(conf_path, "-p", File.dirname(plugin_path)),
+        "#0 fluentd worker is now running worker=0",
+        "#1 fluentd worker is now running worker=1",
+        '#1 adding source type="single"'
+      )
+    end
+
+    test 'success to start workers when file buffer is configured in non-workers way only for specific worker' do
+      conf = <<CONF
+<system>
+  workers 2
+</system>
+<source>
+  @type dummy
+  @id dummy
+  tag dummy
+  dummy {"message": "yay!"}
+</source>
+<worker 1>
+  <match dummy>
+    @type null
+    @id   blackhole
+    <buffer>
+      @type file
+      path #{File.join(@root_path, "buf", "file.*.log")}
+    </buffer>
+  </match>
+</worker>
+CONF
+      conf_path = create_conf_file('worker_section2.conf', conf)
+      assert_log_matches(
+        create_cmdline(conf_path),
+        "#0 fluentd worker is now running worker=0",
+        "#1 fluentd worker is now running worker=1",
+        '#1 adding match pattern="dummy" type="null"'
+      )
+    end
+
+    test 'success to start workers when configured plugins as a chidren of MultiOutput only for specific worker do not support multi worker configuration' do
+      script =  "require 'fluent/plugin/output'\n"
+      script << "module Fluent::Plugin\n"
+      script << "  class SingleOutput < Output\n"
+      script << "    Fluent::Plugin.register_output('single', self)\n"
+      script << "    def multi_workers_ready?\n"
+      script << "      false\n"
+      script << "    end\n"
+      script << "    def write(chunk)\n"
+      script << "    end\n"
+      script << "  end\n"
+      script << "end\n"
+      plugin_path = create_plugin_file('out_single.rb', script)
+
+      conf = <<CONF
+<system>
+  workers 2
+</system>
+<source>
+  @type dummy
+  @id dummy
+  tag dummy
+  dummy {"message": "yay!"}
+</source>
+<worker 1>
+  <match dummy>
+    @type copy
+    <store>
+      @type single
+    </store>
+    <store>
+      @type single
+    </store>
+  </match>
+</worker>
+CONF
+      conf_path = create_conf_file('worker_section3.conf', conf)
+      assert_log_matches(
+        create_cmdline(conf_path, "-p", File.dirname(plugin_path)),
+        "#0 fluentd worker is now running worker=0",
+        "#1 fluentd worker is now running worker=1",
+        '#1 adding match pattern="dummy" type="copy"'
       )
     end
   end

--- a/test/config/test_element.rb
+++ b/test/config/test_element.rb
@@ -413,16 +413,16 @@ CONF
     end
   end
 
-  sub_test_case '#has_target?' do
+  sub_test_case '#has_target_worker_id?' do
     test 'has target_worker_id' do
       e = element()
       e.set_target_worker_id(1)
-      assert e.has_target?
+      assert e.has_target_worker_id?
     end
 
     test "don't have target_worker_id" do
       e = element()
-      refute e.has_target?
+      refute e.has_target_worker_id?
     end
   end
 end

--- a/test/config/test_element.rb
+++ b/test/config/test_element.rb
@@ -400,4 +400,29 @@ CONF
       end
     end
   end
+
+  sub_test_case '#set_target_worker' do
+    test 'set target_worker_id recursively' do
+      e = element('label', '@mytest', {}, [ element('filter', '**'), element('match', '**', {}, [ element('store'), element('store') ]) ])
+      e.set_target_worker_id(1)
+      assert_equal 1, e.target_worker_id
+      assert_equal 1, e.elements[0].target_worker_id
+      assert_equal 1, e.elements[1].target_worker_id
+      assert_equal 1, e.elements[1].elements[0].target_worker_id
+      assert_equal 1, e.elements[1].elements[1].target_worker_id
+    end
+  end
+
+  sub_test_case '#has_target?' do
+    test 'has target_worker_id' do
+      e = element()
+      e.set_target_worker_id(1)
+      assert e.has_target?
+    end
+
+    test "don't have target_worker_id" do
+      e = element()
+      refute e.has_target?
+    end
+  end
 end

--- a/test/config/test_element.rb
+++ b/test/config/test_element.rb
@@ -413,16 +413,54 @@ CONF
     end
   end
 
-  sub_test_case '#has_target_worker_id?' do
+  sub_test_case '#for_every_workers?' do
     test 'has target_worker_id' do
       e = element()
       e.set_target_worker_id(1)
-      assert e.has_target_worker_id?
+      assert_false e.for_every_workers?
     end
 
-    test "don't have target_worker_id" do
+    test "doesn't have target_worker_id" do
       e = element()
-      refute e.has_target_worker_id?
+      assert e.for_every_workers?
+    end
+  end
+
+  sub_test_case '#for_this_workers?' do
+    test 'target_worker_id == current worker_id' do
+      e = element()
+      e.set_target_worker_id(0)
+      assert e.for_this_worker?
+    end
+
+    test 'target_worker_id != current worker_id' do
+      e = element()
+      e.set_target_worker_id(1)
+      assert_false e.for_this_worker?
+    end
+
+    test "doesn't have target_worker_id" do
+      e = element()
+      assert_false e.for_this_worker?
+    end
+  end
+
+  sub_test_case '#for_another_worker?' do
+    test 'target_worker_id == current worker_id' do
+      e = element()
+      e.set_target_worker_id(0)
+      assert_false e.for_another_worker?
+    end
+
+    test 'target_worker_id != current worker_id' do
+      e = element()
+      e.set_target_worker_id(1)
+      assert e.for_another_worker?
+    end
+
+    test "doesn't have target_worker_id" do
+      e = element()
+      assert_false e.for_another_worker?
     end
   end
 end

--- a/test/test_plugin_classes.rb
+++ b/test/test_plugin_classes.rb
@@ -235,6 +235,21 @@ module FluentTest
     end
   end
 
+  class FluentTestBuffer < Fluent::Plugin::Buffer
+    ::Fluent::Plugin.register_buffer('test_buffer', self)
+
+    def resume
+      return {}, []
+    end
+
+    def generate_chunk(metadata)
+    end
+
+    def multi_workers_ready?
+      false
+    end
+  end
+
   class TestEmitErrorHandler
     def initialize
       @events = Hash.new { |h, k| h[k] = [] }

--- a/test/test_root_agent.rb
+++ b/test/test_root_agent.rb
@@ -643,7 +643,7 @@ EOC
     end
 
     test 'raises configuration error for too big worker id' do
-      errmsg = "worker4 specified by <worker> directive doesn't exist. Specify id between 0 and 3"
+      errmsg = "worker id 4 specified by <worker> directive is not allowed. Available worker id is between 0 and 3"
       assert_raise Fluent::ConfigError.new(errmsg) do
         conf = <<-EOC
 <worker 4>

--- a/test/test_root_agent.rb
+++ b/test/test_root_agent.rb
@@ -608,4 +608,208 @@ EOC
       assert_equal [true, true], dyn_out.child.outputs.map{|i| i.terminated? }
     end
   end
+
+  sub_test_case 'configured at worker2 with 4 workers environment' do
+    setup do
+      ENV['SERVERENGINE_WORKER_ID'] = '2'
+      @ra = RootAgent.new(log: $log)
+      system_config = SystemConfig.new
+      system_config.workers = 4
+      stub(Engine).worker_id { 2 }
+      stub(Engine).root_agent { @ra }
+      stub(Engine).system_config { system_config }
+      @ra
+    end
+
+    teardown '' do
+      ENV.delete('SERVERENGINE_WORKER_ID')
+    end
+
+    def configure_ra(conf_str)
+      conf = Config.parse(conf_str, "(test)", "(test_dir)", true)
+      @ra.configure(conf)
+      @ra
+    end
+
+    test 'raises configuration error for missing worker id' do
+      errmsg = 'Missing worker id on <worker> directive'
+      assert_raise Fluent::ConfigError.new(errmsg) do
+        conf = <<-EOC
+<worker>
+</worker>
+EOC
+        configure_ra(conf)
+      end
+    end
+
+    test 'raises configuration error for too big worker id' do
+      errmsg = "worker4 specified by <worker> directive doesn't exist. Specify id between 0 and 3"
+      assert_raise Fluent::ConfigError.new(errmsg) do
+        conf = <<-EOC
+<worker 4>
+</worker>
+EOC
+        configure_ra(conf)
+      end
+    end
+
+    test 'raises configuration error for invalid elements as a child of worker section' do
+      errmsg = '<worker> section cannot have <system> directive'
+      assert_raise Fluent::ConfigError.new(errmsg) do
+        conf = <<-EOC
+<worker 2>
+<system>
+</system>
+</worker>
+EOC
+        configure_ra(conf)
+      end
+    end
+
+    test 'raises configuration error when configured plugins do not have support multi worker configuration' do
+      errmsg = "Plugin 'test_out' does not support multi workers configuration (FluentTest::FluentTestOutput)"
+      assert_raise Fluent::ConfigError.new(errmsg) do
+        conf = <<-EOC
+<match **>
+@type test_out
+</match>
+EOC
+        configure_ra(conf)
+      end
+    end
+
+    test 'does not raise configuration error when configured plugins in worker section do not have support multi worker configuration' do
+      assert_nothing_raised do
+        conf = <<-EOC
+<worker 2>
+<match **>
+  @type test_out
+</match>
+</worker>
+EOC
+        configure_ra(conf)
+      end
+    end
+
+    test 'does not raise configuration error when configured plugins as a children of MultiOutput in worker section do not have support multi worker configuration' do
+      assert_nothing_raised do
+        conf = <<-EOC
+<worker 2>
+<match **>
+  @type copy
+  <store>
+    @type test_out
+  </store>
+  <store>
+    @type test_out
+  </store>
+</match>
+</worker>
+EOC
+        configure_ra(conf)
+      end
+    end
+
+    test 'does not raise configuration error when configured plugins owned by plugin do not have support multi worker configuration' do
+      assert_nothing_raised do
+        conf = <<-EOC
+<worker 2>
+<match **>
+  @type test_out_buffered
+  <buffer>
+    @type test_buffer
+  </buffer>
+</match>
+</worker>
+EOC
+        configure_ra(conf)
+      end
+    end
+
+    test 'with plugins' do
+      conf = <<-EOC
+<worker 2>
+<source>
+  @type test_in
+  @id test_in
+</source>
+<filter>
+  type test_filter
+  id test_filter
+</filter>
+<match **>
+  @type relabel
+  @id test_relabel
+  @label @test
+</match>
+<label @test>
+  <match **>
+    type test_out
+    id test_out
+  </match>
+</label>
+<label @ERROR>
+  <match>
+    @type null
+  </match>
+</label>
+</worker>
+EOC
+      ra = configure_ra(conf)
+      assert_kind_of FluentTestInput, ra.inputs.first
+      assert_kind_of Plugin::RelabelOutput, ra.outputs.first
+      assert_kind_of FluentTestFilter, ra.filters.first
+      assert ra.error_collector
+
+      %W(@test @ERROR).each { |label_symbol|
+        assert_include ra.labels, label_symbol
+        assert_kind_of Label, ra.labels[label_symbol]
+      }
+
+      test_label = ra.labels['@test']
+      assert_kind_of FluentTestOutput, test_label.outputs.first
+      assert_equal ra, test_label.root_agent
+
+      error_label = ra.labels['@ERROR']
+      assert_kind_of Fluent::Plugin::NullOutput, error_label.outputs.first
+      assert_kind_of RootAgent::RootAgentProxyWithoutErrorCollector, error_label.root_agent
+    end
+
+    test 'with plugins but for another worker' do
+      conf = <<-EOC
+<worker 0>
+<source>
+  @type test_in
+  @id test_in
+</source>
+<filter>
+  type test_filter
+  id test_filter
+</filter>
+<match **>
+  @type relabel
+  @id test_relabel
+  @label @test
+</match>
+<label @test>
+  <match **>
+    type test_out
+    id test_out
+  </match>
+</label>
+<label @ERROR>
+  <match>
+    @type null
+  </match>
+</label>
+</worker>
+EOC
+      ra = configure_ra(conf)
+      assert_equal 0, ra.inputs.size
+      assert_equal 0, ra.outputs.size
+      assert_equal 0, ra.filters.size
+      assert_equal 0, ra.labels.size
+      refute ra.error_collector
+    end
+  end
 end


### PR DESCRIPTION
Closes #1392.

This PR introduce `<worker n>` section. Configurations under this section is enabled only in specified worker and act as if they work in single worker environment. More precisely, config elements in worker section get `worker_target_id` recursively. Prior to configure phase of corresponding plugins, `system_config.workers` for the plugins is overwritten as `1` if target_worker_id equals the worker's worker_id.
It also means that plugins(including owned plugins) which doesn't support multi worker feature can run only in worker section.
A worker section can have `<label>`, `<source>`, `<filter>` and `<match>` as a child element.

Example from #1392

```
<system>
  workers 8
  root_dir /path/fluentd/root
</system>
<source>  # top-level sections works on all workers in parallel
  @id edge_input
  @type forward
  @label @traffic
  port 24224
</source>
<label @traffic>  # this section works on all workers too
  <match **>
    @id backend_output
    @type forward
    <buffer>
      @type file
      flush_interval 8m
    </buffer>
  </match>
</label>
<worker 0> # this section works only on first worker process
  <source>
    @id system_log_reader
    @type tail
    tag monitoring
    path /path/now/watching/...
  </source>
  <match monitoring>
    @id output_for_monitoring
    @type elasticsearch
    # ...
  </match>
</worker>
```