### PR TITLE
Consider timezone when calculate timekey

### DIFF
--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -829,7 +829,7 @@ module Fluent
         if @timekey_use_utc
           (time_int - (time_int % @timekey)).to_i
         else
-          offset = Time.at(time_int).utc_offset
+          offset = Fluent::Timezone.utc_offset(time, @timekey_zone)
           (time_int - ((time_int + offset)% @timekey)).to_i
         end
       end

--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -304,6 +304,8 @@ module Fluent
             raise Fluent::ConfigError, "<buffer ...> argument includes 'time', but timekey is not configured" unless @buffer_config.timekey
             Fluent::Timezone.validate!(@buffer_config.timekey_zone)
             @timekey_zone = @buffer_config.timekey_use_utc ? '+0000' : @buffer_config.timekey_zone
+            @timekey = @buffer_config.timekey
+            @timekey_use_utc = @buffer_config.timekey_use_utc
             @output_time_formatter_cache = {}
           end
 
@@ -824,11 +826,11 @@ module Fluent
 
       def calculate_timekey(time)
         time_int = time.to_i
-        if @buffer_config.timekey_use_utc
-          (time_int - (time_int % @buffer_config.timekey)).to_i
+        if @timekey_use_utc
+          (time_int - (time_int % @timekey)).to_i
         else
           offset = Time.at(time_int).utc_offset
-          (time_int - ((time_int + offset)% @buffer_config.timekey)).to_i
+          (time_int - ((time_int + offset)% @timekey)).to_i
         end
       end
 

--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -306,6 +306,8 @@ module Fluent
             @timekey_zone = @buffer_config.timekey_use_utc ? '+0000' : @buffer_config.timekey_zone
             @timekey = @buffer_config.timekey
             @timekey_use_utc = @buffer_config.timekey_use_utc
+            @offset = Fluent::Timezone.utc_offset(@timekey_zone)
+            @calculate_offset = @offset.respond_to?(:call) ? @offset : nil
             @output_time_formatter_cache = {}
           end
 
@@ -829,7 +831,7 @@ module Fluent
         if @timekey_use_utc
           (time_int - (time_int % @timekey)).to_i
         else
-          offset = Fluent::Timezone.utc_offset(time, @timekey_zone)
+          offset = @calculate_offset ? @calculate_offset.call(time) : @offset
           (time_int - ((time_int + offset)% @timekey)).to_i
         end
       end

--- a/lib/fluent/timezone.rb
+++ b/lib/fluent/timezone.rb
@@ -140,7 +140,7 @@ module Fluent
       return nil
     end
 
-    def self.utc_offset(time, timezone)
+    def self.utc_offset(timezone)
       return 0 if timezone.nil?
 
       case timezone
@@ -148,7 +148,9 @@ module Fluent
         Time.zone_offset(timezone)
       when NAME_PATTERN
         tz = TZInfo::Timezone.get(timezone)
-        tz.period_for_utc(time).utc_total_offset
+        ->(time) {
+          tz.period_for_utc(time).utc_total_offset
+        }
       end
     end
   end

--- a/lib/fluent/timezone.rb
+++ b/lib/fluent/timezone.rb
@@ -139,5 +139,17 @@ module Fluent
 
       return nil
     end
+
+    def self.utc_offset(time, timezone)
+      return 0 if timezone.nil?
+
+      case timezone
+      when NUMERIC_PATTERN
+        Time.zone_offset(timezone)
+      when NAME_PATTERN
+        tz = TZInfo::Timezone.get(timezone)
+        tz.period_for_utc(time).utc_total_offset
+      end
+    end
   end
 end

--- a/test/plugin/test_out_file.rb
+++ b/test/plugin/test_out_file.rb
@@ -558,7 +558,7 @@ class FileOutputTest < Test::Unit::TestCase
   end
 
   test 'append when JST' do
