### PR TITLE
out_forward: Separate parameter names for certificates

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -92,7 +92,8 @@ module Fluent::Plugin
     config_param :tls_verify_hostname, :bool, default: true
     desc 'The additional CA certificate path for TLS.'
     config_param :tls_ca_cert_path, :array, value_type: :string, default: nil
-    config_param :tls_cert_path, :array, value_type: :string, default: nil, deprecated: "Use tls_ca_cert_path instead"
+    desc 'The additional certificate path for TLS.'
+    config_param :tls_cert_path, :array, value_type: :string, default: nil
 
     config_section :security, required: false, multi: false do
       desc 'The hostname'
@@ -167,7 +168,7 @@ module Fluent::Plugin
       end
 
       if @transport == :tls
-        # for backward compatibility
+        # socket helper adds CA cert or signed certificate to same cert store internally so unify it in this place.
         if @tls_cert_path && !@tls_cert_path.empty?
           @tls_ca_cert_path = @tls_cert_path
         end

--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -157,14 +157,16 @@ EOL
     assert{ logs.any?{|log| log.include?(expected_log) && log.include?(expected_detail) } }
   end
 
-  test 'configure tls_cert_path is deprecated' do
+  data('CA cert'     => 'tls_ca_cert_path',
+       'non CA cert' => 'tls_cert_path')
+  test 'configure tls_cert_path/tls_ca_cert_path' do |param|
     dummy_cert_path = File.join(TMP_DIR, "dummy_cert.pem")
     FileUtils.touch(dummy_cert_path)
     conf = %[
       send_timeout 5
       transport tls
       tls_insecure_mode true
-      tls_cert_path #{dummy_cert_path}
+      #{param} #{dummy_cert_path}
       <server>
         host #{TARGET_HOST}
         port #{TARGET_PORT}
@@ -172,10 +174,7 @@ EOL
     ]
 
     @d = d = create_driver(conf)
-    expected_log = "'tls_cert_path' parameter is deprecated: Use tls_ca_cert_path instead"
-    logs = d.logs
-    assert{ logs.any?{|log| log.include?(expected_log) } }
-    assert_equal([dummy_cert_path], d.instance.tls_cert_path)
+    # In the plugin, tls_ca_cert_path is used for both cases
     assert_equal([dummy_cert_path], d.instance.tls_ca_cert_path)
   end
 


### PR DESCRIPTION
Follow up of https://github.com/fluent/fluentd/pull/2181

I reconsider for deprecated parameter. The use-case of cert_path, non CA cert can be specified for server certificate case. See https://www.fluentd.org/blog/fluentd-v0.14.12-has-been-released
So I just removed `deprecated` but keep to provide 2 parameters for clear naming.

Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>