### PR TITLE
in_http: Add support for subdomain in CORS domain

### DIFF
--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -518,7 +518,10 @@ module Fluent::Plugin
           return true
         end
         filtered_cors_allow_origins = @cors_allow_origins.select {|origin| origin != ""}
-        return filtered_cors_allow_origins.find {|origin| (start_str,end_str) = origin.split("*",2); @origin.start_with?(start_str) and @origin.end_with?(end_str)} != nil
+        return filtered_cors_allow_origins.find do |origin|
+          (start_str,end_str) = origin.split("*",2)
+          @origin.start_with?(start_str) and @origin.end_with?(end_str)
+        end != nil
       end
     end
   end

--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -394,7 +394,7 @@ module Fluent::Plugin
         if @cors_allow_origins.include?('*')
           header["Access-Control-Allow-Origin"] = "*"
           send_response_and_close("200 OK", header, "")
-        elsif @cors_allow_origins.include?(@origin)
+        elsif include_cors_allow_origin
           header["Access-Control-Allow-Origin"] = @origin
           send_response_and_close("200 OK", header, "")
         else
@@ -414,7 +414,7 @@ module Fluent::Plugin
         # For every incoming request, we check if we have some CORS
         # restrictions and white listed origins through @cors_allow_origins.
         unless @cors_allow_origins.nil?
-          unless @cors_allow_origins.include?('*') or @cors_allow_origins.include?(@origin)
+          unless @cors_allow_origins.include?('*') or include_cors_allow_origin
             send_response_and_close("403 Forbidden", {'Connection' => 'close'}, "")
             return
           end
@@ -464,7 +464,7 @@ module Fluent::Plugin
         unless @cors_allow_origins.nil?
           if @cors_allow_origins.include?('*')
             header['Access-Control-Allow-Origin'] = '*'
-          elsif @cors_allow_origins.include?(@origin)
+          elsif include_cors_allow_origin
             header['Access-Control-Allow-Origin'] = @origin
           end
         end
@@ -511,6 +511,14 @@ module Fluent::Plugin
         }
         data << "\r\n"
         write data
+      end
+
+      def include_cors_allow_origin
+        if @cors_allow_origins.include?(@origin)
+          return true
+        end
+        filtered_cors_allow_origins = @cors_allow_origins.select {|origin| origin != ""}
+        return filtered_cors_allow_origins.find {|origin| (start_str,end_str) = origin.split("*",2); @origin.start_with?(start_str) and @origin.end_with?(end_str)} != nil
       end
     end
   end

--- a/test/plugin/test_in_http.rb
+++ b/test/plugin/test_in_http.rb
@@ -641,6 +641,63 @@ class HttpInputTest < Test::Unit::TestCase
     end
   end
 
+  def test_cors_allowed_wildcard_for_subdomain
+    d = create_driver(CONFIG + 'cors_allow_origins ["http://*.foo.com"]')
+
+    time = event_time("2011-01-02 13:14:15 UTC")
+    events = [
+      ["tag1", time, {"a"=>1}],
+    ]
+
+    d.run do
+      events.each do |tag, time, record|
+        headers = {"Origin" => "http://subdomain.foo.com"}
+
+        res = post("/#{tag}", {"json" => record.to_json, "time" => time.to_i}, headers)
+
+        assert_equal "200", res.code
+        assert_equal "http://subdomain.foo.com", res["Access-Control-Allow-Origin"]
+      end
+    end
+  end
+  
+  def test_cors_allowed_exclude_empty_string
+    d = create_driver(CONFIG + 'cors_allow_origins ["", "http://*.foo.com"]')
+
+    time = event_time("2011-01-02 13:14:15 UTC")
+    events = [
+      ["tag1", time, {"a"=>1}],
+    ]
+
+    d.run do
+      events.each do |tag, time, record|
+        headers = {"Origin" => "http://subdomain.foo.com"}
+
+        res = post("/#{tag}", {"json" => record.to_json, "time" => time.to_i}, headers)
+
+        assert_equal "200", res.code
+        assert_equal "http://subdomain.foo.com", res["Access-Control-Allow-Origin"]
+      end
+    end
+  end
+  
+  def test_cors_allowed_wildcard_preflight_for_subdomain
+    d = create_driver(CONFIG + 'cors_allow_origins ["http://*.foo.com"]')
+
+    d.run do
+      header = {
+        "Origin" => "http://subdomain.foo.com",
+        "Access-Control-Request-Method" => "POST",
+        "Access-Control-Request-Headers" => "Content-Type",
+      }
+      res = options("/cors.test", {}, header)
+
+      assert_equal "200", res.code
+      assert_equal "http://subdomain.foo.com", res["Access-Control-Allow-Origin"]
+      assert_equal "POST", res["Access-Control-Allow-Methods"]
+    end
+  end
+
   def test_content_encoding_gzip
     d = create_driver
 


### PR DESCRIPTION
Signed-off-by: Hiroki Takayasu <hiroki.kana@gmail.com>

**Which issue(s) this PR fixes**: 
#2336 

**What this PR does / why we need it**: 
Currently `cors_allow_origins` could only use `*` or exact matching.  I modified able to could use wildcard in domain setting(ex: `http://*.example.com` )

**Docs Changes**:
No need

**Release Note**: 
See PR title