### PR TITLE
Use Strftime to improve fixed timestamp performance

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("sigdump", ["~> 0.2.2"])
   gem.add_runtime_dependency("tzinfo", ["~> 1.0"])
   gem.add_runtime_dependency("tzinfo-data", ["~> 1.0"])
-  gem.add_runtime_dependency("strptime", [">= 0.2.1", "< 1.0.0"])
+  gem.add_runtime_dependency("strptime", [">= 0.2.2", "< 1.0.0"])
   gem.add_runtime_dependency("dig_rb", ["~> 1.0.0"])
 
   # build gem for a certain platform. see also Rakefile

--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("sigdump", ["~> 0.2.2"])
   gem.add_runtime_dependency("tzinfo", ["~> 1.0"])
   gem.add_runtime_dependency("tzinfo-data", ["~> 1.0"])
-  gem.add_runtime_dependency("strptime", ["~> 0.1"])
+  gem.add_runtime_dependency("strptime", [">= 0.2.1", "< 1.0.0"])
   gem.add_runtime_dependency("dig_rb", ["~> 1.0.0"])
 
   # build gem for a certain platform. see also Rakefile

--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -163,10 +163,12 @@ module Fluent
     def format=(fmt)
       return if @format == fmt
 
+      @time_format = '%Y-%m-%d %H:%M:%S %z'
+      @time_formatter = Strftime.new(@time_format)
+
       case fmt
       when :text
         @format = :text
-        @time_format = '%Y-%m-%d %H:%M:%S %z'
         @formatter = Proc.new { |type, time, level, msg|
           r = caller_line(type, time, @depth_offset, level)
           r << msg
@@ -174,10 +176,9 @@ module Fluent
         }
       when :json
         @format = :json
