### PR TITLE
Add error location to emit error logs. fix #1737

### DIFF
--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -292,7 +292,7 @@ module Fluent
     end
 
     def emit_error_event(tag, time, record, error)
-      error_info = {error: error, tag: tag, time: time}
+      error_info = {error: error, location: (error.backtrace ? error.backtrace.first : nil), tag: tag, time: time}
       if @error_collector
         # A record is not included in the logs because <@ERROR> handles it. This warn is for the notification
         log.warn "send an error event to @ERROR:", error_info


### PR DESCRIPTION
I consider dump entire stacktrace but it sometimes bloats log size.
The important point is checking which plugin causes the error, so I added only first line of stacktrace to show plugin name.