### PR TITLE
Update url from http to https

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We'd love your contribution. Here are the guidelines!
 
 ## Got a question or problem?
 
-RESOURCES of [Official site](http://www.fluentd.org/) and [Fluentd documentation](http://docs.fluentd.org/) may help you.
+RESOURCES of [Official site](https://www.fluentd.org/) and [Fluentd documentation](https://docs.fluentd.org/) may help you.
 
 If you have further questions about Fluentd and plugins, please direct these to [Mailing List](https://groups.google.com/forum/#!forum/fluentd).
 Don't use Github issue for asking questions. Here are examples:

--- a/ENTERPRISE_PROVIDERS.md
+++ b/ENTERPRISE_PROVIDERS.md
@@ -1,6 +1,6 @@
 # Fluentd Enterprise Providers
 
-[Fluentd](http://www.fluentd.org) is widely adopted in the enterprise and in most of scenarios, production environments requires special support and services. The following document describe the certified  service providers and further guidelines to apply to become one.
+[Fluentd](https://www.fluentd.org) is widely adopted in the enterprise and in most of scenarios, production environments requires special support and services. The following document describe the certified  service providers and further guidelines to apply to become one.
 
 ## Fluentd Providers
 
@@ -10,7 +10,7 @@ The following section lists the companies that provides Support, Consulting Serv
 
 ### Treasure Data
 
-[Treasure Data](https://www.treasuredata.com) is one of the principal sponsors of Fluentd, it provides technical support, consulting services and [Fluentd Enterprise](https://fluentd.treasuredata.com/), a Fluentd-on steroids with enhanced security and connectors for enterprise backends such as [Apache Kafka](http://kafka.apache.org) and [Splunk](http://www.splunk.com) within others.
+[Treasure Data](https://www.treasuredata.com) is one of the principal sponsors of Fluentd, it provides technical support, consulting services and [Fluentd Enterprise](https://fluentd.treasuredata.com/), a Fluentd-on steroids with enhanced security and connectors for enterprise backends such as [Apache Kafka](https://kafka.apache.org) and [Splunk](https://www.splunk.com) within others.
 
 For more details about Fluentd Enterprise provided by Treasure Data, click [here](https://fluentd.treasuredata.com/).
 
@@ -35,7 +35,7 @@ In order to be listed as a service provider, please send an email using your cor
   - What kind of services around Fluentd do you provide ?
 - Community
   - List of activities of your company within the Fluentd community in the last 12 months
-  - Are you a member of the [Cloud Native Computing Foundation](http://cncf.io) ?
+  - Are you a member of the [Cloud Native Computing Foundation](https://cncf.io) ?
 
 ### Maintainers / Recipients
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Fluentd: Open-Source Log Collector
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1189/badge)](https://bestpractices.coreinfrastructure.org/projects/1189)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Ffluent%2Ffluentd.svg?type=shield)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Ffluent%2Ffluentd?ref=badge_shield)
 
-[Fluentd](http://fluentd.org/) collects events from various data sources and writes them to files, RDBMS, NoSQL, IaaS, SaaS, Hadoop and so on. Fluentd helps you unify your logging infrastructure (Learn more about the [Unified Logging Layer](http://www.fluentd.org/blog/unified-logging-layer)).
+[Fluentd](https://fluentd.org/) collects events from various data sources and writes them to files, RDBMS, NoSQL, IaaS, SaaS, Hadoop and so on. Fluentd helps you unify your logging infrastructure (Learn more about the [Unified Logging Layer](https://www.fluentd.org/blog/unified-logging-layer)).
 
 <p align="center">
-<img src="http://docs.fluentd.org/images/fluentd-architecture.png" width="500px"/>
+<img src="https://docs.fluentd.org/images/fluentd-architecture.png" width="500px"/>
 </p>
 
 An event consists of *tag*, *time* and *record*. Tag is a string separated with '.' (e.g. myapp.access). It is used to categorize events. Time is a UNIX time recorded at occurrence of an event. Record is a JSON object.
@@ -62,15 +62,15 @@ Many enterprises run Fluentd in production to handle all of their logging needs.
 
 [Fluentd UI](https://github.com/fluent/fluentd-ui) is a graphical user interface to start/stop/configure Fluentd.
 
-<p align="center"><img width="500" src="http://www.fluentd.org/images/blog/fluentd-ui.gif"/></p>
+<p align="center"><img width="500" src="https://www.fluentd.org/images/blog/fluentd-ui.gif"/></p>
 
 ## More Information
 
 - Website: https://www.fluentd.org/
-- Documentation: http://docs.fluentd.org/
-- Project repository: http://github.com/fluent
-- Discussion: http://groups.google.com/group/fluentd
-- Slack / Community: http://slack.fluentd.org
+- Documentation: https://docs.fluentd.org/
+- Project repository: https://github.com/fluent
+- Discussion: https://groups.google.com/group/fluentd
+- Slack / Community: https://slack.fluentd.org
 - Newsletters: https://www.fluentd.org/newsletter_signup
 - Author: Sadayuki Furuhashi
 - Copyright: (c) 2011 FURUHASHI Sadayuki

--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["frsyuki@gmail.com"]
   gem.description   = %q{Fluentd is an open source data collector designed to scale and simplify log management. It can collect, process and ship many kinds of data in near real-time.}
   gem.summary       = %q{Fluentd event collector}
-  gem.homepage      = "http://fluentd.org/"
+  gem.homepage      = "https://fluentd.org/"
 
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }

--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -582,7 +582,7 @@ module Fluent::Plugin
           rescue IO::WaitReadable
             # If the exception is Errno::EWOULDBLOCK or Errno::EAGAIN, it is extended by IO::WaitReadable.
             # So IO::WaitReadable can be used to rescue the exceptions for retrying read_nonblock.
-            # http://docs.ruby-lang.org/en/2.3.0/IO.html#method-i-read_nonblock
+            # https//docs.ruby-lang.org/en/2.3.0/IO.html#method-i-read_nonblock
             sleep @sender.read_interval unless @state == :established
           rescue SystemCallError => e
             @log.warn "disconnected by error", host: @host, port: @port, error: e

--- a/lib/fluent/plugin/out_stream.rb
+++ b/lib/fluent/plugin/out_stream.rb
@@ -93,7 +93,7 @@ module Fluent
     def initialize
       super
       $log.warn "'tcp' output is obsoleted and will be removed. Use 'forward' instead."
-      $log.warn "see 'forward' section in http://docs.fluentd.org/ for the high-availability configuration."
+      $log.warn "see 'forward' section in https://docs.fluentd.org/ for the high-availability configuration."
     end
 
     config_param :port, :integer, default: LISTEN_PORT

--- a/lib/fluent/test/helpers.rb
+++ b/lib/fluent/test/helpers.rb
@@ -21,7 +21,7 @@ require 'fluent/time'
 module Fluent
   module Test
     module Helpers
-      # See "Example Custom Assertion: http://test-unit.github.io/test-unit/en/Test/Unit/Assertions.html
+      # See "Example Custom Assertion: https://test-unit.github.io/test-unit/en/Test/Unit/Assertions.html
       def assert_equal_event_time(expected, actual, message = nil)
         expected_s = "#{Time.at(expected.sec)} (nsec #{expected.nsec})"
         actual_s   = "#{Time.at(actual.sec)  } (nsec #{actual.nsec})"

--- a/templates/new_gem/README.md.erb
+++ b/templates/new_gem/README.md.erb
@@ -1,6 +1,6 @@
 # <%= gem_name %>
 
-[Fluentd](http://fluentd.org/) <%= type %> plugin to do something.
+[Fluentd](https://fluentd.org/) <%= type %> plugin to do something.
 
 TODO: write description for you plugin.
 


### PR DESCRIPTION
I updated url of the following domain from http to https.
- www.fluentd.org
- docs.fluentd.org
- kafka.apache.org
- www.splunk.com
- cncf.io
- fluentd.org
- github.com
- groups.google.com
- slack.fluentd.org
- docs.ruby-lang.org
- test-unit.github.io