### PR TITLE
Support %iso8601 special case for time_format. fix #1528

### DIFF
--- a/lib/fluent/time.rb
+++ b/lib/fluent/time.rb
@@ -208,6 +208,7 @@ module Fluent
       @parse = case
                when format_with_timezone && strptime then ->(v){ Fluent::EventTime.from_time(strptime.exec(v)) }
                when format_with_timezone             then ->(v){ Fluent::EventTime.from_time(Time.strptime(v, format)) }
+               when format == '%iso8601'             then ->(v){ Fluent::EventTime.from_time(Time.iso8601(v)) }
                when strptime then ->(v){ t = strptime.exec(v);         Fluent::EventTime.new(t.to_i + offset_diff, t.nsec) }
                when format   then ->(v){ t = Time.strptime(v, format); Fluent::EventTime.new(t.to_i + offset_diff, t.nsec) }
                else ->(v){ Fluent::EventTime.parse(v) }

--- a/test/test_time_parser.rb
+++ b/test/test_time_parser.rb
@@ -34,6 +34,18 @@ class TimeParserTest < ::Test::Unit::TestCase
     assert_equal_event_time(time, parser.parse('28/Feb/2013:12:00:00:123456789 +0900'))
   end
 
+  def test_parse_iso8601
+    parser = Fluent::TimeParser.new('%iso8601')
+
+    assert(parser.parse('2017-01-01T12:00:00+09:00').is_a?(Fluent::EventTime))
+
+    time = event_time('2017-01-01T12:00:00+09:00')
+    assert_equal(time, parser.parse('2017-01-01T12:00:00+09:00'))
+
+    time_with_msec = event_time('2017-01-01T12:00:00.123+09:00')
+    assert_equal(time_with_msec, parser.parse('2017-01-01T12:00:00.123+09:00'))
+  end
+
   def test_parse_with_invalid_argument
     parser = Fluent::TimeParser.new
 


### PR DESCRIPTION
Ruby's iso8601 parser is a restrict version and it doesn't support `20170101T120000+0900` like format.
But this parser can handle `2017-01-01T12:00:00+09:00` and `2017-01-01T12:00:00.123+09:00` cases, so supporting it makes configuration simpler for iso8601 logs.
