### PR TITLE
out_forward: do not use SO_LINGER on Windows

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -354,7 +354,10 @@ module Fluent::Plugin
           cert_path: @tls_client_cert_path,
           private_key_path: @tls_client_private_key_path,
           private_key_passphrase: @tls_client_private_key_passphrase,
-          linger_timeout: @send_timeout,
+
+          # Enabling SO_LINGER causes data loss on Windows
+          # https://github.com/fluent/fluentd/issues/1968
+          linger_timeout: Fluent.windows? ? nil : @send_timeout,
           send_timeout: @send_timeout,
           recv_timeout: @ack_response_timeout,
           &block


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #1968 

**What this PR does / why we need it**: 

There is an obscure bug in out_forward that prevents events from
being sent to a remote node. It occures only on Windows, and is
reproducable only when SSL/TLS is enabled.
    
The root cause is not fully investigated yet, but disabling
SO_LINGER is confirmed to fix the issue. So this implements it.

**Docs Changes**:

Not required

**Release Note**: 

"out_forward: fix data loss when SSL/TLS is enabled on Windows "