### PR TITLE
in_http: Honor `keep_time_key` parameter in batch mode.

### DIFF
--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -202,11 +202,17 @@ module Fluent::Plugin
             if @add_remote_addr
               single_record['REMOTE_ADDR'] = params['REMOTE_ADDR']
             end
-            single_time = if t = single_record.delete('time')
-                            Fluent::EventTime.from_time(Time.at(t))
-                          else
-                            time
-                          end
+
+            if single_record.has_key?('time')
+                single_time = Fluent::EventTime.from_time(Time.at(single_record['time']))
+            else
+                single_time = time
+            end
+
+            unless @parser and @parser.keep_time_key
+                single_record.delete('time')
+            end
+
             mes.add(single_time, single_record)
           end
           router.emit_stream(tag, mes)

--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -205,12 +205,12 @@ module Fluent::Plugin
 
             if single_record.has_key?('time')
                 single_time = Fluent::EventTime.from_time(Time.at(single_record['time']))
+
+                unless @parser and @parser.keep_time_key
+                    single_record.delete('time')
+                end
             else
                 single_time = time
-            end
-
-            unless @parser and @parser.keep_time_key
-                single_record.delete('time')
             end
 
             mes.add(single_time, single_record)


### PR DESCRIPTION
This patch fixes the issue reported by Eugen Cristea at fluent/fluentd-docs#507.
### Problem

`in_http` plugin supports "batch" mode for sending multiple events in a single HTTP request.
The problem is that in_http does not honor the `keep_time_key` option when processing
those bulk-insertion requests.

This means that "time" key in each record gets discarded unconditionally in batch mode.
For example, the following request:

    $ curl -d '[{"time":1514736000,"key":"foo"}]' http://localhost/

will produces a log record:

    2018-01-01 01:00:00.000000000 +0900 : {"key":"foo"}

... even if the `keep_time_key` option is enabled.

### Solution

This patch fixes this issue by teaching `in_http` to honor the option value of its parser
plugin instance.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>