### PR TITLE
Delay time parser initialization

### DIFF
--- a/lib/fluent/plugin/parser_apache2.rb
+++ b/lib/fluent/plugin/parser_apache2.rb
@@ -26,8 +26,12 @@ module Fluent
 
       def initialize
         super
-        @time_parser = time_parser_create(format: TIME_FORMAT)
         @mutex = Mutex.new
+      end
+
+      def configure(conf)
+        super
+        @time_parser = time_parser_create(format: TIME_FORMAT)
       end
 
       def patterns

--- a/test/plugin/test_parser_apache2.rb
+++ b/test/plugin/test_parser_apache2.rb
@@ -16,6 +16,7 @@ class Apache2ParserTest < ::Test::Unit::TestCase
       'referer' => nil,
       'agent'   => 'Opera/12.0'
     }
+    @parser.configure({})
   end
 
   def test_parse


### PR DESCRIPTION
In previous version,
`Fluent::Plugin::Apache2Parser.new` creates `@time_parser`
but `Fluent::Plugin::Parser#configure` overwrites it with `time_parser_create`.

In this version, `Fluent::Plugin::Apache2Parser#configure` creates
`@time_parser` proper
sequence. `Fluent::Plugin::Apache2Parser#configure` invoked after `Fluent::Plugin::Parser#configure`.