### PR TITLE
Error: uninitialized constant Fluent::Engine

### DIFF
--- a/lib/fluent/command/binlog_reader.rb
+++ b/lib/fluent/command/binlog_reader.rb
@@ -21,6 +21,7 @@ require 'fluent/msgpack_factory'
 require 'fluent/formatter'
 require 'fluent/plugin'
 require 'fluent/config/element'
+require 'fluent/engine'
 
 class FluentBinlogReader
   SUBCOMMAND = %w(cat head formats)


### PR DESCRIPTION
```
# /opt/td-agent/embedded/bin/fluent-binlog-reader cat -f json failed.log.0 
Usage: fluent-binlog-reader cat [options] file
Options:
    -p, --plugin DIR                 add library directory path
    -f, --format TYPE                configure output format
    -e KEY=VALUE                     configure formatter config params
    -n COUNT                         Set the number of lines to display
Error: uninitialized constant Fluent::Engine
```