### PR TITLE
system: Add worker_id to process_name when workers is larger than 1

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -716,7 +716,13 @@ module Fluent
     end
 
     def main_process(&block)
-      Process.setproctitle("worker:#{@process_name}") if @process_name
+      if @process_name
+        if @workers > 1
+          Process.setproctitle("worker:#{@process_name}#{ENV['SERVERENGINE_WORKER_ID']}")
+        else
+          Process.setproctitle("worker:#{@process_name}")
+        end
+      end
 
       unrecoverable_error = false
 


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

**Which issue(s) this PR fixes**: 
No entry.

**What this PR does / why we need it**: 
Currently, worker's process names are same when `workers > 1`. This patch improves such case like below:

```
% ps aux | grep fluentd
repeatedly        7923   0.0  0.1  2521484  21240 s010  S+    4:25AM   0:00.83 worker:fluentd3     
repeatedly        7922   0.0  0.1  2519436  17984 s010  S+    4:25AM   0:00.82 worker:fluentd2     
repeatedly        7921   0.0  0.1  2522520  18676 s010  S+    4:25AM   0:00.86 worker:fluentd1     
repeatedly        7920   0.0  0.1  2522520  23420 s010  S+    4:25AM   0:00.88 worker:fluentd0     
repeatedly        7892   0.0  0.1  2523544  10260 s010  S+    4:25AM   0:00.65 supervisor:fluentd 
```

**Docs Changes**:
Need multi worker article update.

**Release Note**: 

See PR title.