### PR TITLE
out_copy: support ignore_error in store section

### DIFF
--- a/lib/fluent/plugin/multi_output.rb
+++ b/lib/fluent/plugin/multi_output.rb
@@ -29,6 +29,7 @@ module Fluent
       helpers :event_emitter # to get router from agent, which will be supplied to child plugins
 
       config_section :store, param_name: :stores, multi: true, required: true do
+        config_argument :arg, :string, default: ''
         config_param :@type, :string, default: nil
       end
 

--- a/test/plugin/test_out_copy.rb
+++ b/test/plugin/test_out_copy.rb
@@ -156,5 +156,36 @@ class CopyOutputTest < Test::Unit::TestCase
       end
     end
   end
+
+  IGNORE_ERROR_CONFIG = %[
+    <store ignore_error>
+      @type test
+      name c0
+    </store>
+    <store ignore_error>
+      @type test
+      name c1
+    </store>
+    <store>
+      @type test
+      name c2
+    </store>
+  ]
+
+  def test_ignore_error
+    d = create_driver(IGNORE_ERROR_CONFIG)
+
+    # override to raise an error
+    d.instance.outputs[0].define_singleton_method(:process) do |tag, es|
+      raise ArgumentError, 'Failed'
+    end
+
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    assert_nothing_raised do
+      d.run(default_tag: 'test') do
+        d.feed(time, {"a"=>1})
+      end
+    end
+  end
 end
 


### PR DESCRIPTION
out_copy_ex supports `ignore_error` to ignore emit errors in non-important plugin.
First, we provide this feature via 3rd party plugin because we can't judge this feature is useful or not before.
Currenlty, many users still use copy_ex on the production so merging it into core is good.
