### PR TITLE
Support pattern start with character classes

### DIFF
--- a/lib/fluent/plugin/filter_grep.rb
+++ b/lib/fluent/plugin/filter_grep.rb
@@ -41,7 +41,11 @@ module Fluent::Plugin
       config_param :key, :string
       desc "The regular expression."
       config_param :pattern do |value|
-        Regexp.compile(value)
+        if value.start_with?("/") and value.end_with?("/")
+          Regexp.compile(value[1..-2])
+        else
+          Regexp.compile(value)
+        end
       end
     end
 
@@ -50,7 +54,11 @@ module Fluent::Plugin
       config_param :key, :string
       desc "The regular expression."
       config_param :pattern do |value|
-        Regexp.compile(value)
+        if value.start_with?("/") and value.end_with("/")
+          Regexp.compile(value[1..-2])
+        else
+          Regexp.compile(value)
+        end
       end
     end
 

--- a/test/plugin/test_filter_grep.rb
+++ b/test/plugin/test_filter_grep.rb
@@ -73,6 +73,20 @@ class GrepFilterTest < Test::Unit::TestCase
         end
       end
     end
+
+    sub_test_case "pattern with slashes" do
+      test "start with character classes" do
+        conf = %[
+          regexp1 message test
+          <regexp>
+            key message
+            pattern /[a-z]test/
+          </regexp>
+        ]
+        d = create_driver(conf)
+        assert_equal(/[a-z]test/, d.instance.regexps.first.pattern)
+      end
+    end
   end
 
   sub_test_case 'filter_stream' do

--- a/test/plugin/test_filter_grep.rb
+++ b/test/plugin/test_filter_grep.rb
@@ -77,7 +77,6 @@ class GrepFilterTest < Test::Unit::TestCase
     sub_test_case "pattern with slashes" do
       test "start with character classes" do
         conf = %[
-          regexp1 message test
           <regexp>
             key message
             pattern /[a-z]test/


### PR DESCRIPTION
In prevous version, following pattern raises syntax error:

    <filter>
      @type grep
      <regexp>
        key price
        pattern [1-9]\d*
      </regexp>
    </filter>

This example is derrived from [filter-grep](https://docs.fluentd.org/v1.0/articles/filter_grep#<regexp>-directive)