### PR TITLE
Update config becuase format is deprecated

### DIFF
--- a/example/in_http.conf
+++ b/example/in_http.conf
@@ -6,7 +6,9 @@
   keepalive_timeout 10
   # backlog 0
   add_http_headers false
-  format default
+  <parse>
+    @type json
+  </parse>
 </source>
 
 <match test>


### PR DESCRIPTION
ref:https://docs.fluentd.org/v1.0/articles/in_http 

> Deprecated parameter. Use the <parse> directive as explained below instead.

<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
nope

**What this PR does / why we need it**: 
nope

**Docs Changes**:
nope

**Release Note**: 
nope
