### PR TITLE
in_http: Fix "ignored parser options" problem on bulk insertion

### DIFF
--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -209,13 +209,15 @@ module Fluent::Plugin
               single_record['REMOTE_ADDR'] = params['REMOTE_ADDR']
             end
 
-            if single_record.has_key?(@parser_time_key)
-              single_time = Fluent::EventTime.from_time(Time.at(single_record[@parser_time_key]))
-              unless @parser and @parser.keep_time_key
-                single_record.delete(@parser_time_key)
-              end
+            if defined? @parser
+              single_time = @parser.parse_time(single_record)
+              single_time, single_record = @parser.convert_values(single_time, single_record)
             else
-              single_time = time
+              single_time = if t = single_record.delete(@parser_time_key)
+                              Fluent::EventTime.from_time(Time.at(t))
+                            else
+                              time
+                            end
             end
 
             mes.add(single_time, single_record)

--- a/test/plugin/test_in_http.rb
+++ b/test/plugin/test_in_http.rb
@@ -370,16 +370,20 @@ class HttpInputTest < Test::Unit::TestCase
     assert include_http_header?(d.events[1][2])
   end
 
-  def test_multi_json_with_keep_time_key
+  def test_multi_json_with_custom_parser
     d = create_driver(CONFIG + %[
         <parse>
           @type json
           keep_time_key true
+          time_key foo
+          time_format %iso8601
         </parse>
     ])
-    time1 = event_time("2011-01-02 13:14:15 UTC")
-    time2 = event_time("2012-01-02 13:14:15 UTC")
-    records = [{"time"=>time1.to_i},{"time"=>time2.to_i}]
+
+    time = event_time("2011-01-02 13:14:15 UTC")
+    time_s = Time.at(time).iso8601
+
+    records = [{"foo"=>time_s,"bar"=>"test1"},{"foo"=>time_s,"bar"=>"test2"}]
     tag = "tag1"
     res_codes = []
 
@@ -390,11 +394,11 @@ class HttpInputTest < Test::Unit::TestCase
     assert_equal ["200"], res_codes
 
     assert_equal "tag1", d.events[0][0]
-    assert_equal_event_time time1, d.events[0][1]
+    assert_equal_event_time time, d.events[0][1]
     assert_equal d.events[0][2], records[0]
 
     assert_equal "tag1", d.events[1][0]
-    assert_equal_event_time time2, d.events[1][1]
+    assert_equal_event_time time, d.events[1][1]
     assert_equal d.events[1][2], records[1]
   end
 


### PR DESCRIPTION
This patch fixes the bug reported by #2035 (and other related issues as well).

### Problem

What used to happen is that options in the `<parser>` section get ignored
when we send events as a JSON array. This occurs because parser plugins
are designed to handle a single hash value and do not generallly handle
an array input well.

Until now, we have tried to solve this issue by emulating the semantics
of parser plugins in Fluent::Plugin::HttpInput (see 1afbfb1, 39f3a0d
and f560017c). However, this approach turned out to be error prone and
rather tedious.

### More Generalized solution

This patch takes a different path:

 - Whenever `@parser` is available, reuse `@parser.convert_values()` by
   manually applying it to each record in an input array.
 - Otherwise, fall back to the current logic.

The good part of this approach is that we do not need to duplicate the same
code in `in_http` and `parser_json` anymore, and it fixes this class of related
issues.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>
