### PR TITLE
output: Add MessagePack::UnpackError to unrecoverable case

### DIFF
--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -1083,7 +1083,7 @@ module Fluent
         end
       end
 
-      UNRECOVERABLE_ERRORS = [Fluent::UnrecoverableError, TypeError, ArgumentError, NoMethodError]
+      UNRECOVERABLE_ERRORS = [Fluent::UnrecoverableError, TypeError, ArgumentError, NoMethodError, MessagePack::UnpackError]
 
       def try_flush
         chunk = @buffer.dequeue_chunk

--- a/test/plugin/test_output_as_buffered_backup.rb
+++ b/test/plugin/test_output_as_buffered_backup.rb
@@ -177,7 +177,12 @@ class BufferedOutputBackupTest < Test::Unit::TestCase
       }
     end
 
-    test 'backup chunk without secondary' do
+    data('unrecoverable error' => Fluent::UnrecoverableError,
+         'type error' => TypeError,
+         'argument error' => ArgumentError,
+         'no method error' => NoMethodError,
+         'msgpack unpack error' => MessagePack::UnpackError)
+    test 'backup chunk without secondary' do |error_class|
       Fluent::SystemConfig.overwrite_system_config('root_dir' => TMP_DIR) do
         id = 'backup_test'
         hash = {
@@ -188,7 +193,7 @@ class BufferedOutputBackupTest < Test::Unit::TestCase
         @i.configure(config_element('ROOT', '', {'@id' => id}, [config_element('buffer', 'tag', hash)]))
         @i.register(:write) { |chunk|
           chunk_id = chunk.unique_id;
-          raise Fluent::UnrecoverableError, "yay, your #write must fail"
+          raise error_class, "yay, your #write must fail"
         }
 
         flush_chunks


### PR DESCRIPTION
Output plugin can't recover broken msgpack so it should be unrecoverable error.
See: https://github.com/fluent/fluent-plugin-kafka/issues/243

This PR includes small enchancement for unrecoverable error test.

Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>