### PR TITLE
encryption: Interpret the `allow_self_signed_cert` option correctly.

### DIFF
--- a/lib/fluent/plugin_helper/socket.rb
+++ b/lib/fluent/plugin_helper/socket.rb
@@ -101,7 +101,7 @@ module Fluent
           context.verify_mode = OpenSSL::SSL::VERIFY_NONE
         else
           cert_store = OpenSSL::X509::Store.new
-          if allow_self_signed_cert && OpenSSL::X509.const_defined?('V_FLAG_CHECK_SS_SIGNATURE')
+          if !allow_self_signed_cert && OpenSSL::X509.const_defined?('V_FLAG_CHECK_SS_SIGNATURE')
             cert_store.flags = OpenSSL::X509::V_FLAG_CHECK_SS_SIGNATURE
           end
           begin


### PR DESCRIPTION
### What's the problem?

In the current implementation, enabling the `allow_self_signed_cert`
option sets the 'CHECK_SS_SIGNATURE' flag of the cert_store object.
It seems to me that this is exactly opposite to the supposed behaviour.

In fact, according to `x509_verify_param_set_flags(3)`:

> X509_V_FLAG_CHECK_SS_SIGNATURE enables checking of the root CA
> self signed cerificate signature.

Thus, in effect, enabling `allow_self_signed_cert` will make Fluentd to *reject*
self-signed certificates for now.

This patch fixes the erroneous conditional statement in `socket_create_tls()`.

### Note on the context

I've noticed this issue while writing a user documentation on TLS/SSL:
fluent/fluentd-docs#450