### PR TITLE
Detach watchers before run `update_watcher` when detect log rotation

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -508,11 +508,13 @@ module Fluent
               io_handler = IOHandler.new(io, @pe, @log, @read_lines_limit, &method(:wrap_receive_lines))
               @io_handler = io_handler
             else # file is rotated and new file found
+              detach
               @update_watcher.call(@path, swap_state(@pe))
             end
           else # file is rotated and new file not found
             # Clear RotateHandler to avoid duplicated file watch in same path.
             @rotate_handler = nil
+            detach
             @update_watcher.call(@path, swap_state(@pe))
           end
         end


### PR DESCRIPTION
Because StatWatcher and TimerWatcher should not fire
events (inotify, timer) until close their owner TailWatcher after
detect log rotation.

Fix #1383