### PR TITLE
parser_json: Add EncodingError to rescue list for oj 3.x. fix #1866

### DIFF
--- a/lib/fluent/plugin/parser_json.rb
+++ b/lib/fluent/plugin/parser_json.rb
@@ -62,7 +62,7 @@ module Fluent
         r = @load_proc.call(text)
         time, record = convert_values(parse_time(r), r)
         yield time, record
-      rescue @error_class
+      rescue @error_class, EncodingError # EncodingError is for oj 3.x or later
         yield nil, nil
       end
 


### PR DESCRIPTION
oj 3.x sometimes raises an EncodingError for input string and it beaks parser_json behaviour.
This patch fixes it.

Here is test code:

```
Oj.load('+ cat /etc/resolv.conf')
```

- oj 3.4.0

```
test_oj.rb:6:in `load': Empty input at line 1, column 1 [parse.c:926] in '+ cat /etc/resolv.conf (EncodingError)
```

- oj 2.18.5

```
test_oj.rb:6:in `load': unexpected character at line 1, column 3 [parse.c:671] (Oj::ParseError)
```
