### PR TITLE
Move tick check to after heartbeat for avoiding the impact of other node heartbeat. fix #1719

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -395,9 +395,6 @@ module Fluent::Plugin
 
     def on_timer
       @nodes.each {|n|
-        if n.tick
-          rebuild_weight_array
-        end
         begin
           log.trace "sending heartbeat", host: n.host, port: n.port, heartbeat_type: @heartbeat_type
           n.usock = @usock if @usock
@@ -406,6 +403,9 @@ module Fluent::Plugin
           log.debug "failed to send heartbeat packet", host: n.host, port: n.port, heartbeat_type: @heartbeat_type, error: e
         rescue => e
           log.debug "unexpected error happen during heartbeat", host: n.host, port: n.port, heartbeat_type: @heartbeat_type, error: e
+        end
+        if n.tick
+          rebuild_weight_array
         end
       }
     end


### PR DESCRIPTION
In the past, fluentd supports only UDP heartbeat and it uses async check between fluentd nodes.
So if previous node takes longer time for heartbeat, it doesn't affect elapsed time.
On the other hand, recent fluentd supports TCP heartbeat and it uses sync check via tcp connection.
So if previous node takes longer time, it affects elapsed time for current node and it causes misjudgment.
To avoid the problem, elapsed time calculation should be done after heartbeat.