### PR TITLE
Added rvm support for ppc64le builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ matrix:
       os: linux
     - rvm: ruby-head
       os: linux
+    - rvm: ruby-head
+      os: linux-ppc64le
     - rvm: 2.1.10
       os: osx
       osx_image: xcode8.3 # OSX 10.12


### PR DESCRIPTION
Adding power support to travis.yml for "rvm:ruby-head"
Signed-off-by : ghatwala@us.ibm.com

<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes # Adding power support to the travis.yml builds ( rvm:ruby-head)

**What this PR does / why we need it**: 
Travis deployments on power , similar to PR- https://github.com/fluent/fluentd/pull/2386

**Docs Changes**:
None

**Release Note**: 
None