### PR TITLE
Disable tracepoint feature to omit unnecessary insts

### DIFF
--- a/bin/fluentd
+++ b/bin/fluentd
@@ -1,5 +1,8 @@
 #!/usr/bin/env ruby
 # -*- coding: utf-8 -*-
+
+RubyVM::InstructionSequence.compile_option = {trace_instruction: false} rescue nil
+
 here = File.dirname(__FILE__)
 $LOAD_PATH << File.expand_path(File.join(here, '..', 'lib'))
 require 'fluent/command/fluentd'


### PR DESCRIPTION
Based on http://atdot.net/~ko1/activities/2017_fukuoka_rubykaigi_02.pdf
It reduces avg 0.5 mb at startup. I'm not sure performace improvement but default setting should be better.
This option also works on ruby 2.5.