### PR TITLE
supervisor: Clear previous worker pids when receives kill signals. ref #1674

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -173,7 +173,9 @@ module Fluent
 
     def kill_worker
       if config[:worker_pid]
-        config[:worker_pid].each do |pid|
+        pids = config[:worker_pid].clone
+        config[:worker_pid].clear
+        pids.each do |pid|
           if Fluent.windows?
             Process.kill :KILL, pid
           else


### PR DESCRIPTION
Without this patch, sending multiple signals, e.g. call `kill -HUP pid` twice, causes "No such process"