### PR TITLE
Add connection check at startup when out_forward.

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -262,7 +262,7 @@ module Fluent::Plugin
           begin
             node.verify_connection
           rescue StandardError => e
-            log.fatal e.message
+            log.fatal "forward's connection setting error: #{e.message}"
             raise Fluent::UnrecoverableError, e.message
           end
         end

--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -77,6 +77,9 @@ module Fluent::Plugin
     desc 'Ignore DNS resolution and errors at startup time.'
     config_param :ignore_network_errors_at_startup, :bool, default: false
 
+    desc 'Verify that a connection can be made with one of out_forward nodes at the time of startup.'
+    config_param :verify_connection_at_startup, :bool, default: false
+
     desc 'Compress buffered data.'
     config_param :compress, :enum, list: [:text, :gzip], default: :text
 
@@ -252,6 +255,17 @@ module Fluent::Plugin
         @sock_ack_waiting_mutex = Mutex.new
         @sock_ack_waiting = []
         thread_create(:out_forward_receiving_ack, &method(:ack_reader))
+      end
+
+      if @verify_connection_at_startup
+        @nodes.each do |node|
+          begin
+            node.verify_connection
+          rescue StandardError => e
+            log.fatal e.message
+            raise Fluent::UnrecoverableError, e.message
+          end
+        end
       end
     end
 
@@ -566,6 +580,19 @@ module Fluent::Plugin
 
       def standby?
         @standby
+      end
+
+      def verify_connection
+        sock = @sender.create_transfer_socket(resolved_host, port, @hostname)
+        begin
+          ri = RequestInfo.new(@sender.security ? :helo : :established)
+          if ri.state != :established
+            establish_connection(sock, ri)
+            raise if ri.state != :established
+          end
+        ensure
+          sock.close
+        end
       end
 
       def establish_connection(sock, ri)

--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -787,7 +787,7 @@ EOL
     end
   end
 
