### PR TITLE
Fix some minor typos

### DIFF
--- a/lib/fluent/counter/client.rb
+++ b/lib/fluent/counter/client.rb
@@ -288,7 +288,7 @@ module Fluent
       def join
         until @set
           @mutex.synchronize do
-            @loop.run_once(0.0001) # retun a lock as soon as possible
+            @loop.run_once(0.0001) # return a lock as soon as possible
           end
         end
       end

--- a/lib/fluent/plugin/compressable.rb
+++ b/lib/fluent/plugin/compressable.rb
@@ -44,7 +44,7 @@ module Fluent
           # check compressed_data(String) is 0 length
           compressed_data
         when output_io
-          # exeucte after checking compressed_data is empty or not
+          # execute after checking compressed_data is empty or not
           io = StringIO.new(compressed_data)
           io_decompress(io, output_io)
         else


### PR DESCRIPTION
This PR fixes some minor typos:
"retun" => "return"
"exeucte" => "execute"