### PR TITLE
compat_parameters: support all syslog parser parameters

### DIFF
--- a/lib/fluent/plugin_helper/compat_parameters.rb
+++ b/lib/fluent/plugin_helper/compat_parameters.rb
@@ -65,7 +65,9 @@ module Fluent
         "label_delimiter"  => "label_delimiter", # LabeledTSVParser
         "format_firstline" => "format_firstline", # MultilineParser
         "message_key"      => "message_key", # NoneParser
-        "with_priority"    => "with_priority", # SyslogParser
+        "with_priority"       => "with_priority", # SyslogParser
+        "message_format"      => "message_format", # SyslogParser
+        "rfc5424_time_format" => "rfc5424_time_format", # SyslogParser
         # There has been no parsers which can handle timezone in v0.12
       }
 

--- a/test/plugin_helper/test_compat_parameters.rb
+++ b/test/plugin_helper/test_compat_parameters.rb
@@ -328,4 +328,26 @@ class CompatParameterTest < Test::Unit::TestCase
       # TODO:
     end
   end
+
+  sub_test_case 'parser plugins' do
+    test 'syslog parser parameters' do
+      hash = {
+        'format' => 'syslog',
+        'message_format' => 'rfc5424',
+        'with_priority' => 'true',
+        'rfc5424_time_format' => '%Y'
+      }
+      conf = config_element('ROOT', '', hash)
+      @i = DummyI0.new
+      @i.configure(conf)
+      @i.start
+      @i.after_start
+
+      parser = @i.parser
+      assert_kind_of(Fluent::Plugin::SyslogParser, parser)
+      assert_equal :rfc5424, parser.message_format
+      assert_equal true, parser.with_priority
+      assert_equal '%Y', parser.rfc5424_time_format
+    end
+  end
 end


### PR DESCRIPTION
Add missing syslog parameters.