-        @time_format = '%Y-%m-%d %H:%M:%S %z'
         @formatter = Proc.new { |type, time, level, msg|
           r = {
-            'time' => time.strftime(@time_format),
+            'time' => @time_formatter.exec(time),
             'level' => LEVEL_TEXT[level],
             'message' => msg
           }
@@ -189,6 +190,11 @@ module Fluent
       end
 
       nil
+    end
+
+    def time_format=(time_fmt)
+      @time_format = time_fmt
+      @time_formatter = Strftime.new(@time_format)
     end
 
     def reopen!
@@ -423,7 +429,7 @@ module Fluent
         end
       else
         r = {
-          'time' => time.strftime(@time_format),
+          'time' => @time_formatter.exec(time),
           'level' => LEVEL_TEXT[level],
         }
         if wid = get_worker_id(type)
@@ -491,7 +497,7 @@ module Fluent
                        else
                          "".freeze
                        end
-      log_msg = "#{time.strftime(@time_format)} [#{LEVEL_TEXT[level]}]: #{worker_id_part}"
+      log_msg = "#{@time_formatter.exec(time)} [#{LEVEL_TEXT[level]}]: #{worker_id_part}"
       if @debug_mode
         line = caller(depth+1)[0]
         if match = /^(.+?):(\d+)(?::in `(.*)')?/.match(line)
@@ -545,8 +551,8 @@ module Fluent
     extend Forwardable
     def_delegators '@logger', :get_worker_id, :enable_color?, :enable_debug, :enable_event,
       :disable_events, :log_event_enabled, :log_event_enamed=, :time_format, :time_format=,
-      :event, :caller_line, :puts, :write, :<<, :flush, :reset, :out, :out=,
-      :optional_header, :optional_header=, :optional_attrs, :optional_attrs=
+      :time_formatter, :time_formatter=, :event, :caller_line, :puts, :write, :<<, :flush,
+      :reset, :out, :out=, :optional_header, :optional_header=, :optional_attrs, :optional_attrs=
   end
 
 

--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -164,7 +164,7 @@ module Fluent
       return if @format == fmt
 
       @time_format = '%Y-%m-%d %H:%M:%S %z'
-      @time_formatter = Strftime.new(@time_format)
+      @time_formatter = Strftime.new(@time_format) rescue nil
 
       case fmt
       when :text
@@ -178,7 +178,7 @@ module Fluent
         @format = :json
         @formatter = Proc.new { |type, time, level, msg|
           r = {
-            'time' => @time_formatter.exec(time),
+            'time' => @time_formatter ? @time_formatter.exec(time) : time.strftime(@time_format),
             'level' => LEVEL_TEXT[level],
             'message' => msg
           }
@@ -194,7 +194,7 @@ module Fluent
 
     def time_format=(time_fmt)
       @time_format = time_fmt
-      @time_formatter = Strftime.new(@time_format)
+      @time_formatter = Strftime.new(@time_format) rescue nil
     end
 
     def reopen!
@@ -429,7 +429,7 @@ module Fluent
         end
       else
         r = {
-          'time' => @time_formatter.exec(time),
+          'time' => @time_formatter ? @time_formatter.exec(time) : time.strftime(@time_format),
           'level' => LEVEL_TEXT[level],
         }
         if wid = get_worker_id(type)
@@ -497,7 +497,7 @@ module Fluent
                        else
                          "".freeze
                        end
-      log_msg = "#{@time_formatter.exec(time)} [#{LEVEL_TEXT[level]}]: #{worker_id_part}"
+      log_msg = "#{@time_formatter ? @time_formatter.exec(time): time.strftime(@time_format)} [#{LEVEL_TEXT[level]}]: #{worker_id_part}"
       if @debug_mode
         line = caller(depth+1)[0]
         if match = /^(.+?):(\d+)(?::in `(.*)')?/.match(line)

--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -178,7 +178,7 @@ module Fluent
         @format = :json
         @formatter = Proc.new { |type, time, level, msg|
           r = {
-            'time' => @time_formatter ? @time_formatter.exec(time) : time.strftime(@time_format),
+            'time' => format_time(time),
             'level' => LEVEL_TEXT[level],
             'message' => msg
           }
@@ -429,7 +429,7 @@ module Fluent
         end
       else
         r = {
-          'time' => @time_formatter ? @time_formatter.exec(time) : time.strftime(@time_format),
+          'time' => format_time(time),
           'level' => LEVEL_TEXT[level],
         }
         if wid = get_worker_id(type)
@@ -497,7 +497,7 @@ module Fluent
                        else
                          "".freeze
                        end
-      log_msg = "#{@time_formatter ? @time_formatter.exec(time): time.strftime(@time_format)} [#{LEVEL_TEXT[level]}]: #{worker_id_part}"
+      log_msg = "#{format_time(time)} [#{LEVEL_TEXT[level]}]: #{worker_id_part}"
       if @debug_mode
         line = caller(depth+1)[0]
         if match = /^(.+?):(\d+)(?::in `(.*)')?/.match(line)
@@ -508,6 +508,10 @@ module Fluent
         end
       end
       return log_msg
+    end
+
+    def format_time(time)
+      @time_formatter ? @time_formatter.exec(time) : time.strftime(@time_format)
     end
   end
 

--- a/lib/fluent/plugin/formatter_stdout.rb
+++ b/lib/fluent/plugin/formatter_stdout.rb
@@ -21,13 +21,14 @@ module Fluent
     class StdoutFormatter < Formatter
       Plugin.register_formatter('stdout', self)
 
-      TIME_FORMAT = '%Y-%m-%d %H:%M:%S.%9N %z'
+      TIME_FORMAT = '%Y-%m-%d %H:%M:%S.%N %z'
 
       config_param :output_type, :string, default: 'json'
 
       def configure(conf)
         super
 
+        @time_formatter = Strftime.new(TIME_FORMAT)
         @sub_formatter = Plugin.new_formatter(@output_type, parent: self.owner)
         @sub_formatter.configure(conf)
       end
@@ -38,7 +39,7 @@ module Fluent
       end
 
       def format(tag, time, record)
-        "#{Time.at(time).localtime.strftime(TIME_FORMAT)} #{tag}: #{@sub_formatter.format(tag, time, record).chomp}\n"
+        "#{@time_formatter.exec(Time.at(time).localtime)} #{tag}: #{@sub_formatter.format(tag, time, record).chomp}\n"
       end
 
       def stop

--- a/lib/fluent/plugin/out_stdout.rb
+++ b/lib/fluent/plugin/out_stdout.rb
@@ -24,7 +24,6 @@ module Fluent::Plugin
 
     DEFAULT_LINE_FORMAT_TYPE = 'stdout'
     DEFAULT_FORMAT_TYPE = 'json'
-    TIME_FORMAT = '%Y-%m-%d %H:%M:%S.%9N %z'
 
     config_section :buffer do
       config_set_default :chunk_keys, ['tag']

--- a/lib/fluent/timezone.rb
+++ b/lib/fluent/timezone.rb
@@ -97,9 +97,14 @@ module Fluent
       if NUMERIC_PATTERN === timezone
         offset = Time.zone_offset(timezone)
 
-        if format
+        case
+        when format.is_a?(String)
           return Proc.new {|time|
             Time.at(time).localtime(offset).strftime(format)
+          }
+        when format.is_a?(Strftime)
+          return Proc.new {|time|
+            format.exec(Time.at(time).localtime(offset))
           }
         else
           return Proc.new {|time|
@@ -116,9 +121,14 @@ module Fluent
           return nil
         end
 
-        if format
+        case
+        when format.is_a?(String)
           return Proc.new {|time|
             Time.at(time).localtime(tz.period_for_utc(time).utc_total_offset).strftime(format)
+          }
+        when format.is_a?(Strftime)
+          return Proc.new {|time|
+            format.exec(Time.at(time).localtime(tz.period_for_utc(time).utc_total_offset))
           }
         else
           return Proc.new {|time|


### PR DESCRIPTION
Use `Strftime` instead of `Time#strftime` improves the performance of time formatting.