### PR TITLE
Consider hyphen and underscore in fluent-plugin-generate arguments

### DIFF
--- a/lib/fluent/command/plugin_generator.rb
+++ b/lib/fluent/command/plugin_generator.rb
@@ -137,32 +137,36 @@ BANNER
   end
 
   def gem_name
-    "fluent-plugin-#{name}"
+    "fluent-plugin-#{dash_name}"
+  end
+
+  def plugin_name
+    underscore_name
   end
 
   def class_name
-    "#{name.capitalize}#{type.capitalize}"
+    "#{capitalized_name}#{type.capitalize}"
   end
 
   def plugin_filename
     case type
     when "input"
-      "in_#{name}.rb"
+      "in_#{underscore_name}.rb"
     when "output"
-      "out_#{name}.rb"
+      "out_#{underscore_name}.rb"
     else
-      "#{type}_#{name}.rb"
+      "#{type}_#{underscore_name}.rb"
     end
   end
 
   def test_filename
     case type
     when "input"
-      "test_in_#{name}.rb"
+      "test_in_#{underscore_name}.rb"
     when "output"
-      "test_out_#{name}.rb"
+      "test_out_#{underscore_name}.rb"
     else
-      "test_#{type}_#{name}.rb"
+      "test_#{type}_#{underscore_name}.rb"
     end
   end
 
@@ -177,6 +181,18 @@ BANNER
     else
       path.basename.sub_ext("")
     end
+  end
+
+  def capitalized_name
+    @capitalized_name ||= name.split(/[-_]/).map(&:capitalize).join
+  end
+
+  def underscore_name
+    @underscore_name ||= name.tr("-", "_")
+  end
+
+  def dash_name
+    @dash_name ||= name.tr("_", "-")
   end
 
   def preamble

--- a/templates/new_gem/lib/fluent/plugin/filter.rb.erb
+++ b/templates/new_gem/lib/fluent/plugin/filter.rb.erb
@@ -5,7 +5,7 @@ require "fluent/plugin/filter"
 module Fluent
   module Plugin
     class <%= class_name %> < Fluent::Plugin::Filter
-      Fluent::Plugin.register_filter("<%= name %>", self)
+      Fluent::Plugin.register_filter("<%= plugin_name %>", self)
 
       def filter(tag, time, record)
       end

--- a/templates/new_gem/lib/fluent/plugin/input.rb.erb
+++ b/templates/new_gem/lib/fluent/plugin/input.rb.erb
@@ -5,7 +5,7 @@ require "fluent/plugin/input"
 module Fluent
   module Plugin
     class <%= class_name %> < Fluent::Plugin::Input
-      Fluent::Plugin.register_input("<%= name %>", self)
+      Fluent::Plugin.register_input("<%= plugin_name %>", self)
     end
   end
 end

--- a/templates/new_gem/lib/fluent/plugin/output.rb.erb
+++ b/templates/new_gem/lib/fluent/plugin/output.rb.erb
@@ -5,7 +5,7 @@ require "fluent/plugin/output"
 module Fluent
   module Plugin
     class <%= class_name %> < Fluent::Plugin::Output
-      Fluent::Plugin.register_output("<%= name %>", self)
+      Fluent::Plugin.register_output("<%= plugin_name %>", self)
     end
   end
 end

--- a/templates/new_gem/lib/fluent/plugin/parser.rb.erb
+++ b/templates/new_gem/lib/fluent/plugin/parser.rb.erb
@@ -5,7 +5,7 @@ require "fluent/plugin/parser"
 module Fluent
   module Plugin
     class <%= class_name %> < Fluent::Plugin::Parser
-      Fluent::Plugin.register_parser("<%= name %>", self)
+      Fluent::Plugin.register_parser("<%= plugin_name %>", self)
     end
 
     def parse(text)

--- a/test/command/test_plugin_generator.rb
+++ b/test/command/test_plugin_generator.rb
@@ -5,64 +5,64 @@ require 'fluent/command/plugin_generator'
 
 class TestFluentPluginGenerator < Test::Unit::TestCase
   sub_test_case "generate plugin" do
-  TEMP_DIR = "tmp/plugin_generator"
-  setup do
-    FileUtils.mkdir_p(TEMP_DIR)
-    @pwd = Dir.pwd
-    Dir.chdir(TEMP_DIR)
-  end
-
-  teardown do
-    Dir.chdir(@pwd)
-    FileUtils.rm_rf(TEMP_DIR)
-  end
-
-  data(input: ["input", "in"],
-       output: ["output", "out"],
-       filter: ["filter", "filter"],
-       parser: ["parser", "parser"],
-       formatter: ["formatter", "formatter"])
-  test "generate plugin" do |(type, part)|
-    capture_stdout do
-      FluentPluginGenerator.new([type, "fake"]).call
+    TEMP_DIR = "tmp/plugin_generator"
+    setup do
+      FileUtils.mkdir_p(TEMP_DIR)
+      @pwd = Dir.pwd
+      Dir.chdir(TEMP_DIR)
     end
