### PR TITLE
Handle wildcards in windows files paths in the in_tail plugin.

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -100,7 +100,7 @@ module Fluent::Plugin
 
       super
 
-      @paths = @path.split(',').map {|path| path.strip }
+      @paths = @path.split(',').map {|path| path.strip.gsub('\\', '/') }
       if @paths.empty?
         raise Fluent::ConfigError, "tail: 'path' parameter is required on tail input"
       end


### PR DESCRIPTION
Currently tail plugins on windows will work if a specific file is targeted:
```
<source>
  type tail
  format none
  path C:\SomeDir\Logs\the.logs
  tag custom-logs
</source>
```

However with wildcards the log files will not be picked up:
```
<source>
  type tail
  format none
  path C:\SomeDir\Logs\**\*'
  tag custom-logs
</source>
```

This is due to Dir.glob not handing '\'s properly.  The '\' must be converted to '/'.  FIle.* methods will take either a '\' or '/'.

Users could define paths with '/'s but this is not idiomatic for windows users.