### PR TITLE
Add ignore_repeated_permission_error

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -42,6 +42,7 @@ module Fluent::Plugin
       @tails = {}
       @pf_file = nil
       @pf = nil
+      @ignore_list = []
     end
 
     desc 'The paths to read. Multiple paths can be specified, separated by comma.'
@@ -81,6 +82,8 @@ module Fluent::Plugin
     config_param :limit_recently_modified, :time, default: nil
     desc 'Enable the option to skip the refresh of watching list on startup.'
     config_param :skip_refresh_on_startup, :bool, default: false
+    desc 'Ignore repeated permission error logs'
+    config_param :ignore_repeated_permission_error, :bool, default: false
 
     attr_reader :paths
 
@@ -198,7 +201,10 @@ module Fluent::Plugin
               end
             else
               if is_file
-                log.warn "#{p} unreadable. It is excluded and would be examined next time."
+                unless @ignore_list.include?(path)
+                  log.warn "#{p} unreadable. It is excluded and would be examined next time."
+                  @ignore_list << path if @ignore_repeated_permission_error
+                end
               end
               false
             end

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -72,6 +72,7 @@ class TailInputTest < Test::Unit::TestCase
       assert_equal 2, d.instance.rotate_wait
       assert_equal "#{TMP_DIR}/tail.pos", d.instance.pos_file
       assert_equal 1000, d.instance.read_lines_limit
+      assert_equal false, d.instance.ignore_repeated_permission_error
     end
 
     data("empty" => config_element,


### PR DESCRIPTION
This option is useful when non-readable file exist in tailing directory and hard to exclude via `exclude_path`, e.g. file is generated dynamically.