### PR TITLE
Create pos file directory if it doesn't exist

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -185,6 +185,8 @@ module Fluent::Plugin
       super
 
       if @pos_file
+        pos_file_dir = File.dirname(@pos_file)
+        FileUtils.mkdir_p(pos_file_dir) unless Dir.exist?(pos_file_dir)
         @pf_file = File.open(@pos_file, File::RDWR|File::CREAT|File::BINARY, @file_perm)
         @pf_file.sync = true
         @pf = PositionFile.parse(@pf_file)
@@ -946,7 +948,7 @@ module Fluent::Plugin
         @file = file
         @file_mutex = file_mutex
         @seek = seek
-        @pos = pos 
+        @pos = pos
         @inode = inode
       end
 

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -1011,6 +1011,25 @@ class TailInputTest < Test::Unit::TestCase
     end
   end
 
+  def test_pos_file_dir_creation
+    config = config_element("", "", {
+      "tag" => "tail",
+      "path" => "#{TMP_DIR}/*.txt",
+      "format" => "none",
+      "pos_file" => "#{TMP_DIR}/pos/tail.pos",
+      "read_from_head" => true,
+      "refresh_interval" => 1
+    })
+    d = create_driver(config, false)
+    d.run(expect_emits: 1, shutdown: false) do
+      File.open("#{TMP_DIR}/tail.txt", "ab") { |f| f.puts "test3\n" }
+    end
+    assert_path_exist("#{TMP_DIR}/pos/tail.pos")
+    cleanup_directory(TMP_DIR)
+
+    d.instance_shutdown
+  end
+
   def test_z_refresh_watchers
     plugin = create_driver(EX_CONFIG, false).instance
     sio = StringIO.new


### PR DESCRIPTION
We recently encountered an issue where the subdirectory the `pos_file` should be written to didn't exist, causing the in_tail plugin to emit an exception and crash fluentd, resulting in a crash loop. The process had permission to write to the parent directory so it could have easily created the directory and avoided an outage. This change adds a mkdir_p call to create the directory if it detects that the directory the pos_file is in doesn't exist.

/cc @repeatedly 