### PR TITLE
Fix out_file test with timezone

### DIFF
--- a/lib/fluent/plugin/out_file.rb
+++ b/lib/fluent/plugin/out_file.rb
@@ -105,6 +105,11 @@ module Fluent::Plugin
         buffer_conf['path'] = conf['path'] || '/tmp/dummy_path'
       end
 
+      if conf.has_key?('utc') || conf.has_key?('localtime')
+        param_name = conf.has_key?('utc') ? 'utc' : 'localtime'
+        log.warn "'#{param_name}' is deperecated for output plugin. This parameter is used for formatter plugin in compatibility layer. If you want to use same feature, use timekey_use_utc parameter in <buffer> directive instead"
+      end
+
       super
 
       @compress_method = SUPPORTED_COMPRESS_MAP[@compress]

--- a/lib/fluent/plugin_helper/compat_parameters.rb
+++ b/lib/fluent/plugin_helper/compat_parameters.rb
@@ -55,7 +55,7 @@ module Fluent
         "keys" => "keys", # CSVParser, TSVParser (old ValuesParser)
         "time_key"    => "time_key",
         "time_format" => "time_format",
-        "localtim" => nil,
+        "localtime" => nil,
         "utc" => nil,
         "delimiter"   => "delimiter",
         "keep_time_key" => "keep_time_key",

--- a/test/plugin/test_out_file.rb
+++ b/test/plugin/test_out_file.rb
@@ -20,6 +20,9 @@ class FileOutputTest < Test::Unit::TestCase
     path #{TMP_DIR}/out_file_test
     compress gz
     utc
+    <buffer>
+      timekey_use_utc true
+    </buffer>
   ]
 
   def create_driver(conf = CONFIG, opts = {})
@@ -405,6 +408,9 @@ class FileOutputTest < Test::Unit::TestCase
       path #{TMP_DIR_WITH_SYSTEM}/out_file_test
       compress gz
       utc
+      <buffer>
+        timekey_use_utc true
+      </buffer>
       <system>
         file_permission #{OVERRIDE_FILE_PERMISSION}
         dir_permission #{OVERRIDE_DIR_PERMISSION}
@@ -527,6 +533,9 @@ class FileOutputTest < Test::Unit::TestCase
         compress gz
         utc
         append true
+        <buffer>
+          timekey_use_utc true
+        </buffer>
       ]
       d.run(default_tag: 'test'){
         d.feed(time, {"a"=>1})


### PR DESCRIPTION
@mururu Could you test this on your environment?

In v0.14, compat parameters handles `utc` parameter for parsers / formatters.
So if we want to use `utc` in buffer, need to specify `timekey_use_utc` in `<buffer>`.