### PR TITLE
test_retry_state: Fix a test failure on AppVeyor with Ruby 2.3 (x86)

### DIFF
--- a/test/plugin_helper/test_retry_state.rb
+++ b/test/plugin_helper/test_retry_state.rb
@@ -422,7 +422,7 @@ class RetryStateHelperTest < Test::Unit::TestCase
 
   sub_test_case 'exponential backoff' do
     test 'too big steps(check inf handling)' do
-      s = @d.retry_state_create(:t11, :exponential_backoff, 0.1, 300, randomize: false, forever: true, backoff_base: 2)
+      s = @d.retry_state_create(:t11, :exponential_backoff, 1, 300, randomize: false, forever: true, backoff_base: 2)
       dummy_current_time = s.start
       override_current_time(s, dummy_current_time)
 
@@ -431,7 +431,7 @@ class RetryStateHelperTest < Test::Unit::TestCase
         if i >= 1025
           # With this setting, 1025+ number causes inf in `calc_interval`, so 1024 value is used for next_time
           assert_nothing_raised(FloatDomainError) { s.step }
-          assert_equal (dummy_current_time + 0.1 * (2 ** (1024 - 1))), s.next_time
+          assert_equal (dummy_current_time + (2 ** (1024 - 1))), s.next_time
         else
           s.step
         end


### PR DESCRIPTION
This fixes 'check inf handling' test not to fail on AppVeyor CI anymore.

### Problem

Specifically, in this test script, it is assumed that `0.1 * 2 ** 10.25`
overflows the float boundary and becomes an infinite number. This is not
quite true because the result is roughly `1.79e+307` and it's actually well
below the upper boundary of double-precision floats.

Still, even though the resulting number is within the maximum limit, the
test case passes on *most* environments because an overflow *will* occur
while computing raw_interval():

```ruby
def raw_interval(num)
    @constant_factor.to_f * (@backoff_base ** (num))
end
```

Note: In the line above, `@backoff_base ** num` is roughly 1.79e+308, so it will
become an infinite number *if implicit type conversion occurs while evaluation.* In
other words, this line will be reduced to `0.1 * infinity` in such a case.

### Solution

Evidently, this behaviour is not so reliable across various environments.
Let's make the interval actually go over the boundary, instead of relying on an
unreliable behaviour.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>