### PR TITLE
Add more errors to ignore list in UDP socket

### DIFF
--- a/lib/fluent/plugin_helper/server.rb
+++ b/lib/fluent/plugin_helper/server.rb
@@ -523,7 +523,7 @@ module Fluent
           def on_readable_without_sock
             begin
               data = @sock.recv(@max_bytes, @flags)
-            rescue Errno::EAGAIN, Errno::EWOULDBLOCK, Errno::EINTR, Errno::ECONNRESET
+            rescue Errno::EAGAIN, Errno::EWOULDBLOCK, Errno::EINTR, Errno::ECONNRESET, IOError, Errno::EBADF
               return
             end
             @callback.call(data)
@@ -536,7 +536,7 @@ module Fluent
           def on_readable_with_sock
             begin
               data, addr = @sock.recvfrom(@max_bytes)
-            rescue Errno::EAGAIN, Errno::EWOULDBLOCK, Errno::EINTR, Errno::ECONNRESET
+            rescue Errno::EAGAIN, Errno::EWOULDBLOCK, Errno::EINTR, Errno::ECONNRESET, IOError, Errno::EBADF
               return
             end
             @callback.call(data, UDPCallbackSocket.new(@sock, addr, close_socket: @close_socket))


### PR DESCRIPTION
UDPServer overwrites Cool.io's IO#on_readable so
it should handle unrecoverable IO error like TCPSocket.

https://github.com/tarcieri/cool.io/blob/c79b4dff788071fcc45fac838d5d76dc645b8c1d/lib/cool.io/io.rb#L128

UDP's stream model is different from TCP. Some errors, e.g. EOFError, don't happen.
Related with https://github.com/fluent/fluentd/pull/2292

Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>