### PR TITLE
Add parameter delimiter_pattern to parser_ltsv

### DIFF
--- a/lib/fluent/plugin/parser_ltsv.rb
+++ b/lib/fluent/plugin/parser_ltsv.rb
@@ -32,10 +32,14 @@ module Fluent
 
       config_set_default :time_key, 'time'
 
+      def configure(conf)
+        super
+        @delimiter = @delimiter_pattern || @delimiter
+      end
+
       def parse(text)
         r = {}
-        delimiter = @delimiter_pattern || @delimiter
-        text.split(delimiter).each do |pair|
+        text.split(@delimiter).each do |pair|
           key, value = pair.split(@label_delimiter, 2)
           r[key] = value
         end

--- a/lib/fluent/plugin/parser_ltsv.rb
+++ b/lib/fluent/plugin/parser_ltsv.rb
@@ -23,6 +23,10 @@ module Fluent
 
       desc 'The delimiter character (or string) of TSV values'
       config_param :delimiter, :string, default: "\t"
+      desc 'The delimiter pattern of TSV values'
+      config_param :delimiter_pattern, default: nil do |value|
+        Regexp.compile(value[1..-2]) if value
+      end
       desc 'The delimiter character between field name and value'
       config_param :label_delimiter, :string, default: ":"
 
@@ -30,7 +34,8 @@ module Fluent
 
       def parse(text)
         r = {}
-        text.split(@delimiter).each do |pair|
+        delimiter = @delimiter_pattern || @delimiter
+        text.split(delimiter).each do |pair|
           key, value = pair.split(@label_delimiter, 2)
           r[key] = value
         end

--- a/test/plugin/test_parser_labeled_tsv.rb
+++ b/test/plugin/test_parser_labeled_tsv.rb
@@ -125,4 +125,21 @@ class LabeledTSVParserTest < ::Test::Unit::TestCase
       assert_equal record['b'], ' '
     end
   end
+
+  data("single space" => ["k1=v1 k2=v2", { "k1" => "v1", "k2" => "v2" }],
+       "multiple space" => ["k1=v1    k2=v2", { "k1" => "v1", "k2" => "v2" }],
+       "reverse" => ["k2=v2 k1=v1", { "k1" => "v1", "k2" => "v2" }],
+       "tab" => ["k2=v2\tk1=v1", { "k1" => "v1", "k2" => "v2" }],
+       "tab and space" => ["k2=v2\t k1=v1", { "k1" => "v1", "k2" => "v2" }])
+  def test_parse_with_delimiter_pattern(data)
+    text, expected = data
+    parser = Fluent::Test::Driver::Parser.new(Fluent::Plugin::LabeledTSVParser)
+    parser.configure(
+                     'delimiter_pattern' => '/\s+/',
+                     'label_delimiter' => '='
+                    )
+    parser.instance.parse(text) do |_time, record|
+      assert_equal(expected, record)
+    end
+  end
 end


### PR DESCRIPTION
The feature is taken from
https://github.com/fluent-plugins-nursery/fluent-plugin-kv-parser

fluent-plugin-kv-parser is very simple and similar to parser_ltsv.
So we can integrate fluent-plugin-kv-parser with parser_ltsv.