### PR TITLE
Fix a bug to leak non-repeating timer watchers

### DIFF
--- a/lib/fluent/plugin_helper/event_loop.rb
+++ b/lib/fluent/plugin_helper/event_loop.rb
@@ -43,6 +43,15 @@ module Fluent
         end
       end
 
+      def event_loop_detach(watcher)
+        if watcher.attached?
+          watcher.detach
+        end
+        @_event_loop_mutex.synchronize do
+          @_event_loop_attached_watchers.delete(watcher)
+        end
+      end
+
       def event_loop_wait_until_start
         sleep(0.1) until event_loop_running?
       end


### PR DESCRIPTION
Timer plugin helpers may be used to call delayed processing with `repeat: false` option.
But if plugin authors call this method once per minute, `@_event_loop_attached_watchers` will have 60 undeleted objects per hour: that means object leakage.

This change is to fix that problem.