### PR TITLE
buffer: Add queued_chunks_limit_size to control the number of queued chunks

### DIFF
--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -1197,7 +1197,7 @@ module Fluent
 
       def force_flush
         if @buffering
-          @buffer.enqueue_all
+          @buffer.enqueue_all(true)
           submit_flush_all
         end
       end


### PR DESCRIPTION
Releated to https://github.com/fluent/fluentd/issues/1904
Current patch resolves generating lots of queued chunks with small flush_interval.
Note that v0.12's the number of queues is 1.

I will check how control this parameter with `write` families.