### PR TITLE
Check the remote connection is available in the in_forward plugin

### DIFF
--- a/lib/fluent/plugin/in_forward.rb
+++ b/lib/fluent/plugin/in_forward.rb
@@ -47,6 +47,8 @@ module Fluent::Plugin
     config_param :resolve_hostname, :bool, default: nil
     desc 'Connections will be disconnected right after receiving first message if this value is true.'
     config_param :deny_keepalive, :bool, default: false
+    desc 'Check the remote connection is still available by sending a keepalive packet if this value is true.'
+    config_param :send_keepalive_packet, :bool, default: false
 
     desc 'Log warning if received chunk size is larger than this value.'
     config_param :chunk_size_warn_limit, :size, default: nil
@@ -141,6 +143,10 @@ module Fluent::Plugin
             })
         end
       end
+
+      if @send_keepalive_packet && @deny_keepalive
+        raise Fluent::ConfigError, "both 'send_keepalive_packet' and 'deny_keepalive' cannot be set to true"
+      end
     end
 
     def multi_workers_ready?
@@ -161,6 +167,7 @@ module Fluent::Plugin
         shared: shared_socket,
         resolve_name: @resolve_hostname,
         linger_timeout: @linger_timeout,
+        send_keepalive_packet: @send_keepalive_packet,
         backlog: @backlog,
         &method(:handle_connection)
       )

--- a/test/plugin/test_in_forward.rb
+++ b/test/plugin/test_in_forward.rb
@@ -81,6 +81,27 @@ class ForwardInputTest < Test::Unit::TestCase
       assert_equal 1, d.instance.security.users.size
       assert_equal 1, d.instance.security.clients.size
     end
+
+    test 'send_keepalive_packet is disabled by default' do
+      @d = d = create_driver(CONFIG_AUTH)
+      assert_false d.instance.send_keepalive_packet
+    end
+
+    test 'send_keepalive_packet can be enabled' do
+      @d = d = create_driver(CONFIG_AUTH + %[
+        send_keepalive_packet true
+      ])
+      assert_true d.instance.send_keepalive_packet
+    end
+
+    test 'both send_keepalive_packet and deny_keepalive cannot be enabled' do
+      assert_raise(Fluent::ConfigError.new("both 'send_keepalive_packet' and 'deny_keepalive' cannot be set to true")) do
+        create_driver(CONFIG_AUTH + %[
+          send_keepalive_packet true
+          deny_keepalive true
+        ])
+      end
+    end
   end
 
   sub_test_case 'message' do

--- a/test/plugin_helper/test_server.rb
+++ b/test/plugin_helper/test_server.rb
@@ -237,6 +237,15 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     end
 
     data(
+      'server_create udp' => [:server_create, :udp],
+    )
+    test 'raise error if tcp/tls/unix options specified for udp' do |(m, proto)|
+      assert_raise(ArgumentError.new("BUG: send_keepalive_packet is available for tcp")) do
+        @d.__send__(m, :myserver, PORT, proto: proto, send_keepalive_packet: true){|x| x }
+      end
+    end
+
+    data(
       'server_create tcp' => [:server_create, :tcp, {}],
       'server_create udp' => [:server_create, :udp, {max_bytes: 128}],
       # 'server_create unix' => [:server_create, :unix, {}],
@@ -352,7 +361,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
   sub_test_case '#server_create_tcp' do
     test 'can accept all keyword arguments valid for tcp server' do
       assert_nothing_raised do
-        @d.server_create_tcp(:s, PORT, bind: '127.0.0.1', shared: false, resolve_name: true, linger_timeout: 10, backlog: 500) do |data, conn|
+        @d.server_create_tcp(:s, PORT, bind: '127.0.0.1', shared: false, resolve_name: true, linger_timeout: 10, backlog: 500, send_keepalive_packet: true) do |data, conn|
           # ...
         end
       end


### PR DESCRIPTION
 <!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 

**What this PR does / why we need it**: 

I'd like to detect half open connections and prevent them from consuming too many file descriptors because this can lead to a `"No file descriptors available"` error.

example stacktrace
```
"Unexpected error raised. Stopping the timer. title=:child_process_execute error_class=Errno::EMFILE error=\"No file descriptors available - ruby\"",
"/usr/lib/ruby/2.4.0/open3.rb:199:in `spawn'",
"/usr/lib/ruby/2.4.0/open3.rb:199:in `popen_run'",
"/usr/lib/ruby/2.4.0/open3.rb:95:in `popen3'",
"/fluentd/etc/vendor/bundle/ruby/2.4.0/gems/fluentd-1.2.2/lib/fluent/plugin_helper/child_process.rb:265:in `child_process_execute_once'",
"/fluentd/etc/vendor/bundle/ruby/2.4.0/gems/fluentd-1.2.2/lib/fluent/plugin_helper/child_process.rb:96:in `block in child_process_execute'",
"/fluentd/etc/vendor/bundle/ruby/2.4.0/gems/fluentd-1.2.2/lib/fluent/plugin_helper/child_process.rb:114:in `block in child_process_execute'",
"/fluentd/etc/vendor/bundle/ruby/2.4.0/gems/fluentd-1.2.2/lib/fluent/plugin_helper/timer.rb:80:in `on_timer'",
"/fluentd/etc/vendor/bundle/ruby/2.4.0/gems/cool.io-1.5.3/lib/cool.io/loop.rb:88:in `run_once'",
"/fluentd/etc/vendor/bundle/ruby/2.4.0/gems/cool.io-1.5.3/lib/cool.io/loop.rb:88:in `run'",
"/fluentd/etc/vendor/bundle/ruby/2.4.0/gems/fluentd-1.2.2/lib/fluent/plugin_helper/event_loop.rb:93:in `block in start'",
"/fluentd/etc/vendor/bundle/ruby/2.4.0/gems/fluentd-1.2.2/lib/fluent/plugin_helper/thread.rb:78:in `block in thread_create'",
```

In my case, half open connections happen in the following way
 
```
forwarder => AWS Networking Load Balancer(NLB) => aggregator
```

1. The forwarder sends a log data to the aggregator through NLB
2. The forwarder sends a log data to the aggregator after 350 seconds(NLB idle timeout)
3. The forwarder receives a RST packet from the NLB due to an idle timeout
   - NLB does not send a RST packet to the other side(aggregator)
   - Accoring to the document, This seems to be the expected behavior
   - [Connection Idle Timeout](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#connection-idle-timeout)
4. The forwarder reconnects to the aggregator and sends a log data again
5. Now, the aggregator has two active connections established in step 1 and 4

To fix the issue described above, this commit introduces `send_keepalive_packet` parameter and checks that the remote connections are still available by sending a keepalive packet.

In this commit, OS level parameters are used to configure how tcp keepalive works.
For example, they are `tcp_keepalive_time`, `tcp_keepalive_probes` and `tcp_keepalive_intvl` on Linux.

```shell
$ sysctl -A | grep "net.ipv4.tcp_keepalive"
net.ipv4.tcp_keepalive_intvl = 75
net.ipv4.tcp_keepalive_probes = 5
net.ipv4.tcp_keepalive_time = 7200
```

ref
- https://blog.stephencleary.com/2009/05/detection-of-half-open-dropped.html
- http://coryklein.com/tcp/2015/11/25/custom-configuration-of-tcp-socket-keep-alive-timeouts.html
- https://www.rsyslog.com/files/temp/doc-indent/configuration/modules/imtcp.html#module-parameters
 
**Docs Changes**:

need to update

https://github.com/fluent/fluentd-docs/blob/master/docs/v1.0/in_forward.txt

**Release Note**: 
