### PR TITLE
Fix boolean parameters without value with following comment

### DIFF
--- a/lib/fluent/config/types.rb
+++ b/lib/fluent/config/types.rb
@@ -60,7 +60,13 @@ module Fluent
       when ''
         true
       else
-        nil
+        # Current parser passes comment without actual values, e.g. "param #foo".
+        # parser should pass empty string in this case but changing behaviour may break existing environment so keep parser behaviour. Just ignore comment value in boolean handling for now.
+        if str.respond_to?('start_with?') && str.start_with?('#')
+          true
+        else
+          nil
+        end
       end
     end
 

--- a/test/config/test_plugin_configuration.rb
+++ b/test/config/test_plugin_configuration.rb
@@ -1,0 +1,56 @@
+require_relative '../helper'
+require 'fluent/plugin/input'
+require 'fluent/test/driver/input'
+
+module ConfigurationForPlugins
+  class Base1 < Fluent::Plugin::Input
+    config_param :flag1, :bool, default: true
+    config_param :flag2, :bool, default: true
+    config_param :flag3, :bool, default: false
+    config_param :flag4, :bool, default: false
+
+    config_section :child, param_name: :children, multi: true, required: true do
+      config_param :flag1, :bool, default: true
+      config_param :flag2, :bool, default: true
+      config_param :flag3, :bool, default: false
+      config_param :flag4, :bool, default: false
+    end
+  end
+
+  class WithoutValue < ::Test::Unit::TestCase
+    CONFIG = <<CONFIG
+    flag1 
+    flag2 # yaaaaaaaaaay
+    flag3 
+    flag4 # yaaaaaaaaaay
+    <child>
+      flag1
+      flag2 # yaaaaaaaaaay
+      flag3
+      flag4 # yaaaaaaaaaay
+    </child>
+    <child>
+      flag1 # yaaaaaaaaaay
+      flag2
+      flag3 # yaaaaaaaaaay
+      flag4
+    </child>
+    # with following whitespace
+    <child>
+      flag1 
+      flag2 
+      flag3 
+      flag4 
+    </child>
+CONFIG
+
+    test 'create plugin via driver' do
+      d = Fluent::Test::Driver::Input.new(Base1)
+      d.configure(CONFIG)
+      assert_equal([true] * 4, [d.instance.flag1, d.instance.flag2, d.instance.flag3, d.instance.flag4])
+      num_of_sections = 3
+      assert_equal num_of_sections, d.instance.children.size
+      assert_equal([true] * (num_of_sections * 4), d.instance.children.map{|c| [c.flag1, c.flag2, c.flag3, c.flag4]}.flatten)
+    end
+  end
+end

--- a/test/config/test_plugin_configuration.rb
+++ b/test/config/test_plugin_configuration.rb
@@ -3,7 +3,7 @@ require 'fluent/plugin/input'
 require 'fluent/test/driver/input'
 
 module ConfigurationForPlugins
-  class Base1 < Fluent::Plugin::Input
+  class AllBooleanParams < Fluent::Plugin::Input
     config_param :flag1, :bool, default: true
     config_param :flag2, :bool, default: true
     config_param :flag3, :bool, default: false
@@ -17,7 +17,7 @@ module ConfigurationForPlugins
     end
   end
 
-  class WithoutValue < ::Test::Unit::TestCase
+  class BooleanParamsWithoutValue < ::Test::Unit::TestCase
     CONFIG = <<CONFIG
     flag1 
     flag2 # yaaaaaaaaaay
@@ -45,7 +45,7 @@ module ConfigurationForPlugins
 CONFIG
 
     test 'create plugin via driver' do
-      d = Fluent::Test::Driver::Input.new(Base1)
+      d = Fluent::Test::Driver::Input.new(AllBooleanParams)
       d.configure(CONFIG)
       assert_equal([true] * 4, [d.instance.flag1, d.instance.flag2, d.instance.flag3, d.instance.flag4])
       num_of_sections = 3


### PR DESCRIPTION
As reported at https://github.com/tagomoris/fluent-plugin-route/issues/10, `config_param :name, :bool` returns falsely value (`nil`) when it's configured without explicit value with following comment.

```ruby
# parameter definition
config_param :b1, :bool, default: false
config_param :b2, :bool, default: false

# configuration
# b1 will be true
b1
# b2 will be nil
b2 # comment here
```

This bug cannot be reproducible via test cases of v1 parser, but I succeeded to reproduce it using plugin code and test driver. This bug was reported to be reproducible on actual Fluentd processes.
