### PR TITLE
Write buffer metadata into file ASAP

### DIFF
--- a/lib/fluent/plugin/buffer/file_chunk.rb
+++ b/lib/fluent/plugin/buffer/file_chunk.rb
@@ -285,6 +285,7 @@ module Fluent
             @meta.set_encoding(Encoding::ASCII_8BIT)
             @meta.sync = true
             @meta.binmode
+            write_metadata(update: false)
           rescue => e
             # This case is easier than enqueued!. Just removing pre-create buffer file
             @chunk.close rescue nil

--- a/lib/fluent/plugin/buffer/file_chunk.rb
+++ b/lib/fluent/plugin/buffer/file_chunk.rb
@@ -244,9 +244,10 @@ module Fluent
               c: @created_at.to_i,
               m: (update ? Time.now : @modified_at).to_i,
           })
+          bin = msgpack_packer.pack(data).to_s
           @meta.seek(0, IO::SEEK_SET)
-          @meta.truncate(0)
-          @meta.write(msgpack_packer.pack(data))
+          @meta.write(bin)
+          @meta.truncate(bin.bytesize)
         end
 
         def file_rename(file, old_path, new_path, callback=nil)


### PR DESCRIPTION
As shown in #1589, file buffer chunks possibly make broken/empty .meta files for its metadata.
I found that some points to be improved to prevent such cases:

* write metadata into files just after initializing buffer chunk object
  * before: .meta content is written at the time of `#commit` or `enqueue!` - it's too late
* write metadata msgpack binary, then truncate .meta file into the size of metadata
  * before: .meta was truncated into 0 at first, then msgpack binary was written