### PR TITLE
test_out_file.rb: Fix test failures due to Zlib::DataError.

### DIFF
--- a/test/plugin/test_out_file.rb
+++ b/test/plugin/test_out_file.rb
@@ -304,7 +304,11 @@ class FileOutputTest < Test::Unit::TestCase
       assert_equal r4, d.formatted[3]
       assert_equal r5, d.formatted[4]
 
-      read_gunzip = ->(path){ File.open(path){|fio| Zlib::GzipReader.open(fio){|io| io.read } } }
+      read_gunzip = ->(path){
+        File.open(path){ |fio|
+          Zlib::GzipReader.new(StringIO.new(fio.read)).read
+        }
+      }
       assert_equal r1 + r2, read_gunzip.call("#{TMP_DIR}/my.data/a/full.20161003.2345.log.gz")
       assert_equal r3, read_gunzip.call("#{TMP_DIR}/your.data/a/full.20161003.2345.log.gz")
       assert_equal r4, read_gunzip.call("#{TMP_DIR}/my.data/a/full.20161004.0000.log.gz")
@@ -370,7 +374,7 @@ class FileOutputTest < Test::Unit::TestCase
     result = ''
     File.open(path, "rb") { |io|
       loop do
-        gzr = Zlib::GzipReader.new(io)
+        gzr = Zlib::GzipReader.new(StringIO.new(io.read))
         result << gzr.read
         unused = gzr.unused
         gzr.finish


### PR DESCRIPTION
AppVeyor CI tests are constantly failing due to Zlib-related exceptions
like below:

    Error: test: append(FileOutputTest): Zlib::DataError: invalid
    distance too far back

This is a very weird error, because the file seems to contain a proper
gzip-compressed data stream. In fact, by inserting the following code
before the failing line, I can confirm that the file itself is NOT
broken:

```ruby
bytes = File.open(path).read   // Read the file being tested
puts(Zlib::GzipReader.new(StringIO.new(bytes)).read)
```

The strong suspicion is that Ruby's Zlib wrapper (or its build on
AppVeyor) has a serious bug that corrupts file pointers passed to
GzipReader, thus it ends up reading garbage data.

This patch is my attempt to mitigate the issue by modifying the test
functions to pass bytes (rather than file objects) to GzipReader, and
it should protect zlib from read-time data corruptions.