### PR TITLE
Add follow_inodes flag to tail files by inodes, not by names

### DIFF
--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -950,7 +950,7 @@ class TailInputTest < Test::Unit::TestCase
     plugin = create_driver(EX_CONFIG, false).instance
     sio = StringIO.new
     plugin.instance_eval do
-      @pf = Fluent::Plugin::TailInput::PositionFile.parse(sio, EX_FOLLOW_INODES)
+      @pf = Fluent::Plugin::TailInput::PositionFile.parse(sio, EX_FOLLOW_INODES, nil)
       @loop = Coolio::Loop.new
     end
 

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -1285,7 +1285,7 @@ class TailInputTest < Test::Unit::TestCase
 
       d.run(expect_emits: 2, shutdown: false) do
         File.open("#{TMP_DIR}/tail.txt", "ab") {|f| f.puts "test3\n"}
-        FileUtils.rm("#{TMP_DIR}/tail.txt")
+        FileUtils.remove_entry_secure("#{TMP_DIR}/tail.txt")
         File.open("#{TMP_DIR}/tail.txt", "wb") {|f| f.puts "test4\n"}
       end
 
@@ -1350,7 +1350,7 @@ class TailInputTest < Test::Unit::TestCase
         File.open("#{TMP_DIR}/tail.txt", "ab") {|f| f.puts "test3\n"}
       end
 
-      FileUtils.rm("#{TMP_DIR}/tail.txt")
+      FileUtils.remove_entry_secure("#{TMP_DIR}/tail.txt")
       File.open("#{TMP_DIR}/tail.txt", "wb") {|f|
         f.puts "test3"
         f.puts "test4"

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -1285,6 +1285,7 @@ class TailInputTest < Test::Unit::TestCase
 
       d.run(expect_emits: 2, shutdown: false) do
         File.open("#{TMP_DIR}/tail.txt", "ab") {|f| f.puts "test3\n"}
+        GC.start(full_mark: true, immediate_mark: true, immediate_sweep: true)
         FileUtils.remove_entry_secure("#{TMP_DIR}/tail.txt")
         File.open("#{TMP_DIR}/tail.txt", "wb") {|f| f.puts "test4\n"}
       end
@@ -1350,6 +1351,7 @@ class TailInputTest < Test::Unit::TestCase
         File.open("#{TMP_DIR}/tail.txt", "ab") {|f| f.puts "test3\n"}
       end
 
+      GC.start(full_mark: true, immediate_mark: true, immediate_sweep: true)
       FileUtils.remove_entry_secure("#{TMP_DIR}/tail.txt")
       File.open("#{TMP_DIR}/tail.txt", "wb") {|f|
         f.puts "test3"

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -17,6 +17,7 @@ class TailInputTest < Test::Unit::TestCase
 
   def teardown
     super
+    cleanup_directory(TMP_DIR)
     Fluent::Engine.stop
   end
 
@@ -36,7 +37,8 @@ class TailInputTest < Test::Unit::TestCase
   CONFIG = config_element("ROOT", "", {
                             "path" => "#{TMP_DIR}/tail.txt",
                             "tag" => "t1",
-                            "rotate_wait" => "2s"
+                            "rotate_wait" => "2s",
+                            "refresh_interval" => "1s"
                           })
   COMMON_CONFIG = CONFIG + config_element("", "", { "pos_file" => "#{TMP_DIR}/tail.pos" })
   CONFIG_READ_FROM_HEAD = config_element("", "", { "read_from_head" => true })
@@ -58,6 +60,19 @@ class TailInputTest < Test::Unit::TestCase
                       "format_firstline" => "/^[s]/"
                     })
     ])