-    plugin_base_dir = Pathname("fluent-plugin-fake")
-    assert { plugin_base_dir.directory? }
-    expected = [
-      "fluent-plugin-fake",
-      "fluent-plugin-fake/Gemfile",
-      "fluent-plugin-fake/LICENSE",
-      "fluent-plugin-fake/README.md",
-      "fluent-plugin-fake/Rakefile",
-      "fluent-plugin-fake/fluent-plugin-fake.gemspec",
-      "fluent-plugin-fake/lib",
-      "fluent-plugin-fake/lib/fluent",
-      "fluent-plugin-fake/lib/fluent/plugin",
-      "fluent-plugin-fake/lib/fluent/plugin/#{part}_fake.rb",
-      "fluent-plugin-fake/test",
-      "fluent-plugin-fake/test/helper.rb",
-      "fluent-plugin-fake/test/plugin",
-      "fluent-plugin-fake/test/plugin/test_#{part}_fake.rb",
-    ]
-    actual = plugin_base_dir.find.reject {|f| f.fnmatch("*/.git*") }.map(&:to_s).sort
-    assert_equal(expected, actual)
-  end
 
-  test "no license" do
-    capture_stdout do
-      FluentPluginGenerator.new(["--no-license", "filter", "fake"]).call
+    teardown do
+      Dir.chdir(@pwd)
+      FileUtils.rm_rf(TEMP_DIR)
     end
-    assert { !Pathname("fluent-plugin-fake/LICENSE").exist? }
-    assert { Pathname("fluent-plugin-fake/Gemfile").exist? }
-  end
 
-  test "unknown license" do
-    out = capture_stdout do
-      assert_raise(SystemExit) do
-        FluentPluginGenerator.new(["--license=unknown", "filter", "fake"]).call
+    data(input: ["input", "in"],
+         output: ["output", "out"],
+         filter: ["filter", "filter"],
+         parser: ["parser", "parser"],
+         formatter: ["formatter", "formatter"])
+    test "generate plugin" do |(type, part)|
+      capture_stdout do
+        FluentPluginGenerator.new([type, "fake"]).call
       end
+      plugin_base_dir = Pathname("fluent-plugin-fake")
+      assert { plugin_base_dir.directory? }
+      expected = [
+        "fluent-plugin-fake",
+        "fluent-plugin-fake/Gemfile",
+        "fluent-plugin-fake/LICENSE",
+        "fluent-plugin-fake/README.md",
+        "fluent-plugin-fake/Rakefile",
+        "fluent-plugin-fake/fluent-plugin-fake.gemspec",
+        "fluent-plugin-fake/lib",
+        "fluent-plugin-fake/lib/fluent",
+        "fluent-plugin-fake/lib/fluent/plugin",
+        "fluent-plugin-fake/lib/fluent/plugin/#{part}_fake.rb",
+        "fluent-plugin-fake/test",
+        "fluent-plugin-fake/test/helper.rb",
+        "fluent-plugin-fake/test/plugin",
+        "fluent-plugin-fake/test/plugin/test_#{part}_fake.rb",
+      ]
+      actual = plugin_base_dir.find.reject {|f| f.fnmatch("*/.git*") }.map(&:to_s).sort
+      assert_equal(expected, actual)
     end
-    assert { out.lines.include?("License: unknown\n") }
-  end
+
+    test "no license" do
+      capture_stdout do
+        FluentPluginGenerator.new(["--no-license", "filter", "fake"]).call
+      end
+      assert { !Pathname("fluent-plugin-fake/LICENSE").exist? }
+      assert { Pathname("fluent-plugin-fake/Gemfile").exist? }
+    end
+
+    test "unknown license" do
+      out = capture_stdout do
+        assert_raise(SystemExit) do
+          FluentPluginGenerator.new(["--license=unknown", "filter", "fake"]).call
+        end
+      end
+      assert { out.lines.include?("License: unknown\n") }
+    end
   end
 end

--- a/test/command/test_plugin_generator.rb
+++ b/test/command/test_plugin_generator.rb
@@ -4,6 +4,7 @@ require 'pathname'
 require 'fluent/command/plugin_generator'
 
 class TestFluentPluginGenerator < Test::Unit::TestCase
+  sub_test_case "generate plugin" do
   TEMP_DIR = "tmp/plugin_generator"
   setup do
     FileUtils.mkdir_p(TEMP_DIR)
@@ -62,5 +63,6 @@ class TestFluentPluginGenerator < Test::Unit::TestCase
       end
     end
     assert { out.lines.include?("License: unknown\n") }
+  end
   end
 end


### PR DESCRIPTION
For example:

Following commands will generate fluent-plugin-rewrite-tag-filter
and register "rewrite_tag_filter".

    $ fluent-plugin-generate output rewrite_tag_filter
    $ fluent-plugin-generate output rewrite-tag-filter