### PR TITLE
command: Add --conf-encoding option to accept non utf-8 configuration file

### DIFF
--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -155,6 +155,10 @@ op.on('-G', '--gem-path GEM_INSTALL_PATH', "Gemfile install path (default: $(dir
   opts[:gem_install_path] = s
 }
 
+op.on('--conf-encoding ENCODING', "specify configuration file encoding") { |s|
+  opts[:conf_encoding] = s
+}
+
 if Fluent.windows?
   require 'windows/library'
   include Windows::Library

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -249,7 +249,7 @@ module Fluent
       config_fname = File.basename(path)
       config_basedir = File.dirname(path)
       # Assume fluent.conf encoding is UTF-8
-      config_data = File.open(path, "r:utf-8:utf-8") {|f| f.read }
+      config_data = File.open(path, "r:#{params['conf_encoding']}:utf-8") {|f| f.read }
       inline_config = params['inline_config']
       if inline_config == '-'
         config_data << "\n" << STDIN.read
@@ -422,6 +422,7 @@ module Fluent
         supervise: true,
         standalone_worker: false,
         signame: nil,
+        conf_encoding: 'utf-8'
       }
     end
 
@@ -440,6 +441,7 @@ module Fluent
       @config_path = opt[:config_path]
       @inline_config = opt[:inline_config]
       @use_v1_config = opt[:use_v1_config]
+      @conf_encoding = opt[:conf_encoding]
       @log_path = opt[:log_path]
       @dry_run = opt[:dry_run]
       @show_plugin_config = opt[:show_plugin_config]
@@ -618,6 +620,7 @@ module Fluent
       params['chuser'] = @chuser
       params['chgroup'] = @chgroup
       params['use_v1_config'] = @use_v1_config
+      params['conf_encoding'] = @conf_encoding
 
       # system config parameters
       params['workers'] = @workers
@@ -763,7 +766,7 @@ module Fluent
     def read_config
       @config_fname = File.basename(@config_path)
       @config_basedir = File.dirname(@config_path)
-      @config_data = File.open(@config_path, "r:utf-8:utf-8") {|f| f.read }
+      @config_data = File.open(@config_path, "r:#{@conf_encoding}:utf-8") {|f| f.read }
       if @inline_config == '-'
         @config_data << "\n" << STDIN.read
       elsif @inline_config

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -274,6 +274,7 @@ class SupervisorTest < ::Test::Unit::TestCase
     params['log_path'] = 'test/tmp/supervisor/log'
     params['suppress_repeated_stacktrace'] = true
     params['log_level'] = Fluent::Log::LEVEL_INFO
+    params['conf_encoding'] = 'utf-8'
     load_config_proc =  Proc.new { Fluent::Supervisor.load_config(tmp_dir, params) }
 
     # first call
@@ -340,6 +341,7 @@ class SupervisorTest < ::Test::Unit::TestCase
     params['suppress_repeated_stacktrace'] = true
     params['log_level'] = Fluent::Log::LEVEL_INFO
     params['daemonize'] = './fluentd.pid'
+    params['conf_encoding'] = 'utf-8'
     load_config_proc = Proc.new { Fluent::Supervisor.load_config(tmp_dir, params) }
 
     # first call
@@ -414,6 +416,7 @@ class SupervisorTest < ::Test::Unit::TestCase
     params['log_path'] = 'test/tmp/supervisor/log'
     params['suppress_repeated_stacktrace'] = true
     params['log_level'] = Fluent::Log::LEVEL_INFO
+    params['conf_encoding'] = 'utf-8'
     load_config_proc =  Proc.new { Fluent::Supervisor.load_config(tmp_path, params) }
 
     se_config = load_config_proc.call


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 
Some environment doesn't use utf-8 for text file and convert encoding is not easy for non technical users. This option reduces the encoding trouble.

**Docs Changes**:
I will add option to command line option article.

**Release Note**: 
Same as title.