### PR TITLE
Avoid NoMethodError while running Fluent::Config::ConfigureProxy#dump_config_definition

### DIFF
--- a/lib/fluent/config/configure_proxy.rb
+++ b/lib/fluent/config/configure_proxy.rb
@@ -384,7 +384,7 @@ module Fluent
         end
         # Overwrite by config_set_default
         @defaults.each do |name, value|
-          if @params.key?(name) || @argument.first == name
+          if @params.key?(name) || (@argument && @argument.first == name)
             dumped_config[name][:default] = value
           else
             dumped_config[name] = { default: value }


### PR DESCRIPTION
In previous version, fluent-plugin-config-format could not dump
configuration for some plugins.

See also, https://gist.github.com/okkez/1ac4b1f322275e72982803856f4737a7