### PR TITLE
Close invalid socket when ssl error happens on reading. fix #1924

### DIFF
--- a/lib/fluent/plugin_helper/server.rb
+++ b/lib/fluent/plugin_helper/server.rb
@@ -717,6 +717,9 @@ module Fluent
             end
           rescue IO::WaitReadable, IO::WaitWritable
             # ignore and return with doing nothing
+          rescue OpenSSL::SSL::SSLError => e
+            @log.warn "close socket due to unexpected ssl error: #{e}"
+            close rescue nil
           end
 
           def on_writable


### PR DESCRIPTION
We can't recover SSL error so closing socket is better than process crash.
in_forward continue to accept new request.

Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>