+  COMMON_FOLLOW_INODE_CONFIG = config_element("ROOT", "", {
+      "path" => "#{TMP_DIR}/tail.txt*",
+      "pos_file" => "#{TMP_DIR}/tail.pos",
+      "tag" => "t1",
+      "refresh_interval" => "1s",
+      "read_from_head" => "true",
+      "format" => "none",
+      "follow_inodes" => "true"
+  })
+
+  def path_to_tuple(path)
+    Fluent::Plugin::TailInput::PathInodeTuple.new(path, Fluent::FileWrapper.stat(path).ino)
+  end
 
   def create_driver(conf = SINGLE_LINE_CONFIG, use_common_conf = true)
     config = use_common_conf ? COMMON_CONFIG + conf : conf
@@ -80,6 +95,13 @@ class TailInputTest < Test::Unit::TestCase
     test "w/o parse section" do |conf|
       assert_raise(Fluent::ConfigError) do
         create_driver(conf)
+      end
+    end
+
+
+    test "follow_inodes w/o pos file" do
+      assert_raise(Fluent::ConfigError) do
+        create_driver(CONFIG + config_element('', '', {'follow_inodes' => 'true'}))
       end
     end
 
@@ -824,6 +846,7 @@ class TailInputTest < Test::Unit::TestCase
     # * path test
     # TODO: Clean up tests
     EX_ROTATE_WAIT = 0
+    EX_FOLLOW_INODES = false
 
     EX_CONFIG = config_element("", "", {
                                  "tag" => "tail",
@@ -833,32 +856,34 @@ class TailInputTest < Test::Unit::TestCase
                                  "read_from_head" => true,
                                  "refresh_interval" => 30,
                                  "rotate_wait" => "#{EX_ROTATE_WAIT}s",
+                                 "follow_inodes" => "#{EX_FOLLOW_INODES}",
                                })
-    EX_PATHS = [
-      'test/plugin/data/2010/01/20100102-030405.log',
-      'test/plugin/data/log/foo/bar.log',
-      'test/plugin/data/log/test.log'
-    ]
 
     def test_expand_paths
+      ex_path = [
+        path_to_tuple('test/plugin/data/2010/01/20100102-030405.log'),
+        path_to_tuple('test/plugin/data/log/foo/bar.log'),
+        path_to_tuple('test/plugin/data/log/test.log')
+      ]
+
       plugin = create_driver(EX_CONFIG, false).instance
       flexstub(Time) do |timeclass|
         timeclass.should_receive(:now).with_no_args.and_return(Time.new(2010, 1, 2, 3, 4, 5))
-        assert_equal EX_PATHS, plugin.expand_paths.sort
+        assert_equal ex_path, plugin.expand_paths.values.sort_by {|path_ino| path_ino.path}
       end
 
       # Test exclusion
-      exclude_config = EX_CONFIG + config_element("", "", { "exclude_path" => %Q(["#{EX_PATHS.last}"]) })
+      exclude_config = EX_CONFIG + config_element("", "", {"exclude_path" => %Q(["#{ex_path.last.path}"])})
       plugin = create_driver(exclude_config, false).instance
-      assert_equal EX_PATHS - [EX_PATHS.last], plugin.expand_paths.sort
+      assert_equal ex_path - [ex_path.last], plugin.expand_paths.values.sort_by {|path_ino| path_ino.path}
     end
 
     def test_log_file_without_extension
       expected_files = [
-        'test/plugin/data/log/bar',
-        'test/plugin/data/log/foo/bar.log',
-        'test/plugin/data/log/foo/bar2',
-        'test/plugin/data/log/test.log'
+          path_to_tuple('test/plugin/data/log/bar'),
+          path_to_tuple('test/plugin/data/log/foo/bar.log'),
+          path_to_tuple('test/plugin/data/log/foo/bar2'),
+          path_to_tuple('test/plugin/data/log/test.log')
       ]
 
       config = config_element("", "", {
@@ -869,7 +894,7 @@ class TailInputTest < Test::Unit::TestCase
       })
 
       plugin = create_driver(config, false).instance
