### PR TITLE
Expose record_accessor internal instance `@keys` variable. Fix #1806

### DIFF
--- a/lib/fluent/plugin_helper/record_accessor.rb
+++ b/lib/fluent/plugin_helper/record_accessor.rb
@@ -32,6 +32,8 @@ module Fluent
       end
 
       class Accessor
+        attr_reader :keys
+
         def initialize(param)
           @keys = Accessor.parse_parameter(param)
 

--- a/test/plugin_helper/test_record_accessor.rb
+++ b/test/plugin_helper/test_record_accessor.rb
@@ -62,6 +62,40 @@ class RecordAccessorHelperTest < Test::Unit::TestCase
     end
   end
 
+  sub_test_case 'attr_reader :keys' do
+    setup do
+      @d = Dummy.new
+    end
+
+    data('normal' => 'key1',
+         'space' => 'ke y2',
+         'dot key' => 'this.is.key3')
+    test 'access single key' do |param|
+      accessor = @d.record_accessor_create(param)
+      assert_equal param, accessor.keys
+    end
+
+    test "nested bracket keys with dot" do
+      accessor = @d.record_accessor_create("$['key1']['this.is.key3']")
+      assert_equal ['key1','this.is.key3'], accessor.keys
+    end
+
+    data('dot' => '$.key1.key2[0]',
+         'bracket' => "$['key1']['key2'][0]",
+         'bracket w/ double quotes' => '$["key1"]["key2"][0]')
+    test "nested keys ['key1', 'key2', 0]" do |param|
+      accessor = @d.record_accessor_create(param)
+      assert_equal ['key1', 'key2', 0], accessor.keys
+    end
+
+    data('bracket' => "$['key1'][0]['ke y2']",
+         'bracket w/ double quotes' => '$["key1"][0]["ke y2"]')
+    test "nested keys ['key1', 0, 'ke y2']" do |param|
+      accessor = @d.record_accessor_create(param)
+      assert_equal ['key1', 0, 'ke y2'], accessor.keys
+    end
+  end
+
   sub_test_case Fluent::PluginHelper::RecordAccessor::Accessor do
     setup do
       @d = Dummy.new


### PR DESCRIPTION
Currently, `record_accessor` does not expose internal @keys instance.
We want to use this variable in [fluent-plugin-anonymizer](https://github.com/y-ken/fluent-plugin-anonymizer).