### PR TITLE
ssl on fluentd.org does not appear to work

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["frsyuki@gmail.com"]
   gem.description   = %q{Fluentd is an open source data collector designed to scale and simplify log management. It can collect, process and ship many kinds of data in near real-time.}
   gem.summary       = %q{Fluentd event collector}
-  gem.homepage      = "https://fluentd.org/"
+  gem.homepage      = "https://www.fluentd.org/"
 
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
The link in rubygems doesn't seem to work for me because `fluentd.org` isn't listening to the https port.  `fluentd.org:80` does forward on to `https://www.fluentd.org`, but that isn't what is in the gemspec file.  Could change it to use http in the gemspec file maybe but better to just https everything I think.