### PR TITLE
Add more available characters for tag part of syslog format

### DIFF
--- a/lib/fluent/parser.rb
+++ b/lib/fluent/parser.rb
@@ -537,9 +537,9 @@ module Fluent
 
     class SyslogParser < Parser
       # From existence TextParser pattern
-      REGEXP = /^(?<time>[^ ]*\s*[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$/
+      REGEXP = /^(?<time>[^ ]*\s*[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[^ :\[]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$/
       # From in_syslog default pattern
-      REGEXP_WITH_PRI = /^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$/
+      REGEXP_WITH_PRI = /^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[^ :\[]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$/
        REGEXP_RFC5424 = /\A^(?<time>[^ ]+) (?<host>[^ ]+) (?<ident>[^ ]+) (?<pid>[-0-9]+) (?<msgid>[^ ]+) (?<extradata>(\[(.*)\]|[^ ])) (?<message>.+)$\z/
       REGEXP_RFC5424_WITH_PRI = /\A^\<(?<pri>[0-9]{1,3})\>[1-9]\d{0,2} (?<time>[^ ]+) (?<host>[^ ]+) (?<ident>[^ ]+) (?<pid>[-0-9]+) (?<msgid>[^ ]+) (?<extradata>(\[(.*)\]|[^ ])) (?<message>.+)$\z/
       REGEXP_DETECT_RFC5424 = /^\<.*\>[1-9]\d{0,2}/

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -374,6 +374,24 @@ module ParserTest
       end
     end
 
+    def test_parse_various_characters_for_tag
+      ident = '~!@#$%^&*()_+=-`]{};"\'/?\\,.<>'
+      @parser.configure({})
+      @parser.parse("Feb 28 12:00:00 192.168.0.1 #{ident}[11111]: [error] Syslog test") { |time, record|
+        assert_equal_event_time(event_time('Feb 28 12:00:00', format: '%b %d %H:%M:%S'), time)
+        assert_equal(@expected.merge('ident' => ident), record)
+      }
+    end
+
+    def test_parse_various_characters_for_tag_with_priority
+      ident = '~!@#$%^&*()_+=-`]{};"\'/?\\,.<>'
+      @parser.configure({'with_priority' => true})
+      @parser.parse("<6>Feb 28 12:00:00 192.168.0.1 #{ident}[11111]: [error] Syslog test") { |time, record|
+        assert_equal_event_time(event_time('Feb 28 12:00:00', format: '%b %d %H:%M:%S'), time)
+        assert_equal(@expected.merge('pri' => 6, 'ident' => ident), record)
+      }
+    end
+
     class TestRFC5424Regexp < self
       def test_parse_with_rfc5424_message
         @parser.configure(


### PR DESCRIPTION
About the TAG part of syslog format (RFC3164).
RFC3164 says "Any non-alphanumeric character will terminate the TAG field". But some syslog senders send non-alphanumeric characters as a part of TAG, so currently fluentd allowed some non-alphanumeric characters: `[a-zA-Z0-9_\/\.\-]`. In the real world, there are cases that require more characters. For example, Cisco ASA Series Syslog Messages includes `%` like `%ASA-1-101001`. It is useful if fluentd can handle such messages.

rsyslog syslog-ng and accept all characters except ` `, `:` and `[`:

https://github.com/rsyslog/rsyslog/blob/master/tools/pmrfc3164.c#L314-L347
https://github.com/balabit/syslog-ng/blob/master/modules/syslogformat/syslog-format.c#L558-L609

This PR follows them.

Once this PR is merged, I will send a PR for the master branch.