### PR TITLE
in_http: Allow specifying the wildcard '*' as the CORS domain 

### DIFF
--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -375,7 +375,7 @@ module Fluent::Plugin
         # For every incoming request, we check if we have some CORS
         # restrictions and white listed origins through @cors_allow_origins.
         unless @cors_allow_origins.nil?
-          unless @cors_allow_origins.include?(@origin)
+          unless @cors_allow_origins.include?('*') or @cors_allow_origins.include?(@origin)
             send_response_and_close("403 Forbidden", {'Connection' => 'close'}, "")
             return
           end
@@ -422,7 +422,14 @@ module Fluent::Plugin
         code, header, body = *@callback.call(path_info, params)
         body = body.to_s
 
-        header['Access-Control-Allow-Origin'] = @origin if !@cors_allow_origins.nil? && @cors_allow_origins.include?(@origin)
+        unless @cors_allow_origins.nil?
+          if @cors_allow_origins.include?('*')
+            header['Access-Control-Allow-Origin'] = '*'
+          elsif @cors_allow_origins.include?(@origin)
+            header['Access-Control-Allow-Origin'] = @origin
+          end
+        end
+
         if @keep_alive
           header['Connection'] = 'Keep-Alive'
           send_response(code, header, body)

--- a/test/plugin/test_in_http.rb
+++ b/test/plugin/test_in_http.rb
@@ -604,6 +604,26 @@ class HttpInputTest < Test::Unit::TestCase
     assert_equal_event_time time, d.events[1][1]
   end
 
+  def test_cors_allowed_wildcard
+    d = create_driver(CONFIG + 'cors_allow_origins ["*"]')
+
+    time = event_time("2011-01-02 13:14:15 UTC")
+    events = [
+      ["tag1", time, {"a"=>1}],
+    ]
+
+    d.run do
+      events.each do |tag, time, record|
+        headers = {"Origin" => "http://foo.com"}
+
+        res = post("/#{tag}", {"json" => record.to_json, "time" => time.to_i}, headers)
+
+        assert_equal "200", res.code
+        assert_equal "*", res["Access-Control-Allow-Origin"]
+      end
+    end
+  end
+
   def test_content_encoding_gzip
     d = create_driver
 


### PR DESCRIPTION
This allows users to set up the configuration like below:

    <match debug.**>
      @type http
      cors_allow_origins ["*"]
    </match>

In this case, any origin can make a request to Fluentd; Plugin users
do not need to enumerate all the possible origins explicitly, so it
should be useful for, say, collecting data from a group of websites.

See [MCD "Access-Control-Allow-Origin" header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin)

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>