### PR TITLE
Fix bug in suppress_emit_error_log_interval

### DIFF
--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -318,7 +318,7 @@ module Fluent
         log.warn "send an error event stream to @ERROR:", error_info
         @error_collector.emit_stream(tag, es)
       else
-        now = Time.now
+        now = Time.now.to_i
         if @suppress_emit_error_log_interval.zero? || now > @next_emit_error_log_time
           log.warn "emit transaction failed:", error_info
           log.warn_backtrace
@@ -347,7 +347,7 @@ module Fluent
       end
 
       def handle_emits_error(tag, es, e)
-        now = EventTime.now
+        now = EventTime.now.to_i
         if @suppress_emit_error_log_interval.zero? || now > @next_emit_error_log_time
           log.warn "emit transaction failed in @ERROR:", error: e, tag: tag
           log.warn_backtrace


### PR DESCRIPTION
## Issue

When setting `--emit-error-log-interval` command line parameter, fluent instead prints the following error which masks other errors:

```
fluentd_1       | 2018-07-12 23:18:26 +0000 [error]: #0 failed to emit fluentd's log event tag="fluent.error" event={"host"=>"172.20.0.1", "port"=>42300, "error"=>"#<ArgumentError: comparison of Time with 1531437277 failed>", "message"=>"unexpected error on reading data host=\"172.20.0.1\" port=42300 error_class=ArgumentError error=\"comparison of Time with 1531437277 failed\"", "time"=>"2018-07-12T23:18:26Z"} error_class=ArgumentError error="comparison of Time with 1531437277 failed"
```

## Fix

Ensure time is in epoch format before comparison
Add tests