### PR TITLE
check variable buffer is a Buffer instance in MonitorAgentInput

### DIFF
--- a/lib/fluent/plugin/in_monitor_agent.rb
+++ b/lib/fluent/plugin/in_monitor_agent.rb
@@ -278,8 +278,8 @@ module Fluent::Plugin
 
     MONITOR_INFO = {
       'output_plugin' => ->(){ is_a?(::Fluent::Plugin::Output) },
-      'buffer_queue_length' => ->(){ throw(:skip) unless instance_variable_defined?(:@buffer) && !@buffer.nil?; @buffer.queue.size },
-      'buffer_total_queued_size' => ->(){ throw(:skip) unless instance_variable_defined?(:@buffer) && !@buffer.nil?; @buffer.stage_size },
+      'buffer_queue_length' => ->(){ throw(:skip) unless instance_variable_defined?(:@buffer) && !@buffer.nil? && @buffer.is_a?(::Fluent::Plugin::Buffer); @buffer.queue.size },
+      'buffer_total_queued_size' => ->(){ throw(:skip) unless instance_variable_defined?(:@buffer) && !@buffer.nil? && @buffer.is_a?(::Fluent::Plugin::Buffer); @buffer.stage_size },
       'retry_count' => ->(){ instance_variable_defined?(:@num_errors) ? @num_errors : nil },
     }
 


### PR DESCRIPTION
in_monitor_agent plugin collects metrics by checking internal variables by `instance_exec`.  It implicitly asserts that `@buffer` is a buffer instance when get metrics of `buffer_queue_length` and `buffer_total_queued_size`. If a plugin uses the variable name for other purpose, `NoMethodError` happens.

Example configuration with fluent-plugin-concat which uses `@buffer` variable as a Hash. On this configuration, doing `curl 'http://localhost:24220/api/plugins.json'` causes
```
[error]: #0 NoMethodError in monitoring plugins key="buffer_queue_length" plugin=Fluent::Plugin::ConcatFilter error_class=NoMethodError error="undefined method `queue' for {}:Hash"
```

```
<source>
  @type monitor_agent
</source>

<filter **>
   @type concat
    key message
    multiline_start_regexp /foo.bar/
    flush_interval 
    stream_identity_key container_id
    timeout_label @OUT
</filter>
```