### PR TITLE
prevent flushing twice

### DIFF
--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -1333,8 +1333,7 @@ module Fluent
         value_for_interval = nil
         if @flush_mode == :interval
           value_for_interval = @buffer_config.flush_interval
-        end
-        if @chunk_key_time
+        elsif @flush_mode == :lazy
           if !value_for_interval || @buffer_config.timekey < value_for_interval
             value_for_interval = [@buffer_config.timekey, @buffer_config.timekey_wait].min
           end
@@ -1368,9 +1367,7 @@ module Fluent
                 # If both of flush_interval & flush_thread_interval are 1s, expected actual flush timing is 1.5s.
                 # If we use integered values for this comparison, expected actual flush timing is 1.0s.
                 @buffer.enqueue_all{ |metadata, chunk| chunk.created_at.to_i + flush_interval <= now_int }
-              end
-
-              if @chunk_key_time
+              elsif @flush_mode == :lazy
                 timekey_unit = @buffer_config.timekey
                 timekey_wait = @buffer_config.timekey_wait
                 current_timekey = now_int - now_int % timekey_unit

--- a/test/plugin/test_output.rb
+++ b/test/plugin/test_output.rb
@@ -813,6 +813,14 @@ class OutputTest < Test::Unit::TestCase
     test 'flush_interval is ignored when flush_mode is not interval' do
       mock(@i.log).warn("'flush_interval' is ignored because default 'flush_mode' is not 'interval': 'lazy'")
       @i.configure(config_element('ROOT', '', {}, [config_element('buffer', 'time', {'timekey' => 60*30, 'flush_interval' => 10})]))
+      assert_equal :lazy, @i.instance_variable_get(:@flush_mode)
+    end
+
+    test 'flush_mode is set explicitly.' do
+      mock(@i.log)
+      @i.configure(config_element('ROOT', '', {},
+                                  [config_element('buffer', 'time', {'flush_mode' => :interval, 'timekey' => 60*30})]))
+      assert_equal :interval, @i.instance_variable_get(:@flush_mode)
     end
 
     data(:lazy => 'lazy', :immediate => 'immediate')


### PR DESCRIPTION
If flush_mode = interval and timekey = 5m, this would be flushed twice.
Though it is configuration mistake, I think it's also unexpected thing. 
Any suggestions welcome and let me know what I do not know:)