### PR TITLE
Fix plugin load order

### DIFF
--- a/lib/fluent/plugin.rb
+++ b/lib/fluent/plugin.rb
@@ -169,7 +169,10 @@ module Fluent
       if spec = specs.last
         spec.require_paths.each { |lib|
           file = "#{spec.full_gem_path}/#{lib}/#{path}"
-          require file
+          if File.exist?("#{file}.rb")
+            require file
+            return
+          end
         }
       end
     end


### PR DESCRIPTION
Will fix #1668.

Somehow Gem::Specification#require_paths prefers extension-install dir than "lib". It breaks plugin load process when it contains native extension.