### PR TITLE
Mask all secret parameters in worker section, fix #1553

### DIFF
--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -43,6 +43,8 @@ module Fluent
       @suppress_config_dump = false
 
       @system_config = SystemConfig.new
+
+      @dry_run_mode = false
     end
 
     MAINLOOP_SLEEP_INTERVAL = 0.3
@@ -53,6 +55,8 @@ module Fluent
     attr_reader :root_agent
     attr_reader :matches, :sources
     attr_reader :system_config
+
+    attr_accessor :dry_run_mode
 
     def init(system_config)
       @system_config = system_config
@@ -157,7 +161,7 @@ module Fluent
       $log.enable_event(true) if @log_event_router
 
       unless @suppress_config_dump
-        $log.info :worker0, "using configuration file: #{conf.to_s.rstrip}"
+        $log.info :supervisor, "using configuration file: #{conf.to_s.rstrip}"
       end
     end
 

--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -76,6 +76,9 @@ module Fluent
           raise ConfigError, "worker id #{target_worker_id} specified by <worker> directive is not allowed. Available worker id is between 0 and #{(Fluent::Engine.system_config.workers - 1)}"
         end
 
+        ## On dry_run mode, all worker sections have to be configured on supervisor (recognized as worker_id = 0).
+        target_worker_id = 0 if Fluent::Engine.dry_run_mode
+
         e.elements.each do |elem|
           unless ['source', 'match', 'filter', 'label'].include?(elem.name)
             raise ConfigError, "<worker> section cannot have <#{elem.name}> directive"

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -534,6 +534,7 @@ module Fluent
       rescue Fluent::ConfigError => e
         $log.error "config error", file: @config_path, error: e
         $log.debug_backtrace
+        exit!(1)
       ensure
         Fluent::Engine.dry_run_mode = false
       end

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -457,7 +457,7 @@ module Fluent
         end
       end
 
-      dry_run if @dry_run
+      dry_run_cmd if @dry_run
       supervise
     end
 
@@ -514,15 +514,28 @@ module Fluent
       ENV['SERVERENGINE_SOCKETMANAGER_PATH'] = socket_manager_path.to_s
     end
 
-    def dry_run
+    def dry_run_cmd
       $log.info "starting fluentd-#{Fluent::VERSION} as dry run mode"
-      change_privilege
-      init_engine
-      run_configure
+      @system_config.suppress_config_dump = true
+      dry_run
       exit 0
     rescue => e
       $log.error "dry run failed: #{e}"
       exit 1
+    end
+
+    ## Set Engine's dry_run_mode true to override all target_id of worker sections
+    def dry_run
+      begin
+        Fluent::Engine.dry_run_mode = true
+        change_privilege
+        init_engine
+        run_configure
+        Fluent::Engine.dry_run_mode = false
+      rescue Fluent::ConfigError => e
+        $log.error "config error", file: @config_path, error: e
+        $log.debug_backtrace
+      end
     end
 
     def show_plugin_config
@@ -532,6 +545,9 @@ module Fluent
     end
 
     def supervise
+      # Make dumpable conf, which is set corresponding_proxies for all elements in all worker sections
+      dry_run
+
       Process.setproctitle("supervisor:#{@process_name}") if @process_name
       $log.info "starting fluentd-#{Fluent::VERSION}", pid: Process.pid
 

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -531,10 +531,11 @@ module Fluent
         change_privilege
         init_engine
         run_configure
-        Fluent::Engine.dry_run_mode = false
       rescue Fluent::ConfigError => e
         $log.error "config error", file: @config_path, error: e
         $log.debug_backtrace
+      ensure
+        Fluent::Engine.dry_run_mode = false
       end
     end
 


### PR DESCRIPTION
Secrete parameters are masked when configuring the plugin instances, but fluentd worker processes don't create and configure the instances of plugins under worker sections for other workers. And config dump is performed on a worker process(worker0). So the secret parameters under worker section are not masked except for worker0.
This patch makes supervisor process create and configure instances of plugins for all workers before spawning worker processes and config_dump performed on supervisor process. This method is the same with dry_run.