### PR TITLE
out_forward: The node should be disabled when TLS socket for ack returns an error. Fix #1923

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -425,7 +425,7 @@ module Fluent::Plugin
     def read_ack_from_sock(sock, unpacker)
       begin
         raw_data = sock.instance_of?(Fluent::PluginHelper::Socket::WrappedSocket::TLS) ? sock.readpartial(@read_length) : sock.recv(@read_length)
-      rescue Errno::ECONNRESET
+      rescue Errno::ECONNRESET, EOFError # ECONNRESET for #recv, #EOFError for #readpartial
         raw_data = ""
       end
       info = @sock_ack_waiting_mutex.synchronize{ @sock_ack_waiting.find{|i| i.sock == sock } }


### PR DESCRIPTION
With TLS socket, `readpartial` raise EOFError unlike `recv` when connection is broken.