-    with_timezone("Asia/Tokyo") do
+    with_timezone(Fluent.windows? ? "JST-9" : "Asia/Tokyo") do
       time = event_time("2011-01-02 03:14:15+09:00")
       formatted_lines = %[2011-01-02T03:14:15+09:00\ttest\t{"a":1}\n] + %[2011-01-02T03:14:15+09:00\ttest\t{"a":2}\n]
 

--- a/test/plugin/test_out_file.rb
+++ b/test/plugin/test_out_file.rb
@@ -558,7 +558,7 @@ class FileOutputTest < Test::Unit::TestCase
   end
 
   test 'append when JST' do
-    with_timezone("JST") do
+    with_timezone("Asia/Tokyo") do
       time = event_time("2011-01-02 03:14:15+09:00")
       formatted_lines = %[2011-01-02T03:14:15+09:00\ttest\t{"a":1}\n] + %[2011-01-02T03:14:15+09:00\ttest\t{"a":2}\n]
 
@@ -569,6 +569,7 @@ class FileOutputTest < Test::Unit::TestCase
           append true
           <buffer>
             timekey_use_utc false
+            timekey_zone Asia/Tokyo
           </buffer>
         ]
         d.run(default_tag: 'test'){

--- a/test/plugin/test_out_file.rb
+++ b/test/plugin/test_out_file.rb
@@ -558,36 +558,38 @@ class FileOutputTest < Test::Unit::TestCase
   end
 
   test 'append when JST' do
-    time = event_time("2011-01-02 03:14:15+09:00")
-    formatted_lines = %[2011-01-02T03:14:15+09:00\ttest\t{"a":1}\n] + %[2011-01-02T03:14:15+09:00\ttest\t{"a":2}\n]
+    with_timezone("JST") do
+      time = event_time("2011-01-02 03:14:15+09:00")
+      formatted_lines = %[2011-01-02T03:14:15+09:00\ttest\t{"a":1}\n] + %[2011-01-02T03:14:15+09:00\ttest\t{"a":2}\n]
 
-    write_once = ->(){
-      d = create_driver %[
-        path #{TMP_DIR}/out_file_test
-        compress gz
-        append true
-        <buffer>
-          timekey_use_utc false
-        </buffer>
-      ]
-      d.run(default_tag: 'test'){
-        d.feed(time, {"a"=>1})
-        d.feed(time, {"a"=>2})
+      write_once = ->(){
+        d = create_driver %[
+          path #{TMP_DIR}/out_file_test
+          compress gz
+          append true
+          <buffer>
+            timekey_use_utc false
+          </buffer>
+        ]
+        d.run(default_tag: 'test'){
+          d.feed(time, {"a"=>1})
+          d.feed(time, {"a"=>2})
+        }
+        d.instance.last_written_path
       }
-      d.instance.last_written_path
-    }
 
-    path = write_once.call
-    assert_equal "#{TMP_DIR}/out_file_test.20110102.log.gz", path
-    check_gzipped_result(path, formatted_lines)
+      path = write_once.call
+      assert_equal "#{TMP_DIR}/out_file_test.20110102.log.gz", path
+      check_gzipped_result(path, formatted_lines)
 
-    path = write_once.call
-    assert_equal "#{TMP_DIR}/out_file_test.20110102.log.gz", path
-    check_gzipped_result(path, formatted_lines * 2)
+      path = write_once.call
+      assert_equal "#{TMP_DIR}/out_file_test.20110102.log.gz", path
+      check_gzipped_result(path, formatted_lines * 2)
 
-    path = write_once.call
-    assert_equal "#{TMP_DIR}/out_file_test.20110102.log.gz", path
-    check_gzipped_result(path, formatted_lines * 3)
+      path = write_once.call
+      assert_equal "#{TMP_DIR}/out_file_test.20110102.log.gz", path
+      check_gzipped_result(path, formatted_lines * 3)
+    end
   end
 
   test '${chunk_id}' do

--- a/test/plugin/test_out_file.rb
+++ b/test/plugin/test_out_file.rb
@@ -593,6 +593,43 @@ class FileOutputTest < Test::Unit::TestCase
     end
   end
 
+  test 'append when UTC-02 but timekey_zone is +0900' do
+    with_timezone("UTC-02") do # +0200
+      time = event_time("2011-01-02 17:14:15+02:00")
+      formatted_lines = %[2011-01-02T17:14:15+02:00\ttest\t{"a":1}\n] + %[2011-01-02T17:14:15+02:00\ttest\t{"a":2}\n]
+
+      write_once = ->(){
+        d = create_driver %[
+          path #{TMP_DIR}/out_file_test
+          compress gz
+          append true
+          <buffer>
+            timekey_use_utc false
+            timekey_zone +0900
+          </buffer>
+        ]
+        d.run(default_tag: 'test'){
+          d.feed(time, {"a"=>1})
+          d.feed(time, {"a"=>2})
+        }
+        d.instance.last_written_path
+      }
+
+      path = write_once.call
+      # Rotated at 2011-01-02 17:00:00+02:00
+      assert_equal "#{TMP_DIR}/out_file_test.20110103.log.gz", path
+      check_gzipped_result(path, formatted_lines)
+
+      path = write_once.call
+      assert_equal "#{TMP_DIR}/out_file_test.20110103.log.gz", path
+      check_gzipped_result(path, formatted_lines * 2)
+
+      path = write_once.call
+      assert_equal "#{TMP_DIR}/out_file_test.20110103.log.gz", path
+      check_gzipped_result(path, formatted_lines * 3)
+    end
+  end
+
   test '${chunk_id}' do
     time = event_time("2011-01-02 13:14:15 UTC")
     formatted_lines = %[2011-01-02T13:14:15Z\ttest\t{"a":1}\n] + %[2011-01-02T13:14:15Z\ttest\t{"a":2}\n]

--- a/test/plugin/test_out_file.rb
+++ b/test/plugin/test_out_file.rb
@@ -557,6 +557,39 @@ class FileOutputTest < Test::Unit::TestCase
     check_gzipped_result(path, formatted_lines * 3)
   end
 
+  test 'append when JST' do
+    time = event_time("2011-01-02 03:14:15+09:00")
+    formatted_lines = %[2011-01-02T03:14:15+09:00\ttest\t{"a":1}\n] + %[2011-01-02T03:14:15+09:00\ttest\t{"a":2}\n]
+
+    write_once = ->(){
+      d = create_driver %[
+        path #{TMP_DIR}/out_file_test
+        compress gz
+        append true
+        <buffer>
+          timekey_use_utc false
+        </buffer>
+      ]
+      d.run(default_tag: 'test'){
+        d.feed(time, {"a"=>1})
+        d.feed(time, {"a"=>2})
+      }
+      d.instance.last_written_path
+    }
+
+    path = write_once.call
+    assert_equal "#{TMP_DIR}/out_file_test.20110102.log.gz", path
+    check_gzipped_result(path, formatted_lines)
+
+    path = write_once.call
+    assert_equal "#{TMP_DIR}/out_file_test.20110102.log.gz", path
+    check_gzipped_result(path, formatted_lines * 2)
+
+    path = write_once.call
+    assert_equal "#{TMP_DIR}/out_file_test.20110102.log.gz", path
+    check_gzipped_result(path, formatted_lines * 3)
+  end
+
   test '${chunk_id}' do
     time = event_time("2011-01-02 13:14:15 UTC")
     formatted_lines = %[2011-01-02T13:14:15Z\ttest\t{"a":1}\n] + %[2011-01-02T13:14:15Z\ttest\t{"a":2}\n]


### PR DESCRIPTION
Because the timestamp of the midnight cannot be divisible by 86400 in
localtime (JST). The timestamp of the midnight is divisible by 86400
only in UTC. Therefore we must consider offset from UTC in localtime.

For example, at `2018-07-04 01:23:23 +0900`:

If timekey is 86400 and path template is `/log/%Y%m%d.log`.
In previous version, extract path template to `/log/20180703.log`.
In this version, extract path template to `/log/20180704.log`.

Fix #1986