### PR TITLE
Add <log> directive to <system>

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -362,6 +362,7 @@ module Fluent
 
       def apply_options(opts)
         $log.format = opts[:format] if opts[:format]
+        $log.time_format = opts[:time_format] if opts[:time_format]
       end
 
       def level=(level)
@@ -443,7 +444,7 @@ module Fluent
       show_plugin_config if @show_plugin_config
       read_config
       set_system_config
-      @log.apply_options(format: @system_config.log.format)
+      @log.apply_options(format: @system_config.log.format, time_format: @system_config.log.time_format)
 
       $log.info :supervisor, "parsing config file is succeeded", path: @config_path
 
@@ -495,7 +496,7 @@ module Fluent
       show_plugin_config if @show_plugin_config
       read_config
       set_system_config
-      @log.apply_options(format: @system_config.log.format)
+      @log.apply_options(format: @system_config.log.format, time_format: @system_config.log.time_format)
 
       Process.setproctitle("worker:#{@process_name}") if @process_name
 

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -48,6 +48,7 @@ module Fluent
     end
     config_section :log, required: false, init: true, multi: false do
       config_param :format, :enum, list: [:text, :json], default: :text
+      config_param :time_format, :string, default: '%Y-%m-%d %H:%M:%S %z'
     end
 
     def self.create(conf)

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -46,6 +46,9 @@ module Fluent
     config_param :dir_permission, default: nil do |v|
       v.to_i(8)
     end
+    config_section :log, required: false, init: true, multi: false do
+      config_param :format, :enum, list: [:text, :json], default: :text
+    end
 
     def self.create(conf)
       systems = conf.elements(name: 'system')

--- a/test/config/test_system_config.rb
+++ b/test/config/test_system_config.rb
@@ -56,6 +56,7 @@ module Fluent::Config
       assert_nil(sc.suppress_config_dump)
       assert_nil(sc.without_source)
       assert_equal(:text, sc.log.format)
+      assert_equal('%Y-%m-%d %H:%M:%S %z', sc.log.time_format)
       assert_equal(1, s.instance_variable_get(:@workers))
       assert_nil(s.instance_variable_get(:@root_dir))
       assert_equal(Fluent::Log::LEVEL_INFO, s.instance_variable_get(:@log_level))
@@ -97,6 +98,7 @@ module Fluent::Config
           <system>
             <log>
               format json
+              time_format %Y
             </log>
           </system>
       EOS
@@ -104,6 +106,7 @@ module Fluent::Config
       sc = Fluent::SystemConfig.new(conf)
       sc.apply(s)
       assert_equal(:json, sc.log.format)
+      assert_equal('%Y', sc.log.time_format)
     end
 
     data(

--- a/test/config/test_system_config.rb
+++ b/test/config/test_system_config.rb
@@ -55,6 +55,7 @@ module Fluent::Config
       assert_nil(sc.emit_error_log_interval)
       assert_nil(sc.suppress_config_dump)
       assert_nil(sc.without_source)
+      assert_equal(:text, sc.log.format)
       assert_equal(1, s.instance_variable_get(:@workers))
       assert_nil(s.instance_variable_get(:@root_dir))
       assert_equal(Fluent::Log::LEVEL_INFO, s.instance_variable_get(:@log_level))
@@ -89,6 +90,20 @@ module Fluent::Config
       assert_not_nil(sc.instance_variable_get("@#{k}"))
       key = (k == 'emit_error_log_interval' ? 'suppress_interval' : k)
       assert_not_nil(s.instance_variable_get("@#{key}"))
+    end
+
+    test "log parameters" do
+      conf = parse_text(<<-EOS)
+          <system>
+            <log>
+              format json
+            </log>
+          </system>
+      EOS
+      s = FakeSupervisor.new
+      sc = Fluent::SystemConfig.new(conf)
+      sc.apply(s)
+      assert_equal(:json, sc.log.format)
     end
 
     data(

--- a/test/test_log.rb
+++ b/test/test_log.rb
@@ -379,6 +379,32 @@ class LogTest < Test::Unit::TestCase
     assert_equal(Fluent::Log::LEVEL_TRACE, log2.level)
   end
 
+  def test_format_json
+    logdev = @log_device
+    logger = ServerEngine::DaemonLogger.new(logdev)
+    log = Fluent::Log.new(logger)
+    log.format = :json
+    log.level = Fluent::Log::LEVEL_TRACE
+    log.trace "trace log"
+    log.debug "debug log"
+    log.info "info log"
+    log.warn "warn log"
+    log.error "error log"
+    log.fatal "fatal log"
+    expected = [
+      "#{@timestamp_str} [trace]: trace log\n",
+      "#{@timestamp_str} [debug]: debug log\n",
+      "#{@timestamp_str} [info]: info log\n",
+      "#{@timestamp_str} [warn]: warn log\n",
+      "#{@timestamp_str} [error]: error log\n",
+      "#{@timestamp_str} [fatal]: fatal log\n"
+    ]
+    assert_equal(expected, log.out.logs.map { |l|
+                   r = JSON.parse(l)
+                   "#{r['time']} [#{r['level']}]: #{r['message']}\n"
+                 })
+  end
+
   def test_disable_events
     dl_opts = {}
     dl_opts[:log_level] = ServerEngine::DaemonLogger::TRACE

--- a/test/test_log.rb
+++ b/test/test_log.rb
@@ -405,6 +405,30 @@ class LogTest < Test::Unit::TestCase
                  })
   end
 