-  test 'verify_connection_at_startup test' do
+  test 'verify_connection_at_startup_nodes_are_not_available' do
       @d = d = create_driver(CONFIG + %[
         verify_connection_at_startup true
         <buffer tag>
@@ -803,7 +803,7 @@ EOL
     d.instance_shutdown
   end
 
-  test 'authentication_with_shared_key_miss_match' do
+  test 'verify_connection_at_startup_nodes_shared_key_miss_match' do
     input_conf = TARGET_CONFIG + %[
                    <security>
                      self_hostname in.localhost
@@ -847,7 +847,7 @@ EOL
     end
   end
 
-  test 'authentication_with_shared_key_match' do
+  test 'verify_connection_at_startup_nodes_shared_key_match' do
       input_conf = TARGET_CONFIG + %[
                        <security>
                          self_hostname in.localhost

--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -217,6 +217,18 @@ EOL
     assert_equal 2, d.instance.ack_response_timeout
   end
 
+  test 'verify_connection_at_startup is disabled in default' do
+    @d = d = create_driver(CONFIG)
+    assert_equal false, d.instance.verify_connection_at_startup
+  end
+
+  test 'verify_connection_at_startup can be enabled' do
+    @d = d = create_driver(CONFIG + %[
+      verify_connection_at_startup true
+    ])
+    assert_equal true, d.instance.verify_connection_at_startup
+  end
+
   test 'send tags in str (utf-8 strings)' do
     target_input_driver = create_target_input_driver
 
@@ -774,4 +786,112 @@ EOL
       i.configure(conf)
     end
   end
+
+  test 'verify_connection_at_startup test' do
+      @d = d = create_driver(CONFIG + %[
+        verify_connection_at_startup true
+        <buffer tag>
+          flush_mode immediate
+          retry_type periodic
+          retry_wait 30s
+          flush_at_shutdown false # suppress errors in d.instance_shutdown
+        </buffer>
+      ])
+    assert_raise Fluent::UnrecoverableError do
+      d.instance_start
+    end
+    d.instance_shutdown
+  end
+
+  test 'authentication_with_shared_key_miss_match' do
+    input_conf = TARGET_CONFIG + %[
+                   <security>
+                     self_hostname in.localhost
+                     shared_key fluentd-sharedkey
+                   </security>
+                 ]
+    target_input_driver = create_target_input_driver(conf: input_conf)
+
+    output_conf = %[
+      send_timeout 30
+      heartbeat_type transport
+      transport tls
+      tls_verify_hostname false
+      verify_connection_at_startup true
+      require_ack_response true
+      ack_response_timeout 5s
+      <security>
+        self_hostname localhost
+        shared_key key_miss_match
+      </security>
+      <buffer tag>
+        flush_mode immediate
+        retry_type periodic
+        retry_wait 30s
+        flush_at_shutdown false # suppress errors in d.instance_shutdown
+        flush_thread_interval 31s
+      </buffer>
+
+      <server>
+        host #{TARGET_HOST}
+        port #{TARGET_PORT}
+      </server>
+    ]
+    @d = d = create_driver(output_conf)
+
+    target_input_driver.run(expect_records: 1, timeout: 15) do
+      assert_raise Fluent::UnrecoverableError do
+        d.instance_start
+      end
+      d.instance_shutdown
+    end
+  end
+
+  test 'authentication_with_shared_key_match' do
+      input_conf = TARGET_CONFIG + %[
+                       <security>
+                         self_hostname in.localhost
+                         shared_key fluentd-sharedkey
+                         <client>
+                           host 127.0.0.1
+                         </client>
+                       </security>
+                     ]
+      target_input_driver = create_target_input_driver(conf: input_conf)
+
+      output_conf = %[
+          send_timeout 51
+          verify_connection_at_startup true
+          <security>
+            self_hostname localhost
+            shared_key fluentd-sharedkey
+          </security>
+          <server>
+            name test
+            host #{TARGET_HOST}
+            port #{TARGET_PORT}
+            shared_key fluentd-sharedkey
+          </server>
+        ]
+      @d = d = create_driver(output_conf)
+
+      time = event_time("2011-01-02 13:14:15 UTC")
+      records = [
+          {"a" => 1},
+          {"a" => 2}
+      ]
+
+      target_input_driver.run(expect_records: 2, timeout: 15) do
+        d.run(default_tag: 'test') do
+          records.each do |record|
+            d.feed(time, record)
+          end
+        end
+      end
+
+      events = target_input_driver.events
+      assert{ events != [] }
+      assert_equal(['test', time, records[0]], events[0])
+      assert_equal(['test', time, records[1]], events[1])
+    end
 end


### PR DESCRIPTION
Added an option to check the out_forward node and communication when starting fluentd.

It is a matter with the following mailing list.
https://groups.google.com/forum/#!topic/fluentd/2ITnHbveYIM

Hello

I am using fluentd v1.2.6 in TLS encryption mode when forwarding in out_forward -> in_forward.

At fluentd startup I'd like to check if the out_forward process can connection with the in_forward node before listening for the forward port.
Does anyone know a good way about this?

The use case is below.
Existing applications are built across AWS and GCP, and the analysis base is in GCP.
I use out_forward TCP encryption for AWS and GCP connections.

The out_forward on the AWS side is redundant with the Active / Standby configuration.
When fluentd is deployed Switch from Active to Standby and return to the original Active / Standby when deployment is completed.

I think that it is desirable that fluentd gets an error as it is when the out_forward -> in_forward connection can not be performed by the new deployment so that the crash occurs.

The assumed error is a certificate validation failure or SHARD key mismatch.

I recognize that these errors are not checked at startup in fluentd now
See you.

I am not familiar with Ruby, and since I read the Fluentd code for the first time this time, please let me know if there is a better implementation.

This pull request is the same as below. #2180
I seemed to be merged because I was force pusn by the bot set in my account and the difference disappeared.
Bot has already been lifted.