### PR TITLE
in_http: Emit event time instead of raw time value in batch

### DIFF
--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -202,7 +202,11 @@ module Fluent::Plugin
             if @add_remote_addr
               single_record['REMOTE_ADDR'] = params['REMOTE_ADDR']
             end
-            single_time = single_record.delete("time") || time
+            single_time = if t = single_record.delete('time')
+                            Fluent::EventTime.from_time(Time.at(t))
+                          else
+                            time
+                          end
             mes.add(single_time, single_record)
           end
           router.emit_stream(tag, mes)

--- a/test/plugin/test_in_http.rb
+++ b/test/plugin/test_in_http.rb
@@ -137,6 +137,31 @@ class HttpInputTest < Test::Unit::TestCase
     assert_equal_event_time time, d.events[1][1]
   end
 
+  def test_multi_json_with_time_field
+    d = create_driver
+    time = event_time("2011-01-02 13:14:15 UTC")
+    time_i = time.to_i
+    time_f = time.to_f
+
+    records = [{"a" => 1, 'time' => time_i},{"a" => 2, 'time' => time_f}]
+    events = [
+      ["tag1", time, {'a' => 1}],
+      ["tag1", time, {'a' => 2}],
+    ]
+    tag = "tag1"
+    res_codes = []
+    d.run(expect_records: 2, timeout: 5) do
+      res = post("/#{tag}", {"json" => records.to_json})
+      res_codes << res.code
+    end
+    assert_equal ["200"], res_codes
+    assert_equal events, d.events
+    assert_instance_of Fluent::EventTime, d.events[0][1]
+    assert_instance_of Fluent::EventTime, d.events[1][1]
+    assert_equal_event_time time, d.events[0][1]
+    assert_equal_event_time time, d.events[1][1]
+  end
+
   def test_json_with_add_remote_addr
     d = create_driver(CONFIG + "add_remote_addr true")
     time = event_time("2011-01-02 13:14:15 UTC")


### PR DESCRIPTION
I noticed current in_http uses 'time' field value in batch request.
Should emit Fluent::EventTime instead of Integer or Float.