### PR TITLE
Update deprecated URL in 'DOCS_BASE_URL'

### DIFF
--- a/lib/fluent/command/plugin_config_formatter.rb
+++ b/lib/fluent/command/plugin_config_formatter.rb
@@ -32,7 +32,7 @@ class FluentPluginConfigFormatter
     "buffer", "parser", "formatter", "storage"
   ]
 
-  DOCS_BASE_URL = "https://docs.fluentd.org/v1.0/articles/"
+  DOCS_BASE_URL = "https://docs.fluentd.org/v1.0/articles/quickstart"
 
   def initialize(argv = ARGV)
     @argv = argv


### PR DESCRIPTION
Currently, the URL that unders **DOCS_BASE_URL** variable has been out of date.
This commit aims to update **DOCS_BASE_URL**'s URL to the working one that
user/deverloper can access.

Co-Authored-By: Nguyen Phuong An <AnNP@vn.fujitsu.com>
Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>