### PR TITLE
time: Add EventTime#to_time for faster Time creation

### DIFF
--- a/lib/fluent/time.rb
+++ b/lib/fluent/time.rb
@@ -69,6 +69,19 @@ module Fluent
       @sec.to_s
     end
 
+    begin
+      # ruby 2.5 or later
+      Time.at(0, 0, :nanosecond)
+
+      def to_time
+        Time.at(@sec, @nsec, :nanosecond)
+      end
+    rescue
+      def to_time
+        Time.at(@sec, @nsec / 1000.0)
+      end
+    end
+
     def to_json(*args)
       @sec.to_s
     end

--- a/test/test_event_time.rb
+++ b/test/test_event_time.rb
@@ -36,6 +36,19 @@ class EventTimeTest < Test::Unit::TestCase
     assert_equal('100', "#{time}")
   end
 
+  test '#to_time' do
+    time = Fluent::EventTime.new(@now.to_i, @now.nsec).to_time
+    assert_instance_of(Time, time)
+    assert_equal(@now.to_i, time.to_i)
+    begin
+      ::Time.at(0, 0, :nanosecond)
+      assert_equal(@now.nsec, time.nsec)
+    rescue
+      # Time.at(@sec, @nsec / 1000.0) sometimes cause 1 diff error in nsec by 1000.0
+      assert_in_delta(@now.nsec, time.nsec, 1)
+    end
+  end
+
   test '#to_json' do
     time = Fluent::EventTime.new(100)
     assert_equal('100', time.to_json)


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 
Fluent::EventTime can be converted into Time via Time.at but
this approach is slower. Output plugins sometimes require Time
for client libraries so adding faster method.

Here is benchmark code:

```
require 'benchmark/ips'
require 'fluent/time'

ot = Time.now
et = Fluent::EventTime.from_time(ot)

Benchmark.ips do |x|
  x.report "to_time" do
    et.to_time
  end

  x.report "Time.at" do
    Time.at(et)
  end
end
```

```
Warming up --------------------------------------
             to_time   171.865k i/100ms
             Time.at    92.733k i/100ms
Calculating -------------------------------------
             to_time      2.861M (± 5.1%) i/s -     14.265M in   5.002172s
             Time.at      1.184M (± 4.1%) i/s -      5.935M in   5.022106s
```

**Docs Changes**:
No need for now.

**Release Note**: 
Same as title