### PR TITLE
Record accessor helper

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("tzinfo", ["~> 1.0"])
   gem.add_runtime_dependency("tzinfo-data", ["~> 1.0"])
   gem.add_runtime_dependency("strptime", ["~> 0.1.7"])
+  gem.add_runtime_dependency("ruby_dig", ["~> 0.0.2"])
 
   # build gem for a certain platform. see also Rakefile
   fake_platform = ENV['GEM_BUILD_FAKE_PLATFORM'].to_s

--- a/lib/fluent/plugin/filter_grep.rb
+++ b/lib/fluent/plugin/filter_grep.rb
@@ -22,6 +22,15 @@ module Fluent::Plugin
   class GrepFilter < Filter
     Fluent::Plugin.register_filter('grep', self)
 
+    def initialize
+      super
+
+      @_regexps = {}
+      @_excludes = {}
+    end
+
+    helpers :record_accessor
+
     REGEXP_MAX_NUM = 20
 
     (1..REGEXP_MAX_NUM).each {|i| config_param :"regexp#{i}",  :string, default: nil, deprecated: "Use <regexp> section" }
@@ -52,31 +61,38 @@ module Fluent::Plugin
     def configure(conf)
       super
 
-      @_regexps = {}
+      rs = {}
       (1..REGEXP_MAX_NUM).each do |i|
         next unless conf["regexp#{i}"]
         key, regexp = conf["regexp#{i}"].split(/ /, 2)
         raise Fluent::ConfigError, "regexp#{i} does not contain 2 parameters" unless regexp
-        raise Fluent::ConfigError, "regexp#{i} contains a duplicated key, #{key}" if @_regexps[key]
-        @_regexps[key] = Regexp.compile(regexp)
+        raise Fluent::ConfigError, "regexp#{i} contains a duplicated key, #{key}" if rs[key]
+        rs[key] = Regexp.compile(regexp)
       end
 
-      @_excludes = {}
+      es = {}
       (1..REGEXP_MAX_NUM).each do |i|
         next unless conf["exclude#{i}"]
         key, exclude = conf["exclude#{i}"].split(/ /, 2)
         raise Fluent::ConfigError, "exclude#{i} does not contain 2 parameters" unless exclude
-        raise Fluent::ConfigError, "exclude#{i} contains a duplicated key, #{key}" if @_excludes[key]
-        @_excludes[key] = Regexp.compile(exclude)
+        raise Fluent::ConfigError, "exclude#{i} contains a duplicated key, #{key}" if es[key]
+        es[key] = Regexp.compile(exclude)
       end
 
       @regexps.each do |e|
-        raise Fluent::ConfigError, "Duplicate key: #{e.key}" if @_regexps.key?(e.key)
-        @_regexps[e.key] = e.pattern
+        raise Fluent::ConfigError, "Duplicate key: #{e.key}" if rs.key?(e.key)
+        rs[e.key] = e.pattern
       end
       @excludes.each do |e|
-        raise Fluent::ConfigError, "Duplicate key: #{e.key}" if @_excludes.key?(e.key)
-        @_excludes[e.key] = e.pattern
+        raise Fluent::ConfigError, "Duplicate key: #{e.key}" if es.key?(e.key)
+        es[e.key] = e.pattern
+      end
+
+      rs.each_pair do |k, v|
+        @_regexps[record_accessor_create(k)] = v
+      end
+      es.each_pair do |k, v|
+        @_excludes[record_accessor_create(k)] = v
       end
     end
 
@@ -85,10 +101,10 @@ module Fluent::Plugin
       begin
         catch(:break_loop) do
           @_regexps.each do |key, regexp|
-            throw :break_loop unless ::Fluent::StringUtil.match_regexp(regexp, record[key].to_s)
+            throw :break_loop unless ::Fluent::StringUtil.match_regexp(regexp, key.call(record).to_s)
           end
           @_excludes.each do |key, exclude|
-            throw :break_loop if ::Fluent::StringUtil.match_regexp(exclude, record[key].to_s)
+            throw :break_loop if ::Fluent::StringUtil.match_regexp(exclude, key.call(record).to_s)
           end
           result = record
         end

