### PR TITLE
in_tcp: in_udp: Add <parse> section checking. Fix #2266

### DIFF
--- a/lib/fluent/plugin/in_tcp.rb
+++ b/lib/fluent/plugin/in_tcp.rb
@@ -41,11 +41,15 @@ module Fluent::Plugin
 
     def configure(conf)
       compat_parameters_convert(conf, :parser)
+      parser_config = conf.elements('parse').first
+      unless parser_config
+        raise Fluent::ConfigError, "<parse> section is required."
+      end
       super
       @_event_loop_blocking_timeout = @blocking_timeout
       @source_hostname_key ||= @source_host_key if @source_host_key
 
-      @parser = parser_create
+      @parser = parser_create(conf: parser_config)
     end
 
     def multi_workers_ready?

--- a/lib/fluent/plugin/in_udp.rb
+++ b/lib/fluent/plugin/in_udp.rb
@@ -47,12 +47,16 @@ module Fluent::Plugin
 
     def configure(conf)
       compat_parameters_convert(conf, :parser)
+      parser_config = conf.elements('parse').first
+      unless parser_config
+        raise Fluent::ConfigError, "<parse> section is required."
+      end
       super
       @_event_loop_blocking_timeout = @blocking_timeout
       @source_hostname_key ||= @source_host_key if @source_host_key
       @message_length_limit = @body_size_limit if @body_size_limit
 
-      @parser = parser_create
+      @parser = parser_create(conf: parser_config)
     end
 
     def multi_workers_ready?

--- a/test/plugin/test_in_tcp.rb
+++ b/test/plugin/test_in_tcp.rb
@@ -48,6 +48,12 @@ class TcpInputTest < Test::Unit::TestCase
     assert_equal "\n", d.instance.delimiter
   end
 
+  test ' configure w/o parse section' do
+    assert_raise(Fluent::ConfigError.new("<parse> section is required.")) {
+      create_driver(BASE_CONFIG)
+    }
+  end
+
   test_case_data = {
     'none' => {
       'format' => 'none',

--- a/test/plugin/test_in_udp.rb
+++ b/test/plugin/test_in_udp.rb
@@ -59,6 +59,12 @@ class UdpInputTest < Test::Unit::TestCase
     assert_equal nil, d.instance.receive_buffer_size
   end
 
+  test ' configure w/o parse section' do
+    assert_raise(Fluent::ConfigError.new("<parse> section is required.")) {
+      create_driver(BASE_CONFIG)
+    }
+  end
+
   data(
     'ipv4' => [CONFIG, '127.0.0.1', :ipv4],
     'ipv6' => [IPv6_CONFIG, '::1', :ipv6],


### PR DESCRIPTION
in_tcp and in_udp might raise the following error:

```log
ArgumentError: parse: init is specified, but there're parameters without default values:@type
  /home/hhatake/GitHub/fluentd/lib/fluent/config/section.rb:178:in `block in generate'
  /home/hhatake/GitHub/fluentd/lib/fluent/config/section.rb:169:in `each'
  /home/hhatake/GitHub/fluentd/lib/fluent/config/section.rb:169:in `generate'
  /home/hhatake/GitHub/fluentd/lib/fluent/configurable.rb:94:in `configure'
  /home/hhatake/GitHub/fluentd/lib/fluent/plugin/base.rb:57:in `configure'
  /home/hhatake/GitHub/fluentd/lib/fluent/plugin_id.rb:39:in `configure'
  /home/hhatake/GitHub/fluentd/lib/fluent/log.rb:580:in `configure'
  /home/hhatake/GitHub/fluentd/lib/fluent/plugin_helper/event_emitter.rb:73:in `configure'
  /home/hhatake/GitHub/fluentd/lib/fluent/plugin_helper/extract.rb:78:in `configure'
  /home/hhatake/GitHub/fluentd/lib/fluent/plugin_helper/parser.rb:83:in `configure'
  /home/hhatake/GitHub/fluentd/lib/fluent/plugin_helper/server.rb:312:in `configure'
  /home/hhatake/GitHub/fluentd/lib/fluent/plugin/in_tcp.rb:44:in `configure'
  /home/hhatake/GitHub/fluentd/lib/fluent/plugin.rb:164:in `configure'
  /home/hhatake/GitHub/fluentd/lib/fluent/root_agent.rb:282:in `add_source'
  /home/hhatake/GitHub/fluentd/lib/fluent/root_agent.rb:122:in `block in configure'
  /home/hhatake/GitHub/fluentd/lib/fluent/root_agent.rb:118:in `each'
  /home/hhatake/GitHub/fluentd/lib/fluent/root_agent.rb:118:in `configure'
  /home/hhatake/GitHub/fluentd/lib/fluent/engine.rb:131:in `configure'
  /home/hhatake/GitHub/fluentd/lib/fluent/engine.rb:96:in `run_configure'
  /home/hhatake/GitHub/fluentd/lib/fluent/supervisor.rb:795:in `run_configure'
  /home/hhatake/GitHub/fluentd/lib/fluent/supervisor.rb:579:in `dry_run'
  /home/hhatake/GitHub/fluentd/lib/fluent/supervisor.rb:597:in `supervise'
  /home/hhatake/GitHub/fluentd/lib/fluent/supervisor.rb:502:in `run_supervisor'
  /home/hhatake/GitHub/fluentd/lib/fluent/command/fluentd.rb:310:in `<top (required)>'
  /home/hhatake/GitHub/fluentd/bin/fluentd:8:in `require'
  /home/hhatake/GitHub/fluentd/bin/fluentd:8:in `<top (required)>'
  /home/hhatake/GitHub/fluentd/vendor/bundle/ruby/2.4.0/bin/fluentd:22:in `load'
  /home/hhatake/GitHub/fluentd/vendor/bundle/ruby/2.4.0/bin/fluentd:22:in `<top (required)>'
```

But it is ambigious.
We should raise this error in each of the plugins, I guess.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>