### PR TITLE
parser_none: Use faster record creation

### DIFF
--- a/lib/fluent/plugin/parser_none.rb
+++ b/lib/fluent/plugin/parser_none.rb
@@ -27,8 +27,7 @@ module Fluent
       config_param :message_key, :string, default: 'message'
 
       def parse(text)
-        record = {}
-        record[@message_key] = text
+        record = {@message_key => text}
         time = @estimate_current_event ? Fluent::EventTime.now : nil
         yield time, record
       end


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 
I found current implementation is bit slower,

```
require 'benchmark/ips'

key = 'message'
value = 'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong'

Benchmark.ips do |x|
  x.report "init" do
    r = {key => value}
  end

  x.report "init + []=" do
    r = {}
    r[key] = value
  end
end
```

```
Warming up --------------------------------------
                init   250.160k i/100ms
          init + []=   243.042k i/100ms
Calculating -------------------------------------
                init      5.944M (± 1.9%) i/s -     29.769M in   5.010006s
          init + []=      5.508M (± 1.2%) i/s -     27.707M in   5.031503s
```

**Docs Changes**:
No need.

**Release Note**: 
Same title