### PR TITLE
in_syslog - Check message lenght when read from buffer

### DIFF
--- a/lib/fluent/plugin/in_syslog.rb
+++ b/lib/fluent/plugin/in_syslog.rb
@@ -169,6 +169,10 @@ module Fluent::Plugin
               num = Integer(buffer[pos..idx])
               pos = idx + num
               msg = buffer[idx + 1...pos]
+              if msg.size < num - 1
+                pos = pos - num - num.to_s.size
+                break
+              end
               message_handler(msg, conn)
             end
           else


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #2298 

**What this PR does / why we need it**: 
To correctly parge message when using in_syslog plugin

**Docs Changes**:

**Release Note**: 