+  def test_time_format
+    logdev = @log_device
+    logger = ServerEngine::DaemonLogger.new(logdev)
+    log = Fluent::Log.new(logger)
+    log.time_format = "%Y"
+    log.level = Fluent::Log::LEVEL_TRACE
+    log.trace "trace log"
+    log.debug "debug log"
+    log.info "info log"
+    log.warn "warn log"
+    log.error "error log"
+    log.fatal "fatal log"
+    timestamp_str = @timestamp.strftime("%Y")
+    expected = [
+      "#{timestamp_str} [trace]: trace log\n",
+      "#{timestamp_str} [debug]: debug log\n",
+      "#{timestamp_str} [info]: info log\n",
+      "#{timestamp_str} [warn]: warn log\n",
+      "#{timestamp_str} [error]: error log\n",
+      "#{timestamp_str} [fatal]: fatal log\n"
+    ]
+    assert_equal(expected, log.out.logs)
+  end
+
   def test_disable_events
     dl_opts = {}
     dl_opts[:log_level] = ServerEngine::DaemonLogger::TRACE

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -132,6 +132,7 @@ class SupervisorTest < ::Test::Unit::TestCase
   root_dir #{TMP_ROOT_DIR}
   <log>
     format json
+    time_format %Y
   </log>
 </system>
     EOC
@@ -149,6 +150,7 @@ class SupervisorTest < ::Test::Unit::TestCase
     assert_equal 2, sys_conf.log_level
     assert_equal TMP_ROOT_DIR, sys_conf.root_dir
     assert_equal :json, sys_conf.log.format
+    assert_equal '%Y', sys_conf.log.time_format
   end
 
   def test_main_process_signal_handlers

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -130,6 +130,9 @@ class SupervisorTest < ::Test::Unit::TestCase
   process_name "process_name"
   log_level info
   root_dir #{TMP_ROOT_DIR}
+  <log>
+    format json
+  </log>
 </system>
     EOC
     conf = Fluent::Config.parse(conf_data, "(test)", "(test_dir)", true)
@@ -145,6 +148,7 @@ class SupervisorTest < ::Test::Unit::TestCase
     assert_equal "process_name", sys_conf.process_name
     assert_equal 2, sys_conf.log_level
     assert_equal TMP_ROOT_DIR, sys_conf.root_dir
+    assert_equal :json, sys_conf.log.format
   end
 
   def test_main_process_signal_handlers


### PR DESCRIPTION
This directive controls fluentd's log behaviour
Now, support two parameters:

```
<system>
  <log>
    format json
    time_format %F
  </log>
</system>
```

- format: Change fluentd log format. text and json

text:

```
2017-07-27 07:37:02 +0900 [info]: #0 fluentd worker is now running worker=0
```

json:

```
{"time":"2017-07-27 06:44:54 +0900","level":"info","message":"fluentd worker is now running worker=0","worker_id":0}
```

- time_format: Change time format of log

`time_format %Y`

```
2017 [info]: #0 fluentd worker is now running worker=0
```

I have a plan to move some logging related parameters to under `<log>` like `log_level`.