### PR TITLE
Fix race condition of retry state in flush thread

### DIFF
--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -1264,7 +1264,7 @@ module Fluent
             current_clock = Fluent::Clock.now
             interval = state.next_clock - current_clock
 
-            if state.next_clock <= current_clock && (!@retry || @retry_mutex.synchronize{ @retry.next_time } <= Time.now)
+            if state.next_clock <= current_clock && @retry_mutex.synchronize { @retry ? @retry.next_time <= Time.now : true }
               try_flush
 
               # next_flush_time uses flush_thread_interval or flush_thread_burst_interval (or retrying)


### PR DESCRIPTION
This is simple solution but performance is bit decreased.
The better solution is changing retry mechanizm, e.g. don't share state, but it makes
the code complicated. This is feature task.

This fixes https://github.com/fluent/fluentd/issues/1555