### PR TITLE
Insert .idea/ in file .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ coverage/*
 .vagrant/
 cov-int/
 cov-fluentd.tar.gz
+.idea/


### PR DESCRIPTION
Ignore folder `.idea/` when open project Fluentd with
IntelliJ IDEA.

Signed-off-by: Nguyen Hai Truong <truongnh@vn.fujitsu.com>