-      assert_equal expected_files, plugin.expand_paths.sort
+      assert_equal expected_files, plugin.expand_paths.values.sort_by {|path_ino| path_ino.path}
     end
 
     # For https://github.com/fluent/fluentd/issues/1455
@@ -916,18 +941,24 @@ class TailInputTest < Test::Unit::TestCase
   end
 
   def test_z_refresh_watchers
+    ex_paths = [
+      path_to_tuple('test/plugin/data/2010/01/20100102-030405.log'),
+      path_to_tuple('test/plugin/data/log/foo/bar.log'),
+      path_to_tuple('test/plugin/data/log/test.log'),
+    ]
+
     plugin = create_driver(EX_CONFIG, false).instance
     sio = StringIO.new
     plugin.instance_eval do
-      @pf = Fluent::Plugin::TailInput::PositionFile.parse(sio)
+      @pf = Fluent::Plugin::TailInput::PositionFile.parse(sio, EX_FOLLOW_INODES)
       @loop = Coolio::Loop.new
     end
 
     Timecop.freeze(2010, 1, 2, 3, 4, 5) do
       flexstub(Fluent::Plugin::TailInput::TailWatcher) do |watcherclass|
-        EX_PATHS.each do |path|
-          watcherclass.should_receive(:new).with(path, EX_ROTATE_WAIT, Fluent::Plugin::TailInput::FilePositionEntry, any, true, true, 1000, any, any, any, any, any, any).once.and_return do
-            flexmock('TailWatcher') { |watcher|
+        ex_paths.each do |path_ino|
+          watcherclass.should_receive(:new).with(path_ino.path, path_ino.ino, EX_ROTATE_WAIT, Fluent::Plugin::TailInput::FilePositionEntry, any, true, true, 1000, any, any, any, any, any, false, any).once.and_return do
+            flexmock('TailWatcher') {|watcher|
               watcher.should_receive(:attach).once
               watcher.should_receive(:unwatched=).zero_or_more_times
               watcher.should_receive(:line_buffer).zero_or_more_times
@@ -939,12 +970,14 @@ class TailInputTest < Test::Unit::TestCase
     end
 
     plugin.instance_eval do
-      @tails['test/plugin/data/2010/01/20100102-030405.log'].should_receive(:close).zero_or_more_times
+      @tails[ex_paths[0]].should_receive(:close).zero_or_more_times
     end
+
+    path_ino = path_to_tuple('test/plugin/data/2010/01/20100102-030406.log')
 
     Timecop.freeze(2010, 1, 2, 3, 4, 6) do
       flexstub(Fluent::Plugin::TailInput::TailWatcher) do |watcherclass|
-        watcherclass.should_receive(:new).with('test/plugin/data/2010/01/20100102-030406.log', EX_ROTATE_WAIT, Fluent::Plugin::TailInput::FilePositionEntry, any, true, true, 1000, any, any, any, any, any, any).once.and_return do
+        watcherclass.should_receive(:new).with(path_ino.path, path_ino.ino, EX_ROTATE_WAIT, Fluent::Plugin::TailInput::FilePositionEntry, any, true, true, 1000, any, any, any, any, any, false, any).once.and_return do
           flexmock('TailWatcher') do |watcher|
             watcher.should_receive(:attach).once
             watcher.should_receive(:unwatched=).zero_or_more_times
@@ -1061,6 +1094,307 @@ class TailInputTest < Test::Unit::TestCase
       assert_equal(2, events.length)
       assert_equal({"message" => "test3"}, events[0][2])
       assert_equal({"message" => "test4"}, events[1][2])
+    end
+  end
+
+  sub_test_case 'inode_processing' do
+    def test_should_delete_file_pos_entry_for_non_existing_file_with_follow_inodes
+      config = COMMON_FOLLOW_INODE_CONFIG
+
+      path = "#{TMP_DIR}/tail.txt"
+      ino = 1
+      pos = 1234
+      File.open("#{TMP_DIR}/tail.pos", "wb") {|f|
+        f.puts ("%s\t%016x\t%016x\n" % [path, pos, ino])
+      }
+
+      d = create_driver(config, false)
+      d.run
+
+      pos_file = File.open("#{TMP_DIR}/tail.pos", "r")
+      pos_file.pos = 0
+
+      assert_raise(EOFError) do
+        pos_file.readline
+      end
+    end
+
+    def test_should_write_latest_offset_after_rotate_wait
+      config = COMMON_FOLLOW_INODE_CONFIG
+      File.open("#{TMP_DIR}/tail.txt", "wb") {|f|
+        f.puts "test1"
+        f.puts "test2"
+      }
+
+      d = create_driver(config, false)
+      d.run(expect_emits: 2, shutdown: false) do
+        File.open("#{TMP_DIR}/tail.txt", "ab") {|f| f.puts "test3\n"}
+        FileUtils.move("#{TMP_DIR}/tail.txt", "#{TMP_DIR}/tail.txt" + "1")
+        sleep 1
+        File.open("#{TMP_DIR}/tail.txt" + "1", "ab") {|f| f.puts "test4\n"}
+      end
+
+      pos_file = File.open("#{TMP_DIR}/tail.pos", "r")
+      pos_file.pos = 0
+      line_parts = /^([^\t]+)\t([0-9a-fA-F]+)\t([0-9a-fA-F]+)/.match(pos_file.readline)
+      waiting(5) {
+        while line_parts[2].to_i(16) != 24
+          sleep(0.1)
+          pos_file.pos = 0
+          line_parts = /^([^\t]+)\t([0-9a-fA-F]+)\t([0-9a-fA-F]+)/.match(pos_file.readline)
+        end
+      }
+      assert_equal(24, line_parts[2].to_i(16))
+      d.instance_shutdown
+    end
+
+    def test_should_keep_and_update_existing_file_pos_entry_for_deleted_file_when_new_file_with_same_name_created
+      config = config_element("", "", {"format" => "none"})
+
+      path = "#{TMP_DIR}/tail.txt"
+      ino = 1
+      pos = 1234
+      File.open("#{TMP_DIR}/tail.pos", "wb") {|f|
+        f.puts ("%s\t%016x\t%016x\n" % [path, pos, ino])
+      }
+
+      d = create_driver(config)
+      d.run(shutdown: false)
+
+      pos_file = File.open("#{TMP_DIR}/tail.pos", "r")
+      pos_file.pos = 0
+
+      path_pos_ino = /^([^\t]+)\t([0-9a-fA-F]+)\t([0-9a-fA-F]+)/.match(pos_file.readline)
+      assert_equal(path, path_pos_ino[1])
+      assert_equal(pos, path_pos_ino[2].to_i(16))
+      assert_equal(ino, path_pos_ino[3].to_i(16))
+
+      File.open("#{TMP_DIR}/tail.txt", "wb") {|f|
+        f.puts "test1"
+        f.puts "test2"
+      }
+      Timecop.travel(Time.now + 10) do
+        sleep 5
+        pos_file.pos = 0
+        tuple = path_to_tuple("#{TMP_DIR}/tail.txt")
+        path_pos_ino = /^([^\t]+)\t([0-9a-fA-F]+)\t([0-9a-fA-F]+)/.match(pos_file.readline)
+        assert_equal(tuple.path, path_pos_ino[1])
+        assert_equal(12, path_pos_ino[2].to_i(16))
+        assert_equal(tuple.ino, path_pos_ino[3].to_i(16))
+      end
+      d.instance_shutdown
+    end
+
+    def test_should_mark_file_unwatched_after_limit_recently_modified_and_rotate_wait
+      config = config_element("ROOT", "", {
+          "path" => "#{TMP_DIR}/tail.txt*",
+          "pos_file" => "#{TMP_DIR}/tail.pos",
+          "tag" => "t1",
+          "rotate_wait" => "1s",
+          "refresh_interval" => "1s",
+          "limit_recently_modified" => "1s",
+          "read_from_head" => "true",
+          "format" => "none"
+      })
+
+      d = create_driver(config, false)
+
+      File.open("#{TMP_DIR}/tail.txt", "wb") {|f|
+        f.puts "test1"
+        f.puts "test2"
+      }
+      path_ino = path_to_tuple("#{TMP_DIR}/tail.txt")
+
+      d.run(expect_emits: 1, shutdown: false) do
+        File.open("#{TMP_DIR}/tail.txt", "ab") {|f| f.puts "test3\n"}
+      end
+
+
+      Timecop.travel(Time.now + 10) do
+        waiting(5) {sleep 0.1 until d.instance.instance_variable_get(:@pf)[path_ino.path, path_ino.ino].read_pos == Fluent::Plugin::TailInput::PositionFile::UNWATCHED_POSITION}
+      end
+
+      assert_equal(Fluent::Plugin::TailInput::PositionFile::UNWATCHED_POSITION, d.instance.instance_variable_get(:@pf)[path_ino.path, path_ino.ino].read_pos)
+
+      d.instance_shutdown
+    end
+
+    def test_should_read_from_head_on_file_renaming_with_star_in_pattern
+      config = config_element("ROOT", "", {
+          "path" => "#{TMP_DIR}/tail.txt*",
+          "pos_file" => "#{TMP_DIR}/tail.pos",
+          "tag" => "t1",
+          "rotate_wait" => "10s",
+          "refresh_interval" => "1s",
+          "limit_recently_modified" => "60s",
+          "read_from_head" => "true",
+          "format" => "none"
+      })
+
+      d = create_driver(config, false)
+
+      File.open("#{TMP_DIR}/tail.txt", "wb") {|f|
+        f.puts "test1"
+        f.puts "test2"
+      }
+
+      d.run(expect_emits: 2, shutdown: false) do
+        File.open("#{TMP_DIR}/tail.txt", "ab") {|f| f.puts "test3\n"}
+        FileUtils.move("#{TMP_DIR}/tail.txt", "#{TMP_DIR}/tail.txt1")
+      end
+
+      events = d.events
+      assert_equal(6, events.length)
+      d.instance_shutdown
+    end
+
+    def test_should_not_read_from_head_on_rotation_when_watching_inodes
+      config = COMMON_FOLLOW_INODE_CONFIG
+
+      d = create_driver(config, false)
+
+      File.open("#{TMP_DIR}/tail.txt", "wb") {|f|
+        f.puts "test1"
+        f.puts "test2"
+      }
+
+      d.run(expect_emits: 1, shutdown: false) do
+        File.open("#{TMP_DIR}/tail.txt", "ab") {|f| f.puts "test3\n"}
+      end
+
+      FileUtils.move("#{TMP_DIR}/tail.txt", "#{TMP_DIR}/tail.txt1")
+      Timecop.travel(Time.now + 10) do
+        sleep 2
+        events = d.events
+        assert_equal(3, events.length)
+      end
+
+      d.instance_shutdown
+    end
+
+    def test_should_mark_file_unwatched_if_same_name_file_created_with_different_inode
+      config = COMMON_FOLLOW_INODE_CONFIG
+
+      d = create_driver(config, false)
+
+      File.open("#{TMP_DIR}/tail.txt", "wb") {|f|
+        f.puts "test1"
+        f.puts "test2"
+      }
+      path_ino = path_to_tuple("#{TMP_DIR}/tail.txt")
+
+      d.run(expect_emits: 2, shutdown: false) do
+        File.open("#{TMP_DIR}/tail.txt", "ab") {|f| f.puts "test3\n"}
+        FileUtils.rm("#{TMP_DIR}/tail.txt")
+        File.open("#{TMP_DIR}/tail.txt", "wb") {|f| f.puts "test4\n"}
+      end
+
+      new_path_ino = path_to_tuple("#{TMP_DIR}/tail.txt")
+
+      pos_file = d.instance.instance_variable_get(:@pf)
+
+      waiting(10) {sleep 0.1 until pos_file[path_ino.path, path_ino.ino].read_pos == Fluent::Plugin::TailInput::PositionFile::UNWATCHED_POSITION}
+      new_position = pos_file[new_path_ino.path, new_path_ino.ino].read_pos
+      assert_equal(6, new_position)
+
+      d.instance_shutdown
+    end
+
+    def test_should_close_watcher_after_rotate_wait
+      now = Time.now
+      config = COMMON_FOLLOW_INODE_CONFIG + config_element('', '', {"rotate_wait" => "1s", "limit_recently_modified" => "1s"})
+
+      d = create_driver(config, false)
+
+      File.open("#{TMP_DIR}/tail.txt", "wb") {|f|
+        f.puts "test1"
+        f.puts "test2"
+      }
+      path_ino = path_to_tuple("#{TMP_DIR}/tail.txt")
+
+      flexstub(Fluent::Plugin::TailInput::TailWatcher) do |watcherclass|
+        watcherclass.should_receive(:new).with(path_ino.path, path_ino.ino, 1, Fluent::Plugin::TailInput::FilePositionEntry, any, true, true, 1000, any, any, any, any, any, true, any).once.and_return do
+          flexmock('TailWatcher') {|watcher|
+            watcher.should_receive(:attach).once
+            watcher.should_receive(:unwatched=).once
+            watcher.should_receive(:detach).once
+            watcher.should_receive(:close).once
+            watcher.should_receive(:line_buffer).zero_or_more_times.and_return nil
+          }
+        end
+        d.run(shutdown: false)
+      end
+
+      Timecop.travel(now + 10) do
+        sleep 3
+        d.instance.instance_eval do
+          @tails[path_ino] == nil
+        end
+      end
+      d.instance_shutdown
+    end
+
+    def test_should_create_new_watcher_for_new_file_with_same_name
+      now = Time.now
+      config = COMMON_FOLLOW_INODE_CONFIG + config_element('', '', {"limit_recently_modified" => "2s"})
+
+      d = create_driver(config, false)
+
+      File.open("#{TMP_DIR}/tail.txt", "wb") {|f|
+        f.puts "test1"
+        f.puts "test2"
+      }
+      path_ino = path_to_tuple("#{TMP_DIR}/tail.txt")
+
+      d.run(expect_emits: 1, shutdown: false) do
+        File.open("#{TMP_DIR}/tail.txt", "ab") {|f| f.puts "test3\n"}
+      end
+
+      FileUtils.rm("#{TMP_DIR}/tail.txt")
+      File.open("#{TMP_DIR}/tail.txt", "wb") {|f|
+        f.puts "test3"
+        f.puts "test4"
+      }
+      new_path_ino = path_to_tuple("#{TMP_DIR}/tail.txt")
+
+      Timecop.travel(now + 10) do
+        sleep 3
+        d.instance.instance_eval do
+          @tails[path_ino] == nil
+          @tails[new_path_ino] != nil
+        end
+      end
+
+      events = d.events
+
+      assert_equal(5, events.length)
+
+      d.instance_shutdown
+    end
+
+    def test_truncate_file_with_follow_inodes
+      config = COMMON_FOLLOW_INODE_CONFIG
+
+      d = create_driver(config, false)
+
+      File.open("#{TMP_DIR}/tail.txt", "wb") {|f|
+        f.puts "test1"
+        f.puts "test2"
+      }
+
+      d.run(expect_emits: 3, shutdown: false) do
+        File.open("#{TMP_DIR}/tail.txt", "ab") {|f| f.puts "test3\n"}
+        sleep 2
+        File.open("#{TMP_DIR}/tail.txt", "w+b") {|f| f.puts "test4\n"}
+      end
+
+      events = d.events
+      assert_equal(4, events.length)
+      assert_equal({"message" => "test1"}, events[0][2])
+      assert_equal({"message" => "test2"}, events[1][2])
+      assert_equal({"message" => "test3"}, events[2][2])
+      assert_equal({"message" => "test4"}, events[3][2])
+      d.instance_shutdown
     end
   end
 
@@ -1190,13 +1524,13 @@ class TailInputTest < Test::Unit::TestCase
     })
 
     expected_files = [
-      "#{TMP_DIR}/tail_watch1.txt",
-      "#{TMP_DIR}/tail_watch2.txt"
+        path_to_tuple("#{TMP_DIR}/tail_watch1.txt"),
+        path_to_tuple("#{TMP_DIR}/tail_watch2.txt")
     ]
 
     Timecop.freeze(now) do
       plugin = create_driver(config, false).instance
