### PR TITLE
Fix log rotete age error handling

### DIFF
--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -93,7 +93,7 @@ op.on('--log-rotate-age AGE', 'generations to keep rotated log files') {|age|
     begin
       opts[:log_rotate_age] = Integer(age)
     rescue TypeError, ArgumentError
-      usage "log-rotate-age should be #{rotate_ages.join(', ')} or a number"
+      usage "log-rotate-age should be #{ROTATE_AGE.join(', ')} or a number"
     end
   end
 }

--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -92,7 +92,7 @@ op.on('--log-rotate-age AGE', 'generations to keep rotated log files') {|age|
   else
     begin
       opts[:log_rotate_age] = Integer(age)
-    rescue TypeError
+    rescue TypeError, ArgumentError
       usage "log-rotate-age should be #{rotate_ages.join(', ')} or a number"
     end
   end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
nothing

**What this PR does / why we need it**: 

Kernel.#Integer can raise ArgumentError https://docs.ruby-lang.org/ja/2.5.0/method/Kernel/m/Integer.html  (Sorry. but I wasn't able to find the English document...  
English document which I found(https://ruby-doc.org/core-2.5.1/Kernel.html#method-i-Integer)  doesn't refer to ArgumentError. )
And I also noticed the variable name  (`rotate_ages`) is used.

https://ruby-doc.org/core-2.5.1/Kernel.html

**Docs Changes**:

not needed

**Release Note**: 

not needed