### PR TITLE
Support parser option

### DIFF
--- a/lib/fluent/compat/parser.rb
+++ b/lib/fluent/compat/parser.rb
@@ -98,15 +98,14 @@ module Fluent
           raise ConfigError, "'format' parameter is required"
         end
 
-        if format[0] == ?/ && format[format.length-1] == ?/
-          # regexp
+        if /^\/(.*)\/([im]?)$/.match(format)
           begin
-            regexp = Regexp.new(format[1..-2])
+            regexp = Regexp.new($~[1], if $~[2]=='m' then Regexp::MULTILINE elsif $~[2]=='i' then Regexp::IGNORECASE nil end)
             if regexp.named_captures.empty?
               raise "No named captures"
             end
           rescue
-            raise ConfigError, "Invalid regexp '#{format[1..-2]}': #{$!}"
+            raise ConfigError, "Invalid regexp '#{format}': #{$!}"
           end
 
           RegexpParser.new(regexp)

--- a/lib/fluent/compat/parser.rb
+++ b/lib/fluent/compat/parser.rb
@@ -100,7 +100,7 @@ module Fluent
 
         if /^\/(.*)\/([im]?)$/.match(format)
           begin
-            regexp = Regexp.new($~[1], if $~[2]=='m' then Regexp::MULTILINE elsif $~[2]=='i' then Regexp::IGNORECASE nil end)
+            regexp = Regexp.new($~[1], if $~[2]=='m' then Regexp::MULTILINE elsif $~[2]=='i' then Regexp::IGNORECASE else nil end)
             if regexp.named_captures.empty?
               raise "No named captures"
             end

--- a/test/compat/test_parser.rb
+++ b/test/compat/test_parser.rb
@@ -89,4 +89,27 @@ class TextParserTest < ::Test::Unit::TestCase
     regexp = parser.instance_variable_get("@regexp")
     assert_equal(options, regexp.options)
   end
+
+  def test_text_parser_options
+    p1 = Fluent::TextParser.new
+    p1.configure('format' => '/(?<message>.*)/')
+    assert_equal true, p1.parser.estimate_current_event
+    
+    _time, record = p1.parse("log message!\naaa")
+    assert_equal({'message' => 'log message!'}, record)
+
+    p2 = Fluent::TextParser.new
+    p2.configure('format' => '/(?<message>.*)/m')
+    assert_equal true, p2.parser.estimate_current_event
+    
+    _time, record = p2.parse("log message!\naaa")
+    assert_equal({'message' => "log message!\naaa"}, record)
+
+    p3 = Fluent::TextParser.new
+    p3.configure('format' => '/(?<message>TEST.*)/i')
+    assert_equal true, p3.parser.estimate_current_event
+    
+    _time, record = p3.parse("test log message!")
+    assert_equal({'message' => "test log message!"}, record)
+  end
 end


### PR DESCRIPTION
日本語で失礼します。
parser の format で option をサポートするようにしてみました。

`format /^(?<datetime>\d{4}-\d{1,2}-\d{1,2} \d{1,2}:\d{1,2}:\d{1,2}),\d{3}\s{1,2}(?<level>[^ ]+) (?<message>.*)$/m`

のように使います。
