### PR TITLE
Do not warn that directories are unreadable in the in_tail plugin.

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -189,15 +189,15 @@ module Fluent::Plugin
         path = date.strftime(path)
         if path.include?('*')
           paths += Dir.glob(path).select { |p|
-            is_directory = File.directory?(p)
-            if File.readable?(p) && !is_directory
+            is_file = !File.directory?(p)
+            if File.readable?(p) && is_file
               if @limit_recently_modified && File.mtime(p) < (date - @limit_recently_modified)
                 false
               else
                 true
               end
             else
-              if !is_directory
+              if is_file
                 log.warn "#{p} unreadable. It is excluded and would be examined next time."
               end
               false

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -189,14 +189,17 @@ module Fluent::Plugin
         path = date.strftime(path)
         if path.include?('*')
           paths += Dir.glob(path).select { |p|
-            if File.readable?(p) && !File.directory?(p)
+		    is_directory = File.directory?(p)
+            if File.readable?(p) && !is_directory
               if @limit_recently_modified && File.mtime(p) < (date - @limit_recently_modified)
                 false
               else
                 true
               end
             else
-              log.warn "#{p} unreadable. It is excluded and would be examined next time."
+			  if !is_directory
+                log.warn "#{p} unreadable. It is excluded and would be examined next time."
+			  end
               false
             end
           }

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -189,7 +189,7 @@ module Fluent::Plugin
         path = date.strftime(path)
         if path.include?('*')
           paths += Dir.glob(path).select { |p|
-		    is_directory = File.directory?(p)
+            is_directory = File.directory?(p)
             if File.readable?(p) && !is_directory
               if @limit_recently_modified && File.mtime(p) < (date - @limit_recently_modified)
                 false
@@ -197,9 +197,9 @@ module Fluent::Plugin
                 true
               end
             else
-			  if !is_directory
+              if !is_directory
                 log.warn "#{p} unreadable. It is excluded and would be examined next time."
-			  end
+              end
               false
             end
           }


### PR DESCRIPTION
Currently a warning will appear for each directory in globbed results.  They will never be readable so the message appears on each refresh.