### PR TITLE
Add support to enable writing to new lines for tsv formatter

### DIFF
--- a/lib/fluent/plugin/formatter_tsv.rb
+++ b/lib/fluent/plugin/formatter_tsv.rb
@@ -27,7 +27,7 @@ module Fluent
       config_param :delimiter, :string, default: "\t"
 
       def format(tag, time, record)
-        @keys.map{|k| record[k].to_s }.join(@delimiter)
+        @keys.map{|k| record[k].to_s }.join(@delimiter) << "\n".freeze
       end
     end
   end

--- a/lib/fluent/plugin/formatter_tsv.rb
+++ b/lib/fluent/plugin/formatter_tsv.rb
@@ -25,9 +25,14 @@ module Fluent
       config_param :keys, :array, value_type: :string
       desc 'The delimiter character (or string) of TSV values'
       config_param :delimiter, :string, default: "\t"
+      desc 'The parameter to enable writing to new lines'
+      config_param :add_newline, :bool, default: true
 
       def format(tag, time, record)
-        @keys.map{|k| record[k].to_s }.join(@delimiter) << "\n".freeze
+        formatted = ""
+        formatted << @keys.map{|k| record[k].to_s }.join(@delimiter)
+        formatted << "\n".freeze if @add_newline
+        formatted
       end
     end
   end

--- a/lib/fluent/plugin/formatter_tsv.rb
+++ b/lib/fluent/plugin/formatter_tsv.rb
@@ -29,8 +29,7 @@ module Fluent
       config_param :add_newline, :bool, default: true
 
       def format(tag, time, record)
-        formatted = ""
-        formatted << @keys.map{|k| record[k].to_s }.join(@delimiter)
+        formatted = @keys.map{|k| record[k].to_s }.join(@delimiter)
         formatted << "\n".freeze if @add_newline
         formatted
       end

--- a/test/plugin/test_formatter_tsv.rb
+++ b/test/plugin/test_formatter_tsv.rb
@@ -1,0 +1,55 @@
+require_relative '../helper'
+require 'fluent/test/driver/formatter'
+require 'fluent/plugin/formatter_tsv'
+
+class TSVFormatterTest < ::Test::Unit::TestCase
+  def setup
+    @time = event_time
+  end
+
+  def create_driver(conf = "")
+    Fluent::Test::Driver::Formatter.new(Fluent::Plugin::TSVFormatter).configure(conf)
+  end
+
+  def tag
+    "tag"
+  end
+
+  def record
+    {'message' => 'awesome', 'greeting' => 'hello'}
+  end
+
+  def test_config_params
+    d = create_driver(
+      'keys' => 'message,greeting',
+    )
+    assert_equal ["message", "greeting"], d.instance.keys
+    assert_equal "\t", d.instance.delimiter
+
+    d = create_driver(
+      'keys' => 'message,greeting',
+      'delimiter'       => ',',
+    )
+    assert_equal ["message", "greeting"], d.instance.keys
+    assert_equal ",", d.instance.delimiter
+  end
+
+  def test_format
+    d = create_driver(
+      'keys' => 'message,greeting',
+    )
+    formatted = d.instance.format(tag, @time, record)
+
+    assert_equal("awesome\thello\n", formatted)
+  end
+
+  def test_format_with_customized_delimiters
+    d = create_driver(
+      'keys' => 'message,greeting',
+      'delimiter'       => ',',
+    )
+    formatted = d.instance.format(tag, @time, record)
+
+    assert_equal("awesome,hello\n", formatted)
+  end
+end

--- a/test/plugin/test_formatter_tsv.rb
+++ b/test/plugin/test_formatter_tsv.rb
@@ -59,7 +59,7 @@ class TSVFormatterTest < ::Test::Unit::TestCase
   def test_format_with_customized_delimiters
     d = create_driver(
       'keys' => 'message,greeting',
-      'delimiter'       => ',',
+      'delimiter' => ',',
     )
     formatted = d.instance.format(tag, @time, record)
 

--- a/test/plugin/test_formatter_tsv.rb
+++ b/test/plugin/test_formatter_tsv.rb
@@ -25,13 +25,16 @@ class TSVFormatterTest < ::Test::Unit::TestCase
     )
     assert_equal ["message", "greeting"], d.instance.keys
     assert_equal "\t", d.instance.delimiter
+    assert_equal true, d.instance.add_newline
 
     d = create_driver(
       'keys' => 'message,greeting',
-      'delimiter'       => ',',
+      'delimiter' => ',',
+      'add_newline' => false,
     )
     assert_equal ["message", "greeting"], d.instance.keys
     assert_equal ",", d.instance.delimiter
+    assert_equal false, d.instance.add_newline
   end
 
   def test_format
@@ -41,6 +44,16 @@ class TSVFormatterTest < ::Test::Unit::TestCase
     formatted = d.instance.format(tag, @time, record)
 
     assert_equal("awesome\thello\n", formatted)
+  end
+
+  def test_format_without_newline
+    d = create_driver(
+      'keys' => 'message,greeting',
+      'add_newline' => false,
+    )
+    formatted = d.instance.format(tag, @time, record)
+
+    assert_equal("awesome\thello", formatted)
   end
 
   def test_format_with_customized_delimiters


### PR DESCRIPTION
I found that writing to new line is impossible with tsv formatter.
So, I add `add_newline` parameter to control writing to new line by tsv formatter.