### PR TITLE
Allow null byte in double-quoted string. fix #1358

### DIFF
--- a/lib/fluent/config/literal_parser.rb
+++ b/lib/fluent/config/literal_parser.rb
@@ -181,6 +181,8 @@ module Fluent
           "\f"
         when "b"
           "\b"
+        when "0"
+          "\0"
         when /[a-zA-Z0-9]/
           parse_error! "unexpected back-slash escape character '#{c}'"
         else  # symbols

--- a/test/config/test_literal_parser.rb
+++ b/test/config/test_literal_parser.rb
@@ -105,8 +105,8 @@ module Fluent::Config
       test('"\\.t"') { assert_text_parsed_as(".t", '"\\.t"') }
       test('"\\$t"') { assert_text_parsed_as("$t", '"\\$t"') }
       test('"\\"') { assert_text_parsed_as("#t", '"\\#t"') }
+      test('"\\0"') { assert_text_parsed_as("\0", '"\\0"') }
       test('"\\z"') { assert_parse_error('"\\z"') }  # unknown escaped character
-      test('"\\0"') { assert_parse_error('"\\0"') }  # unknown escaped character
       test('"\\1"') { assert_parse_error('"\\1"') }  # unknown escaped character
       test('"t') { assert_parse_error('"t') }  # non-terminated quoted character
       test("\"t\nt\"") { assert_text_parsed_as("t\nt", "\"t\nt\"" ) } # multiline string


### PR DESCRIPTION
We can use `"\0"` in formatter delimiter, in_tcp delimiter or anywhere.

Previous behaviour is raising error so this patch should not break existing configuration.