### PR TITLE
Add .vscode to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ coverage/*
 .vagrant/
 cov-int/
 cov-fluentd.tar.gz
+.vscode


### PR DESCRIPTION
Some temp file like .vscode should not commit to github repo

Signed-off-by: Nguyen Quang Huy <huynq0911@gmail.com>