### PR TITLE
Use dig_rb instead of ruby_dig when backport_dig is not installed

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("tzinfo", ["~> 1.0"])
   gem.add_runtime_dependency("tzinfo-data", ["~> 1.0"])
   gem.add_runtime_dependency("strptime", ["~> 0.1"])
-  gem.add_runtime_dependency("ruby_dig", ["~> 0.0.2"])
+  gem.add_runtime_dependency("dig_rb", ["~> 1.0.0"])
 
   # build gem for a certain platform. see also Rakefile
   fake_platform = ENV['GEM_BUILD_FAKE_PLATFORM'].to_s

--- a/lib/fluent/plugin_helper/record_accessor.rb
+++ b/lib/fluent/plugin_helper/record_accessor.rb
@@ -17,10 +17,10 @@
 require 'fluent/config/error'
 unless {}.respond_to?(:dig)
   begin
-    # backport_dig is faster than ruby_dig so prefer backport_dig.
+    # backport_dig is faster than dig_rb so prefer backport_dig.
     require 'backport_dig'
   rescue LoadError
-    require 'ruby_dig'
+    require 'dig_rb'
   end
 end
 


### PR DESCRIPTION
Because ruby_dig 0.0.2 does not support a object that responds to dig
method properly. On the other hand, dig_rb 1.0.1 supports it properly.