### PR TITLE
support config delimiter in syslog plugin

### DIFF
--- a/lib/fluent/plugin/in_syslog.rb
+++ b/lib/fluent/plugin/in_syslog.rb
@@ -99,6 +99,9 @@ module Fluent::Plugin
 
     config_param :blocking_timeout, :time, default: 0.5
 
+    desc 'The delimiter value "\n"'
+    config_param :delimiter, :string, default: "\n" # syslog family add "\n" to each message
+
     config_section :parse do
       config_set_default :@type, DEFAULT_PARSER
       config_param :with_priority, :bool, default: true
@@ -156,8 +159,7 @@ module Fluent::Plugin
     def start_tcp_server
       octet_count_frame = @frame_type == :octet_count
 
-      # syslog family adds "\n" to each message when transport is TCP and traditional frame
-      delimiter = octet_count_frame ? " " : "\n"
+      delimiter = octet_count_frame ? " " : @delimiter
       delimiter_size = delimiter.size
       server_create_connection(:in_syslog_tcp_server, @port, bind: @bind, resolve_name: @resolve_hostname) do |conn|
         conn.data do |data|


### PR DESCRIPTION
There are softwares out there that still use NUL-terminating characters when sending events through TCP. Firewalls for example are used a lots, and it's impossible to change their behavior because they are closed source. Most Firewall implement RFC3164 or CEF protocol, so using in_syslog plugin comes very usefull than in_tcp plugin.
I'm adding delimiter we can edit the default delimiter ("\n") from configuration, similar to in_tcp plugin.

I made the change in v0.12, I can do the same for v1.x If this change is good to merge.

Something important to know is that NUL(\0) or newline(\n) characters must be used with double-quote in configuration:
```
<source>
    type syslog
    protocol_type tcp
    delimiter "\0"
</source>
```
**Docs Changes**:
I will update documentation when this PR make it 