### PR TITLE
in_tail: increase read block size

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -732,7 +732,7 @@ module Fluent::Plugin
               if !io.nil? && @lines.empty?
                 begin
                   while true
-                    @fifo << io.readpartial(2048, @iobuf)
+                    @fifo << io.readpartial(8192, @iobuf)
                     while (line = @fifo.next_line)
                       @lines << line
                     end

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -196,7 +196,7 @@ class TailInputTest < Test::Unit::TestCase
         config = CONFIG_READ_FROM_HEAD + config_element("", "", { "read_lines_limit" => limit }) + PARSE_SINGLE_LINE_CONFIG
       end
       d = create_driver(config)
-      msg = 'test' * 500 # in_tail reads 2048 bytes at once.
+      msg = 'test' * 2000 # in_tail reads 8192 bytes at once.
 
       d.run(expect_emits: 1) do
         File.open("#{TMP_DIR}/tail.txt", "ab") {|f|


### PR DESCRIPTION
2048 was too small for large logs.
8192 is chosen because BUFSIZ in stdio.h is 8192
on Ubuntu and Debian.

Signed-off-by: Inada Naoki <songofacandy@gmail.com>

<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #2416

**What this PR does / why we need it**: 

**Docs Changes**:

**Release Note**: 
in_tail: increased read block size from 2048 to 8192.