### PR TITLE
out_file/out_secondary_file: Support ${chunk_id} placeholder. fix #1705

### DIFF
--- a/lib/fluent/plugin/out_file.rb
+++ b/lib/fluent/plugin/out_file.rb
@@ -142,7 +142,7 @@ module Fluent::Plugin
         dummy_record = Hash[dummy_record_keys.zip(['data'] * dummy_record_keys.size)]
 
         test_meta1 = metadata_for_test(dummy_tag, Fluent::Engine.now, dummy_record)
-        test_path = extract_placeholders(@path_template, test_meta1)
+        test_path = extract_placeholders(@path_template.gsub(CHUNK_ID_PLACEHOLDER_PATTERN, 'test'), test_meta1)
         unless ::Fluent::FileUtil.writable_p?(test_path)
           raise Fluent::ConfigError, "out_file: `#{test_path}` is not writable"
         end
@@ -178,7 +178,7 @@ module Fluent::Plugin
     end
 
     def write(chunk)
-      path = extract_placeholders(@path_template, chunk.metadata)
+      path = extract_placeholders(@path_template.gsub(CHUNK_ID_PLACEHOLDER_PATTERN, dump_unique_id_hex(chunk.unique_id)), chunk.metadata)
       FileUtils.mkdir_p File.dirname(path), mode: @dir_perm
 
       writer = case

--- a/lib/fluent/plugin/out_file.rb
+++ b/lib/fluent/plugin/out_file.rb
@@ -141,8 +141,8 @@ module Fluent::Plugin
         dummy_record_keys = get_placeholders_keys(@path_template) || ['message']
         dummy_record = Hash[dummy_record_keys.zip(['data'] * dummy_record_keys.size)]
 
-        test_meta1 = metadata_for_test(dummy_tag, Fluent::Engine.now, dummy_record)
-        test_path = extract_placeholders(@path_template.gsub(CHUNK_ID_PLACEHOLDER_PATTERN, 'test'), test_meta1)
+        test_chunk1 = chunk_for_test(dummy_tag, Fluent::Engine.now, dummy_record)
+        test_path = extract_placeholders(@path_template, test_chunk1)
         unless ::Fluent::FileUtil.writable_p?(test_path)
           raise Fluent::ConfigError, "out_file: `#{test_path}` is not writable"
         end

--- a/lib/fluent/plugin/out_file.rb
+++ b/lib/fluent/plugin/out_file.rb
@@ -178,7 +178,7 @@ module Fluent::Plugin
     end
 
     def write(chunk)
-      path = extract_placeholders(@path_template.gsub(CHUNK_ID_PLACEHOLDER_PATTERN, dump_unique_id_hex(chunk.unique_id)), chunk.metadata)
+      path = extract_placeholders(@path_template, chunk)
       FileUtils.mkdir_p File.dirname(path), mode: @dir_perm
 
       writer = case

--- a/lib/fluent/plugin/out_secondary_file.rb
+++ b/lib/fluent/plugin/out_secondary_file.rb
@@ -71,7 +71,7 @@ module Fluent::Plugin
     end
 
     def write(chunk)
-      path_without_suffix = extract_placeholders(@path_without_suffix.gsub(CHUNK_ID_PLACEHOLDER_PATTERN, dump_unique_id_hex(chunk.unique_id)), chunk.metadata)
+      path_without_suffix = extract_placeholders(@path_without_suffix, chunk)
       path = generate_path(path_without_suffix)
       FileUtils.mkdir_p File.dirname(path), mode: @dir_perm
 

--- a/lib/fluent/plugin/out_secondary_file.rb
+++ b/lib/fluent/plugin/out_secondary_file.rb
@@ -71,7 +71,7 @@ module Fluent::Plugin
     end
 
     def write(chunk)
-      path_without_suffix = extract_placeholders(@path_without_suffix, chunk.metadata)
+      path_without_suffix = extract_placeholders(@path_without_suffix.gsub(CHUNK_ID_PLACEHOLDER_PATTERN, dump_unique_id_hex(chunk.unique_id)), chunk.metadata)
       path = generate_path(path_without_suffix)
       FileUtils.mkdir_p File.dirname(path), mode: @dir_perm
 
@@ -106,7 +106,7 @@ module Fluent::Plugin
         raise Fluent::ConfigError, "out_secondary_file: basename or directory has an incompatible placeholder #{ph}, remove tag placeholder, like `${tag}`, from basename or directory"
       end
 
-      vars = placeholders.reject { |placeholder| placeholder.match(/tag(\[\d+\])?/) }
+      vars = placeholders.reject { |placeholder| placeholder.match(/tag(\[\d+\])?/) || (placeholder == 'chunk_id') }
 
       if ph = vars.find { |v| !@chunk_keys.include?(v) }
         raise Fluent::ConfigError, "out_secondary_file: basename or directory has an incompatible placeholder #{ph}, remove variable placeholder, like `${varname}`, from basename or directory"

--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -39,6 +39,7 @@ module Fluent
       CHUNK_KEY_PATTERN = /^[-_.@a-zA-Z0-9]+$/
       CHUNK_KEY_PLACEHOLDER_PATTERN = /\$\{[-_.@$a-zA-Z0-9]+\}/
       CHUNK_TAG_PLACEHOLDER_PATTERN = /\$\{(tag(?:\[\d+\])?)\}/
+      CHUNK_ID_PLACEHOLDER_PATTERN = /\$\{chunk_id\}/
 
       CHUNKING_FIELD_WARN_NUM = 4
 
@@ -679,7 +680,7 @@ module Fluent
       end
 
       def get_placeholders_keys(str)
-        str.scan(CHUNK_KEY_PLACEHOLDER_PATTERN).map{|ph| ph[2..-2]}.reject{|s| s == "tag"}.sort
+        str.scan(CHUNK_KEY_PLACEHOLDER_PATTERN).map{|ph| ph[2..-2]}.reject{|s| (s == "tag") || (s == 'chunk_id') }.sort
       end
 
       # TODO: optimize this code

--- a/test/plugin/test_out_secondary_file.rb
+++ b/test/plugin/test_out_secondary_file.rb
@@ -260,6 +260,20 @@ class FileOutputSecondaryTest < Test::Unit::TestCase
       assert_equal "#{TMP_DIR}/dump.bin", path
     end
 
+    test 'path with ${chunk_id}' do
+      d = create_driver %[
+        directory #{TMP_DIR}
+        basename out_file_chunk_id_${chunk_id}
+      ]
+      path = d.instance.write(@c)
+      if File.basename(path) =~ /out_file_chunk_id_([-_.@a-zA-Z0-9].*).0/
+        unique_id = Fluent::UniqueId.hex(Fluent::UniqueId.generate)
+        assert_equal unique_id.size, $1.size, "chunk_id size is mismatched"
+      else
+        flunk "chunk_id is not included in the path"
+      end
+    end
+
     data(
       invalid_tag: [/tag/, '${tag}'],
       invalid_tag0: [/tag\[0\]/, '${tag[0]}'],


### PR DESCRIPTION
`${chunk_id}` placeholder is useful for out_file like plugins.
So I added `CHUNK_ID_PLACEHOLDER_PATTERN` in Output to share.
For example, out_webhdfs uses own `${chunk_id}` value but it should use this predefined constant.