### PR TITLE
rollback_count should be incremented when takeback_chunk succeeded

### DIFF
--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -1173,7 +1173,10 @@ module Fluent
               @dequeued_chunks.delete_if{|d| d.chunk_id == chunk.unique_id }
             end
           end
-          @buffer.takeback_chunk(chunk.unique_id)
+
+          if @buffer.takeback_chunk(chunk.unique_id)
+            @counters_monitor.synchronize { @rollback_count += 1 }
+          end
 
           update_retry_state(chunk.unique_id, using_secondary, e)
 


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
no

**What this PR does / why we need it**: 

Increment `@rollback_count` when `@buffer.takeback_chunk(chunk.unique_id)` succeeded. 

**Docs Changes**:

no

**Release Note**: 

no
