### PR TITLE
Always lock chunks first to avoid deadlock

### DIFF
--- a/lib/fluent/plugin/buffer.rb
+++ b/lib/fluent/plugin/buffer.rb
@@ -323,7 +323,7 @@ module Fluent
             else
               @queue << chunk
               @queued_num[metadata] = @queued_num.fetch(metadata, 0) + 1
-              chunk.enqueued! if chunk.respond_to?(:enqueued!)
+              chunk.enqueued!
             end
           end
           bytesize = chunk.bytesize
@@ -340,7 +340,7 @@ module Fluent
             metadata = chunk.metadata
             @queue << chunk
             @queued_num[metadata] = @queued_num.fetch(metadata, 0) + 1
-            chunk.enqueued! if chunk.respond_to?(:enqueued!)
+            chunk.enqueued!
           end
           @queue_size += chunk.bytesize
         end

--- a/lib/fluent/plugin/buffer.rb
+++ b/lib/fluent/plugin/buffer.rb
@@ -319,20 +319,18 @@ module Fluent
         return nil unless chunk
 
         chunk.synchronize do
-          if chunk.empty?
-            chunk.close
-          else
-            synchronize do
+          synchronize do
+            if chunk.empty?
+              chunk.close
+            else
               @queue << chunk
               @queued_num[metadata] = @queued_num.fetch(metadata, 0) + 1
+              chunk.enqueued!
             end
-            chunk.enqueued!
+            bytesize = chunk.bytesize
+            @stage_size -= bytesize
+            @queue_size += bytesize
           end
-        end
-        bytesize = chunk.bytesize
-        synchronize do
-          @stage_size -= bytesize
-          @queue_size += bytesize
         end
         nil
       end

--- a/lib/fluent/plugin/buffer.rb
+++ b/lib/fluent/plugin/buffer.rb
@@ -352,6 +352,8 @@ module Fluent
         log.trace "enqueueing all chunks in buffer", instance: self.object_id
         if block_given?
           synchronize{ @stage.keys }.each do |metadata|
+            # NOTE: The following line might cause data race depending on Ruby implementations except CRuby
+            # cf. https://github.com/fluent/fluentd/pull/1721#discussion_r146170251
             chunk = @stage[metadata]
             next unless chunk
             v = yield metadata, chunk

--- a/lib/fluent/plugin/buffer.rb
+++ b/lib/fluent/plugin/buffer.rb
@@ -313,20 +313,24 @@ module Fluent
 
       def enqueue_chunk(metadata)
         log.trace "enqueueing chunk", instance: self.object_id, metadata: metadata
-        synchronize do
-          chunk = @stage.delete(metadata)
-          return nil unless chunk
+        chunk = synchronize do
+          @stage.delete(metadata)
+        end
+        return nil unless chunk
 
-          chunk.synchronize do
-            if chunk.empty?
-              chunk.close
-            else
+        chunk.synchronize do
+          if chunk.empty?
+            chunk.close
+          else
+            synchronize do
               @queue << chunk
               @queued_num[metadata] = @queued_num.fetch(metadata, 0) + 1
-              chunk.enqueued!
             end
+            chunk.enqueued!
           end
-          bytesize = chunk.bytesize
+        end
+        bytesize = chunk.bytesize
+        synchronize do
           @stage_size -= bytesize
           @queue_size += bytesize
         end
@@ -348,17 +352,16 @@ module Fluent
 
       def enqueue_all
         log.trace "enqueueing all chunks in buffer", instance: self.object_id
-        synchronize do
-          if block_given?
-            @stage.keys.each do |metadata|
-              chunk = @stage[metadata]
-              v = yield metadata, chunk
-              enqueue_chunk(metadata) if v
-            end
-          else
-            @stage.keys.each do |metadata|
-              enqueue_chunk(metadata)
-            end
+        if block_given?
+          synchronize{ @stage.keys }.each do |metadata|
+            chunk = @stage[metadata]
+            next unless chunk
+            v = yield metadata, chunk
+            enqueue_chunk(metadata) if v
+          end
+        else
+          synchronize{ @stage.keys }.each do |metadata|
+            enqueue_chunk(metadata)
           end
         end
       end


### PR DESCRIPTION
This PR resolves https://github.com/fluent/fluentd/issues/1549.

For example, deadlock occurs by the following steps before this commit:

1. input plugin thread receives multiple events
  (`metadata_and_data.size > 1`)
2. input plugin thread processes the first `metadata_and_data` element
  and aquires the lock of chunk1 (`chunk.mon_exit` in `Buffer#write`)
3. enqueue thread aquires the lock of buffer
  (`synchronize` in `Buffer#enqueue_chunk`)
4. enqueue thread tries to aquire the lock of chunk1
  (`chunk.synchronize` in `Buffer#enqueue_chunk`)
5. input plugin thread processes the second `metadata_and_data` element
  and tries to aquire the lock of buffer (`synchronize` in `Buffer#write_once`)

cf. https://github.com/fluent/fluentd/issues/1549#issuecomment-335736547