### PR TITLE
output: Work retry_forever and <secondary> together. fix #2257

### DIFF
--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -364,7 +364,9 @@ module Fluent
           raise Fluent::ConfigError, "Invalid <secondary> section for non-buffered plugin" unless @buffering
           raise Fluent::ConfigError, "<secondary> section cannot have <buffer> section" if @secondary_config.buffer
           raise Fluent::ConfigError, "<secondary> section cannot have <secondary> section" if @secondary_config.secondary
-          raise Fluent::ConfigError, "<secondary> section and 'retry_forever' are exclusive" if @buffer_config.retry_forever
+          if @buffer_config.retry_forever
+            log.warn "<secondary> with 'retry_forever', only unrecoverable errors are moved to secondary"
+          end
 
           secondary_type = @secondary_config[:@type]
           unless secondary_type

--- a/lib/fluent/plugin_helper/retry_state.rb
+++ b/lib/fluent/plugin_helper/retry_state.rb
@@ -53,10 +53,6 @@ module Fluent
           @randomize = randomize
           @randomize_width = randomize_width
 
-          if forever && secondary
-            raise "BUG: forever and secondary are exclusive to each other"
-          end
-
           @forever = forever
           @max_steps = max_steps
 
@@ -118,12 +114,12 @@ module Fluent
         end
 
         def secondary?
-          @secondary && (@current == :secondary || current_time >= @secondary_transition_at)
+          !@forever && @secondary && (@current == :secondary || current_time >= @secondary_transition_at)
         end
 
         def step
           @steps += 1
-          if @secondary && @current != :secondary && current_time >= @secondary_transition_at
+          if !@forever && @secondary && @current != :secondary && current_time >= @secondary_transition_at
             @current = :secondary
             @secondary_transition_steps = @steps
           end


### PR DESCRIPTION
Enable retry_forever with `<secondary>`.
Only unrecoverable errors are moved to secondary output.

Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>