### PR TITLE
Port certificates generating command from secure-forward

### DIFF
--- a/bin/fluent-ca-generate
+++ b/bin/fluent-ca-generate
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 
 $LOAD_PATH.unshift(File.join(__dir__, 'lib'))
-require 'fileutils'
 require 'fluent/command/ca_generate'
 
 Fluent::CaGenerate.new.call

--- a/bin/fluent-ca-generate
+++ b/bin/fluent-ca-generate
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH.unshift(File.join(__dir__, 'lib'))
+require 'fileutils'
+require 'fluent/command/ca_generate'
+
+ca_dir, passphrase = ARGV
+
+unless ca_dir && passphrase
+  puts 'USAGE: fluent-ca-generate  DIR_PATH  PRIVATE_KEY_PASSPHRASE'
+  puts ''
+  exit 0
+end
+
+FileUtils.mkdir_p(ca_dir)
+
+opt = {
+  private_key_length: 2048,
+  cert_country:  'US',
+  cert_state:    'CA',
+  cert_locality: 'Mountain View',
+  cert_common_name: 'Fluentd Forward CA',
+}
+cert, key = Fluent::CaGenerate.generate_ca_pair(opt)
+
+key_data = key.export(OpenSSL::Cipher.new('aes256'), passphrase)
+File.open(File.join(ca_dir, 'ca_key.pem'), 'w') do |file|
+  file.write key_data
+end
+File.open(File.join(ca_dir, 'ca_cert.pem'), 'w') do |file|
+  file.write cert.to_pem
+end
+
+puts "successfully generated: ca_key.pem, ca_cert.pem"
+puts "copy and use ca_cert.pem to client(out_forward)"

--- a/bin/fluent-ca-generate
+++ b/bin/fluent-ca-generate
@@ -4,32 +4,4 @@ $LOAD_PATH.unshift(File.join(__dir__, 'lib'))
 require 'fileutils'
 require 'fluent/command/ca_generate'
 
-ca_dir, passphrase = ARGV
-
-unless ca_dir && passphrase
-  puts 'USAGE: fluent-ca-generate  DIR_PATH  PRIVATE_KEY_PASSPHRASE'
-  puts ''
-  exit 0
-end
-
-FileUtils.mkdir_p(ca_dir)
-
-opt = {
-  private_key_length: 2048,
-  cert_country:  'US',
-  cert_state:    'CA',
-  cert_locality: 'Mountain View',
-  cert_common_name: 'Fluentd Forward CA',
-}
-cert, key = Fluent::CaGenerate.generate_ca_pair(opt)
-
-key_data = key.export(OpenSSL::Cipher.new('aes256'), passphrase)
-File.open(File.join(ca_dir, 'ca_key.pem'), 'w') do |file|
-  file.write key_data
-end
-File.open(File.join(ca_dir, 'ca_cert.pem'), 'w') do |file|
-  file.write cert.to_pem
-end
-
-puts "successfully generated: ca_key.pem, ca_cert.pem"
-puts "copy and use ca_cert.pem to client(out_forward)"
+Fluent::CaGenerate.new.call

