### PR TITLE
socket helper: Support connect_timeout for TCP/TLS

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -39,6 +39,8 @@ module Fluent::Plugin
 
     desc 'The timeout time when sending event logs.'
     config_param :send_timeout, :time, default: 60
+    desc 'The timeout time for socket connect'
+    config_param :connect_timeout, :time, default: nil
     # TODO: add linger_timeout, recv_timeout
 
     desc 'The protocol to use for heartbeats (default is the same with "transport").'
@@ -376,6 +378,7 @@ module Fluent::Plugin
           linger_timeout: Fluent.windows? ? nil : @send_timeout,
           send_timeout: @send_timeout,
           recv_timeout: @ack_response_timeout,
+          connect_timeout: @connect_timeout,
           &block
         )
       when :tcp
@@ -384,6 +387,7 @@ module Fluent::Plugin
           linger_timeout: @send_timeout,
           send_timeout: @send_timeout,
           recv_timeout: @ack_response_timeout,
+          connect_timeout: @connect_timeout,
           &block
         )
       else

--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -78,6 +78,7 @@ class ForwardOutputTest < Test::Unit::TestCase
     assert_equal 60, d.instance.send_timeout
     assert_equal :transport, d.instance.heartbeat_type
     assert_equal 1, nodes.length
+    assert_nil d.instance.connect_timeout
     node = nodes.first
     assert_equal "test", node.name
     assert_equal '127.0.0.1', node.host
@@ -100,6 +101,23 @@ EOL
     assert_equal [], instance.chunk_keys
     assert{ instance.buffer.is_a?(Fluent::Plugin::MemoryBuffer) }
     assert_equal( 10*1024*1024, instance.buffer.chunk_limit_size )
+  end
+
+  test 'configure timeouts' do
+    @d = d = create_driver(%[
+      send_timeout 30
+      connect_timeout 10
+      hard_timeout 15
+      ack_response_timeout 20
+      <server>
+        host #{TARGET_HOST}
+        port #{TARGET_PORT}
+      </server>
+    ])
+    assert_equal 30, d.instance.send_timeout
+    assert_equal 10, d.instance.connect_timeout
+    assert_equal 15, d.instance.hard_timeout
+    assert_equal 20, d.instance.ack_response_timeout
   end
 
   test 'configure_udp_heartbeat' do


### PR DESCRIPTION
out_forward also supports connect_timeout parameter

Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 


**Docs Changes**:
After release v1.6.0, need to add connect_timeout parameter to socket helper/out_forward article.

**Release Note**: 
socket helper/out_forward: Support connect_timeout parameter