### PR TITLE
Combine before_shutdown and shutdown call in one sequence.

### DIFF
--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -228,11 +228,18 @@ module Fluent
             Thread.current.abort_on_exception = true
             begin
               if method == :shutdown
+                # To avoid Input#shutdown and Output#before_shutdown mismatch problem, combine before_shutdown and shutdown call in one sequence.
+                # The problem is in_tail flushes buffered multiline in shutdown but output's flush_at_shutdown is invoked in before_shutdown
+                operation = "preparing shutdown" # for error message
+                log.debug "#{operation} #{kind} plugin", type: Plugin.lookup_type_from_class(instance.class), plugin_id: instance.plugin_id
+                instance.send(:before_shutdown) unless instance.send(:before_shutdown?)
+                operation = "shutting down"
                 log.info "#{operation} #{kind} plugin", type: Plugin.lookup_type_from_class(instance.class), plugin_id: instance.plugin_id
+                instance.send(:shutdown) unless instance.send(:shutdown?)
               else
                 log.debug "#{operation} #{kind} plugin", type: Plugin.lookup_type_from_class(instance.class), plugin_id: instance.plugin_id
+                instance.send(method) unless instance.send(checker)
               end
-              instance.send(method) unless instance.send(checker)
             rescue Exception => e
               log.warn "unexpected error while #{operation} on #{kind} plugin", plugin: instance.class, plugin_id: instance.plugin_id, error: e
               log.warn_backtrace
@@ -245,8 +252,6 @@ module Fluent
       lifecycle_safe_sequence.call(:stop, :stopped?)
 
       # before_shutdown does force_flush for output plugins: it should block, so it's unsafe operation
-      lifecycle_unsafe_sequence.call(:before_shutdown, :before_shutdown?)
-
       lifecycle_unsafe_sequence.call(:shutdown, :shutdown?)
 
       lifecycle_safe_sequence.call(:after_shutdown, :after_shutdown?)

--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -212,7 +212,6 @@ module Fluent
 
       lifecycle_unsafe_sequence = ->(method, checker) {
         operation = case method
-                    when :before_shutdown then "preparing shutdown"
                     when :shutdown then "shutting down"
                     when :close    then "closing"
                     else


### PR DESCRIPTION
Currently, Output's flush_at_shutdown is executed in before_shutdown but
in_tail's multiline buffered logs are flushed in shutdown.
This mismatch causes log lost at shutdown/restart.
To avoid such problem, Input#shutdown should be called before Output#before_shutdown.

If this approach doesn't resolve all cases,
calling order will be changed to v0.12 like sequence.

In addition, we will consider moving flush_at_shutdown routine to `shutdown`.