### PR TITLE
Ruby 2.4 warns to forward private methods

### DIFF
--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -248,25 +248,6 @@ module Fluent
       @out.flush
     end
 
-    private
-
-    def dump_stacktrace(backtrace, level)
-      return if @level > level
-
-      time = Time.now
-      line = caller_line(time, 5, level)
-      if @suppress_repeated_stacktrace && (Thread.current[:last_repeated_stacktrace] == backtrace)
-        puts ["  ", line, 'suppressed same stacktrace'].join
-      else
-        backtrace.each { |msg|
-          puts ["  ", line, msg].join
-        }
-        Thread.current[:last_repeated_stacktrace] = backtrace if @suppress_repeated_stacktrace
-      end
-
-      nil
-    end
-
     def event(level, args)
       time = Time.now
       message = ''
@@ -309,6 +290,25 @@ module Fluent
         end
       end
       return log_msg
+    end
+
+    private
+
+    def dump_stacktrace(backtrace, level)
+      return if @level > level
+
+      time = Time.now
+      line = caller_line(time, 5, level)
+      if @suppress_repeated_stacktrace && (Thread.current[:last_repeated_stacktrace] == backtrace)
+        puts ["  ", line, 'suppressed same stacktrace'].join
+      else
+        backtrace.each { |msg|
+          puts ["  ", line, msg].join
+        }
+        Thread.current[:last_repeated_stacktrace] = backtrace if @suppress_repeated_stacktrace
+      end
+
+      nil
     end
   end
 


### PR DESCRIPTION
Like following:
```
/home/travis/build/fluent/fluentd/lib/fluent/log.rb:149:in `debug': Fluent::PluginLogger#event at /home/travis/.rvm/rubies/ruby-2.4.0/lib/ruby/2.4.0/forwardable.rb:156 forwarding to private method Fluent::Log#event
/home/travis/build/fluent/fluentd/lib/fluent/log.rb:150:in `debug': Fluent::PluginLogger#caller_line at /home/travis/.rvm/rubies/ruby-2.4.0/lib/ruby/2.4.0/forwardable.rb:156 forwarding to private method Fluent::Log#caller_line
```