### PR TITLE
Dump config_argument by dump_config_definition

### DIFF
--- a/lib/fluent/config/configure_proxy.rb
+++ b/lib/fluent/config/configure_proxy.rb
@@ -370,6 +370,12 @@ module Fluent
 
       def dump_config_definition
         dumped_config = {}
+        if @argument
+          argument_name, _block, options = @argument
+          options[:required] = !@defaults.key?(argument_name)
+          options[:argument] = true
+          dumped_config[argument_name] = options
+        end
         @params.each do |name, config|
           dumped_config[name] = config[1]
           dumped_config[name][:required] = !@defaults.key?(name)
@@ -378,7 +384,7 @@ module Fluent
         end
         # Overwrite by config_set_default
         @defaults.each do |name, value|
-          if @params.key?(name)
+          if @params.key?(name) || @argument.first == name
             dumped_config[name][:default] = value
           else
             dumped_config[name] = { default: value }

--- a/test/command/test_plugin_config_formatter.rb
+++ b/test/command/test_plugin_config_formatter.rb
@@ -132,6 +132,7 @@ helpers: inject,compat_parameters
 time_as_integer: bool: (false)
 slow_flush_log_threshold: float: (20.0)
 <buffer>: optional, single
+ chunk_keys: array: ([])
  @type: string: ("memory")
  timekey: time: (nil)
  timekey_wait: time: (600)
@@ -154,7 +155,6 @@ slow_flush_log_threshold: float: (20.0)
  retry_exponential_backoff_base: float: (2)
  retry_max_interval: time: (nil)
  retry_randomize: bool: (true)
- chunk_keys: : ([])
 <secondary>: optional, single
  @type: string: (nil)
  <buffer>: optional, single

--- a/test/config/test_configure_proxy.rb
+++ b/test/config/test_configure_proxy.rb
@@ -435,6 +435,43 @@ module Fluent::Config
           assert_equal(expected, @proxy.dump_config_definition)
         end
 
+        test 'plain proxy w/ argument' do
+          @proxy.instance_eval do
+            config_argument(:argname, :string)
+            config_param(:name, :string, default: "name1")
+          end
+          expected = {
+            argname: { type: :string, required: true, argument: true },
+            name: { type: :string, default: "name1", required: false }
+          }
+          assert_equal(expected, @proxy.dump_config_definition)
+        end
+
+        test 'plain proxy w/ argument default value' do
+          @proxy.instance_eval do
+            config_argument(:argname, :string, default: "value")
+            config_param(:name, :string, default: "name1")
+          end
+          expected = {
+            argname: { type: :string, default: "value", required: false, argument: true },
+            name: { type: :string, default: "name1", required: false }
+          }
+          assert_equal(expected, @proxy.dump_config_definition)
+        end
+
+        test 'plain proxy w/ argument overwriting default value' do
+          @proxy.instance_eval do
+            config_argument(:argname, :string)
+            config_param(:name, :string, default: "name1")
+            config_set_default(:argname, "value1")
+          end
+          expected = {
+            argname: { type: :string, default: "value1", required: false, argument: true },
+            name: { type: :string, default: "name1", required: false }
+          }
+          assert_equal(expected, @proxy.dump_config_definition)
+        end
+
         test 'single sub proxy' do
           @proxy.config_section(:sub) do
             config_param(:name, :string, default: "name1")


### PR DESCRIPTION
In previous version, fluent-plugin-config-format command does not dump
information defined by config_argument. We cannot reconstruct a plugin
config definition from dumped config.