### PR TITLE
Match result contents

### DIFF
--- a/lib/fluent/plugin/in_monitor_agent.rb
+++ b/lib/fluent/plugin/in_monitor_agent.rb
@@ -55,8 +55,8 @@ module Fluent::Plugin
           code, header, body = render_error_json(
             code: 500,
             msg: 'Internal Server Error',
-            'error' => "#{$!}",
-            'backtrace' => $!.backtrace,
+            error: "#{$!}",
+            backtrace: $!.backtrace,
           )
         end
 

--- a/lib/fluent/plugin/in_monitor_agent.rb
+++ b/lib/fluent/plugin/in_monitor_agent.rb
@@ -224,13 +224,7 @@ module Fluent::Plugin
         opts = build_option(req)
         result = build_object(opts)
 
-        row = []
-        JSON.parse(result.to_json).each_pair { |k, v|
-          row << "#{k}:#{v}"
-        }
-        text = row.join("\t")
-
-        [200, {'Content-Type'=>'text/plain'}, text]
+        render_lstv([result])
       end
     end
 

--- a/lib/fluent/plugin/in_monitor_agent.rb
+++ b/lib/fluent/plugin/in_monitor_agent.rb
@@ -174,8 +174,12 @@ module Fluent::Plugin
         text = ''
         JSON.parse(list.to_json).map {|hash|
           row = []
-          hash.each_pair {|k,v|
-            unless v.is_a?(Hash) || v.is_a?(Array)
+          hash.each { |k,v|
+            if v.is_a?(Array)
+              row << "#{k}:#{v.join(',')}"
+            elsif v.is_a?(Hash)
+              next
+            else
               row << "#{k}:#{v}"
             end
           }

--- a/lib/fluent/plugin/in_monitor_agent.rb
+++ b/lib/fluent/plugin/in_monitor_agent.rb
@@ -171,11 +171,8 @@ module Fluent::Plugin
         list = build_object(opts)
         return unless list
 
-        normalized = JSON.parse(list.to_json)
-
         text = ''
-
-        normalized.map {|hash|
+        JSON.parse(list.to_json).map {|hash|
           row = []
           hash.each_pair {|k,v|
             unless v.is_a?(Hash) || v.is_a?(Array)

--- a/lib/fluent/plugin/in_monitor_agent.rb
+++ b/lib/fluent/plugin/in_monitor_agent.rb
@@ -159,22 +159,12 @@ module Fluent::Plugin
 
         [code, { 'Content-Type' => 'application/json' }, body]
       end
-    end
 
-    class LTSVMonitorServlet < MonitorServlet
-      def process(req)
-        unless req.path_info == ''
-          return render_not_found_json
-        end
-
-        opts = build_option(req)
-        list = build_object(opts)
-        return unless list
-
+      def render_lstv(obj, code: 200)
         text = ''
-        JSON.parse(list.to_json).map {|hash|
+        JSON.parse(obj.to_json).each do |hash|
           row = []
-          hash.each { |k,v|
+          hash.each do |k,v|
             if v.is_a?(Array)
               row << "#{k}:#{v.join(',')}"
             elsif v.is_a?(Hash)
@@ -182,11 +172,21 @@ module Fluent::Plugin
             else
               row << "#{k}:#{v}"
             end
-          }
-          text << row.join("\t") << "\n"
-        }
+          end
 
-        [200, {'Content-Type'=>'text/plain'}, text]
+          text << row.join("\t") << "\n"
+        end
+
+        [code, { 'Content-Type' => 'text/plain' }, text]
+      end
+    end
+
+    class LTSVMonitorServlet < MonitorServlet
+      def process(req)
+        opts = build_option(req)
+        list = build_object(opts)
+        return unless list
+        render_lstv(list)
       end
     end
 

--- a/test/plugin/test_in_monitor_agent.rb
+++ b/test/plugin/test_in_monitor_agent.rb
@@ -408,7 +408,7 @@ plugin_id:test_filter\tplugin_category:filter\ttype:test_filter\toutput_plugin:f
   tag monitor
 ")
       d.instance.start
-      expected_response_regex = /pid:\d+\tppid:\d+\tconfig_path:\/etc\/fluent\/fluent.conf\tpid_file:\tplugin_dirs:\[\"\/etc\/fluent\/plugin\"\]\tlog_path:/
+      expected_response_regex = /pid:\d+\tppid:\d+\tconfig_path:\/etc\/fluent\/fluent.conf\tpid_file:\tplugin_dirs:\/etc\/fluent\/plugin\tlog_path:/
 
       assert_match(expected_response_regex,
                    get("http://127.0.0.1:#{@port}/api/config").body)


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 

nothing

**What this PR does / why we need it**: 

Match the response form of `/api/config` and `/api/plugins`.
`/api/plugins` doesn't include the value which is the instance of Hash or Array class at [here](https://github.com/fluent/fluentd/blob/b3abefcd166aa99bcaded1cf52f8b71177e3af3d/lib/fluent/plugin/in_monitor_agent.rb#L168-L170) into the response body .
But `/api/plugins` includes  such a value[*](https://github.com/fluent/fluentd/blob/b3abefcd166aa99bcaded1cf52f8b71177e3af3d/lib/fluent/plugin/in_monitor_agent.rb#L206-L208).

I think it's safe that this diff is released as v1.6 since it includes breaking change which changes the form of the response body.

**Docs Changes**:

not needed

**Release Note**: 
not needed
