### PR TITLE
Check right slash position

### DIFF
--- a/lib/fluent/config/types.rb
+++ b/lib/fluent/config/types.rb
@@ -74,6 +74,9 @@ module Fluent
       return nil unless str
       return Regexp.compile(str) unless str.start_with?("/")
       right_slash_position = str.rindex("/")
+      if right_slash_position < str.size - 3
+        raise ConfigError, "invalid regexp: missing right slash: #{str}"
+      end
       options = str[(right_slash_position + 1)..-1]
       option = 0
       option |= Regexp::IGNORECASE if options.include?("i")

--- a/lib/fluent/config/types.rb
+++ b/lib/fluent/config/types.rb
@@ -75,7 +75,7 @@ module Fluent
       return Regexp.compile(str) unless str.start_with?("/")
       right_slash_position = str.rindex("/")
       if right_slash_position < str.size - 3
-        raise ConfigError, "invalid regexp: missing right slash: #{str}"
+        raise Fluent::ConfigError, "invalid regexp: missing right slash: #{str}"
       end
       options = str[(right_slash_position + 1)..-1]
       option = 0

--- a/test/config/test_types.rb
+++ b/test/config/test_types.rb
@@ -79,6 +79,14 @@ class TestConfigTypes < ::Test::Unit::TestCase
     test 'w/o slashes' do |(expected, str)|
       assert_equal(expected, Config.regexp_value(str))
     end
+
+    data("missing right slash" => "/regexp",
+         "too many options" => "/regexp/imx",)
+    test 'invalid regexp' do |(str)|
+      assert_raise(Fluent::ConfigError.new("invalid regexp: missing right slash: #{str}")) do
+        Config.regexp_value(str)
+      end
+    end
   end
 
   sub_test_case 'type converters for config_param definitions' do


### PR DESCRIPTION
This change can raise Fluent::ConfigError when right slash is missing.
This helps users to notice the weird behavior like #2175.