### PR TITLE
Make sure log events generated at shutdown phase of plugins (except

### DIFF
--- a/lib/fluent/agent.rb
+++ b/lib/fluent/agent.rb
@@ -38,6 +38,11 @@ module Fluent
       @started_outputs = []
       @started_filters = []
 
+      @outputs_for_log_event = []
+      @filters_for_log_event = []
+      @started_outputs_for_log_event = []
+      @started_filters_for_log_event = []
+
       @log = Engine.log
       @event_router = EventRouter.new(NoMatchMatch.new(log), self)
       @error_collector = nil
@@ -70,16 +75,18 @@ module Fluent
       @outputs.each { |o|
         o.start
         @started_outputs << o
+        @started_outputs_for_log_event << o if @outputs_for_log_event.include?(o)
       }
 
       @filters.each { |f|
         f.start
         @started_filters << f
+        @started_filters_for_log_event << f if @filters_for_log_event.include?(f)
       }
     end
 
     def shutdown
-      @started_filters.map { |f|
+      (@started_filters - @started_filters_for_log_event).map { |f|
         Thread.new do
           begin
             log.info "shutting down filter#{@context.nil? ? '' : " in #{@context}"}", type: Plugin.lookup_name_from_class(f.class), plugin_id: f.plugin_id
@@ -93,7 +100,36 @@ module Fluent
 
       # Output plugin as filter emits records at shutdown so emit problem still exist.
       # This problem will be resolved after actual filter mechanizm.
-      @started_outputs.map { |o|
+      (@started_outputs - @started_outputs_for_log_event).map { |o|
+        Thread.new do
+          begin
+            log.info "shutting down output#{@context.nil? ? '' : " in #{@context}"}", type: Plugin.lookup_name_from_class(o.class), plugin_id: o.plugin_id
+            o.shutdown
+          rescue => e
+            log.warn "unexpected error while shutting down output plugins", plugin: o.class, plugin_id: o.plugin_id, error_class: e.class, error: e
+            log.warn_backtrace
+          end
+        end
+      }.each { |t| t.join }
+
+      ## execute callback from Engine to flush log event queue before shutting down corresponding filters and outputs
+      yield if block_given?
+
+      @started_filters_for_log_event.map { |f|
+        Thread.new do
+          begin
+            log.info "shutting down filter#{@context.nil? ? '' : " in #{@context}"}", type: Plugin.lookup_name_from_class(f.class), plugin_id: f.plugin_id
+            f.shutdown
+          rescue => e
+            log.warn "unexpected error while shutting down filter plugins", plugin: f.class, plugin_id: f.plugin_id, error_class: e.class, error: e
+            log.warn_backtrace
+          end
+        end
+      }.each { |t| t.join }
+
+      # Output plugin as filter emits records at shutdown so emit problem still exist.
+      # This problem will be resolved after actual filter mechanizm.
+      @started_outputs_for_log_event.map { |o|
         Thread.new do
           begin
             log.info "shutting down output#{@context.nil? ? '' : " in #{@context}"}", type: Plugin.lookup_name_from_class(o.class), plugin_id: o.plugin_id
@@ -134,6 +170,10 @@ module Fluent
       @outputs << output
       @event_router.add_rule(pattern, output)
 
+      if match_event_log_tag?(pattern)
+        @outputs_for_log_event << output
+      end
+
       output
     end
 
@@ -146,7 +186,15 @@ module Fluent
       @filters << filter
       @event_router.add_rule(pattern, filter)
 
+      if match_event_log_tag?(pattern)
+        @filters_for_log_event << filter
+      end
+
       filter
+    end
+
+    def match_event_log_tag?(pattern)
+      EventRouter::Rule.new(pattern, nil).match?($log.tag)
     end
 
     # For handling invalid record

--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -210,10 +210,13 @@ module Fluent
       ensure
         $log.info "shutting down fluentd"
         if @log_emit_thread
-          @log_event_loop_stop = true
-          @log_emit_thread.join
+          shutdown do
+            @log_event_loop_stop = true
+            @log_emit_thread.join
+          end
+        else
+          shutdown
         end
-        shutdown
       end
     end
 
@@ -237,8 +240,8 @@ module Fluent
       @root_agent.start
     end
 
-    def shutdown
-      @root_agent.shutdown
+    def shutdown(&block)
+      @root_agent.shutdown(&block)
     end
   end
 


### PR DESCRIPTION
corresponding filter and output) are emitted

Here is an example. In this case, `out-ok-1`, `in-ok`, `filter-ok` and `out-ok-2` should be captured. `filter-ng` and `out-ng` should not be captured because they match fluentd's event logs. Note that the captured logs appear twice due to stdout filter.

```
<match test>
  @type null
  @id out-ok-1
</match>

<source>
  @type dummy
  tag dummy
  @id in-ok
</source>

<filter test>
  @type stdout
  @id filter-ok
</filter>

<label @X>
  <match hoge>
    @type null
    @id out-ok-2
  </match>
</label>

<filter fluent.**>
  @type stdout
  @id filter-ng
</filter>

<match fluent.**>
  @type stdout
  @id out-ng
</match>
```

```
2017-07-12 19:25:28 +0900 [info]: shutting down fluentd
2017-07-12 19:25:28 +0900 [info]: shutting down input type="dummy" plugin_id="in-ok"
2017-07-12 19:25:29 +0900 fluent.info: {"message":"shutting down fluentd"}
2017-07-12 19:25:28 +0900 fluent.info: {"message":"shutting down fluentd"}
2017-07-12 19:25:29 +0900 fluent.info: {"type":"dummy","plugin_id":"in-ok","message":"shutting down input type=\"dummy\" plugin_id=\"in-ok\""}
2017-07-12 19:25:28 +0900 fluent.info: {"type":"dummy","plugin_id":"in-ok","message":"shutting down input type=\"dummy\" plugin_id=\"in-ok\""}
2017-07-12 19:25:29 +0900 [warn]: no patterns matched tag="dummy"
2017-07-12 19:25:29 +0900 [info]: shutting down output in @X type="null" plugin_id="out-ok-2"
2017-07-12 19:25:29 +0900 [info]: shutting down filter type="stdout" plugin_id="filter-ok"
2017-07-12 19:25:29 +0900 [info]: shutting down output type="null" plugin_id="out-ok-1"
2017-07-12 19:25:29 +0900 fluent.warn: {"tag":"dummy","message":"no patterns matched tag=\"dummy\""}
2017-07-12 19:25:29 +0900 fluent.warn: {"tag":"dummy","message":"no patterns matched tag=\"dummy\""}
2017-07-12 19:25:29 +0900 fluent.info: {"type":"null","plugin_id":"out-ok-2","message":"shutting down output in @X type=\"null\" plugin_id=\"out-ok-2\""}
2017-07-12 19:25:29 +0900 fluent.info: {"type":"null","plugin_id":"out-ok-2","message":"shutting down output in @X type=\"null\" plugin_id=\"out-ok-2\""}
2017-07-12 19:25:29 +0900 fluent.info: {"type":"stdout","plugin_id":"filter-ok","message":"shutting down filter type=\"stdout\" plugin_id=\"filter-ok\""}
2017-07-12 19:25:29 +0900 fluent.info: {"type":"stdout","plugin_id":"filter-ok","message":"shutting down filter type=\"stdout\" plugin_id=\"filter-ok\""}
2017-07-12 19:25:29 +0900 fluent.info: {"type":"null","plugin_id":"out-ok-1","message":"shutting down output type=\"null\" plugin_id=\"out-ok-1\""}
2017-07-12 19:25:29 +0900 fluent.info: {"type":"null","plugin_id":"out-ok-1","message":"shutting down output type=\"null\" plugin_id=\"out-ok-1\""}
2017-07-12 19:25:29 +0900 [info]: shutting down filter type="stdout" plugin_id="filter-ng"
2017-07-12 19:25:29 +0900 [info]: shutting down output type="stdout" plugin_id="out-ng"
2017-07-12 19:25:29 +0900 [info]: process finished code=0
```