### PR TITLE
Fix log when main process is finished

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -349,13 +349,14 @@ module Fluent
 
       Process.waitpid(@main_pid)
       @main_pid = nil
-      ecode = $?.to_i
+      exitstatus = $?.exitstatus
+      signal = $?.termsig
 
-      $log.info "process finished", code: ecode
+      $log.info "process finished", status: exitstatus, signal: signal
 
       if !@finished && Time.now - start_time < 1
         $log.warn "process died within 1 second. exit."
-        exit ecode
+        exit exitstatus || 1
       end
     end
 


### PR DESCRIPTION
When the main process ends, the supervisor outputs an info log containing its exit status.
However, It seems confusing when the exit status of the main process is not 0.

E.g. (In my environemnt)
```
# finished with exit status 1
2018-07-04 09:45:38 +0900 [info]: process finished code=256

# finished by signal 9
2018-07-04 09:44:26 +0900 [info]: process finished code=9
```

It seems to be caused by using `$?.to_i`.
Therefore, I tried to output the exit status and signal separately by using `$?.exitstatus` and` $?.termsig`.

E.g.
```
# finished with exit status 1
2018-07-04 09:47:30 +0900 [info]: process finished status=1 signal=nil

# finished by signal 9
2018-07-04 09:49:11 +0900 [info]: process finished status=nil signal=9
```

I hope this help. (Is this the format of the log message OK?)