### PR TITLE
Reduce delay before flush when large timekey and small timekey_wait a…

### DIFF
--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -1336,7 +1336,7 @@ module Fluent
         end
         if @chunk_key_time
           if !value_for_interval || @buffer_config.timekey < value_for_interval
-            value_for_interval = @buffer_config.timekey
+            value_for_interval = [@buffer_config.timekey, @buffer_config.timekey_wait].min
           end
         end
         unless value_for_interval


### PR DESCRIPTION
When large timekey and relatively small timekey_wait are given, the delay before flush could be too long. The cause is running interval of enqueue thread which is set as timekey / 11.0. If timekey is 86400 (1 day), the interval is 7854 seconds. Even if timekey_wait is set to 600 seconds in this case, the actual delay before flush could be up to 600+7854 seconds. Taking timekey_wait into account for deciding enqueue thread interval would mitigate this.