### PR TITLE
Keep 'class' method to avoid error with Sigdump.dump on server stop.

### DIFF
--- a/lib/fluent/plugin/filter_record_transformer.rb
+++ b/lib/fluent/plugin/filter_record_transformer.rb
@@ -316,7 +316,7 @@ module Fluent::Plugin
         end
 
         (Object.instance_methods).each do |m|
-          undef_method m unless m.to_s =~ /^__|respond_to_missing\?|object_id|public_methods|instance_eval|method_missing|define_singleton_method|respond_to\?|new_ostruct_member/
+          undef_method m unless m.to_s =~ /^__|respond_to_missing\?|object_id|public_methods|instance_eval|method_missing|define_singleton_method|respond_to\?|new_ostruct_member|^class$/
         end
       end
     end


### PR DESCRIPTION
When stopping fluentd, sometime I get follwoing error message on stderr;

```
Unexpected error undefined method `class' for #<Fluent::Plugin::RecordTransformerFilter::RubyPlaceholderExpander::CleanroomExpander:0x00007f7f1aca50d0>
  /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/sigdump-0.2.4/lib/sigdump.rb:74:in `block in dump_object_count'
  /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/sigdump-0.2.4/lib/sigdump.rb:73:in `each_object'
  /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/sigdump-0.2.4/lib/sigdump.rb:73:in `dump_object_count'
  /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/sigdump-0.2.4/lib/sigdump.rb:18:in `block in dump'
  /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/sigdump-0.2.4/lib/sigdump.rb:136:in `open'
  /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/sigdump-0.2.4/lib/sigdump.rb:136:in `_open_dump_path'
  /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/sigdump-0.2.4/lib/sigdump.rb:14:in `dump'
  /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/serverengine-2.0.7/lib/serverengine/server.rb:74:in `dump'
  /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/serverengine-2.0.7/lib/serverengine/server.rb:112:in `block (2 levels) in install_signal_handlers'
  /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/serverengine-2.0.7/lib/serverengine/signal_thread.rb:96:in `main'
```

This cause by Sigdump.dump fails with CleanroomExpander because it will call `class` method for all objects to gathering stats.

This patch just keep `class` method to avoid error.