### PR TITLE
filter_grep: strip input regexp before compiling

### DIFF
--- a/lib/fluent/plugin/filter_grep.rb
+++ b/lib/fluent/plugin/filter_grep.rb
@@ -67,7 +67,7 @@ module Fluent::Plugin
         key, regexp = conf["regexp#{i}"].split(/ /, 2)
         raise Fluent::ConfigError, "regexp#{i} does not contain 2 parameters" unless regexp
         raise Fluent::ConfigError, "regexp#{i} contains a duplicated key, #{key}" if rs[key]
-        rs[key] = Regexp.compile(regexp)
+        rs[key] = Regexp.compile(regexp.strip)
       end
 
       es = {}
@@ -76,7 +76,7 @@ module Fluent::Plugin
         key, exclude = conf["exclude#{i}"].split(/ /, 2)
         raise Fluent::ConfigError, "exclude#{i} does not contain 2 parameters" unless exclude
         raise Fluent::ConfigError, "exclude#{i} contains a duplicated key, #{key}" if es[key]
-        es[key] = Regexp.compile(exclude)
+        es[key] = Regexp.compile(exclude.strip)
       end
 
       @regexps.each do |e|

--- a/test/plugin/test_filter_grep.rb
+++ b/test/plugin/test_filter_grep.rb
@@ -43,9 +43,9 @@ class GrepFilterTest < Test::Unit::TestCase
     end
 
     test "regexpN can contain leading \\s" do
-      d = create_driver(%[regexp1 message \sfoo])
+      d = create_driver(%[regexp1 message \\sfoo])
       d.instance._regexps.each_pair { |key, value|
-        assert_equal(Regexp.compile(/ foo/), value)
+        assert_equal(Regexp.compile(/\sfoo/), value)
       }
     end
 
@@ -57,9 +57,9 @@ class GrepFilterTest < Test::Unit::TestCase
     end
 
     test "excludeN can contain leading \\s" do
-      d = create_driver(%[exclude1 message \sfoo])
+      d = create_driver(%[exclude1 message \\sfoo])
       d.instance._excludes.each_pair { |key, value|
-        assert_equal(Regexp.compile(/ foo/), value)
+        assert_equal(Regexp.compile(/\sfoo/), value)
       }
     end
 

--- a/test/plugin/test_filter_grep.rb
+++ b/test/plugin/test_filter_grep.rb
@@ -21,15 +21,43 @@ class GrepFilterTest < Test::Unit::TestCase
       assert_empty(d.instance.excludes)
     end
 
+    test "regexpN is stripped before being compiled" do
+      d = create_driver(%[regexp1 message  foo ])
+      d.instance._regexps.each_pair { |key, value|
+        assert_equal(Regexp.compile(/foo/), value)
+      }
+    end
+
+    test "excludeN is stripped before being compiled" do
+      d = create_driver(%[exclude1 message  foo ])
+      d.instance._excludes.each_pair { |key, value|
+        assert_equal(Regexp.compile(/foo/), value)
+      }
+    end
+
     test "regexpN can contain a space" do
-      d = create_driver(%[regexp1 message  foo])
+      d = create_driver(%[regexp1 message  foo  bar])
+      d.instance._regexps.each_pair { |key, value|
+        assert_equal(Regexp.compile(/foo  bar/), value)
+      }
+    end
+
+    test "regexpN can contain leading \\s" do
+      d = create_driver(%[regexp1 message \sfoo])
       d.instance._regexps.each_pair { |key, value|
         assert_equal(Regexp.compile(/ foo/), value)
       }
     end
 
     test "excludeN can contain a space" do
-      d = create_driver(%[exclude1 message  foo])
+      d = create_driver(%[exclude1 message  foo  bar])
+      d.instance._excludes.each_pair { |key, value|
+        assert_equal(Regexp.compile(/foo  bar/), value)
+      }
+    end
+
+    test "excludeN can contain leading \\s" do
+      d = create_driver(%[exclude1 message \sfoo])
       d.instance._excludes.each_pair { |key, value|
         assert_equal(Regexp.compile(/ foo/), value)
       }
@@ -160,7 +188,7 @@ class GrepFilterTest < Test::Unit::TestCase
       end
 
       test "don't raise an exception" do
-        assert_nothing_raised { 
+        assert_nothing_raised {
           filter(%[regexp1 message WARN], ["\xff".force_encoding('UTF-8')])
         }
       end


### PR DESCRIPTION
The leading/trailing spaces are not easy to see in editor,
and it may make debugging process harder.

Allowing such spaces disallows us to format configuration file, e.g,

   exclude foo   test1
   exclude foo2  test2

Without stripping, "foo" only matches "  test1".

Now user should use \s to specify leading/trailing spaces explicitly:

   exclude bar   \s+test