-      assert_equal expected_files, plugin.expand_paths.sort
+      assert_equal expected_files, plugin.expand_paths.values.sort_by {|path_ino| path_ino.path}
     end
   end
 


### PR DESCRIPTION
## Use case
We have a lot of servers with up to 300 application deployed on each server (mostly Java/Scala). Each application writes log files using log4j library. Each log file is rotated daily in the same directory, with up to 10 back up files possible. Events are fed to realtime processing system(critical to time delays up to 1 second) and to HBase.  We want to replace current heavy log collector with lightweight solution.

## Problem
We tried to use default tail plugin. Most basic configuration will look like this: 
```
<source>
  @type tail
  read_from_head true
  path /var/log/*/app*.log  
  tag app.log.*
  format none
  refresh_interval 10
  pos_file /var/log/pos/app.log.pos
  rotate_wait 3600
  path_key path
  limit_recently_modified 86400
</source>
```
According to fluentd in_tail plugin documentation - every time file is rotated for such configuration, it will be treated by in_tail plugin as new one, and will be read from it's head, even though file inode has not changed, and in position file we have latest read position (but just for last line before rotation; during `rotate_wait` time position stored in memory only - https://github.com/fluent/fluentd/blob/master/lib/fluent/plugin/in_tail.rb#L554)

