### PR TITLE
Fix plugin log time format if format is JSON

### DIFF
--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -532,6 +532,7 @@ module Fluent
       end
 
       self.format = @logger.format
+      self.time_format = @logger.time_format
       enable_color @logger.enable_color?
     end
 
@@ -540,11 +541,17 @@ module Fluent
     end
 
     alias orig_format= format=
+    alias orig_time_format= time_format=
     alias orig_enable_color enable_color
 
     def format=(fmt)
       self.orig_format = fmt
       @logger.format = fmt
+    end
+
+    def time_format=(fmt)
+      self.orig_time_format = fmt
+      @logger.time_format = fmt
     end
 
     def enable_color(b = true)
@@ -554,9 +561,9 @@ module Fluent
 
     extend Forwardable
     def_delegators '@logger', :get_worker_id, :enable_color?, :enable_debug, :enable_event,
-      :disable_events, :log_event_enabled, :log_event_enabled=, :time_format, :time_format=,
-      :time_formatter, :time_formatter=, :event, :caller_line, :puts, :write, :<<, :flush,
-      :reset, :out, :out=, :optional_header, :optional_header=, :optional_attrs, :optional_attrs=
+      :disable_events, :log_event_enabled, :log_event_enabled=, :event, :caller_line, :puts, :write,
+      :<<, :flush, :reset, :out, :out=, :optional_header, :optional_header=, :optional_attrs,
+      :optional_attrs=
   end
 
 

--- a/test/test_log.rb
+++ b/test/test_log.rb
@@ -814,7 +814,6 @@ class PluginLoggerTest < Test::Unit::TestCase
       fmt, expected_log_line = data
       @log.format = fmt
       @log.time_format = "%Y"
-      timestamp_str = '2016'
       @log.info "yaaay"
       assert{ @log_device.logs.include? expected_log_line }
     end


### PR DESCRIPTION
Fixes #2355 

The time format for a plugin logger was out of sync with the parent logger, and the delegation of `#time_format` and `#time_format=` made it impossible to fix the plugin logger's time format without hacks.

This problem was not noticeable if the log format was text, because time formatting was delegated via `#caller_line` to the parent logger. However, in the case of JSON output, the plugin logger's `#format_time` method was called, yielding incorrectly-formatted timestamps.

Added tests for both text and JSON, and added tests for format changes in general while I was in there.