### PR TITLE
out_file: Create directory for symlink. fix #2346

### DIFF
--- a/lib/fluent/plugin/out_file.rb
+++ b/lib/fluent/plugin/out_file.rb
@@ -68,6 +68,7 @@ module Fluent::Plugin
       config_set_default :timekey, DEFAULT_TIMEKEY
     end
 
+    attr_reader :dir_perm
     attr_accessor :last_written_path # for tests
 
     module SymlinkBufferMixin
@@ -87,7 +88,9 @@ module Fluent::Plugin
         # These chunks will be enqueued immediately, and will be flushed soon.
         latest_metadata = metadata_list.select{|m| m.timekey }.sort_by(&:timekey).last
         if chunk.metadata == latest_metadata
-          FileUtils.ln_sf(chunk.path, @_output_plugin_for_symlink.extract_placeholders(@_symlink_path, chunk))
+          sym_path = @_output_plugin_for_symlink.extract_placeholders(@_symlink_path, chunk)
+          FileUtils.mkdir_p(File.dirname(sym_path), mode: @_output_plugin_for_symlink.dir_perm)
+          FileUtils.ln_sf(chunk.path, sym_path)
         end
         chunk
       end

--- a/test/plugin/test_out_file.rb
+++ b/test/plugin/test_out_file.rb
@@ -684,11 +684,11 @@ class FileOutputTest < Test::Unit::TestCase
       omit "Windows doesn't support symlink" if Fluent.windows?
       conf = %[
         path #{TMP_DIR}/${tag}/out_file_test
-        symlink_path #{SYMLINK_PATH}-${tag}
+        symlink_path #{SYMLINK_PATH}/foo/${tag}
         <buffer tag,time>
         </buffer>
       ]
-      symlink_path = "#{SYMLINK_PATH}-tag"
+      symlink_path = "#{SYMLINK_PATH}/foo/tag"
 
       d = create_driver(conf)
       begin


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

**Which issue(s) this PR fixes**: 
Fixes #2346

**What this PR does / why we need it**: 
Create directory when parent directories don't exist.

**Docs Changes**:
No need.

**Release Note**: 
Use title