### PR TITLE
in_forward: Add tag and add_tag_prefix parameters

### DIFF
--- a/lib/fluent/plugin/in_forward.rb
+++ b/lib/fluent/plugin/in_forward.rb
@@ -62,6 +62,11 @@ module Fluent::Plugin
     desc "The field name of the client's hostname."
     config_param :source_hostname_key, :string, default: nil
 
+    desc "New tag instead of incoming tag"
+    config_param :tag, :string, default: nil
+    desc "Add prefix to incoming tag"
+    config_param :add_tag_prefix, :string, default: nil
+
     config_section :security, required: false, multi: false do
       desc 'The hostname'
       config_param :self_hostname, :string
@@ -292,6 +297,9 @@ module Fluent::Plugin
       elsif @chunk_size_warn_limit && (chunk_size > @chunk_size_warn_limit)
         log.warn "Input chunk size is larger than 'chunk_size_warn_limit':", tag: tag, host: conn.remote_host, limit: @chunk_size_warn_limit, size: chunk_size
       end
+
+      tag = @tag.dup if @tag
+      tag = "#{@add_tag_prefix}.#{tag}" if @add_tag_prefix
 
       case entries
       when String

--- a/lib/fluent/plugin/in_forward.rb
+++ b/lib/fluent/plugin/in_forward.rb
@@ -111,6 +111,9 @@ module Fluent::Plugin
       end
       @enable_field_injection = @source_address_key || @source_hostname_key
 
+      raise Fluent::ConfigError, "'tag' parameter must not be empty" if @tag && @tag.empty?
+      raise Fluent::ConfigError, "'add_tag_prefix' parameter must not be empty" if @add_tag_prefix && @add_tag_prefix.empty?
+
       if @security
         if @security.user_auth && @security.users.empty?
           raise Fluent::ConfigError, "<user> sections required if user_auth enabled"

--- a/test/plugin/test_in_forward.rb
+++ b/test/plugin/test_in_forward.rb
@@ -269,6 +269,34 @@ class ForwardInputTest < Test::Unit::TestCase
       assert_equal(records, d.events)
     end
 
+    data(tag: {
+           param: "tag new_tag",
+           result: "new_tag"
+         },
+         add_tag_prefix: {
+           param: "add_tag_prefix new_prefix",
+           result: "new_prefix.tag1"
+         })
+    test 'tag parameters' do |data|
+      @d = create_driver(CONFIG + data[:param])
+      time = event_time("2011-01-02 13:14:15 UTC")
+      options = {auth: false}
+
+      records = [
+        ["tag1", time, {"a"=>1}],
+        ["tag1", time, {"a"=>2}],
+      ]
+
+      @d.run(expect_records: records.length, timeout: 20) do
+        entries = []
+        records.each {|tag, _time, record|
+          entries << [_time, record]
+        }
+        send_data packer.write(["tag1", entries]).to_s, **options
+      end
+      assert_equal(data[:result], @d.events[0][0])
+    end
+
     data(tcp: {
            config: CONFIG,
            options: {
@@ -376,6 +404,34 @@ class ForwardInputTest < Test::Unit::TestCase
         send_data packer.write(["tag1", entries]).to_s, **options
       end
       assert_equal(records, d.events)
+    end
+
+    data(tag: {
+           param: "tag new_tag",
+           result: "new_tag"
+         },
+         add_tag_prefix: {
+           param: "add_tag_prefix new_prefix",
+           result: "new_prefix.tag1"
+         })
+    test 'tag parameters' do |data|
+      @d = create_driver(CONFIG + data[:param])
+      time = event_time("2011-01-02 13:14:15 UTC")
+      options = {auth: false}
+
+      records = [
+        ["tag1", time, {"a"=>1}],
+        ["tag1", time, {"a"=>2}],
+      ]
+
+      @d.run(expect_records: records.length, timeout: 20) do
+        entries = ''
+        records.each {|_tag, _time, record|
+          packer(entries).write([_time, record]).flush
+        }
+        send_data packer.write(["tag1", entries]).to_s, **options
+      end
+      assert_equal(data[:result], @d.events[0][0])
     end
 
     data(tcp: {

--- a/test/plugin/test_in_forward.rb
+++ b/test/plugin/test_in_forward.rb
@@ -82,6 +82,14 @@ class ForwardInputTest < Test::Unit::TestCase
       assert_equal 1, d.instance.security.clients.size
     end
 
+    data(tag: "tag",
+         add_tag_prefix: "add_tag_prefix")
+    test 'tag parameters' do |data|
+      assert_raise(Fluent::ConfigError.new("'#{data}' parameter must not be empty")) {
+        create_driver(CONFIG + "#{data} ''")
+      }
+    end
+
     test 'send_keepalive_packet is disabled by default' do
       @d = d = create_driver(CONFIG_AUTH)
       assert_false d.instance.send_keepalive_packet


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

**Which issue(s) this PR fixes**: 
none

**What this PR does / why we need it**: 
I sometimes receive this request from users for aggregator.
There are several reasons:

- Port based tag handling

```
<source>
  @type forward
  port 24224
  add_tag_prefix cluster1
</source>

<source>
  @type forward
  port 24225
  add_tag_prefix cluster2
</source>
```

We can simulate this by adding new field for cluster detection in forwarder side and check it in aggregator side. But it makes configuration complicated.

- Make tag handling cost lower

We can rewrite tag with `route` or similar plugins but it has performance penalty for large traffic.

The implementation is very simple and it resolves above cases. So supporting these parameters is reasonable.

**Docs Changes**:
Will send a patch to fluentd-docs after merged.

**Release Note**: 
Same as title.