### PR TITLE
Get rid of ERB warning for Ruby 2.6+

### DIFF
--- a/lib/fluent/command/plugin_config_formatter.rb
+++ b/lib/fluent/command/plugin_config_formatter.rb
@@ -164,7 +164,13 @@ class FluentPluginConfigFormatter
     params.each do |name, config|
       next if name == :section
       template_name = @compact ? "param.md-compact.erb" : "param.md.erb"
-      dumped << ERB.new(template_path(template_name).read, nil, "-").result(binding)
+      template = template_path(template_name).read
+      dumped <<
+        if ERB.instance_method(:initialize).parameters.assoc(:key) # Ruby 2.6+
+          ERB.new(template, trim_mode: "-")
+        else
+          ERB.new(template, nil, "-")
+        end.result(binding)
     end
     dumped << "\n"
     sections.each do |section_name, sub_section|
@@ -172,7 +178,13 @@ class FluentPluginConfigFormatter
       multi = sub_section.delete(:multi)
       alias_name = sub_section.delete(:alias)
       sub_section.delete(:section)
-      dumped << ERB.new(template_path("section.md.erb").read, nil, "-").result(binding)
+      template = template_path("section.md.erb").read
+      dumped <<
+        if ERB.instance_method(:initialize).parameters.assoc(:key) # Ruby 2.6+
+          ERB.new(template, trim_mode: "-")
+        else
+          ERB.new(template, nil, "-")
+        end.result(binding)
     end
     dumped
   end

--- a/lib/fluent/command/plugin_generator.rb
+++ b/lib/fluent/command/plugin_generator.rb
@@ -72,7 +72,12 @@ class FluentPluginGenerator
 
   def template(source, dest)
     dest.dirname.mkpath
-    contents = ERB.new(source.read, nil, "-").result(binding)
+    contents =
+      if ERB.instance_method(:initialize).parameters.assoc(:key) # Ruby 2.6+
+        ERB.new(source.read, trim_mode: "-")
+      else
+        ERB.new(source.read, nil, "-")
+      end.result(binding)
     label = create_label(dest, contents)
     puts "\t#{label} #{dest}"
     if label == "conflict"


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: None

**What this PR does / why we need it**: I found lots of `ERB.new` warnings (https://github.com/ruby/ruby/commit/cc777d09f44) in https://travis-ci.org/fluent/fluentd/jobs/539499703 and I thought it'd be annoying.

**Docs Changes**: None

**Release Note**: Suppress deprecation warnings of ERB for Ruby 2.6+
