### PR TITLE
Support multi worker environment in in_debug_agent

### DIFF
--- a/test/plugin/test_in_debug_agent.rb
+++ b/test/plugin/test_in_debug_agent.rb
@@ -25,4 +25,25 @@ class DebugAgentInputTest < Test::Unit::TestCase
       create_driver %[unix_path #{TMP_DIR}/does_not_exist/test_path]
     end
   end
+
+  def test_multi_worker_environment_with_port
+    Fluent::SystemConfig.overwrite_system_config('workers' => 4) do
+      d = Fluent::Test::Driver::Input.new(Fluent::Plugin::DebugAgentInput)
+      d.instance.instance_eval { @_fluentd_worker_id = 2 }
+      d.configure('port 24230')
+
+      assert_true d.instance.multi_workers_ready?
+      assert_equal(24232, d.instance.instance_variable_get(:@port))
+    end
+  end
+
+  def test_multi_worker_environment_with_unix_path
+    Fluent::SystemConfig.overwrite_system_config('workers' => 4) do
+      d = Fluent::Test::Driver::Input.new(Fluent::Plugin::DebugAgentInput)
+      d.instance.instance_eval { @_fluentd_worker_id = 2 }
+      d.configure("unix_path #{TMP_DIR}/test_path")
+
+      assert_false d.instance.multi_workers_ready?
+    end
+  end
 end


### PR DESCRIPTION
in_debug_agent will listen sequential port number based on worker_id
just like in_monitor_agent. #1493