### PR TITLE
Resolve unexpected exit on SIGUSR1

### DIFF
--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -625,5 +625,12 @@ module Fluent
         super
       end
     end
+
+    def reopen(path, mode)
+      if mode != 'a'
+        raise "Unsupported mode: #{mode}"
+      end
+      super(path)
+    end
   end
 end

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -160,7 +160,11 @@ module Fluent
 
     def supervisor_sigusr1_handler
       if log = config[:logger_initializer]
-        log.reopen!
+        # Creating new thread due to mutex can't lock
+        # in main thread during trap context
+        Thread.new {
+          log.reopen!
+        }.run
       end
 
       if config[:worker_pid]
@@ -663,14 +667,13 @@ module Fluent
     end
 
     def flush_buffer
-      $log.debug "fluentd main process get SIGUSR1"
-      $log.info "force flushing buffered events"
-      @log.reopen!
-
       # Creating new thread due to mutex can't lock
       # in main thread during trap context
       Thread.new {
         begin
+          $log.debug "fluentd main process get SIGUSR1"
+          $log.info "force flushing buffered events"
+          @log.reopen!
           Fluent::Engine.flush!
           $log.debug "flushing thread: flushed"
         rescue Exception => e


### PR DESCRIPTION
This PR resolves https://github.com/fluent/fluentd/issues/1951.

## Before

```
% git rev-parse HEAD
59d96759253c3894d7a7d398f2647f218ffdae18
% bundle exec ./bin/fluentd -c ./fluent.conf --log /tmp/fluent.log --log-rotate-age 1 --log-rotate-size 1024 &
[1] 19569
% kill -USR1 19569
Unexpected error wrong number of arguments (given 2, expected 0..1)
  /Users/arabiki/.anyenv/envs/rbenv/versions/2.4.2/lib/ruby/2.4.0/logger.rb:715:in `reopen'
  /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/supervisor.rb:364:in `reopen!'
  /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/supervisor.rb:163:in `supervisor_sigusr1_handler'
  /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/supervisor.rb:137:in `block in install_supervisor_signal_handlers'
  /Users/arabiki/.anyenv/envs/rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/serverengine-2.0.6/lib/serverengine/process_manager.rb:252:in `select'
  /Users/arabiki/.anyenv/envs/rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/serverengine-2.0.6/lib/serverengine/process_manager.rb:252:in `tick'
  /Users/arabiki/.anyenv/envs/rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/serverengine-2.0.6/lib/serverengine/multi_spawn_server.rb:91:in `wait_tick'
  /Users/arabiki/.anyenv/envs/rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/serverengine-2.0.6/lib/serverengine/multi_worker_server.rb:60:in `run'
  /Users/arabiki/.anyenv/envs/rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/serverengine-2.0.6/lib/serverengine/multi_spawn_server.rb:57:in `run'
  /Users/arabiki/.anyenv/envs/rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/serverengine-2.0.6/lib/serverengine/server.rb:123:in `main'
(snip)
```

## After

```
% bundle exec ./bin/fluentd -c ./fluent.conf --log /tmp/fluent.log --log-rotate-age 1 --log-rotate-size 1024 &
[1] 19163
% kill -USR1 19163
% tail -2 /tmp/fluent.log
2018-04-18 20:46:19 +0900 [info]: #0 force flushing buffered events
2018-04-18 20:46:19 +0900 [info]: #0 flushing all buffer forcedly
```