### PR TITLE
added http-x-forwarded-for field to nginx parser

### DIFF
--- a/lib/fluent/plugin/parser_nginx.rb
+++ b/lib/fluent/plugin/parser_nginx.rb
@@ -21,7 +21,7 @@ module Fluent
     class NginxParser < RegexpParser
       Plugin.register_parser("nginx", self)
 
-      config_set_default :expression, /^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$/
+      config_set_default :expression, /^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)"(?:\s+(?<http_x_forwarded_for>[^ ]+))?)?$/
       config_set_default :time_format, "%d/%b/%Y:%H:%M:%S %z"
     end
   end

--- a/test/plugin/test_parser_nginx.rb
+++ b/test/plugin/test_parser_nginx.rb
@@ -16,6 +16,18 @@ class NginxParserTest < ::Test::Unit::TestCase
       'referer' => '-',
       'agent'   => 'Opera/12.0'
     }
+    @expected_extended = {
+      'remote'               => '127.0.0.1',
+      'host'                 => '192.168.0.1',
+      'user'                 => '-',
+      'method'               => 'GET',
+      'path'                 => '/',
+      'code'                 => '200',
+      'size'                 => '777',
+      'referer'              => '-',
+      'agent'                => 'Opera/12.0',
+      'http_x_forwarded_for' => '-'
+    }
   end
 
   def create_driver
@@ -43,6 +55,14 @@ class NginxParserTest < ::Test::Unit::TestCase
     d.instance.parse('127.0.0.1 192.168.0.1 - [28/Feb/2013:12:00:00 +0900] "GET /" 200 777 "-" "Opera/12.0"') { |time, record|
       assert_equal(event_time('28/Feb/2013:12:00:00 +0900', format: '%d/%b/%Y:%H:%M:%S %z'), time)
       assert_equal(@expected, record)
+    }
+  end
+
+  def test_parse_with_http_x_forwarded_for
+    d = create_driver
+    d.instance.parse('127.0.0.1 192.168.0.1 - [28/Feb/2013:12:00:00 +0900] "GET / HTTP/1.1" 200 777 "-" "Opera/12.0" -') { |time, record|
+      assert_equal(event_time('28/Feb/2013:12:00:00 +0900', format: '%d/%b/%Y:%H:%M:%S %z'), time)
+      assert_equal(@expected_extended, record)
     }
   end
 end


### PR DESCRIPTION
Closing #1907, an update to the docs has been proposed in fluent/fluentd-docs#471.
Signed-off-by: yaron-idan <yaronidan@gmail.com>