### PR TITLE
Add allow_without_priority and default_priority option to syslog input

### DIFF
--- a/lib/fluent/plugin/in_syslog.rb
+++ b/lib/fluent/plugin/in_syslog.rb
@@ -104,7 +104,7 @@ module Fluent
     desc 'If true, accept syslog message without PRI part'
     config_param :allow_without_priority, :bool, default: false
     # 13 is the default value of rsyslog and syslog-ng
-    desc 'The default PRI value'
+    desc 'The default PRI value (0 - 191 are available)'
     config_param :default_priority, :integer, default: 13
 
     def configure(conf)


### PR DESCRIPTION
This PR introduces `allow_without_priority` and `default_priority` option to syslog input.
I have syslog-like message formats like Common Event Format, which don't have PRI part at the top of the message. The current syslog input requires PRI part, so we can't receive both such messages and normal syslog messages on the same port. 
They're invalid as RFC, but there are some such formats in the real world. So I think it is very useful if fluentd can handle such logs with on the same way.

Actually, major syslog servers (rsyslog/syslog-ng) accept such format:

https://github.com/rsyslog/rsyslog/blob/master/runtime/parser.c#L576-L609
https://github.com/balabit/syslog-ng/blob/master/modules/syslogformat/syslog-format.c#L43-L85

By default, `default_priority` is `13`. It also follows rsyslog and syslog-ng:

https://github.com/rsyslog/rsyslog/blob/master/runtime/parser.c#L47
https://github.com/balabit/syslog-ng/blob/master/modules/syslogformat/syslog-format.c#L79

In the case of `message_format auto`, it is difficult to detect the format if PRI part is missing because the next part of PRI part is time part which is configurable. So `message_format auto` with `allow_without_priority` isn't allowed for now. If I can implement it, I'll send a PR after this PR merged.

Once this PR is merged, I will send a PR for the master branch.