### PR TITLE
Fix the several typos detected by github.com/client9/misspell

### DIFF
--- a/lib/fluent/agent.rb
+++ b/lib/fluent/agent.rb
@@ -41,7 +41,7 @@ module Fluent
       # from plugins which DOES emit, then DOESN'T emit
       # (input -> output w/ router -> filter -> output w/o router)
       # for start: use this order DESC
-      #   (because plugins which appears later in configurations will receive events from plugins which appears ealier)
+      #   (because plugins which appears later in configurations will receive events from plugins which appears earlier)
       # for stop/before_shutdown/shutdown/after_shutdown/close/terminate: use this order ASC
       @lifecycle_cache = nil
 

--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -177,7 +177,7 @@ if Fluent.windows?
     opts[:regwinsvcautostart] = s
   }
 
-  op.on('--reg-winsvc-fluentdopt OPTION', "specify fluentd option paramters for Windows Service. (Windows only)") {|s|
+  op.on('--reg-winsvc-fluentdopt OPTION', "specify fluentd option parameters for Windows Service. (Windows only)") {|s|
     opts[:fluentdopt] = s
   }
   

--- a/lib/fluent/config/literal_parser.rb
+++ b/lib/fluent/config/literal_parser.rb
@@ -198,7 +198,7 @@ EOM
 
       def scan_json(is_array)
         result = nil
-        # Yajl does not raise ParseError for imcomplete json string, like '[1', '{"h"', '{"h":' or '{"h1":1'
+        # Yajl does not raise ParseError for incomplete json string, like '[1', '{"h"', '{"h":' or '{"h1":1'
         # This is the reason to use JSON module.
 
         buffer = (is_array ? "[" : "{")

--- a/lib/fluent/event_router.rb
+++ b/lib/fluent/event_router.rb
@@ -217,7 +217,7 @@ module Fluent
           @optimizable = if fs_filters.empty?
                            true
                          else
-                           # skip log message when filter is only 1, because its performace is same as non optimized chain.
+                           # skip log message when filter is only 1, because its performance is same as non optimized chain.
                            if @filters.size > 1 && fs_filters.size >= 1
                              $log.info "disable filter chain optimization because #{fs_filters.map(&:class)} uses `#filter_stream` method."
                            end

--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -442,7 +442,7 @@ module Fluent::Plugin
         res = unpacker.read
         log.trace "getting response from destination", host: info.node.host, port: info.node.port, chunk_id: dump_unique_id_hex(info.chunk_id), response: res
         if res['ack'] != info.chunk_id_base64
-          # Some errors may have occured when ack and chunk id is different, so send the chunk again.
+          # Some errors may have occurred when ack and chunk id is different, so send the chunk again.
           log.warn "ack in response and chunk id in sent data are different", chunk_id: dump_unique_id_hex(info.chunk_id), ack: res['ack']
           rollback_write(info.chunk_id, update_retry: false)
           return nil

--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -92,8 +92,8 @@ module Fluent
         # k: times
         # total retry time: c + c * b^1 + (...) + c*b^k = c*b^(k+1) - 1
         config_param :retry_wait, :time, default: 1, desc: 'Seconds to wait before next retry to flush, or constant factor of exponential backoff.'
-        config_param :retry_exponential_backoff_base, :float, default: 2, desc: 'The base number of exponencial backoff for retries.'
-        config_param :retry_max_interval, :time, default: nil, desc: 'The maximum interval seconds for exponencial backoff between retries while failing.'
+        config_param :retry_exponential_backoff_base, :float, default: 2, desc: 'The base number of exponential backoff for retries.'
+        config_param :retry_max_interval, :time, default: nil, desc: 'The maximum interval seconds for exponential backoff between retries while failing.'
 
         config_param :retry_randomize, :bool, default: true, desc: 'If true, output plugin will retry after randomized interval not to do burst retries.'
       end

--- a/test/config/test_config_parser.rb
+++ b/test/config/test_config_parser.rb
@@ -374,7 +374,7 @@ module Fluent::Config
         </elem2>
       ]
         write_config "#{TMP_DIR}/dir/config_test_9.conf", %[
-        k9 embeded
+        k9 embedded
         <elem3 name>
           nested nested_value
           include hoge
@@ -418,7 +418,7 @@ module Fluent::Config
         elem2 = c.elements.find { |e| e.name == 'elem2' }
         assert(elem2)
         assert_equal('name', elem2.arg)
-        assert_equal('embeded', elem2['k9'])
+        assert_equal('embedded', elem2['k9'])
         assert_not_include(elem2, 'include')
 
         elem3 = elem2.elements.find { |e| e.name == 'elem3' }

--- a/test/config/test_configurable.rb
+++ b/test/config/test_configurable.rb
@@ -1032,12 +1032,12 @@ module Fluent::Config
           detail_base = base.class.merged_configure_proxy.sections[:detail]
           detail_sub = sub.class.merged_configure_proxy.sections[:detail]
           detail_base_attributes = {
-            requried: detail_base.required,
+            required: detail_base.required,
             multi: detail_base.multi,
             alias: detail_base.alias,
           }
           detail_sub_attributes = {
-            requried: detail_sub.required,
+            required: detail_sub.required,
             multi: detail_sub.multi,
             alias: detail_sub.alias,
           }

--- a/test/config/test_dsl.rb
+++ b/test/config/test_dsl.rb
@@ -44,7 +44,7 @@ def prepare_config1
   </elem2>
 ]
   write_config "#{TMP_DIR}/dir/config_test_9.conf", %[
-  k9 embeded
+  k9 embedded
   <elem3 name>
     nested nested_value
     include hoge
@@ -262,7 +262,7 @@ module Fluent::Config
         elem2 = @root.elements.find { |e| e.name == 'elem2' }
         assert(elem2)
         assert_equal('name', elem2.arg)
-        assert_equal('embeded', elem2['k9'])
+        assert_equal('embedded', elem2['k9'])
         assert_not_include(elem2, 'include')
 
         elem3 = elem2.elements.find { |e| e.name == 'elem3' }

--- a/test/config/test_system_config.rb
+++ b/test/config/test_system_config.rb
@@ -7,7 +7,7 @@ require 'fluent/system_config'
 module Fluent::Config
   class FakeLoggerInitializer
     attr_accessor :level
-    def initalize
+    def initialize
       @level = nil
     end
   end

--- a/test/plugin/test_in_syslog.rb
+++ b/test/plugin/test_in_syslog.rb
@@ -49,7 +49,7 @@ EOS
 
     data('resolve_hostname' => 'resolve_hostname true',
          'source_hostname_key' => 'source_hostname_key source_host')
-    def test_configure_reslove_hostname(param)
+    def test_configure_resolve_hostname(param)
       d = create_driver([CONFIG, param].join("\n"))
       assert_true d.instance.resolve_hostname
     end

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -969,7 +969,7 @@ class TailInputTest < Test::Unit::TestCase
     end
 
     # For https://github.com/fluent/fluentd/issues/1455
-    # This test is fragile because test content depends on internal implementaion.
+    # This test is fragile because test content depends on internal implementation.
     # So if you modify in_tail internal, this test may break.
     def test_unwatched_files_should_be_removed
       config = config_element("", "", {
@@ -990,7 +990,7 @@ class TailInputTest < Test::Unit::TestCase
       waiting(20) { sleep 0.1 until Dir.glob("#{TMP_DIR}/*.txt").size == 0 } # Ensure file is deleted on Windows
       waiting(5) { sleep 0.1 until d.instance.instance_variable_get(:@tails).keys.size == 0 }
 
-      # Previous implementaion has an infinite watcher creation bug.
+      # Previous implementation has an infinite watcher creation bug.
       # Following code checks such unexpected bug by couting  actual object allocation.
       base_num = count_timer_object
       2.times {

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -53,7 +53,7 @@ class ConfigTest < Test::Unit::TestCase
       </elem2>
     ]
     write_config "#{TMP_DIR}/dir/config_test_9.conf", %[
-      k9 embeded
+      k9 embedded
       <elem3 name>
         nested nested_value
         include hoge
@@ -98,7 +98,7 @@ class ConfigTest < Test::Unit::TestCase
     elem2 = c.elements.find { |e| e.name == 'elem2' }
     assert_not_nil elem2
     assert_equal 'name', elem2.arg
-    assert_equal 'embeded', elem2['k9']
+    assert_equal 'embedded', elem2['k9']
     assert !elem2.has_key?('include')
 
     elem3 = elem2.elements.find { |e| e.name == 'elem3' }
@@ -145,7 +145,7 @@ class ConfigTest < Test::Unit::TestCase
     not_fetched = []; rule_conf.check_not_fetched {|key, e| not_fetched << key }
     assert_equal %w[pattern replace], not_fetched
 
-    # repeateadly accessing should not grow memory usage
+    # repeatedly accessing should not grow memory usage
     before_size = match_conf.unused.size
     10.times { match_conf['type'] }
     assert_equal before_size, match_conf.unused.size

--- a/test/test_log.rb
+++ b/test/test_log.rb
@@ -493,7 +493,7 @@ class LogTest < Test::Unit::TestCase
     end
   end
 
-  def test_log_rotates_specifed_size_with_logdevio
+  def test_log_rotates_specified_size_with_logdevio
     with_timezone('utc') do
       rotate_age = 2
       rotate_size = 100


### PR DESCRIPTION
This pull request fixes several typos detected by [misspell](https://github.com/client9/misspell).

```
$ misspell .
lib/fluent/agent.rb:44:112: "ealier" is a misspelling of "earlier"
lib/fluent/command/fluentd.rb:180:66: "paramters" is a misspelling of "parameters"
lib/fluent/config/literal_parser.rb:201:45: "imcomplete" is a misspelling of "incomplete"
lib/fluent/event_router.rb:220:81: "performace" is a misspelling of "performance"
lib/fluent/plugin/out_forward.rb:445:33: "occured" is a misspelling of "occurred"
lib/fluent/plugin/output.rb:95:100: "exponencial" is a misspelling of "exponential"
lib/fluent/plugin/output.rb:96:103: "exponencial" is a misspelling of "exponential"
test/config/test_config_parser.rb:377:11: "embeded" is a misspelling of "embedded"
test/config/test_dsl.rb:47:5: "embeded" is a misspelling of "embedded"
test/config/test_system_config.rb:10:8: "initalize" is a misspelling of "initialize"
test/config/test_configurable.rb:1035:12: "requried" is a misspelling of "required"
test/config/test_configurable.rb:1040:12: "requried" is a misspelling of "required"
test/plugin/test_in_syslog.rb:52:23: "reslove" is a misspelling of "resolve"
test/plugin/test_in_tail.rb:972:68: "implementaion" is a misspelling of "implementation"
test/plugin/test_in_tail.rb:993:17: "implementaion" is a misspelling of "implementation"
test/test_config.rb:56:9: "embeded" is a misspelling of "embedded"
test/test_config.rb:148:6: "repeateadly" is a misspelling of "repeatedly"
test/test_log.rb:496:23: "specifed" is a misspelling of "specified"
```