### PR TITLE
in_tail: Prevent IOHandler.on_notify() being called concurrently

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -678,10 +678,15 @@ module Fluent::Plugin
           @iobuf = ''.force_encoding('ASCII-8BIT')
           @lines = []
           @io = nil
+          @notify_mutex = Mutex.new
           @watcher.log.info "following tail of #{@watcher.path}"
         end
 
         def on_notify
+          @notify_mutex.synchronize { handle_notify }
+        end
+
+        def handle_notify
           with_io do |io|
             begin
               read_more = false


### PR DESCRIPTION
This patch is a fix for a multi-threading bug in Fluentd core. Apparently, this bug
has been one of major causes of the long-standing testing failures on Travis CI.

### Problem

Essentially, there is a concurrency bug in the implementation of `in_tail`.

While `IOHandler` (in_tail#L673) is not designed to be thread-safe, its method
`on_notify` can be called by multiple threads concurrently.

Here is how it occurs:

 1. TailInput calls `on_notify` on detach/shutdown (main thread)
 2. In the same time, StatWatcher triggers `on_notify` on filesystem events
    (eventloop thread)

In this situation, one thread can see the data retrieved (and being actively
processed) by another thread, which will result in duplication of data records.

### Solution

This patch fixes the issue by introducing a mutex, which should prevent two
threads from entering into the critical session simultaneously.