### PR TITLE
Update buffer.rb to recovery memory leak

### DIFF
--- a/lib/fluent/buffer.rb
+++ b/lib/fluent/buffer.rb
@@ -194,7 +194,11 @@ module Fluent
         begin
           # chunk unique id is generated in #new_chunk
           chunk = (@map[key] ||= new_chunk(key))
-
+          
+          if @queue.size >= @buffer_queue_limit
+             raise BufferQueueLimitError, "queue size exceeds limit"
+          end 
+          
           if storable?(chunk, data)
             chain.next
             chunk << data
@@ -297,8 +301,15 @@ module Fluent
     def push(key)
       synchronize do
         chunk = @map[key]
-        if !chunk || chunk.empty?
+        
+        if !chunk
           return false
+        end
+        
+        if chunk.empty?
+          chunk.purge
+          @map.delete(key)
+          return true
         end
 
         @queue.synchronize do


### PR DESCRIPTION
Update buffer.rb to recovery memory leak when using @copy

<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #
   memory leak in my environment
**What this PR does / why we need it**: 
    when new emit requests come,first judge if queue size is less than limit. if exceed limit, raise error.
**Docs Changes**:
     No
**Release Note**: 
     can release new version for v0.12