### PR TITLE
Fix Parser plugin template for fluent-plugin-generate

### DIFF
--- a/templates/new_gem/lib/fluent/plugin/parser.rb.erb
+++ b/templates/new_gem/lib/fluent/plugin/parser.rb.erb
@@ -6,10 +6,10 @@ module Fluent
   module Plugin
     class <%= class_name %> < Fluent::Plugin::Parser
       Fluent::Plugin.register_parser("<%= plugin_name %>", self)
-    end
 
-    def parse(text)
-      yield time, record
+      def parse(text)
+        yield time, record
+      end
     end
   end
 end


### PR DESCRIPTION
In Parser plugin template for fluent-plugin-generate, parse method definition is in `Fluent::Plugin` module.
I think it should be in `Fluent::Plugin::<class_name>` class.
