### PR TITLE
Handle LoadError properly

### DIFF
--- a/lib/fluent/plugin/parser_json.rb
+++ b/lib/fluent/plugin/parser_json.rb
@@ -52,9 +52,15 @@ module Fluent
         else
           raise "BUG: unknown json parser specified: #{name}"
         end
-      rescue LoadError
+      rescue LoadError => ex
         name = :yajl
-        log.info "Oj is not installed, and failing back to Yajl for json parser" if log
+        if log
+          if /\boj\z/ =~ ex.message
+            log.info "Oj is not installed, and failing back to Yajl for json parser"
+          else
+            log.warn ex.message
+          end
+        end
         retry
       end
 


### PR DESCRIPTION
Sometimes LoadError is raised while loading oj gem, even if oj gem is
installed. Therefore we want to see the correct message of LoadError.

For example, Alpine Linux provides the package ruby which does not
include bigdecimal and provides ruby-bigdecimal.

See #2136

Signed-off-by: Kenji Okimoto <okimoto@clear-code.com>