This doesn't suit our needs, because:
- we will generate a lot of unneeded traffic, which will be irrelevant to realtime part
- disk I/O increase
- longer ingestion into HBase

One of the possible solution proposed by @repeatedly in https://github.com/fluent/fluentd/issues/1613 is to avoid '*' in file pattern discovery. This also doesn't suit us, because we'd like to reliably store events with no or minimum loss because they are very crucial for business analysis. Possible data loss scenario: 

1. Fluentd goes down at 23:45 UTC 
2. Log file is rotated at 00:00:00 UTC, app.log is renamed to app.2017-08-02.log (just for example)
3. Fluentd goes up at 00:15 UTC
4. Tail plugin reads all data from in new app.log file
5. Data from app.2017-08-02.log file from 23:45 - 00:00 UTC is lost. No way for us to find out at least latest offset in app.2017-08-02.log because it has been overwritten in position file. 


## Proposed solution
Add ability to track inodes inside fluentd in_tail plugin to enable combination of '*' in `path` configuration with rotation inside same directory and `read_from_head` set to true. In proposed solution we add `follow_inodes` flag (set to `false` by default to preserve current behavior). When `follow_inodes` is set to `true` and file rotation is detected - we do not reread file, instead we are checking if such inode is present inside pos file - if yes, we don't recreate TailWatcher. TailWatcher is closed after `rotate_wait` period and file marked as unwatched inside position file after `limit_recently_modified` time passed. Pos file is cleaned on startup as it was before, but also delete entries for non-existing files.

Please review, and let me know what do you think of such approach? 