### PR TITLE
Fix DataError exception

### DIFF
--- a/test/plugin/test_out_file.rb
+++ b/test/plugin/test_out_file.rb
@@ -420,9 +420,9 @@ class FileOutputTest < Test::Unit::TestCase
         d = create_driver CONFIG_WITH_BUFFER
   
         time = event_time("2011-01-02 13:14:15 UTC")
-        msg = "0"*10000
+        msg = "0"*1000
         d.run() do
-         for i in 0..100000
+         for i in 0..10000
            d.feed("test1", time, {"a"=>i, "msg"=>msg})
            d.feed("test2", time, {"a"=>i, "msg"=>msg})
            d.feed("test3", time, {"a"=>i, "msg"=>msg})

--- a/test/plugin/test_out_file.rb
+++ b/test/plugin/test_out_file.rb
@@ -408,6 +408,8 @@ class FileOutputTest < Test::Unit::TestCase
           timekey 1m
           flush_mode interval
           flush_interval 1s
+          chunk_limit_size 128m
+          total_limit_size 10g
         </buffer>
         <format>
           @type json

--- a/test/plugin/test_out_file.rb
+++ b/test/plugin/test_out_file.rb
@@ -414,22 +414,23 @@ class FileOutputTest < Test::Unit::TestCase
         </format>
       ]
 
-
-      d = create_driver CONFIG_WITH_BUFFER
-
-      time = event_time("2011-01-02 13:14:15 UTC")
-      msg = "0"*10000
-      d.run() do
-       for i in 0..1000000
-         d.feed("test1", time, {"a"=>i, "msg"=>msg})
-         d.feed("test2", time, {"a"=>i, "msg"=>msg})
-         d.feed("test3", time, {"a"=>i, "msg"=>msg})
-         d.feed("test4", time, {"a"=>i, "msg"=>msg})
-         d.feed("test5", time, {"a"=>i, "msg"=>msg})
-         d.feed("test6", time, {"a"=>i, "msg"=>msg})
-         d.feed("test7", time, {"a"=>i, "msg"=>msg})
-         d.feed("test8", time, {"a"=>i, "msg"=>msg})
-       end
+      assert_nothing_raised do
+        d = create_driver CONFIG_WITH_BUFFER
+  
+        time = event_time("2011-01-02 13:14:15 UTC")
+        msg = "0"*10000
+        d.run() do
+         for i in 0..100000
+           d.feed("test1", time, {"a"=>i, "msg"=>msg})
+           d.feed("test2", time, {"a"=>i, "msg"=>msg})
+           d.feed("test3", time, {"a"=>i, "msg"=>msg})
+           d.feed("test4", time, {"a"=>i, "msg"=>msg})
+           d.feed("test5", time, {"a"=>i, "msg"=>msg})
+           d.feed("test6", time, {"a"=>i, "msg"=>msg})
+           d.feed("test7", time, {"a"=>i, "msg"=>msg})
+           d.feed("test8", time, {"a"=>i, "msg"=>msg})
+         end
+       end 
       end
     end
   end

--- a/test/plugin/test_out_file.rb
+++ b/test/plugin/test_out_file.rb
@@ -404,7 +404,7 @@ class FileOutputTest < Test::Unit::TestCase
         compress gzip
         append true
         <buffer tag, time>
-          @type memory
+          @type file
           timekey 1m
           flush_mode interval
           flush_interval 1s


### PR DESCRIPTION
Fixed #1903  #1847

This exception is caused by `submit_flush_once` wake up the output thread and interrupting gzip compression, causing a `DataError` exception to be thrown in the `close`.