### PR TITLE
Support pretty print of Fluent::Config::Element

### DIFF
--- a/lib/fluent/config/element.rb
+++ b/lib/fluent/config/element.rb
@@ -76,6 +76,11 @@ module Fluent
         "name:#{@name}, arg:#{@arg}, " + attrs + ", " + @elements.inspect
       end
 
+      # Used by PP and Pry
+      def pretty_print(q)
+        q.text(inspect)
+      end
+
       # This method assumes _o_ is an Element object. Should return false for nil or other object
       def ==(o)
         self.name == o.name && self.arg == o.arg &&

--- a/test/config/test_element.rb
+++ b/test/config/test_element.rb
@@ -2,6 +2,7 @@ require_relative '../helper'
 require 'fluent/config/element'
 require 'fluent/config/configure_proxy'
 require 'fluent/configurable'
+require 'pp'
 
 class TestConfigElement < ::Test::Unit::TestCase
   def element(name = 'ROOT', arg = '', attrs = {}, elements = [], unused = nil)
@@ -461,6 +462,15 @@ CONF
     test "doesn't have target_worker_id" do
       e = element()
       assert_false e.for_another_worker?
+    end
+  end
+
+  sub_test_case '#pretty_print' do
+    test 'prints inspect to pp object' do
+      q = PP.new
+      e = element()
+      e.pretty_print(q)
+      assert_equal e.inspect, q.output
     end
   end
 end


### PR DESCRIPTION
## Problem
With fluentd v0.14.20, when debugging fluentd config parser with pry, I got following output for non-empty `Fluent::Config::Element`.

<img width="1174" alt="screen shot 2017-08-25 at 18 20 23" src="https://user-images.githubusercontent.com/3138447/29707974-21239e7e-89c2-11e7-9154-ddbc19564ce3.png">

I think the pretty print result (`{}`) is not so pretty and it makes it hard to debug.

## Changes
I changed `Fluent::Config::Element` to pretty print the same string as `#inspect`.

<img width="1176" alt="screen shot 2017-08-25 at 18 22 55" src="https://user-images.githubusercontent.com/3138447/29708084-7c25966a-89c2-11e7-9b93-9801dc76bfed.png">
