### PR TITLE
test: Fix random test failures at test/plugin/test_output.rb#L926

### DIFF
--- a/test/plugin/test_output.rb
+++ b/test/plugin/test_output.rb
@@ -907,7 +907,8 @@ class OutputTest < Test::Unit::TestCase
 
   sub_test_case 'slow_flush_log_threshold' do
     def invoke_slow_flush_log_threshold_test(i)
-      i.configure(config_element('ROOT', '', {'slow_flush_log_threshold' => 0.5}, [config_element('buffer', '', {"flush_mode" => "immediate"})]))
+      i.configure(config_element('ROOT', '', {'slow_flush_log_threshold' => 0.5},
+                                 [config_element('buffer', '', {"flush_mode" => "immediate", "flush_thread_interval" => 30})]))
       i.start
       i.after_start
 


### PR DESCRIPTION
This patch fixes the test failures around `invoke_slow_flush_log_thread_test()` which
have been occurring at Travis CI.

For actual failing test runs, see [job#4160.1](https://travis-ci.org/fluent/fluentd/jobs/348128345#L1336), [job#4169.4](https://travis-ci.org/fluent/fluentd/jobs/350206345#L844) and [job#4154.5](https://travis-ci.org/fluent/fluentd/jobs/347253490#L888)

### Problem

I can reproduce this failure reliably by inserting `sleep 3` into [test_output.rb](https://github.com/fluent/fluentd/blob/master/test/plugin/test_output.rb#L909):

```ruby
def invoke_slow_flush_log_threshold_test(i)
  ...
  i.start
  i.after_start

  sleep 3

  t = event_time()
  i.emit_events('tag', Fluent::ArrayEventStream.new([ [t, {"key" => "value1"}],
                                              [t, {"key" => "value2"}] ]))
  i.force_flush

  waiting(4) { Thread.pass until i.test_finished? }
```

So it is a multi-threading bug. In particular, if the buffer-flushing thread interrupts the
test execution at the code point, it will accidentally turn on the `@test_finished` flag
and breaks the precondition for the test case. This is the exact cause of the test failure.

### Solution

This patch resolves this issue by setting a sufficiently long value to `flush_interval`
(30 sec) so that it won't mess with the test execution.
