### PR TITLE
Fix test_config_params of ltsv formatter

### DIFF
--- a/test/plugin/test_formatter_ltsv.rb
+++ b/test/plugin/test_formatter_ltsv.rb
@@ -23,14 +23,17 @@ class LabeledTSVFormatterTest < ::Test::Unit::TestCase
     d = create_driver
     assert_equal "\t", d.instance.delimiter
     assert_equal  ":", d.instance.label_delimiter
+    assert_equal  true, d.instance.add_newline
 
     d = create_driver(
       'delimiter'       => ',',
       'label_delimiter' => '=',
+      'add_newline' => false,
     )
 
     assert_equal ",", d.instance.delimiter
     assert_equal "=", d.instance.label_delimiter
+    assert_equal  false, d.instance.add_newline
   end
 
   def test_format


### PR DESCRIPTION
Source code
https://github.com/fluent/fluentd/blob/master/lib/fluent/plugin/formatter_ltsv.rb#L26-L28

Document
https://docs.fluentd.org/v0.14/articles/formatter_ltsv#addnewline-boolean-optional-defaults-to-true