### PR TITLE
Fix error if timezone with name is used in parser

### DIFF
--- a/lib/fluent/time.rb
+++ b/lib/fluent/time.rb
@@ -201,14 +201,18 @@ module Fluent
       format_with_timezone = format && (format.include?("%z") || format.include?("%Z"))
 
       # unixtime_in_expected_tz = unixtime_in_localtime + offset_diff
-      offset_diff = ->(t){
-                      case
-                      when format_with_timezone then nil
-                      when timezone  then Time.now.localtime.utc_offset - offset_utc(timezone, t)
-                      when localtime then 0
-                      else Time.now.localtime.utc_offset # utc
+      offset_diff = case
+                    when format_with_timezone then nil
+                    when timezone  then
+                      offset = Fluent::Timezone.utc_offset(timezone)
+                      if offset.respond_to?(:call)
+                        ->(t) { Time.now.localtime.utc_offset - offset.call(t) }
+                      else
+                        ->(t) { Time.now.localtime.utc_offset - offset }
                       end
-                    }
+                    when localtime then 0
+                    else Time.now.localtime.utc_offset # utc
+                    end
 
       strptime = format && (Strptime.new(format) rescue nil)
 
@@ -216,15 +220,15 @@ module Fluent
                when format_with_timezone && strptime then ->(v){ Fluent::EventTime.from_time(strptime.exec(v)) }
                when format_with_timezone             then ->(v){ Fluent::EventTime.from_time(Time.strptime(v, format)) }
                when format == '%iso8601'             then ->(v){ Fluent::EventTime.from_time(Time.iso8601(v)) }
-               when strptime then ->(v){ t = strptime.exec(v);         Fluent::EventTime.new(t.to_i + offset_diff.call(t), t.nsec) }
-               when format   then ->(v){ t = Time.strptime(v, format); Fluent::EventTime.new(t.to_i + offset_diff.call(t), t.nsec) }
+               when strptime then
+                 if offset_diff.respond_to?(:call)
+                   ->(v) { t = strptime.exec(v); Fluent::EventTime.new(t.to_i + offset_diff.call(t), t.nsec) }
+                 else
+                   ->(v) { t = strptime.exec(v); Fluent::EventTime.new(t.to_i + offset_diff, t.nsec) }
+                 end
+               when format   then ->(v){ t = Time.strptime(v, format); Fluent::EventTime.new(t.to_i + offset_diff, t.nsec) }
                else ->(v){ Fluent::EventTime.parse(v) }
                end
-    end
-
-    def offset_utc(timezone, time)
-      offset = Fluent::Timezone.utc_offset(timezone)
-      offset.respond_to?(:call) ? offset.call(time) : offset
     end
 
     # TODO: new cache mechanism using format string

--- a/lib/fluent/time.rb
+++ b/lib/fluent/time.rb
@@ -226,7 +226,12 @@ module Fluent
                  else
                    ->(v) { t = strptime.exec(v); Fluent::EventTime.new(t.to_i + offset_diff, t.nsec) }
                  end
-               when format   then ->(v){ t = Time.strptime(v, format); Fluent::EventTime.new(t.to_i + offset_diff, t.nsec) }
+               when format   then
+                 if offset_diff.respond_to?(:call)
+                   ->(v){ t = Time.strptime(v, format); Fluent::EventTime.new(t.to_i + offset_diff.call(t), t.nsec) }
+                 else
+                   ->(v){ t = Time.strptime(v, format); Fluent::EventTime.new(t.to_i + offset_diff, t.nsec) }
+                 end
                else ->(v){ Fluent::EventTime.parse(v) }
                end
     end

--- a/lib/fluent/time.rb
+++ b/lib/fluent/time.rb
@@ -208,7 +208,7 @@ module Fluent
                       if offset.respond_to?(:call)
                         ->(t) { Time.now.localtime.utc_offset - offset.call(t) }
                       else
-                        ->(t) { Time.now.localtime.utc_offset - offset }
+                        Time.now.localtime.utc_offset - offset
                       end
                     when localtime then 0
                     else Time.now.localtime.utc_offset # utc

--- a/test/test_time_parser.rb
+++ b/test/test_time_parser.rb
@@ -80,6 +80,14 @@ class TimeParserTest < ::Test::Unit::TestCase
     assert_equal_event_time(time, event_time("2016-09-02 18:42:31.123456789 -07:00", format: '%Y-%m-%d %H:%M:%S.%N %z'))
   end
 
+  def test_parse_time_with_expected_timezone_name
+    time = with_timezone("UTC-09") do
+      parser = Fluent::TimeParser.new("%Y-%m-%d %H:%M:%S.%N", nil, "Europe/Zurich")
+      parser.parse("2016-12-02 18:42:31.123456789")
+    end
+    assert_equal_event_time(time, event_time("2016-12-02 18:42:31.123456789 +01:00", format: '%Y-%m-%d %H:%M:%S.%N %z'))
+  end
+
   sub_test_case 'TimeMixin::Parser' do
     class DummyForTimeParser
       include Fluent::Configurable


### PR DESCRIPTION
**What this PR does / why we need it**: 
Fixes a `TypeError: nil can't be coerced into Integer` when a timezone name is used in a parser configuration.