### PR TITLE
Fix tcp + tls degradation

### DIFF
--- a/lib/fluent/plugin_helper/server.rb
+++ b/lib/fluent/plugin_helper/server.rb
@@ -446,9 +446,12 @@ module Fluent
       class TLSCallbackSocket < CallbackSocket
         ENABLED_EVENTS = [:data, :write_complete, :close]
 
+        attr_accessor :buffer
+
         def initialize(sock)
           super("tls", sock, ENABLED_EVENTS)
           @peeraddr = (@sock.to_io.peeraddr rescue PEERADDR_FAILED)
+          @buffer = ''
         end
 
         def write(data)


### PR DESCRIPTION
https://github.com/fluent/fluentd/pull/1729 introduced @buffer to
TCPCallbackSocket. TLSCallbackSocket also has to have it to be used for
in_tcp.