--- a/lib/fluent/plugin_helper.rb
+++ b/lib/fluent/plugin_helper.rb
@@ -27,6 +27,7 @@ require 'fluent/plugin_helper/extract'
 require 'fluent/plugin_helper/socket'
 require 'fluent/plugin_helper/server'
 require 'fluent/plugin_helper/retry_state'
+require 'fluent/plugin_helper/record_accessor'
 require 'fluent/plugin_helper/compat_parameters'
 
 module Fluent

--- a/lib/fluent/plugin_helper/record_accessor.rb
+++ b/lib/fluent/plugin_helper/record_accessor.rb
@@ -81,7 +81,9 @@ module Fluent
           until key.empty?
             if in_bracket
               if i = key.index(']')
-                result << Integer(key[0..i - 1])
+                index_value = key[0..i - 1]
+                raise Fluent::ConfigError, "missing array index in '[]'. Invalid syntax: #{param}" if index_value == ']'
+                result << Integer(index_value)
                 key = key[i + 1..-1]
                 in_bracket = false
               else
@@ -118,7 +120,9 @@ module Fluent
                 end
               else
                 if i = param.index(']')
-                  result << Integer(param[0..i - 1])
+                  index_value = param[0..i - 1]
+                  raise Fluent::ConfigError, "missing array index in '[]'. Invalid syntax: #{param}" if index_value == ']'
+                  result << Integer(index_value)
                   param = param[i + 1..-1]
                   in_bracket = false
                 else

--- a/lib/fluent/plugin_helper/record_accessor.rb
+++ b/lib/fluent/plugin_helper/record_accessor.rb
@@ -15,6 +15,14 @@
 #
 
 require 'fluent/config/error'
+unless {}.respond_to?(:dig)
+  begin
+    # backport_dig is faster than ruby_dig so prefer backport_dig.
+    require 'backport_dig'
+  rescue LoadError
+    require 'ruby_dig'
+  end
+end
 
 module Fluent
   module PluginHelper
@@ -102,7 +110,7 @@ module Fluent
                   param = param[i + 2..-1]
                   in_bracket = false
                 else
-                  raise Fluent::ConfigError, "Incomplete bracket. Invalid syntax: #{param}"
+                  raise Fluent::ConfigError, "Incomplete bracket. Invalid syntax: #{orig_param}"
                 end
               else
                 if i = param.index(']')
@@ -110,7 +118,7 @@ module Fluent
                   param = param[i + 1..-1]
                   in_bracket = false
                 else
-                  raise Fluent::ConfigError, "'[' found but ']' not found. Invalid syntax: #{param}"
+                  raise Fluent::ConfigError, "'[' found but ']' not found. Invalid syntax: #{orig_param}"
                 end
               end
             else
@@ -118,7 +126,7 @@ module Fluent
                 param = param[i + 1..-1]
                 in_bracket = true
               else
-                raise Fluent::ConfigError, "found more characters after ']'. Invalid syntax: #{param}"
+                raise Fluent::ConfigError, "found more characters after ']'. Invalid syntax: #{orig_param}"
               end
             end
           end

--- a/lib/fluent/plugin_helper/record_accessor.rb
+++ b/lib/fluent/plugin_helper/record_accessor.rb
@@ -77,8 +77,18 @@ module Fluent
           }
 
           raise Fluent::ConfigError, "empty keys in dot notation" if result.empty?
+          validate_dot_keys(result)
 
           result
+        end
+
+        def self.validate_dot_keys(keys)
+          keys.each { |key|
+            next unless key.is_a?(String)
+            if /\s+/.match(key)
+              raise Fluent::ConfigError, "whitespace character is not allowed in dot notation. Use bracket notation: #{key}"
+            end
+          }
         end
 
         def self.parse_dot_array_op(key, param)

--- a/lib/fluent/plugin_helper/record_accessor.rb
+++ b/lib/fluent/plugin_helper/record_accessor.rb
@@ -70,7 +70,11 @@ module Fluent
 
         def self.parse_dot_array_op(key, param)
           start = key.index('[')
-          result = [key[0..start - 1]]
+          result = if start.zero?
+                     []
+                   else
+                     [key[0..start - 1]]
+                   end
           key = key[start + 1..-1]
           in_bracket = true
 

--- a/lib/fluent/plugin_helper/record_accessor.rb
+++ b/lib/fluent/plugin_helper/record_accessor.rb
@@ -76,7 +76,7 @@ module Fluent
             end
           }
 
