### PR TITLE
Add debug log to in_tail / buf_file.

### DIFF
--- a/lib/fluent/plugin/buf_file.rb
+++ b/lib/fluent/plugin/buf_file.rb
@@ -133,6 +133,8 @@ module Fluent
         Dir.glob(patterns) do |path|
           next unless File.file?(path)
 
+          log.debug { "restoring buffer file: path = #{path}" }
+
           m = new_metadata() # this metadata will be overwritten by resuming .meta file content
                              # so it should not added into @metadata_list for now
           mode = Fluent::Plugin::Buffer::FileChunk.assume_chunk_state(path)

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -171,7 +171,7 @@ module Fluent::Plugin
 
       @encoding = parse_encoding_param(@encoding) if @encoding
       @from_encoding = parse_encoding_param(@from_encoding) if @from_encoding
-      if @encoding == @from_encoding
+      if @encoding && (@encoding == @from_encoding)
         log.warn "'encoding' and 'from_encoding' are same encoding. No effect"
       end
     end

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -239,6 +239,7 @@ module Fluent::Plugin
                 false
               end
             rescue Errno::ENOENT
+              log.debug("#{p} is missing after refresh file list")
               false
             end
           }
@@ -259,6 +260,8 @@ module Fluent::Plugin
     def refresh_watchers
       target_paths = expand_paths
       existence_paths = @tails.keys
+
+      log.debug { "tailing paths: target = #{target_paths.join(",")} | existing = #{existence_paths.join(",")}" }
 
       unwatched = existence_paths - target_paths
       added = target_paths - existence_paths
@@ -337,7 +340,7 @@ module Fluent::Plugin
     def update_watcher(path, pe)
       if @pf
         unless pe.read_inode == @pf[path].read_inode
-          log.trace "Skip update_watcher because watcher has been already updated by other inotify event"
+          log.debug "Skip update_watcher because watcher has been already updated by other inotify event"
           return
         end
       end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Related to https://github.com/fluent/fluentd/issues/2348

**What this PR does / why we need it**: 
To investigate reading files, output debug messages when `log_level` is `debug`.

**Docs Changes**:
No need.

**Release Note**: 
Use PR title.

In addition, this patch includes small patch for in_tail.