### PR TITLE
Fix in_monitor_agent's buffer_total_queued_size

### DIFF
--- a/lib/fluent/plugin/in_monitor_agent.rb
+++ b/lib/fluent/plugin/in_monitor_agent.rb
@@ -279,7 +279,7 @@ module Fluent::Plugin
     MONITOR_INFO = {
       'output_plugin' => ->(){ is_a?(::Fluent::Plugin::Output) },
       'buffer_queue_length' => ->(){ throw(:skip) unless instance_variable_defined?(:@buffer) && !@buffer.nil? && @buffer.is_a?(::Fluent::Plugin::Buffer); @buffer.queue.size },
-      'buffer_total_queued_size' => ->(){ throw(:skip) unless instance_variable_defined?(:@buffer) && !@buffer.nil? && @buffer.is_a?(::Fluent::Plugin::Buffer); @buffer.stage_size },
+      'buffer_total_queued_size' => ->(){ throw(:skip) unless instance_variable_defined?(:@buffer) && !@buffer.nil? && @buffer.is_a?(::Fluent::Plugin::Buffer); @buffer.stage_size + @buffer.queue_size },
       'retry_count' => ->(){ instance_variable_defined?(:@num_errors) ? @num_errors : nil },
     }
 

--- a/test/plugin/test_in_monitor_agent.rb
+++ b/test/plugin/test_in_monitor_agent.rb
@@ -455,7 +455,7 @@ plugin_id:test_filter\tplugin_category:filter\ttype:test_filter\toutput_plugin:f
       d.instance.start
       expected_test_out_fail_write_response = {
           "buffer_queue_length" => 1,
-          "buffer_total_queued_size" => 0,
+          "buffer_total_queued_size" => 40,
           "output_plugin" => true,
           "plugin_category" => "output",
           "plugin_id" => "test_out_fail_write",


### PR DESCRIPTION
### Abstract

Now, in_monitor_agent's buffer_total_queued_size does't count queued chunk's sizes.
So fix for counting them.

### Problem

- Version: Fluent1.1.3

- Buffer Settings

```
<buffer topic,tag>
  @type                       file
  path                        "/var/log/td-agent/buffer/#{ENV['PROCESS_NAME']}.forward_to_kafka.*.log"
  queued_chunks_limit_size    10000
  chunk_limit_size            32m
  total_limit_size            2400m
  flush_mode                  interval
  flush_interval              1.0
  flush_thread_burst_interval 0.1
  flush_thread_count          5
  retry_forever               true
  retry_max_interval          30s
  overflow_action             drop_oldest_chunk
</buffer>
```

- When that buffer plugin occured `dropping oldest chunk to make space after buffer overflow`, in_monitor agent returned below results.

```
plugin_category:output	type:kafka2	output_plugin:true	buffer_queue_length:10002	buffer_total_queued_size:39154788	retry_count:395
```

Queued total buffer size was about 2400mb, but in_monitor_agent's output was under 40mb, they were significantly different.

### Reason

in_monitor_agent counts only stage_size, does't count queue_size.

https://github.com/fluent/fluentd/blob/v1.1.3/lib/fluent/plugin/in_monitor_agent.rb#L282

### Fix detail

Fix in_monitor_agent's buffer_total_queued_size for counting queued chunk's sizes.

Fixed environment, in_monitor_agent's output was below, about 2400mb.

```
plugin_category:output	type:kafka2	output_plugin:true	buffer_queue_length:10002	buffer_total_queued_size:2513712017	retry_count:12
```