### PR TITLE
Quote the file path to the Ruby bin directory when starting fluentd as a windows service

### DIFF
--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -256,7 +256,7 @@ if winsvcinstmode = opts[:regwinsvc]
       description: FLUENTD_WINSVC_DESC,
       start_type: start_type,
       error_control: Service::ERROR_NORMAL,
-      binary_path_name: ruby_path+" -C "+binary_path+" winsvc.rb",
+      binary_path_name: "\"#{ruby_path}\" -C \"#{binary_path}\"  winsvc.rb",
       load_order_group: "",
       dependencies: [""],
       display_name: FLUENTD_WINSVC_DISPLAYNAME

--- a/lib/fluent/winsvc.rb
+++ b/lib/fluent/winsvc.rb
@@ -40,7 +40,7 @@ begin
     ruby_path = ruby_path.rstrip.gsub(/\\/, '/')
     rubybin_dir = ruby_path[0, ruby_path.rindex("/")]
     opt = read_fluentdopt
-    Process.spawn(rubybin_dir + "/ruby.exe " + rubybin_dir + "/fluentd " + opt + " -x " + INTEVENTOBJ_NAME)
+    Process.spawn("\"#{rubybin_dir}/ruby.exe\" \"#{rubybin_dir}/fluentd\" #{opt} -x #{INTEVENTOBJ_NAME}")
   end
 
   class FluentdService < Daemon


### PR DESCRIPTION
The the file path is passed to win32-service (which calls windows functions [CreateService]( https://msdn.microsoft.com/en-us/library/windows/desktop/ms682450(v=vs.85).aspx)) and to [Process.spawn](https://ruby-doc.org/core-2.2.0/Process.html#method-c-spawn).  Both require spaces to be wrapped in quotes or windows will not properly handle them.

Without this fix fluentd will fail fail when initializing or when starting with a ruby directory that contains spaces.