### PR TITLE
test: Fix random test failures in test/plugin/test_out_forward.rb

### DIFF
--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -486,6 +486,7 @@ EOL
         retry_type periodic
         retry_wait 30s
         flush_at_shutdown false # suppress errors in d.instance_shutdown
+        flush_thread_interval 30s
       </buffer>
     ])
 
@@ -501,7 +502,7 @@ EOL
     target_input_driver.end_if{ d.instance.rollback_count > 0 }
     target_input_driver.end_if{ !node.available }
     target_input_driver.run(expect_records: 2, timeout: 25) do
-      d.run(default_tag: 'test', timeout: 20, wait_flush_completion: false, shutdown: false) do
+      d.run(default_tag: 'test', timeout: 20, wait_flush_completion: false, shutdown: false, flush: false) do
         delayed_commit_timeout_value = d.instance.delayed_commit_timeout
         d.feed([[time, records[0]], [time,records[1]]])
       end
@@ -530,6 +531,7 @@ EOL
         retry_type periodic
         retry_wait 30s
         flush_at_shutdown false # suppress errors in d.instance_shutdown
+        flush_thread_interval 30s
       </buffer>
     ])
 
@@ -545,7 +547,7 @@ EOL
     target_input_driver.end_if{ d.instance.rollback_count > 0 }
     target_input_driver.end_if{ !node.available }
     target_input_driver.run(expect_records: 2, timeout: 25) do
-      d.run(default_tag: 'test', timeout: 20, wait_flush_completion: false, shutdown: false) do
+      d.run(default_tag: 'test', timeout: 20, wait_flush_completion: false, shutdown: false, flush: false) do
         delayed_commit_timeout_value = d.instance.delayed_commit_timeout
         d.feed([[time, records[0]], [time,records[1]]])
       end


### PR DESCRIPTION
This is a fix for the test failures occurring on Travis CI every now and then. 

For actual cases of this failure, please see [job#4143.2](https://travis-ci.org/fluent/fluentd/jobs/339180777#L655), [job#4066.5](https://travis-ci.org/fluent/fluentd/jobs/312704505#L175) and [job#4167.2](https://travis-ci.org/fluent/fluentd/jobs/349665601#L907).

### How the failure happens

The failing test cases are supposed to test the handling of "broken ack responses";
To cut it short, these test cases are designed to perform the following steps:

 1. Create an `in_forward` server (which sends back a broken ack response).
 2. Create an `out_forward` server.
 3. Send some data and check the handling of the broken ack response.
 4. Shutdown the both forwarding servers.

The problem is that there might be another flush attempt occurring between step 3 and 4.
If one occurs, it will cause an unexpected `NoNodeAvailable` exception (since the destination
node is already labelled as "unavailable" due to the broken ack response in step 3).

In most environments, this possibility does not pose any real problem because the test execution
is modestly fast (so there is very little space for an additional flush attempt to occur). But since
the CI server is known to become very slow from time to time, we need to take special care for it.

### Solution

This patch fixes this issue by taking additional care to prevent unintended buffer flushes:

 - Setting a sufficiently long flush_thread_interval (30 seconds)
 - Disable `flush_buffer_at_cleanup` of the testing driver for the test cases.

Also, this should resolve the annoying "unexpected error while after_shutdown" warnings
produced while the test execution.