### PR TITLE
root_agent flush labels

### DIFF
--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -138,6 +138,11 @@ module Fluent
       super
     end
 
+    def flush!
+      super
+      @labels.each{ |name, label| label.flush! }
+    end
+
     def suppress_interval(interval_time)
       @suppress_emit_error_log_interval = interval_time
       @next_emit_error_log_time = Time.now.to_i


### PR DESCRIPTION
fluentd v0.12 cannot send a USR1 signal to the output instances in the label sections, so that it can not flush parts of the buffers.
This patch solves it.

before:
```
$ ./bin/fluentd -c fluent.conf
2017-03-19 16:52:08 +0900 [info]: reading config file path="fluent.conf"
2017-03-19 16:52:08 +0900 [info]: starting fluentd-0.12.33
2017-03-19 16:52:08 +0900 [info]: gem 'fluent-plugin-elasticsearch' version '1.3.0'
2017-03-19 16:52:08 +0900 [info]: gem 'fluentd' version '0.12.19'
2017-03-19 16:52:08 +0900 [info]: adding match in @fuga pattern="fuga" type="file"
2017-03-19 16:52:08 +0900 [info]: adding match pattern="hoge" type="file"
2017-03-19 16:52:08 +0900 [info]: adding match pattern="fuga" type="relabel"
2017-03-19 16:52:08 +0900 [info]: adding source type="forward"
2017-03-19 16:52:08 +0900 [info]: using configuration file: <ROOT>
  <source>
    @type forward
  </source>
  <match hoge>
    @type file
    path /tmp/hoge
    time_slice_format %Y%m%d
    buffer_path /tmp/hoge.*
  </match>
  <match fuga>
    @type relabel
    @label @fuga
  </match>
  <label @fuga>
    <match fuga>
      @type file
      path /tmp/fuga
      time_slice_format %Y%m%d
      buffer_path /tmp/fuga.*
    </match>
  </label>
</ROOT>
2017-03-19 16:52:08 +0900 [info]: listening fluent socket on 0.0.0.0:24224
...
2017-03-19 16:57:07 +0900 [info]: force flushing buffered events

$ echo '{"msg":"this is test"}' |./bin/fluent-cat hoge
$ ls -l /tmp/hoge.20170319.b54b109ecfa4c00f1
-rw-r--r-- 1 tatsu-yam tatsu-yam 54  3 19 16:47 /tmp/hoge.20170319.b54b109ecfa4c00f1

$ echo '{"msg":"this is test"}' |./bin/fluent-cat fuga
$ ls -l /tmp/fuga.20170319.b54b10a1c81f12693
-rw-r--r-- 1 tatsu-yam tatsu-yam 54  3 19 16:48 /tmp/fuga.20170319.b54b10a1c81f12693

$ kill -USR1 xxx
$ ls -l /tmp/ |egrep 'hoge|fuga'
-rw-r--r-- 1 tatsu-yam tatsu-yam  54  3 19 16:48 fuga.20170319.b54b10a1c81f12693
-rw-r--r-- 1 tatsu-yam tatsu-yam  54  3 19 16:49 hoge.20170319_0.log
```

after:
```
$ kill -USR1 xxx
$ ls -l /tmp/ |egrep 'hoge|fuga'
-rw-r--r-- 1 tatsu-yam tatsu-yam  54  3 19 16:57 fuga.20170319_0.log
-rw-r--r-- 1 tatsu-yam tatsu-yam  54  3 19 16:57 hoge.20170319_0.log
```

This problem has already solved in fluentd v0.14.