### PR TITLE
Unify parameter name between udp and syslog plugins

### DIFF
--- a/lib/fluent/plugin/in_syslog.rb
+++ b/lib/fluent/plugin/in_syslog.rb
@@ -85,14 +85,15 @@ module Fluent::Plugin
     config_param :source_hostname_key, :string, default: nil
     desc 'The field name of source address of sender.'
     config_param :source_address_key, :string, default: nil
-
     desc 'The field name of the priority.'
     config_param :priority_key, :string, default: nil
     desc 'The field name of the facility.'
     config_param :facility_key, :string, default: nil
 
-    config_param :blocking_timeout, :time, default: 0.5
+    desc "The max bytes of message"
     config_param :message_length_limit, :size, default: 2048
+
+    config_param :blocking_timeout, :time, default: 0.5
 
     config_section :parse do
       config_set_default :@type, DEFAULT_PARSER

--- a/test/plugin/test_in_udp.rb
+++ b/test/plugin/test_in_udp.rb
@@ -54,7 +54,7 @@ class UdpInputTest < Test::Unit::TestCase
     d = create_driver(conf)
     assert_equal PORT, d.instance.port
     assert_equal bind, d.instance.bind
-    assert_equal 4096, d.instance.body_size_limit
+    assert_equal 4096, d.instance.message_length_limit
   end
 
   data(
@@ -84,6 +84,16 @@ class UdpInputTest < Test::Unit::TestCase
     tests.each_with_index do |t, i|
       assert_equal_event_time(t['expected'], events[i][1])
     end
+  end
+
+  data(
+    'message_length_limit' => 'message_length_limit 2048',
+    'body_size_limit' => 'body_size_limit 2048'
+  )
+  test 'message_length_limit/body_size_limit compatibility' do |param|
+
+    d = create_driver(CONFIG + param)
+    assert_equal 2048, d.instance.message_length_limit
   end
 
   data(


### PR DESCRIPTION
`in_syslog` is widely used so using `message_length_limit` is better for users.