### PR TITLE
Allow the Windows Service name Fluentd runs as to be configurable.

### DIFF
--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -158,6 +158,12 @@ op.on('-G', '--gem-path GEM_INSTALL_PATH', "Gemfile install path (default: $(dir
 if Fluent.windows?
   require 'windows/library'
   include Windows::Library
+  
+  opts.merge!(
+    :winsvc_name => 'fluentdwinsvc',
+    :winsvc_display_name => 'Fluentd Windows Service',
+    :winsvc_desc => 'Fluentd is an event collector system.',
+  )
 
   op.on('-x', '--signame INTSIGNAME', "an object name which is used for Windows Service signal (Windows only)") {|s|
     opts[:signame] = s

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -385,6 +385,9 @@ module Fluent
         standalone_worker: false,
         signame: nil,
         winsvcreg: nil,
+        winsvc_name: 'fluentdwinsvc',
+        winsvc_display_name: 'Fluentd Windows Service',
+        winsvc_desc: 'Fluentd is an event collector system.',
       }
     end
 

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -384,10 +384,6 @@ module Fluent
         supervise: true,
         standalone_worker: false,
         signame: nil,
-        winsvcreg: nil,
-        winsvc_name: 'fluentdwinsvc',
-        winsvc_display_name: 'Fluentd Windows Service',
-        winsvc_desc: 'Fluentd is an event collector system.',
       }
     end
 


### PR DESCRIPTION
This will allow the name, display name and description fluentd is running as when it is a Windows Service to be configured.

This also removes an unneeded option 'winsvcreg'