### PR TITLE
appveyor: Remove Ruby 2.1 CI targets on appveyor. Fix #2255

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,12 +30,7 @@ environment:
       devkit: C:\Ruby23\DevKit
     - ruby_version: "22-x64"
       devkit: C:\Ruby23-x64\DevKit
-    - ruby_version: "21-x64"
-      devkit: C:\Ruby23-x64\DevKit
     - ruby_version: "22"
-      devkit: C:\Ruby23\DevKit
-      WIN_RAPID: true
-    - ruby_version: "21"
       devkit: C:\Ruby23\DevKit
       WIN_RAPID: true
 matrix:


### PR DESCRIPTION
Discussed in #2255.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>