### PR TITLE
Treat empty hash_value_field as nil

### DIFF
--- a/lib/fluent/plugin/filter_parser.rb
+++ b/lib/fluent/plugin/filter_parser.rb
@@ -120,7 +120,7 @@ module Fluent::Plugin
       if values && @inject_key_prefix
         values = Hash[values.map { |k, v| [@inject_key_prefix + k, v] }]
       end
-      r = @hash_value_field ? {@hash_value_field => values} : values
+      r = @hash_value_field && @hash_value_field != '' ? {@hash_value_field => values} : values
       if @reserve_data
         r = r ? record.merge(r) : record
       end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
No issue connected to this.

**What this PR does / why we need it**: 
When configuring `hash_value_field` in a parser filter, it will treat empty values as `nil`, as if it was not configured at all.

This enables you to configure it conditionally. For example, you only want the `hash_value_field` if the environment variable "HASH" is set to true. Then you can configure the parser with: 

```
<filter *.*.*.*.*.*.raw_json>
  @type parser
  ...
  hash_value_field "#{'parsed' if ENV['HASH']=='TRUE'}"
  ...
</filter>
```
With current code (before this PR), this would generate an empty value for `hash_value_field`, and not `nil`. The result would be an empty parent field like this:  `{ "": {"key1":"value1"} }`. 

**Docs Changes**:
No changes

**Release Note**: 
* An empty `hash_value_field` will be treated as `nil` (not configured).
