### PR TITLE
Delete top level using bracket style properly

### DIFF
--- a/lib/fluent/plugin_helper/record_accessor.rb
+++ b/lib/fluent/plugin_helper/record_accessor.rb
@@ -40,8 +40,14 @@ module Fluent
           if @keys.is_a?(Array)
             @last_key = @keys.last
             @dig_keys = @keys[0..-2]
-            mcall = method(:call_dig)
-            mdelete = method(:delete_nest)
+            if @dig_keys.empty?
+              @keys = @keys.first
+              mcall = method(:call_index)
+              mdelete = method(:delete_top)
+            else
+              mcall = method(:call_dig)
+              mdelete = method(:delete_nest)
+            end
           else
             # Call [] for single key to reduce dig overhead
             mcall = method(:call_index)

--- a/test/plugin_helper/test_record_accessor.rb
+++ b/test/plugin_helper/test_record_accessor.rb
@@ -110,6 +110,12 @@ class RecordAccessorHelperTest < Test::Unit::TestCase
       assert_equal r[param], accessor.call(r)
     end
 
+    test "access single dot key using bracket style" do
+      r = {'key1' => 'v1', 'ke y2' => 'v2', 'this.is.key3' => 'v3'}
+      accessor = @d.record_accessor_create('$["this.is.key3"]')
+      assert_equal 'v3', accessor.call(r)
+    end
+
     test "nested bracket keys with dot" do
       r = {'key1' => {'this.is.key3' => 'value'}}
       accessor = @d.record_accessor_create("$['key1']['this.is.key3']")
@@ -162,6 +168,13 @@ class RecordAccessorHelperTest < Test::Unit::TestCase
       accessor = @d.record_accessor_create(param)
       accessor.delete(r)
       assert_not_include(r, param)
+    end
+
+    test "delete top key using bracket style" do
+      r = {'key1' => 'v1', 'ke y2' => 'v2', 'this.is.key3' => 'v3'}
+      accessor = @d.record_accessor_create('$["this.is.key3"]')
+      accessor.delete(r)
+      assert_not_include(r, 'this.is.key3')
     end
 
     data('bracket' => "$['key1'][0]['ke y2']",


### PR DESCRIPTION
In previous version, following configuration does not work properly:

```
<source>
  @type dummy
  dummy [
    {"foo.bar": "test1234", "message": "Hello"}
  ]
  tag dummy
</source>

<filter dummy>
  @type record_transformer
  remove_keys "$['foo.bar']"
</filter>

<match dummy>
  @type stdout
</match>
```

This shows like following:

```
2018-11-27 15:19:18 +0900 [info]: #0 fluentd worker is now running worker=0
2018-11-27 15:19:19.008586045 +0900 dummy: {"foo.bar":"test1234","message":"Hello"}
2018-11-27 15:19:20.009721132 +0900 dummy: {"foo.bar":"test1234","message":"Hello"}
2018-11-27 15:19:21.010784035 +0900 dummy: {"foo.bar":"test1234","message":"Hello"}
```

In this version, it works well.

See also #2109