--- a/lib/fluent/command/ca_generate.rb
+++ b/lib/fluent/command/ca_generate.rb
@@ -1,0 +1,91 @@
+require 'openssl'
+
+module Fluent
+  module CaGenerate
+    def self.certificates_from_file(path)
+      data = File.read(path)
+      pattern = Regexp.compile('-+BEGIN CERTIFICATE-+\n(?:[^-]*\n)+-+END CERTIFICATE-+\n', Regexp::MULTILINE)
+      list = []
+      data.scan(pattern){|match| list << OpenSSL::X509::Certificate.new(match)}
+      list
+    end
+
+    def self.generate_ca_pair(opts={})
+      key = OpenSSL::PKey::RSA.generate(opts[:private_key_length])
+
+      issuer = subject = OpenSSL::X509::Name.new
+      subject.add_entry('C', opts[:cert_country])
+      subject.add_entry('ST', opts[:cert_state])
+      subject.add_entry('L', opts[:cert_locality])
+      subject.add_entry('CN', opts[:cert_common_name])
+
+      digest = OpenSSL::Digest::SHA256.new
+
+      cert = OpenSSL::X509::Certificate.new
+      cert.not_before = Time.at(0)
+      cert.not_after = Time.now + 5 * 365 * 86400 # 5 years after
+      cert.public_key = key
+      cert.serial = 1
+      cert.issuer = issuer
+      cert.subject = subject
+      cert.add_extension OpenSSL::X509::Extension.new('basicConstraints', OpenSSL::ASN1.Sequence([OpenSSL::ASN1::Boolean(true)]))
+      cert.sign(key, digest)
+
+      return cert, key
+    end
+
+    def self.generate_server_pair(opts={})
+      key = OpenSSL::PKey::RSA.generate(opts[:private_key_length])
+
+      ca_key = OpenSSL::PKey::RSA.new(File.read(opts[:ca_key_path]), opts[:ca_key_passphrase])
+      ca_cert = OpenSSL::X509::Certificate.new(File.read(opts[:ca_cert_path]))
+      issuer = ca_cert.issuer
+
+      subject = OpenSSL::X509::Name.new
+      subject.add_entry('C', opts[:country])
+      subject.add_entry('ST', opts[:state])
+      subject.add_entry('L', opts[:locality])
+      subject.add_entry('CN', opts[:common_name])
+
+      digest = OpenSSL::Digest::SHA256.new
+
+      cert = OpenSSL::X509::Certificate.new
+      cert.not_before = Time.at(0)
+      cert.not_after = Time.now + 5 * 365 * 86400 # 5 years after
+      cert.public_key = key
+      cert.serial = 2
+      cert.issuer = issuer
+      cert.subject = subject
+
+      cert.add_extension OpenSSL::X509::Extension.new('basicConstraints', OpenSSL::ASN1.Sequence([OpenSSL::ASN1::Boolean(false)]))
+      cert.add_extension OpenSSL::X509::Extension.new('nsCertType', 'server')
+
+      cert.sign ca_key, digest
+
+      return cert, key
+    end
+
+    def self.generate_self_signed_server_pair(opts={})
+      key = OpenSSL::PKey::RSA.generate(opts[:private_key_length])
+
+      issuer = subject = OpenSSL::X509::Name.new
+      subject.add_entry('C', opts[:country])
+      subject.add_entry('ST', opts[:state])
+      subject.add_entry('L', opts[:locality])
+      subject.add_entry('CN', opts[:common_name])
+
+      digest = OpenSSL::Digest::SHA256.new
+
+      cert = OpenSSL::X509::Certificate.new
+      cert.not_before = Time.at(0)
+      cert.not_after = Time.now + 5 * 365 * 86400 # 5 years after
+      cert.public_key = key
+      cert.serial = 1
+      cert.issuer = issuer
+      cert.subject  = subject
+      cert.sign(key, digest)
+
+      return cert, key
+    end
+  end
+end

--- a/lib/fluent/command/ca_generate.rb
+++ b/lib/fluent/command/ca_generate.rb
@@ -1,5 +1,6 @@
 require 'openssl'
 require 'optparse'
+require 'fileutils'
 
 module Fluent
   class CaGenerate

--- a/test/command/test_ca_generate.rb
+++ b/test/command/test_ca_generate.rb
@@ -35,4 +35,24 @@ copy and use ca_cert.pem to client(out_forward)
 TEXT
     assert_equal(expected, dumped_output)
   end
+
+  sub_test_case "configure options" do
+    test "should respond multiple options" do
+      dumped_output = capture_stdout do
+        Dir.mktmpdir do |dir|
+          Fluent::CaGenerate.new([dir, "fluentd",
+                                  "--country", "JP", "--key-length", "4096",
+                                  "--state", "Tokyo", "--locality", "Chiyoda-ku",
+                                  "--common-name", "Forward CA"]).call
+          assert_true(File.exist?(File.join(dir, "ca_key.pem")))
+          assert_true(File.exist?(File.join(dir, "ca_cert.pem")))
+        end
+      end
+      expected = <<TEXT
+successfully generated: ca_key.pem, ca_cert.pem
+copy and use ca_cert.pem to client(out_forward)
+TEXT
+      assert_equal(expected, dumped_output)
+    end
+  end
 end

