### PR TITLE
Fix backward compatibility with Fluent::DetachProcess and Fluent::DetachMultiProcess

### DIFF
--- a/lib/fluent/compat/detach_process_mixin.rb
+++ b/lib/fluent/compat/detach_process_mixin.rb
@@ -17,9 +17,17 @@
 module Fluent
   module Compat
     module DetachProcessMixin
+      def detach_process
+        log.warn "#{__method__} is not supported in this version. ignored."
+        yield
+      end
     end
 
     module DetachMultiProcessMixin
+      def detach_multi_process
+        log.warn "#{__method__} is not supported in this version. ignored."
+        yield
+      end
     end
   end
 end

--- a/lib/fluent/compat/input.rb
+++ b/lib/fluent/compat/input.rb
@@ -44,16 +44,6 @@ module Fluent
       def shutdown
         super
       end
-
-      def detach_process(&block)
-        log.warn "detach_process is not supported in this version. ignored."
-        block.call
-      end
-
-      def detach_multi_process(&block)
-        log.warn "detach_multi_process is not supported in this version. ignored."
-        block.call
-      end
     end
   end
 end

--- a/lib/fluent/compat/output.rb
+++ b/lib/fluent/compat/output.rb
@@ -190,16 +190,6 @@ module Fluent
           end
         end
       end
-
-      def detach_process(&block)
-        log.warn "detach_process is not supported in this version. ignored."
-        block.call
-      end
-
-      def detach_multi_process(&block)
-        log.warn "detach_process is not supported in this version. ignored."
-        block.call
-      end
     end
 
     class MultiOutput < Fluent::Plugin::BareOutput


### PR DESCRIPTION
Some 3rd party plugins use these methods in their code:

```ruby
class HTTPServer # w/o inheriting Fluent::Input, Fluent::Output
  include DetachMultiProcess

  def start
    detach_multi_process do
      # Do something to run HTTP server
    end
  end
end
```

See also:
  * https://github.com/groonga/fluent-plugin-groonga/blob/530f421080cd4ad131eacc1cfd6ade474fabc19d/lib/fluent/plugin/in_groonga.rb#L144
  * https://github.com/groonga/fluent-plugin-groonga/blob/530f421080cd4ad131eacc1cfd6ade474fabc19d/lib/fluent/plugin/in_groonga.rb#L83-L85