### PR TITLE
Doc: Update Fluentd Maintainers List

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,6 +1,7 @@
-- Sadayuki Furuhashi <frsyuki@gmail.com>
-- Masahiro Nakagawa <repeatedly@gmail.com>
-- Kiyoto Tamura <me@ktamura.com>
-- Kazuki Ohta <kazuki.ohta@gmail.com>
-- Satoshi "Moris" Tagomori <tagomoris@gmail.com>
-- Eduardo Silva <eduardo@treasure-data.com>
+# Fluentd Maintainers
+
+- [Naotoshi Seo](https://github.com/sonots), [DeNA](http://dena.com/intl/)
+- [Okkez](https://github.com/okkez), [Clearcode](https://clearcode.cc/)
+- [Hiroshi Hatake](https://github.com/cosmo0920), [Clearcode](https://clearcode.cc/)
+- [Masahiro Nakagawa](https://github.com/repeatedly), [Treasure Data](https://www.treasuredata.com/)
+- [Satoshi Tagomori](https://github.com/tagomoris), [Treasure Data](https://www.treasuredata.com/)


### PR DESCRIPTION
Update new list of Fluentd maintainers.

Signed-off-by: Eduardo Silva <edsiper@gmail.com>