--- a/test/command/test_ca_generate.rb
+++ b/test/command/test_ca_generate.rb
@@ -20,4 +20,19 @@ class TestFluentCaGenerate < ::Test::Unit::TestCase
     assert_equal(OpenSSL::X509::Certificate, cert.class)
     assert_true(key.private?)
   end
+
+  def test_ca_generate
+    dumped_output = capture_stdout do
+      Dir.mktmpdir do |dir|
+        Fluent::CaGenerate.new([dir, "fluentd"]).call
+        assert_true(File.exist?(File.join(dir, "ca_key.pem")))
+        assert_true(File.exist?(File.join(dir, "ca_cert.pem")))
+      end
+    end
+    expected = <<TEXT
+successfully generated: ca_key.pem, ca_cert.pem
+copy and use ca_cert.pem to client(out_forward)
+TEXT
+    assert_equal(expected, dumped_output)
+  end
 end

--- a/test/command/test_ca_generate.rb
+++ b/test/command/test_ca_generate.rb
@@ -9,14 +9,7 @@ require 'fluent/event'
 
 class TestFluentCaGenerate < ::Test::Unit::TestCase
   def test_generate_ca_pair
-    opt = {
-      private_key_length: 2048,
-      cert_country:  'US',
-      cert_state:    'CA',
-      cert_locality: 'Mountain View',
-      cert_common_name: 'Fluentd Forward CA',
-    }
-    cert, key = Fluent::CaGenerate.generate_ca_pair(opt)
+    cert, key = Fluent::CaGenerate.generate_ca_pair(Fluent::CaGenerate::DEFAULT_OPTIONS)
     assert_equal(OpenSSL::X509::Certificate, cert.class)
     assert_true(key.private?)
   end

--- a/test/command/test_ca_generate.rb
+++ b/test/command/test_ca_generate.rb
@@ -47,5 +47,24 @@ copy and use ca_cert.pem to client(out_forward)
 TEXT
       assert_equal(expected, dumped_output)
     end
+
+    test "invalid options" do
+      Dir.mktmpdir do |dir|
+        assert_raise(OptionParser::InvalidOption) do
+          Fluent::CaGenerate.new([dir, "fluentd",
+                                  "--invalid"]).call
+        end
+        assert_false(File.exist?(File.join(dir, "ca_key.pem")))
+        assert_false(File.exist?(File.join(dir, "ca_cert.pem")))
+      end
+    end
+
+    test "empty options" do
+      assert_raise(SystemExit) do
+        capture_stdout do
+          Fluent::CaGenerate.new([]).call
+        end
+      end
+    end
   end
 end

--- a/test/command/test_ca_generate.rb
+++ b/test/command/test_ca_generate.rb
@@ -1,0 +1,23 @@
+require_relative '../helper'
+
+require 'yajl'
+require 'flexmock/test_unit'
+require 'tmpdir'
+
+require 'fluent/command/ca_generate'
+require 'fluent/event'
+
+class TestFluentCaGenerate < ::Test::Unit::TestCase
+  def test_generate_ca_pair
+    opt = {
+      private_key_length: 2048,
+      cert_country:  'US',
+      cert_state:    'CA',
+      cert_locality: 'Mountain View',
+      cert_common_name: 'Fluentd Forward CA',
+    }
+    cert, key = Fluent::CaGenerate.generate_ca_pair(opt)
+    assert_equal(OpenSSL::X509::Certificate, cert.class)
+    assert_true(key.private?)
+  end
+end


### PR DESCRIPTION
I ported secure-forward's certificates generating command from fluent-plugin-secure-forward.

 Fix #1795