### PR TITLE
Remove duplicated method

### DIFF
--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -148,10 +148,10 @@ module Fluent
     end
 
     attr_reader :format
+    attr_reader :time_format
     attr_accessor :log_event_enabled
     attr_accessor :out
     attr_accessor :level
-    attr_accessor :time_format
     attr_accessor :optional_header, :optional_attrs
 
     def logdev=(logdev)


### PR DESCRIPTION
L195 overwrite Fluentd::Log#time_format= which is defined by `attr_accessor`.
This has been introduced since https://github.com/fluent/fluentd/commit/80e45ea2db99b2e3624e8ea9dde6b1707162416e

<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 

nope

**What this PR does / why we need it**: 

To fix the warning from ruby such as `warning: method redefined; discarding old time_format=`.

**Docs Changes**:

No need.

**Release Note**: 

No need.