-          raise Fluent::ConfigError, "empty keys" if result.empty?
+          raise Fluent::ConfigError, "empty keys in dot notation" if result.empty?
 
           result
         end
@@ -152,7 +152,7 @@ module Fluent
             end
           end
 
-          raise Fluent::ConfigError, "empty keys" if result.empty?
+          raise Fluent::ConfigError, "empty keys in bracket notation" if result.empty?
 
           result
         end

--- a/lib/fluent/plugin_helper/record_accessor.rb
+++ b/lib/fluent/plugin_helper/record_accessor.rb
@@ -34,12 +34,25 @@ module Fluent
       class Accessor
         def initialize(param)
           @keys = Accessor.parse_parameter(param)
+
+          # Call [] for single key to reduce dig overhead
+          m = method(@keys.is_a?(Array) ? :call_dig : :call_index)
+          (class << self; self; end).module_eval do
+            define_method(:call, m)
+          end
+        end
+
+        def call(r)
         end
 
         # To optimize the performance, use class_eval with pre-expanding @keys
         # See https://gist.github.com/repeatedly/ab553ed260cd080bd01ec71da9427312
-        def call(r)
+        def call_dig(r)
           r.dig(*@keys)
+        end
+
+        def call_index(r)
+          r[@keys]
         end
 
         def self.parse_parameter(param)

--- a/lib/fluent/plugin_helper/record_accessor.rb
+++ b/lib/fluent/plugin_helper/record_accessor.rb
@@ -1,0 +1,133 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'fluent/config/error'
+
+module Fluent
+  module PluginHelper
+    module RecordAccessor
+      def record_accessor_create(param)
+        Accessor.new(param)
+      end
+
+      class Accessor
+        def initialize(param)
+          @keys = Accessor.parse_parameter(param)
+        end
+
+        # To optimize the performance, use class_eval with pre-expanding @keys
+        # See https://gist.github.com/repeatedly/ab553ed260cd080bd01ec71da9427312
+        def call(r)
+          r.dig(*@keys)
+        end
+
+        def self.parse_parameter(param)
+          if param.start_with?('$.')
+            parse_dot_notation(param)
+          elsif param.start_with?('$[')
+            parse_bracket_notation(param)
+          else
+            param
+          end
+        end
+
+        def self.parse_dot_notation(param)
+          result = []
+          keys = param[2..-1].split('.')
+          keys.each { |key|
+            if key.include?('[')
+              result.concat(parse_dot_array_op(key, param))
+            else
+              result << key
+            end
+          }
+
+          raise Fluent::ConfigError, "empty keys" if result.empty?
+
+          result
+        end
+
+        def self.parse_dot_array_op(key, param)
+          start = key.index('[')
+          result = [key[0..start - 1]]
+          key = key[start + 1..-1]
+          in_bracket = true
+
+          until key.empty?
+            if in_bracket
+              if i = key.index(']')
+                result << Integer(key[0..i - 1])
+                key = key[i + 1..-1]
+                in_bracket = false
+              else
+                raise Fluent::ConfigError, "'[' found but ']' not found. Invalid syntax: #{param}"
+              end
+            else
+              if i = key.index('[')
+                key = key[i + 1..-1]
+                in_bracket = true
+              else
+                raise Fluent::ConfigError, "found more characters after ']'. Invalid syntax: #{param}"
+              end
+            end
+          end
+
+          result
+        end
+
+        def self.parse_bracket_notation(param)
+          orig_param = param
+          result = []
+          param = param[1..-1]
+          in_bracket = false
+
+          until param.empty?
+            if in_bracket
+              if param[0] == "'"
+                if i = param.index("']")
+                  result << param[1..i - 1]
+                  param = param[i + 2..-1]
+                  in_bracket = false
+                else
+                  raise Fluent::ConfigError, "Incomplete bracket. Invalid syntax: #{param}"
+                end
+              else
+                if i = param.index(']')
+                  result << Integer(param[0..i - 1])
+                  param = param[i + 1..-1]
+                  in_bracket = false
+                else
+                  raise Fluent::ConfigError, "'[' found but ']' not found. Invalid syntax: #{param}"
+                end
+              end
+            else
+              if i = param.index('[')
+                param = param[i + 1..-1]
+                in_bracket = true
+              else
+                raise Fluent::ConfigError, "found more characters after ']'. Invalid syntax: #{param}"
+              end
+            end
+          end
+
+          raise Fluent::ConfigError, "empty keys" if result.empty?
+
+          result
+        end
+      end
+    end
+  end
+end

