### PR TITLE
Fix deadlock between on_writable and close

### DIFF
--- a/lib/fluent/plugin/in_forward.rb
+++ b/lib/fluent/plugin/in_forward.rb
@@ -199,7 +199,7 @@ module Fluent::Plugin
         when :pingpong
           success, reason_or_salt, shared_key = check_ping(msg, conn.remote_addr, user_auth_salt, nonce)
           unless success
-            conn.on(:write_complete) { |c| c.close }
+            conn.on(:write_complete) { |c| c.close_after_write_complete }
             send_data.call(serializer, generate_pong(false, reason_or_salt, nonce, shared_key))
             next
           end

--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -828,7 +828,7 @@ module Fluent::Plugin
         when :pingpong
           succeeded, reason = check_pong(ri, data)
           unless succeeded
-            @log.warn "connection refused to #{@name}: #{reason}"
+            @log.warn "connection refused to #{@name || @host}: #{reason}"
             disable! # shutdown
             return
           end


### PR DESCRIPTION
TLSServer acquires lock in `on_writable` and `on_write_complete` callback is called inside its lock via cool.io.
To avoid this problem, callback order is moved to after cool.io's `on_writable`.

This patch includes out_forward tiny change to show the destination.