### PR TITLE
server: Ignore ECONNRESET in TLS accept to avoid fluentd restart. fixes #2135

### DIFF
--- a/lib/fluent/plugin_helper/server.rb
+++ b/lib/fluent/plugin_helper/server.rb
@@ -722,7 +722,7 @@ module Fluent
 
                 return true
               end
-            rescue OpenSSL::SSL::SSLError => e
+            rescue Errno::ECONNRESET, OpenSSL::SSL::SSLError => e
               @log.trace "unexpected error before accepting TLS connection", error: e
               close rescue nil
             end


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>