### PR TITLE
Add missing '<<' method to delegators

### DIFF
--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -472,7 +472,7 @@ module Fluent
     extend Forwardable
     def_delegators '@logger', :enable_color?, :enable_debug, :enable_event,
       :disable_events, :log_event_enabled, :log_event_enamed=, :time_format, :time_format=,
-      :event, :caller_line, :puts, :write, :flush, :reset, :out, :out=,
+      :event, :caller_line, :puts, :write, :<<, :flush, :reset, :out, :out=,
       :optional_header, :optional_header=, :optional_attrs, :optional_attrs=
   end
 

--- a/test/test_log.rb
+++ b/test/test_log.rb
@@ -722,6 +722,8 @@ class PluginLoggerTest < Test::Unit::TestCase
 
     def test_write_alias
       assert(@log.respond_to?(:<<))
+      mock(@log.out).write("log")
+      @log << "log"
     end
 
     def test_out


### PR DESCRIPTION
Fix https://github.com/fluent/fluent-plugin-s3/issues/191