### PR TITLE
Enable pretty print in config

### DIFF
--- a/lib/fluent/plugin/in_monitor_agent.rb
+++ b/lib/fluent/plugin/in_monitor_agent.rb
@@ -216,7 +216,7 @@ module Fluent::Plugin
       def process(req)
         opts = build_option(req)
         result = build_object(req, opts)
-        render_json(result)
+        render_json(result, opts)
       end
     end
 

--- a/lib/fluent/plugin/in_monitor_agent.rb
+++ b/lib/fluent/plugin/in_monitor_agent.rb
@@ -67,12 +67,11 @@ module Fluent::Plugin
         res.body = body
       end
 
-      def build_object(req)
+      def build_object(req, opts)
         unless req.path_info == ""
           return render_json_error(404, "Not found")
         end
 
-        opts = build_option(req)
         qs = opts[:query]
         if tag = qs['tag'.freeze].first
           # ?tag= to search an output plugin by match pattern
@@ -96,7 +95,7 @@ module Fluent::Plugin
           list = @agent.plugins_info_all(opts)
         end
 
-        [list, opts]
+        list
       end
 
       def render_json(obj, opts={})
@@ -155,7 +154,8 @@ module Fluent::Plugin
 
     class LTSVMonitorServlet < MonitorServlet
       def process(req)
-        list, _opts = build_object(req)
+        opts = build_option(req)
+        list = build_object(req, opts)
         return unless list
 
         normalized = JSON.parse(list.to_json)
@@ -178,7 +178,8 @@ module Fluent::Plugin
 
     class JSONMonitorServlet < MonitorServlet
       def process(req)
-        list, opts = build_object(req)
+        opts = build_option(req)
+        list = build_object(req, opts)
         return unless list
 
         render_json({
@@ -188,7 +189,7 @@ module Fluent::Plugin
     end
 
     class ConfigMonitorServlet < MonitorServlet
-      def build_object(req)
+      def build_object(req, _opt)
         {
           'pid' => Process.pid,
           'ppid' => Process.ppid
@@ -198,7 +199,8 @@ module Fluent::Plugin
 
     class LTSVConfigMonitorServlet < ConfigMonitorServlet
       def process(req)
-        result = build_object(req)
+        opts = build_option(req)
+        result = build_object(req, opts)
 
         row = []
         JSON.parse(result.to_json).each_pair { |k, v|
@@ -212,7 +214,8 @@ module Fluent::Plugin
 
     class JSONConfigMonitorServlet < ConfigMonitorServlet
       def process(req)
-        result = build_object(req)
+        opts = build_option(req)
+        result = build_object(req, opts)
         render_json(result)
       end
     end

--- a/test/plugin/test_in_monitor_agent.rb
+++ b/test/plugin/test_in_monitor_agent.rb
@@ -414,6 +414,19 @@ plugin_id:test_filter\tplugin_category:filter\ttype:test_filter\toutput_plugin:f
       assert_equal(["/etc/fluent/plugin"], res["plugin_dirs"])
       assert_nil(res["log_path"])
     end
+
+    test "/api/config.json?debug=1" do
+      d = create_driver("
+  @type monitor_agent
+  bind '127.0.0.1'
+  port #{@port}
+  tag monitor
+")
+      d.instance.start
+      # To check pretty print
+      assert_true !get("http://127.0.0.1:#{@port}/api/config.json").body.include?("\n")
+      assert_true get("http://127.0.0.1:#{@port}/api/config.json?debug=1").body.include?("\n")
+    end
   end
 
   sub_test_case "check retry of buffered plugins" do


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 

Related https://github.com/fluent/fluentd/pull/2422.
Please merge this patch after #2422 is merged.

**What this PR does / why we need it**: 

In the current implementation, `/api/config.json` endpoint ignores `?debug=1` parameters even though `/api/plugins.json` endpoint respects the parameter.

**Docs Changes**:

not needed

**Release Note**: 

not needed