### PR TITLE
out_forward: Add secret to tls_client_private_key_passphrase

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -102,7 +102,7 @@ module Fluent::Plugin
     desc 'The client private key path for TLS.'
     config_param :tls_client_private_key_path, :string, default: nil
     desc 'The client private key passphrase for TLS.'
-    config_param :tls_client_private_key_passphrase, :string, default: nil
+    config_param :tls_client_private_key_passphrase, :string, default: nil, secret: true
 
     config_section :security, required: false, multi: false do
       desc 'The hostname'


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

**Which issue(s) this PR fixes**: 
Follow up of https://github.com/fluent/fluentd/pull/2187

**What this PR does / why we need it**: 
Make important parameter secret.

**Docs Changes**:
No need.

**Release Note**: 
See title.
