### PR TITLE
Remove the duplicated words in printing

### DIFF
--- a/test/counter/test_store.rb
+++ b/test/counter/test_store.rb
@@ -89,7 +89,7 @@ class CounterStoreTest < ::Test::Unit::TestCase
       assert_equal nil, @store.get('unknown_key')
     end
 
-    test "raise a error when when a passed key doesn't exist and raise_error option is true" do
+    test "raise a error when a passed key doesn't exist and raise_error option is true" do
       assert_raise Fluent::Counter::UnknownKey do
         @store.get('unknown_key', raise_error: true)
       end

--- a/test/plugin/test_buffer.rb
+++ b/test/plugin/test_buffer.rb
@@ -211,7 +211,7 @@ class BufferTest < Test::Unit::TestCase
       assert_equal 2, @p.queued_num[@dm1]
     end
 
-    test '#close closes all chunks in in dequeued, enqueued and staged' do
+    test '#close closes all chunks in dequeued, enqueued and staged' do
       dmx = create_metadata(Time.parse('2016-04-11 15:50:00 +0000').to_i, nil, nil)
       cx = create_chunk(dmx, ["x" * 1024])
       @p.dequeued[cx.unique_id] = cx
@@ -1027,7 +1027,7 @@ class BufferTest < Test::Unit::TestCase
       ##### 900 + 9500 + 9900 * 4 == 5000 + 45000
     end
 
-    test '#write raises BufferChunkOverflowError if a record is biggar than chunk limit size' do
+    test '#write raises BufferChunkOverflowError if a record is bigger than chunk limit size' do
       assert_equal [@dm0], @p.stage.keys
       assert_equal [], @p.queue.map(&:metadata)
 


### PR DESCRIPTION
Although it is spelling mistakes, it might make an affects while reading.

Co-Authored-By: Nguyen Phuong An <AnNP@vn.fujitsu.com>
Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>