--- a/test/plugin_helper/test_record_accessor.rb
+++ b/test/plugin_helper/test_record_accessor.rb
@@ -30,8 +30,7 @@ class RecordAccessorHelperTest < Test::Unit::TestCase
       assert_equal ['key1', 'key2', 0], result
     end
 
-    data('dot' => '$.key1[0].ke y2',
-         'bracket' => "$['key1'][0]['ke y2']")
+    data('bracket' => "$['key1'][0]['ke y2']")
     test "nested keys ['key1', 0, 'ke y2']" do |param|
       result = Fluent::PluginHelper::RecordAccessor::Accessor.parse_parameter(param)
       assert_equal ['key1', 0, 'ke y2'], result
@@ -48,6 +47,7 @@ class RecordAccessorHelperTest < Test::Unit::TestCase
          "missing array index with dot" => "$.hello[]",
          "missing array index with braket" => "$[]",
          "more chars" => "$.key1[0]foo",
+         "whitespace char included key in dot notation" => "$.key[0].ke y",
          "empty keys with dot" => "$.",
          "empty keys with bracket" => "$[")
     test 'invalid syntax' do |param|
@@ -85,8 +85,7 @@ class RecordAccessorHelperTest < Test::Unit::TestCase
       assert_equal 1, accessor.call(r)
     end
 
-    data('dot' => '$.key1[0].ke y2',
-         'bracket' => "$['key1'][0]['ke y2']")
+    data('bracket' => "$['key1'][0]['ke y2']")
     test "nested keys ['key1', 0, 'ke y2']" do |param|
       r = {'key1' => [{'ke y2' => "value"}]}
       accessor = @d.record_accessor_create(param)
@@ -94,6 +93,9 @@ class RecordAccessorHelperTest < Test::Unit::TestCase
     end
 
     data("missing ']'" => "$['key1'",
+         "missing array index with dot" => "$.hello[]",
+         "missing array index with braket" => "$['hello'][]",
+         "whitespace char included key in dot notation" => "$.key[0].ke y",
          "more chars" => "$.key1[0]foo",
          "empty keys with dot" => "$.",
          "empty keys with bracket" => "$[")

--- a/test/plugin_helper/test_record_accessor.rb
+++ b/test/plugin_helper/test_record_accessor.rb
@@ -45,6 +45,8 @@ class RecordAccessorHelperTest < Test::Unit::TestCase
     end
 
     data("missing ']'" => "$['key1'",
+         "missing array index with dot" => "$.hello[]",
+         "missing array index with braket" => "$[]",
          "more chars" => "$.key1[0]foo",
          "empty keys with dot" => "$.",
          "empty keys with bracket" => "$[")

--- a/test/plugin_helper/test_record_accessor.rb
+++ b/test/plugin_helper/test_record_accessor.rb
@@ -37,6 +37,13 @@ class RecordAccessorHelperTest < Test::Unit::TestCase
       assert_equal ['key1', 0, 'ke y2'], result
     end
 
+    data('dot' => '$.[0].key1.[1].key2',
+         'bracket' => "$[0]['key1'][1]['key2']")
+    test "nested keys [0, 'key1', 1, 'key2']" do |param|
+      result = Fluent::PluginHelper::RecordAccessor::Accessor.parse_parameter(param)
+      assert_equal [0, 'key1', 1, 'key2'], result
+    end
+
     data("missing ']'" => "$['key1'",
          "more chars" => "$.key1[0]foo",
          "empty keys with dot" => "$.",


### PR DESCRIPTION
Implement record_accessor helper for nested record support.
Support two jsonpath like syntaxes.

- dot notation: `$.key1.key2[0]`
- bracket notation: `$['key1'][0]['this.is.key2']`
- single key: `key`

In this patch, I also update `filter_grep` to use this helper.

NOTE: I implement Accessor with normal way. If need the performance, I will change its implementaion to eval way: https://gist.github.com/repeatedly/ab553ed260cd080bd01ec71da9427312