### PR TITLE
in_tail: Handle records in the correct order on file rotation

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -580,6 +580,8 @@ module Fluent::Plugin
               @pe.update(inode, 0)
             else # file is rotated and new file found
               watcher_needs_update = true
+              # Handle the old log file before renewing TailWatcher [fluentd#1055]
+              @io_handler.on_notify
             end
           else # file is rotated and new file not found
             # Clear RotateHandler to avoid duplicated file watch in same path.


### PR DESCRIPTION
This is the fix for the issue reported by the bug report #1055.

### Problem

It turned out that this bug was a matter of the calling order of functions in `TailWatcher.on_rotate()`.

In particular, when TailWatcher detects a log rotation and immediately finds a new file, it performs the following steps:

  1) Create a new TailWatcher for the new file.
      * In this process, it reads the new file and emit its contents.
      * This all happens before proceeding to (2).
  2) Dispatch the `on_notify()` for the archived file.
      * In this process, it reads the content of the old file and emit its contents.

So naturally, newer log records (written to the new log file) will be emitted before older records in the archived log file.

### Solution

This patch fixes it by enforcing flush of older log records before performing the step (1).

