### PR TITLE
out_forward: Rename parameter tls_cert_path to tls_ca_cert_path

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -167,6 +167,10 @@ module Fluent::Plugin
       end
 
       if @transport == :tls
+        # for backward compatibility
+        if @tls_cert_path && !@tls_cert_path.empty?
+          @tls_ca_cert_path = @tls_cert_path
+        end
         if @tls_ca_cert_path && !@tls_ca_cert_path.empty?
           @tls_ca_cert_path.each do |path|
             raise Fluent::ConfigError, "specified cert path does not exist:#{path}" unless File.exist?(path)

--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -91,7 +91,8 @@ module Fluent::Plugin
     desc 'Verify hostname of servers and certificates or not in TLS transport.'
     config_param :tls_verify_hostname, :bool, default: true
     desc 'The additional CA certificate path for TLS.'
-    config_param :tls_cert_path, :array, value_type: :string, default: nil
+    config_param :tls_ca_cert_path, :array, value_type: :string, default: nil
+    config_param :tls_cert_path, :array, value_type: :string, default: nil, deprecated: "Use tls_ca_cert_path instead"
 
     config_section :security, required: false, multi: false do
       desc 'The hostname'
@@ -166,8 +167,8 @@ module Fluent::Plugin
       end
 
       if @transport == :tls
-        if @tls_cert_path && !@tls_cert_path.empty?
-          @tls_cert_path.each do |path|
+        if @tls_ca_cert_path && !@tls_ca_cert_path.empty?
+          @tls_ca_cert_path.each do |path|
             raise Fluent::ConfigError, "specified cert path does not exist:#{path}" unless File.exist?(path)
             raise Fluent::ConfigError, "specified cert path is not readable:#{path}" unless File.readable?(path)
           end
@@ -324,7 +325,7 @@ module Fluent::Plugin
           verify_fqdn: @tls_verify_hostname,
           fqdn: hostname,
           allow_self_signed_cert: @tls_allow_self_signed_cert,
-          cert_paths: @tls_cert_path,
+          cert_paths: @tls_ca_cert_path,
           linger_timeout: @send_timeout,
           send_timeout: @send_timeout,
           recv_timeout: @ack_response_timeout,

--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -153,6 +153,24 @@ EOL
     assert{ logs.any?{|log| log.include?(expected_log) && log.include?(expected_detail) } }
   end
 
+  test 'configure tls_cert_path is deprecated' do
+    conf = %[
+      send_timeout 5
+      transport tls
+      tls_insecure_mode true
+      tls_cert_path /tmp/dummy/cert.pem
+      <server>
+        host #{TARGET_HOST}
+        port #{TARGET_PORT}
+      </server>
+    ]
+
+    d = create_driver(conf)
+    expected_log = "'tls_cert_path' parameter is deprecated: Use tls_ca_cert_path instead"
+    logs = d.logs
+    assert{ logs.any?{|log| log.include?(expected_log) } }
+  end
+
   test 'compress_default_value' do
     @d = d = create_driver
     assert_equal :text, d.instance.compress


### PR DESCRIPTION
Clarify the meaning of the parameter.

See #1879 for more details