### PR TITLE
crypto: Remove the `tls_allow_self_signed_cert` option.

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -86,8 +86,6 @@ module Fluent::Plugin
     config_param :tls_ciphers, :string, default: Fluent::PluginHelper::Socket::CIPHERS_DEFAULT
     desc 'Skip all verification of certificates or not.'
     config_param :tls_insecure_mode, :bool, default: false
-    desc 'Allow self signed certificates or not.'
-    config_param :tls_allow_self_signed_cert, :bool, default: false
     desc 'Verify hostname of servers and certificates or not in TLS transport.'
     config_param :tls_verify_hostname, :bool, default: true
     desc 'The additional CA certificate path for TLS.'
@@ -176,7 +174,6 @@ module Fluent::Plugin
         if @tls_insecure_mode
           log.warn "TLS transport is configured in insecure way"
           @tls_verify_hostname = false
-          @tls_allow_self_signed_cert = true
         end
       end
 
@@ -323,7 +320,6 @@ module Fluent::Plugin
           insecure: @tls_insecure_mode,
           verify_fqdn: @tls_verify_hostname,
           fqdn: hostname,
-          allow_self_signed_cert: @tls_allow_self_signed_cert,
           cert_paths: @tls_cert_path,
           linger_timeout: @send_timeout,
           send_timeout: @send_timeout,

--- a/lib/fluent/plugin_helper/socket.rb
+++ b/lib/fluent/plugin_helper/socket.rb
@@ -89,7 +89,7 @@ module Fluent
       def socket_create_tls(
           host, port,
           version: TLS_DEFAULT_VERSION, ciphers: CIPHERS_DEFAULT, insecure: false, verify_fqdn: true, fqdn: nil,
-          enable_system_cert_store: true, allow_self_signed_cert: false, cert_paths: nil, **kwargs, &block)
+          enable_system_cert_store: true, cert_paths: nil, **kwargs, &block)
 
         host_is_ipaddress = IPAddr.new(host) rescue false
         fqdn ||= host unless host_is_ipaddress
@@ -101,9 +101,6 @@ module Fluent
           context.verify_mode = OpenSSL::SSL::VERIFY_NONE
         else
           cert_store = OpenSSL::X509::Store.new
-          if allow_self_signed_cert && OpenSSL::X509.const_defined?('V_FLAG_CHECK_SS_SIGNATURE')
-            cert_store.flags = OpenSSL::X509::V_FLAG_CHECK_SS_SIGNATURE
-          end
           begin
             if enable_system_cert_store
               log.trace "loading system default certificate store"


### PR DESCRIPTION
### What's the problem?

I've noticed that the current implementation behind `tls_allow_self_signed_cert`
relies on a flawed interpretation of verification-policy flags in libssl.

In particular, this option tries to turn on `X509_V_FLAG_CHECK_SS_SIGNATURE` flag
to "allow self-signed certificates".

The problem is that this policy flag does not work that way.

### What is `X509_V_FLAG_CHECK_SS_SIGNATURE`?

The semantics of this flag is a bit complicated. Here is my short summary:

 1. By default, libssl does not try to check the integrity of signatures in self-signed
     certificates.
 2. This makes a lot sense, because self-signed certs are either trusted *a priori* or not,
     so the signature part is largely irrelevant in this context from a security standpoint.
 3. However, we can still ask libssl to perform the verification step anyway
    by setting `X509_V_FLAG_CHECK_SS_SIGNATURE`.

In essence, this policy flag has nothing to do with allowing (or rejecting) self-signed
certificates. It is supposed to be used for a very different (arguably niche) purpose.

This leads us to a somewhat devastating conclusion: the `tls_allow_self_signed_cert`
option currently does exactly nothing except for *turning on an irrelevant flag*.

### How to fix the problem

In the first place, I do not believe this option (`tls_allow_self_signed_cert`) has a
practical use case, since, if the goal is to reject (non CA-issued?) self-signed certs,
one should just remove these certs from the trusted store.

So I believe removing this option from the source tree is the correct solution.
This patch implements this solution.

### Note on the context of this patch

I've noticed this issue while writing a user documentation on out_forward
at fluent/fluentd-docs#450

### Reference Links

- [x509_verify_param_set_flags(3)](https://linux.die.net/man/3/x509_verify_param_set_flags)
- [openssl/crypto/x509/x509_vfy.c](https://github.com/openssl/openssl/blob/master/crypto/x509/x509_vfy.c#L1712).
