### PR TITLE
test/counter: Fix test failures on AppVeyor due to rounding errors.

### DIFF
--- a/test/counter/test_client.rb
+++ b/test/counter/test_client.rb
@@ -64,6 +64,12 @@ class CounterClientTest < ::Test::Unit::TestCase
     store[key]
   end
 
+  def travel(sec)
+    # Since Timecop.travel() causes test failures on Windows/AppVeyor by inducing
+    # rounding errors to Time.now, we need to use Timecop.freeze() instead.
+    Timecop.freeze(Time.now + sec)
+  end
+
   sub_test_case 'establish' do
     test 'establish a scope' do
       @client.establish(@scope)
@@ -277,7 +283,7 @@ class CounterClientTest < ::Test::Unit::TestCase
       assert_equal 0, v['total']
       assert_equal 0, v['current']
 
-      Timecop.travel(1)
+      travel(1)
       inc_obj = { name: @name, value: 10 }
       @client.inc(inc_obj).get
 
@@ -444,7 +450,7 @@ class CounterClientTest < ::Test::Unit::TestCase
       assert_equal @now, Fluent::EventTime.new(*v1['last_reset_at'])
 
       travel_sec = 6            # greater than reset_interval
-      Timecop.travel(travel_sec)
+      travel(travel_sec)
 
       v2 = @client.reset(@name).get
       data = v2.data.first
@@ -472,7 +478,7 @@ class CounterClientTest < ::Test::Unit::TestCase
       assert_equal @now, Fluent::EventTime.new(*v1['last_reset_at'])
 
       travel_sec = 4            # less than reset_interval
-      Timecop.travel(travel_sec)
+      travel(travel_sec)
 
       v2 = @client.reset(@name).get
       data = v2.data.first
@@ -520,7 +526,7 @@ class CounterClientTest < ::Test::Unit::TestCase
       unknown_name = 'key2'
 
       travel_sec = 6            # greater than reset_interval
-      Timecop.travel(travel_sec)
+      travel(travel_sec)
 
       response = @client.reset(@name, unknown_name).get
       data = response.data.first


### PR DESCRIPTION
This patch fixes the test cases in `test/counter/test_client.rb` which are constantly
failing on AppVeyor right now. For examples:

- https://ci.appveyor.com/project/fluent/fluentd/build/3009/job/linub6g6b83d4t3c
- https://ci.appveyor.com/project/fluent/fluentd/build/3008/job/6ng3not4p900fxrc
- https://ci.appveyor.com/project/fluent/fluentd/build/3007/job/gyxnqulia1eknc6q

### Problem

Evidently, Timecop.travel induces flogting-point errors to Time.now on
Windows environment:

```ruby
>>> Time.freeze(Time.parse('2016-09-22 16:59:59 +0900'))
>>> Timecop.travel(6)
>>> printf("#{Time.now.to_i}.#{Time.now.nsec}\n")
1474531204.999999999
```
... and this seems to be the cause of these test failures.

### Solution

This patch fixes the issue by introducing a helper method `travel()` that
allows to travel back/forward without such errors.