### PR TITLE
in_http: Add debug log for invalid event. ref #2262

### DIFF
--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -163,6 +163,7 @@ module Fluent::Plugin
 
         # Skip nil record
         if record.nil?
+          log.debug { "incoming event is invalid: path=#{path_info} params=#{params.to_json}" }
           if @respond_with_empty_img
             return ["200 OK", {'Content-Type'=>'image/gif; charset=utf-8'}, EMPTY_GIF_IMAGE]
           else


### PR DESCRIPTION
Log example:

```
2019-01-15 20:15:09 +0900 [debug]: #0 fluent/log.rb:302:debug: incoming event is invalid: path=/log : params={"json":"json={\"var1\":\"1001.01\",\"var2\":10222.66}","HTTP_HOST":"localhost:8080","HTTP_USER_AGENT":"curl/7.43.0","HTTP_ACCEPT":"*/*","HTTP_CONTENT_TYPE":"application/json","HTTP_CONTENT_LENGTH":"39","REMOTE_ADDR":"127.0.0.1"}
```

Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>