### PR TITLE
Add deprecated message to show-plugin-config option

### DIFF
--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -40,7 +40,7 @@ op.on('--dry-run', "Check fluentd setup is correct or not", TrueClass) {|b|
   opts[:dry_run] = b
 }
 
-op.on('--show-plugin-config=PLUGIN', "Show PLUGIN configuration and exit(ex: input:dummy)") {|plugin|
+op.on('--show-plugin-config=PLUGIN', "[DEPRECATED] Show PLUGIN configuration and exit(ex: input:dummy)") {|plugin|
   opts[:show_plugin_config] = plugin
 }
 

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -588,7 +588,7 @@ module Fluent
 
     def show_plugin_config
       name, type = @show_plugin_config.split(":") # input:tail
-      $log.info "Use fluent-plugin-config-format --format=txt #{name} #{type}"
+      $log.info "show_plugin_config option is deprecated. Use fluent-plugin-config-format --format=txt #{name} #{type}"
       exit 0
     end
 


### PR DESCRIPTION
Signed-off-by: Yuta Iwama <ganmacs@gmail.com>

<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes https://github.com/fluent/fluentd/issues/2400

**What this PR does / why we need it**: 

I added a deprecated message to `--help` and log.

**Docs Changes**:

none

**Release Note**: 

none
