### PR TITLE
out_forward: Don't stop heartbeat when error happen

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -402,8 +402,10 @@ module Fluent::Plugin
           log.trace "sending heartbeat", host: n.host, port: n.port, heartbeat_type: @heartbeat_type
           n.usock = @usock if @usock
           n.send_heartbeat
-        rescue Errno::EAGAIN, Errno::EWOULDBLOCK, Errno::EINTR, Errno::ECONNREFUSED
-          log.debug "failed to send heartbeat packet", host: n.host, port: n.port, heartbeat_type: @heartbeat_type, error: $!
+        rescue Errno::EAGAIN, Errno::EWOULDBLOCK, Errno::EINTR, Errno::ECONNREFUSED, Errno::ETIMEDOUT => e
+          log.debug "failed to send heartbeat packet", host: n.host, port: n.port, heartbeat_type: @heartbeat_type, error: e
+        rescue => e
+          log.debug "unexpected error happen during heartbeat", host: n.host, port: n.port, heartbeat_type: @heartbeat_type, error: e
         end
       }
     end


### PR DESCRIPTION
v0.14's out_forward uses timer helper and it stops timer when error happens.
It is not good for heartbeat because heartbeat sometimes failed when network has a problem.
v0.14 should follow v0.12's way: https://github.com/fluent/fluentd/blob/bcd37cf71fd904b5d3a88eb9951c9d7b420aa154/lib/fluent/plugin/out_forward.rb#L381

fix: https://github.com/fluent/fluentd/issues/1596