### PR TITLE
drop dig_rb and update required ruby version to 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ cache: bundler
 # See here for osx_image -> OSX versions: https://docs.travis-ci.com/user/languages/objective-c
 matrix:
   include:
-    - rvm: 2.1.10
-      os: linux
-    - rvm: 2.2.10
-      os: linux
     - rvm: 2.4.6
       os: linux
     - rvm: 2.5.5
@@ -19,9 +15,6 @@ matrix:
       os: linux
     - rvm: ruby-head
       os: linux
-    - rvm: 2.1.10
-      os: osx
-      osx_image: xcode8.3 # OSX 10.12
     # - rvm: 2.2.6
     #   os: osx
     #   osx_image: xcode8.2 # OSX 10.12
@@ -37,9 +30,6 @@ matrix:
   allow_failures:
     - rvm: 2.3.8
       os: linux
-    - rvm: 2.1.10
-      os: osx
-      osx_image: xcode8.3
     - rvm: 2.4.1
       os: osx
       osx_image: xcode8.3
@@ -55,7 +45,7 @@ before_install:
   - gem update --system=2.7.8
 
 sudo: false
-dist: trusty # for TLSv1.2 support
+dist: xenial
 
 addons:
   apt:

--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.license = "Apache-2.0"
 
-  gem.required_ruby_version = '>= 2.1'
+  gem.required_ruby_version = '>= 2.3'
 
   gem.add_runtime_dependency("msgpack", [">= 0.7.0", "< 2.0.0"])
   gem.add_runtime_dependency("yajl-ruby", ["~> 1.0"])
@@ -27,7 +27,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("tzinfo", ["~> 1.0"])
   gem.add_runtime_dependency("tzinfo-data", ["~> 1.0"])
   gem.add_runtime_dependency("strptime", [">= 0.2.2", "< 1.0.0"])
-  gem.add_runtime_dependency("dig_rb", ["~> 1.0.0"])
 
   # build gem for a certain platform. see also Rakefile
   fake_platform = ENV['GEM_BUILD_FAKE_PLATFORM'].to_s


### PR DESCRIPTION
ruby2.3 or higher version has dig_rb gem function as default, see top of https://github.com/jrochkind/dig_rb/blob/master/README.md

Now distros support ruby2.3 or higher version, bump up it would be okay, IMO.
 - [Debian9](https://packages.debian.org/source/stable/ruby2.3) or newer (Debian10 will be released 2 or 3 months later)
 - [Ubuntu16.04](https://packages.ubuntu.com/xenial/ruby2.3) or newer
 - [RHEL7 and its clone CentOS has ruby2.0](https://developers.redhat.com/articles/using-native-ruby-rhel-6-or-rhel-7/), so out of the scope already ;)