### PR TITLE
Call proper method for each connection type. fix #1554

### DIFF
--- a/lib/fluent/plugin/in_forward.rb
+++ b/lib/fluent/plugin/in_forward.rb
@@ -211,7 +211,7 @@ module Fluent::Plugin
           options = on_message(msg, chunk_size, conn)
           if options && r = response(options)
             log.trace "sent response to fluent socket", address: conn.remote_addr, response: r
-            conn.on_write_complete{ conn.close } if @deny_keepalive
+            conn.on(:write_complete) { |c| c.close } if @deny_keepalive
             send_data.call(serializer, r)
           else
             if @deny_keepalive

--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -420,7 +420,7 @@ module Fluent::Plugin
     # return chunk id to be committed
     def read_ack_from_sock(sock, unpacker)
       begin
-        raw_data = sock.recv(@read_length)
+        raw_data = sock.instance_of?(Fluent::PluginHelper::Socket::WrappedSocket::TLS) ? sock.read(@read_length) : sock.recv(@read_length)
       rescue Errno::ECONNRESET
         raw_data = ""
       end

--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -420,7 +420,7 @@ module Fluent::Plugin
     # return chunk id to be committed
     def read_ack_from_sock(sock, unpacker)
       begin
-        raw_data = sock.instance_of?(Fluent::PluginHelper::Socket::WrappedSocket::TLS) ? sock.read(@read_length) : sock.recv(@read_length)
+        raw_data = sock.instance_of?(Fluent::PluginHelper::Socket::WrappedSocket::TLS) ? sock.readpartial(@read_length) : sock.recv(@read_length)
       rescue Errno::ECONNRESET
         raw_data = ""
       end


### PR DESCRIPTION
This patch includes additional fixes.

- Use readpartial for SSLSocket
- Fix invalid code for event registration
