### PR TITLE
varying status codes wrt path

### DIFF
--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -162,13 +162,11 @@ module Fluent::Plugin
         path = path_info[1..-1]  # remove /
         tag = path.split('/').join('.')
         record_time, record = parse_params(params)
-        log.debug "http Path =", path
         # Skip nil record
         if record.nil?
           if @respond_with_empty_img
             return ["200 OK", {'Content-Type'=>'image/gif; charset=utf-8'}, EMPTY_GIF_IMAGE]
           else
-            log.debug "http status returned =", @status_codes_by_path.fetch(path,"200 OK")
             return [@status_codes_by_path.fetch(path,"200 OK"), {'Content-Type'=>'text/plain'}, ""]
           end
         end
@@ -236,7 +234,6 @@ module Fluent::Plugin
       if @respond_with_empty_img
         return ["200 OK", {'Content-Type'=>'image/gif; charset=utf-8'}, EMPTY_GIF_IMAGE]
       else
-        log.debug "http status returned =", @status_codes_by_path.fetch(path,"200 OK")
         return [@status_codes_by_path.fetch(path,"200 OK"), {'Content-Type'=>'text/plain'}, ""]
       end
     end

--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -61,7 +61,7 @@ module Fluent::Plugin
     desc 'Respond with empty gif image of 1x1 pixel.'
     config_param :respond_with_empty_img, :bool, default: false
     desc 'status codes by path.'
-    config_param :status_codes_by_path, :hash, default: {}, symbolize_keys: true, value_type: :string
+    config_param :status_codes_by_path, :hash, default: {}, symbolize_keys: false, value_type: :string
 
     config_section :parse do
       config_set_default :@type, 'in_http'
@@ -162,11 +162,13 @@ module Fluent::Plugin
         path = path_info[1..-1]  # remove /
         tag = path.split('/').join('.')
         record_time, record = parse_params(params)
+        log.debug "http Path =", path
         # Skip nil record
         if record.nil?
           if @respond_with_empty_img
             return ["200 OK", {'Content-Type'=>'image/gif; charset=utf-8'}, EMPTY_GIF_IMAGE]
           else
+            log.debug "http status returned =", @status_codes_by_path.fetch(path,"200 OK")
             return [@status_codes_by_path.fetch(path,"200 OK"), {'Content-Type'=>'text/plain'}, ""]
           end
         end
@@ -234,6 +236,7 @@ module Fluent::Plugin
       if @respond_with_empty_img
         return ["200 OK", {'Content-Type'=>'image/gif; charset=utf-8'}, EMPTY_GIF_IMAGE]
       else
+        log.debug "http status returned =", @status_codes_by_path.fetch(path,"200 OK")
         return [@status_codes_by_path.fetch(path,"200 OK"), {'Content-Type'=>'text/plain'}, ""]
       end
     end


### PR DESCRIPTION
@okkez 
HTTP input plugin returns a status code 200 on success but if I want the plugin to return different status code based upon different ur's, it's not possible. This PR is to fill this gap.
My current usecase is, I want to use fluentd to act as a proxy for one of our API's