### PR TITLE
parser_regexp: Check named capture. ref #2330

### DIFF
--- a/lib/fluent/plugin/parser_regexp.rb
+++ b/lib/fluent/plugin/parser_regexp.rb
@@ -40,6 +40,10 @@ module Fluent
           @expression = Regexp.compile(@expression.source, options)
         end
         @regexp = @expression # For backward compatibility
+
+        if @expression.named_captures.empty?
+          raise Fluent::ConfigError, "No named captures in 'expression' parameter. The regexp must have at least one named capture"
+        end
       end
 
       def parse(text)

--- a/test/compat/test_parser.rb
+++ b/test/compat/test_parser.rb
@@ -84,7 +84,7 @@ class TextParserTest < ::Test::Unit::TestCase
        multiline: Regexp::MULTILINE,
        both: Regexp::IGNORECASE & Regexp::MULTILINE)
   def test_regexp_parser_config(options)
-    source = "a"
+    source = "(?<test>.*)"
     parser = Fluent::TextParser::RegexpParser.new(Regexp.new(source, options), { "dummy" => "dummy" })
     regexp = parser.instance_variable_get("@regexp")
     assert_equal(options, regexp.options)

--- a/test/plugin/test_parser_regexp.rb
+++ b/test/plugin/test_parser_regexp.rb
@@ -153,6 +153,15 @@ class RegexpParserTest < ::Test::Unit::TestCase
     end
 
     sub_test_case "configure" do
+      def test_bad_expression
+        conf = {
+          'expression' => %q!/.*/!,
+        }
+        assert_raise Fluent::ConfigError do
+          create_driver(conf)
+        end
+      end
+
       def test_default_options
         conf = {
           'expression' => %q!/^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] \[(?<date>[^\]]*)\] "(?<flag>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)$/!,


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

**Which issue(s) this PR fixes**: 
Avoid unexpected behaviour like #2330

**What this PR does / why we need it**: 
multiline parser does named capture check so regexp parser should also check.

**Docs Changes**:
No need

**Release Note**: 
regexp parser raises configuration error when no named capture in expression.