### PR TITLE
in_tail: There are cases where the excluded_path doesn't apply by timing.

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -187,7 +187,6 @@ module Fluent::Plugin
       date = Time.now
       paths = []
 
-      excluded = @exclude_path.map { |path| path = date.strftime(path); path.include?('*') ? Dir.glob(path) : path }.flatten.uniq
       @paths.each { |path|
         path = date.strftime(path)
         if path.include?('*')
@@ -214,6 +213,7 @@ module Fluent::Plugin
           paths << path
         end
       }
+      excluded = @exclude_path.map { |path| path = date.strftime(path); path.include?('*') ? Dir.glob(path) : path }.flatten.uniq
       paths - excluded
     end
 


### PR DESCRIPTION
Newly created files after creating the `excluded` list may not be excluded.

Fix the order of creating the `paths`/`excluded` list. Creating the `excluded` list should be last for certainly excluding.