### PR TITLE
filter_parser: Add remove_key_name_field parameter

### DIFF
--- a/lib/fluent/plugin/filter_parser.rb
+++ b/lib/fluent/plugin/filter_parser.rb
@@ -32,6 +32,8 @@ module Fluent::Plugin
     config_param :reserve_data, :bool, default: false
     desc 'Keep original event time in parsed result.'
     config_param :reserve_time, :bool, default: false
+    desc 'Remove "key_name" field from the record when parsing is succeeded'
+    config_param :remove_key_name_field, :bool, default: false
     desc 'Store parsed values with specified key name prefix.'
     config_param :inject_key_prefix, :string, default: nil
     desc 'If true, invalid string is replaced with safe characters and re-parse it.'
@@ -75,6 +77,7 @@ module Fluent::Plugin
                 else
                   t.nil? ? time : t
                 end
+            @accessor.delete(record) if @remove_key_name_field
             r = handle_parsed(tag, record, t, values)
             return t, r
           else

--- a/test/plugin/test_filter_parser.rb
+++ b/test/plugin/test_filter_parser.rb
@@ -209,10 +209,13 @@ class ParserFilterTest < Test::Unit::TestCase
 
   end
 
-  def test_filter_with_reserved_data
+  data(:keep_key_name => false,
+       :remove_key_name => true)
+  def test_filter_with_reserved_data(remove_key_name)
     d1 = create_driver(%[
       key_name data
       reserve_data yes
+      remove_key_name_field #{remove_key_name}
       <parse>
         @type regexp
         expression /^(?<x>\\d)(?<y>\\d) (?<t>.+)$/
@@ -230,6 +233,7 @@ class ParserFilterTest < Test::Unit::TestCase
     d2 = create_driver(%[
       key_name data
       reserve_data yes
+      remove_key_name_field #{remove_key_name}
       <parse>
         @type json
       </parse>
@@ -244,7 +248,11 @@ class ParserFilterTest < Test::Unit::TestCase
 
     first = filtered[0]
     assert_equal_event_time time, first[0]
-    assert_equal '{"xxx":"first","yyy":"second"}', first[1]['data']
+    if remove_key_name
+      assert_not_include first[1], 'data'
+    else
+      assert_equal '{"xxx":"first","yyy":"second"}', first[1]['data']
+    end
     assert_equal 'first', first[1]['xxx']
     assert_equal 'second', first[1]['yyy']
 


### PR DESCRIPTION
With reserve_data, key_name field is kept by default. But sometimes
users don't need key_name field when parsing is succeeded, e.g. docker log.
So removing key_name feature is useful for simple configuration.

Currently, we need more filter is needed to remove target field.

Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>