### PR TITLE
Add support for TLS Mutual authentication within forward input

### DIFF
--- a/lib/fluent/plugin_helper/cert_option.rb
+++ b/lib/fluent/plugin_helper/cert_option.rb
@@ -33,6 +33,11 @@ module Fluent
           ctx.ciphers = ciphers
         end
 
+        if conf.client_cert_auth
+            ctx.verify_mode = OpenSSL::SSL::VERIFY_PEER | OpenSSL::SSL::VERIFY_FAIL_IF_NO_PEER_CERT
+        end
+
+        ctx.ca_file = conf.ca_path
         ctx.cert = cert
         ctx.key = key
         if extra && !extra.empty?

--- a/lib/fluent/plugin_helper/server.rb
+++ b/lib/fluent/plugin_helper/server.rb
@@ -237,7 +237,7 @@ module Fluent
 
       SERVER_TRANSPORT_PARAMS = [
         :protocol, :version, :ciphers, :insecure,
-        :cert_path, :private_key_path, :private_key_passphrase,
+        :ca_path, :cert_path, :private_key_path, :private_key_passphrase, :client_cert_auth,
         :ca_cert_path, :ca_private_key_path, :ca_private_key_passphrase,
         :generate_private_key_length,
         :generate_cert_country, :generate_cert_state, :generate_cert_state,
@@ -271,9 +271,11 @@ module Fluent
           config_param :insecure, :bool, default: false
 
           # Cert signed by public CA
+          config_param :ca_path, :string, default: nil
           config_param :cert_path, :string, default: nil
           config_param :private_key_path, :string, default: nil
           config_param :private_key_passphrase, :string, default: nil, secret: true
+          config_param :client_cert_auth, :bool, default: false
 
           # Cert generated and signed by private CA Certificate
           config_param :ca_cert_path, :string, default: nil


### PR DESCRIPTION
Hi,

This PR add support for Client auth (also knows as [Mutual authentication](https://en.wikipedia.org/wiki/Mutual_authentication)).

This mainly consist of two things:
- Configure SSL context to load `ca_file` from `ca_path` config. In case config is not set it will default to null, which is also acceptable.
- If `client_cert_auth` config is set to `true` then configure SSL context to verify peer certificates.

This is my first ever ruby code and I'm having trouble understanding how to write test, so I would appreciate any help with that. 