### PR TITLE
Use server helper in in_http

### DIFF
--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -130,11 +130,7 @@ module Fluent::Plugin
 
       log.debug "listening http", bind: @bind, port: @port
 
-      socket_manager_path = ENV['SERVERENGINE_SOCKETMANAGER_PATH']
-      if Fluent.windows?
-        socket_manager_path = socket_manager_path.to_i
-      end
-      client = ServerEngine::SocketManager::Client.new(socket_manager_path)
+      client = server_socket_manager_client
       lsock = client.listen_tcp(@bind, @port)
 
       @km = KeepaliveManager.new(@keepalive_timeout)

--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -131,7 +131,7 @@ module Fluent::Plugin
       log.debug "listening http", bind: @bind, port: @port
 
       @km = KeepaliveManager.new(@keepalive_timeout)
-      s = server_create_for_tcp_connection(true, @bind, @port, @backlog, ->(_){}) do |conn|
+      server_create_connection(:in_http, @port, bind: @bind, backlog: @backlog) do |conn|
         h = Handler.new(conn, @km, method(:on_request), @body_size_limit, @format_name, log, @cors_allow_origins)
         h.on_connect
 
@@ -147,7 +147,6 @@ module Fluent::Plugin
           h.on_close
         end
       end
-      server_attach('in_http', :tcp, @port, @bind, true, s)
       event_loop_attach(@km)
       @float_time_parser = Fluent::NumericTimeParser.new(:float)
     end

--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -38,7 +38,7 @@ module Fluent::Plugin
 
     # TODO: update this plugin implementation to use server plugin helper, after adding keepalive feature on it
 
-    helpers :parser, :compat_parameters, :event_loop
+    helpers :parser, :compat_parameters, :event_loop, :server
 
     EMPTY_GIF_IMAGE = "GIF89a\u0001\u0000\u0001\u0000\x80\xFF\u0000\xFF\xFF\xFF\u0000\u0000\u0000,\u0000\u0000\u0000\u0000\u0001\u0000\u0001\u0000\u0000\u0002\u0002D\u0001\u0000;".force_encoding("UTF-8")
 

--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -36,8 +36,6 @@ module Fluent::Plugin
   class HttpInput < Input
     Fluent::Plugin.register_input('http', self)
 
-    # TODO: update this plugin implementation to use server plugin helper, after adding keepalive feature on it
-
     helpers :parser, :compat_parameters, :event_loop, :server
 
     EMPTY_GIF_IMAGE = "GIF89a\u0001\u0000\u0001\u0000\x80\xFF\u0000\xFF\xFF\xFF\u0000\u0000\u0000,\u0000\u0000\u0000\u0000\u0001\u0000\u0001\u0000\u0000\u0002\u0002D\u0001\u0000;".force_encoding("UTF-8")

--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -133,7 +133,6 @@ module Fluent::Plugin
       @km = KeepaliveManager.new(@keepalive_timeout)
       server_create_connection(:in_http, @port, bind: @bind, backlog: @backlog) do |conn|
         h = Handler.new(conn, @km, method(:on_request), @body_size_limit, @format_name, log, @cors_allow_origins)
-        h.on_connect
 
         conn.on(:data) do |data|
           h.on_read(data)
@@ -282,6 +281,7 @@ module Fluent::Plugin
         @km.add(self)
 
         @remote_port, @remote_addr = io.remote_port, io.remote_addr
+        @parser = Http::Parser.new(self)
       end
 
       def step_idle
@@ -290,10 +290,6 @@ module Fluent::Plugin
 
       def on_close
         @km.delete(self)
-      end
-
-      def on_connect
-        @parser = Http::Parser.new(self)
       end
 
       def on_read(data)

--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -130,8 +130,7 @@ module Fluent::Plugin
 
       log.debug "listening http", bind: @bind, port: @port
 
-      client = server_socket_manager_client
-      lsock = client.listen_tcp(@bind, @port)
+      lsock = server_create_tcp_socket(true, @bind, @port)
 
       @km = KeepaliveManager.new(@keepalive_timeout)
       @lsock = Coolio::TCPServer.new(


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

~~I couldn't find any issue about HTTPS support of in_http.~~
#2124

**What this PR does / why we need it**: 

I replaced an implementation of in_http with server helper to prepare for HTTPS support.

**Docs Changes**:

no

**Release Note**: 
no