### PR TITLE
in_tail: Explicitly update position to 0 when the file is truncated

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -526,7 +526,7 @@ module Fluent
             stat = io.stat
             inode = stat.ino
             if inode == @pe.read_inode # truncated
-              @pe.update_pos(stat.size)
+              @pe.update_pos(0)
               io_handler = IOHandler.new(io, @pe, @log, @read_lines_limit, &method(:wrap_receive_lines))
               @io_handler.close
               @io_handler = io_handler


### PR DESCRIPTION
Current in_tail already reads the file from head when truncated,
but the position is updated to stat.size. Basically it is misleading and
may cause unexpected behaviour.