### PR TITLE
Update tzinfo to v2

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("serverengine", [">= 2.0.4", "< 3.0.0"])
   gem.add_runtime_dependency("http_parser.rb", [">= 0.5.1", "< 0.7.0"])
   gem.add_runtime_dependency("sigdump", ["~> 0.2.2"])
-  gem.add_runtime_dependency("tzinfo", ["~> 1.0"])
+  gem.add_runtime_dependency("tzinfo", ["~> 2.0"])
   gem.add_runtime_dependency("tzinfo-data", ["~> 1.0"])
   gem.add_runtime_dependency("strptime", [">= 0.2.2", "< 1.0.0"])
   gem.add_runtime_dependency("dig_rb", ["~> 1.0.0"])

--- a/lib/fluent/time.rb
+++ b/lib/fluent/time.rb
@@ -78,7 +78,7 @@ module Fluent
       end
     rescue
       def to_time
-        Time.at(@sec, @nsec / 1000.0)
+        Time.at(Rational(@sec * 1_000_000_000 + @nsec, 1_000_000_000))
       end
     end
 

--- a/test/test_time_formatter.rb
+++ b/test/test_time_formatter.rb
@@ -3,9 +3,8 @@ require 'fluent/test'
 require 'fluent/time'
 
 class TimeFormatterTest < ::Test::Unit::TestCase
-  def setup
-    @time = Time.new(2014, 9, 27, 0, 0, 0, 0).to_i
-    @fmt  = "%Y%m%d %H%M%z"  # YYYYMMDD HHMM[+-]HHMM
+  setup do
+    @fmt ="%Y%m%d %H%M%z"  # YYYYMMDD HHMM[+-]HHMM
   end
 
   def format(format, localtime, timezone)
@@ -13,166 +12,186 @@ class TimeFormatterTest < ::Test::Unit::TestCase
     formatter.format(@time)
   end
 
-  def test_default_utc_nil
-    assert_equal("2014-09-27T00:00:00Z", format(nil, false, nil))
-  end
+  module TestLists
+    def test_default_utc_nil
+      assert_equal("2014-09-27T00:00:00Z", format(nil, false, nil))
+    end
 
-  def test_default_utc_pHH_MM
-    assert_equal("2014-09-27T01:30:00+01:30", format(nil, false, "+01:30"))
-  end
+    def test_default_utc_pHH_MM
+      assert_equal("2014-09-27T01:30:00+01:30", format(nil, false, "+01:30"))
+    end
 
-  def test_default_utc_nHH_MM
-    assert_equal("2014-09-26T22:30:00-01:30", format(nil, false, "-01:30"))
-  end
+    def test_default_utc_nHH_MM
+      assert_equal("2014-09-26T22:30:00-01:30", format(nil, false, "-01:30"))
+    end
 
-  def test_default_utc_pHHMM
-    assert_equal("2014-09-27T02:30:00+02:30", format(nil, false, "+0230"))
-  end
+    def test_default_utc_pHHMM
+      assert_equal("2014-09-27T02:30:00+02:30", format(nil, false, "+0230"))
+    end
 
-  def test_default_utc_nHHMM
-    assert_equal("2014-09-26T21:30:00-02:30", format(nil, false, "-0230"))
-  end
+    def test_default_utc_nHHMM
+      assert_equal("2014-09-26T21:30:00-02:30", format(nil, false, "-0230"))
+    end
 
-  def test_default_utc_pHH
-    assert_equal("2014-09-27T03:00:00+03:00", format(nil, false, "+03"))
-  end
+    def test_default_utc_pHH
+      assert_equal("2014-09-27T03:00:00+03:00", format(nil, false, "+03"))
+    end
 
-  def test_default_utc_nHH
-    assert_equal("2014-09-26T21:00:00-03:00", format(nil, false, "-03"))
-  end
+    def test_default_utc_nHH
+      assert_equal("2014-09-26T21:00:00-03:00", format(nil, false, "-03"))
+    end
 
-  def test_default_utc_timezone_1
-    # Asia/Tokyo (+09:00) does not have daylight saving time.
-    assert_equal("2014-09-27T09:00:00+09:00", format(nil, false, "Asia/Tokyo"))
-  end
+    def test_default_utc_timezone_1
+      # Asia/Tokyo (+09:00) does not have daylight saving time.
+      assert_equal("2014-09-27T09:00:00+09:00", format(nil, false, "Asia/Tokyo"))
+    end
 
-  def test_default_utc_timezone_2
-    # Pacific/Honolulu (-10:00) does not have daylight saving time.
-    assert_equal("2014-09-26T14:00:00-10:00", format(nil, false, "Pacific/Honolulu"))
-  end
+    def test_default_utc_timezone_2
+      # Pacific/Honolulu (-10:00) does not have daylight saving time.
+      assert_equal("2014-09-26T14:00:00-10:00", format(nil, false, "Pacific/Honolulu"))
+    end
 
-  def test_default_utc_timezone_3
-    # America/Argentina/Buenos_Aires (-03:00) does not have daylight saving time.
-    assert_equal("2014-09-26T21:00:00-03:00", format(nil, false, "America/Argentina/Buenos_Aires"))
-  end
+    def test_default_utc_timezone_3
+      # America/Argentina/Buenos_Aires (-03:00) does not have daylight saving time.
+      assert_equal("2014-09-26T21:00:00-03:00", format(nil, false, "America/Argentina/Buenos_Aires"))
+    end
 
-  def test_default_utc_timezone_4
-    # Europe/Paris has daylight saving time. Its UTC offset is +01:00 and its
-    # UTC offset in DST is +02:00. In September, Europe/Paris is in DST.
-    assert_equal("2014-09-27T02:00:00+02:00", format(nil, false, "Europe/Paris"))
-  end
+    def test_default_utc_timezone_4
+      # Europe/Paris has daylight saving time. Its UTC offset is +01:00 and its
+      # UTC offset in DST is +02:00. In September, Europe/Paris is in DST.
+      assert_equal("2014-09-27T02:00:00+02:00", format(nil, false, "Europe/Paris"))
+    end
 
-  def test_default_utc_timezone_5
-    # Europe/Paris has daylight saving time. Its UTC offset is +01:00 and its
-    # UTC offset in DST is +02:00. In January, Europe/Paris is not in DST.
-    @time = Time.new(2014, 1, 24, 0, 0, 0, 0).to_i
-    assert_equal("2014-01-24T01:00:00+01:00", format(nil, false, "Europe/Paris"))
-  end
+    def test_default_utc_timezone_5
+      # Europe/Paris has daylight saving time. Its UTC offset is +01:00 and its
+      # UTC offset in DST is +02:00. In January, Europe/Paris is not in DST.
+      @time = Time.new(2014, 1, 24, 0, 0, 0, 0).to_i
+      assert_equal("2014-01-24T01:00:00+01:00", format(nil, false, "Europe/Paris"))
+    end
 
-  def test_default_utc_invalid
-    assert_equal("2014-09-27T00:00:00Z", format(nil, false, "Invalid"))
-  end
+    def test_default_utc_invalid
+      assert_equal("2014-09-27T00:00:00Z", format(nil, false, "Invalid"))
+    end
 
-  def test_default_localtime_nil_1
-    with_timezone("UTC-04") do
-      assert_equal("2014-09-27T04:00:00+04:00", format(nil, true, nil))
+    def test_default_localtime_nil_1
+      with_timezone("UTC-04") do
+        assert_equal("2014-09-27T04:00:00+04:00", format(nil, true, nil))
+      end
+    end
+
+    def test_default_localtime_nil_2
+      with_timezone("UTC+05") do
+        assert_equal("2014-09-26T19:00:00-05:00", format(nil, true, nil))
+      end
+    end
+
+    def test_default_localtime_timezone
+      # 'timezone' takes precedence over 'localtime'.
+      with_timezone("UTC-06") do
+        assert_equal("2014-09-27T07:00:00+07:00", format(nil, true, "+07"))
+      end
+    end
+
+    def test_specific_utc_nil
+      assert_equal("20140927 0000+0000", format(@fmt, false, nil))
+    end
+
+    def test_specific_utc_pHH_MM
+      assert_equal("20140927 0830+0830", format(@fmt, false, "+08:30"))
+    end
+
+    def test_specific_utc_nHH_MM
+      assert_equal("20140926 1430-0930", format(@fmt, false, "-09:30"))
+    end
+
+    def test_specific_utc_pHHMM
+      assert_equal("20140927 1030+1030", format(@fmt, false, "+1030"))
+    end
+
+    def test_specific_utc_nHHMM
+      assert_equal("20140926 1230-1130", format(@fmt, false, "-1130"))
+    end
+
+    def test_specific_utc_pHH
+      assert_equal("20140927 1200+1200", format(@fmt, false, "+12"))
+    end
+
+    def test_specific_utc_nHH
+      assert_equal("20140926 1100-1300", format(@fmt, false, "-13"))
+    end
+
+    def test_specific_utc_timezone_1
+      # Europe/Moscow (+04:00) does not have daylight saving time.
+      assert_equal("20140927 0400+0400", format(@fmt, false, "Europe/Moscow"))
+    end
+
+    def test_specific_utc_timezone_2
+      # Pacific/Galapagos (-06:00) does not have daylight saving time.
+      assert_equal("20140926 1800-0600", format(@fmt, false, "Pacific/Galapagos"))
+    end
+
+    def test_specific_utc_timezone_3
+      # America/Argentina/Buenos_Aires (-03:00) does not have daylight saving time.
+      assert_equal("20140926 2100-0300", format(@fmt, false, "America/Argentina/Buenos_Aires"))
+    end
+
+    def test_specific_utc_timezone_4
+      # America/Los_Angeles has daylight saving time. Its UTC offset is -08:00 and its
+      # UTC offset in DST is -07:00. In September, America/Los_Angeles is in DST.
+      assert_equal("20140926 1700-0700", format(@fmt, false, "America/Los_Angeles"))
+    end
+
+    def test_specific_utc_timezone_5
+      # America/Los_Angeles has daylight saving time. Its UTC offset is -08:00 and its
+      # UTC offset in DST is -07:00. In January, America/Los_Angeles is not in DST.
+      @time = Time.new(2014, 1, 24, 0, 0, 0, 0).to_i
+      assert_equal("20140123 1600-0800", format(@fmt, false, "America/Los_Angeles"))
+    end
+
+    def test_specific_utc_invalid
+      assert_equal("20140927 0000+0000", format(@fmt, false, "Invalid"))
+    end
+
+    def test_specific_localtime_nil_1
+      with_timezone("UTC-07") do
+        assert_equal("20140927 0700+0700", format(@fmt, true, nil))
+      end
+    end
+
+    def test_specific_localtime_nil_2
+      with_timezone("UTC+08") do
+        assert_equal("20140926 1600-0800", format(@fmt, true, nil))
+      end
+    end
+
+    def test_specific_localtime_timezone
+      # 'timezone' takes precedence over 'localtime'.
+      with_timezone("UTC-09") do
+        assert_equal("20140926 1400-1000", format(@fmt, true, "-10"))
+      end
     end
   end
 
-  def test_default_localtime_nil_2
-    with_timezone("UTC+05") do
-      assert_equal("2014-09-26T19:00:00-05:00", format(nil, true, nil))
+  sub_test_case 'Fluent::EventTime time' do
+    setup do
+      @time = Fluent::EventTime.from_time(Time.new(2014, 9, 27, 0, 0, 0, 0))
     end
+
+    include TestLists
   end
 
-  def test_default_localtime_timezone
-    # 'timezone' takes precedence over 'localtime'.
-    with_timezone("UTC-06") do
-      assert_equal("2014-09-27T07:00:00+07:00", format(nil, true, "+07"))
+  # for v0.12 compatibility
+  sub_test_case 'Integer time' do
+    setup do
+      @time = Time.new(2014, 9, 27, 0, 0, 0, 0).to_i
     end
-  end
 
-  def test_specific_utc_nil
-    assert_equal("20140927 0000+0000", format(@fmt, false, nil))
-  end
-
-  def test_specific_utc_pHH_MM
-    assert_equal("20140927 0830+0830", format(@fmt, false, "+08:30"))
-  end
-
-  def test_specific_utc_nHH_MM
-    assert_equal("20140926 1430-0930", format(@fmt, false, "-09:30"))
-  end
-
-  def test_specific_utc_pHHMM
-    assert_equal("20140927 1030+1030", format(@fmt, false, "+1030"))
-  end
-
-  def test_specific_utc_nHHMM
-    assert_equal("20140926 1230-1130", format(@fmt, false, "-1130"))
-  end
-
-  def test_specific_utc_pHH
-    assert_equal("20140927 1200+1200", format(@fmt, false, "+12"))
-  end
-
-  def test_specific_utc_nHH
-    assert_equal("20140926 1100-1300", format(@fmt, false, "-13"))
-  end
-
-  def test_specific_utc_timezone_1
-    # Europe/Moscow (+04:00) does not have daylight saving time.
-    assert_equal("20140927 0400+0400", format(@fmt, false, "Europe/Moscow"))
-  end
-
-  def test_specific_utc_timezone_2
-    # Pacific/Galapagos (-06:00) does not have daylight saving time.
-    assert_equal("20140926 1800-0600", format(@fmt, false, "Pacific/Galapagos"))
-  end
-
-  def test_specific_utc_timezone_3
-    # America/Argentina/Buenos_Aires (-03:00) does not have daylight saving time.
-    assert_equal("20140926 2100-0300", format(@fmt, false, "America/Argentina/Buenos_Aires"))
-  end
-
-  def test_specific_utc_timezone_4
-    # America/Los_Angeles has daylight saving time. Its UTC offset is -08:00 and its
-    # UTC offset in DST is -07:00. In September, America/Los_Angeles is in DST.
-    assert_equal("20140926 1700-0700", format(@fmt, false, "America/Los_Angeles"))
-  end
-
-  def test_specific_utc_timezone_5
-    # America/Los_Angeles has daylight saving time. Its UTC offset is -08:00 and its
-    # UTC offset in DST is -07:00. In January, America/Los_Angeles is not in DST.
-    @time = Time.new(2014, 1, 24, 0, 0, 0, 0).to_i
-    assert_equal("20140123 1600-0800", format(@fmt, false, "America/Los_Angeles"))
-  end
-
-  def test_specific_utc_invalid
-    assert_equal("20140927 0000+0000", format(@fmt, false, "Invalid"))
-  end
-
-  def test_specific_localtime_nil_1
-    with_timezone("UTC-07") do
-      assert_equal("20140927 0700+0700", format(@fmt, true, nil))
-    end
-  end
-
-  def test_specific_localtime_nil_2
-    with_timezone("UTC+08") do
-      assert_equal("20140926 1600-0800", format(@fmt, true, nil))
-    end
-  end
-
-  def test_specific_localtime_timezone
-    # 'timezone' takes precedence over 'localtime'.
-    with_timezone("UTC-09") do
-      assert_equal("20140926 1400-1000", format(@fmt, true, "-10"))
-    end
+    include TestLists
   end
 
   def test_format_with_subsec
-    time = Fluent::EventTime.new(@time)
+    time = Time.new(2014, 9, 27, 0, 0, 0, 0).to_i
+    time = Fluent::EventTime.new(time)
     formatter = Fluent::TimeFormatter.new("%Y%m%d %H%M.%N", false, nil)
     assert_equal("20140927 0000.000000000", formatter.format(time))
   end


### PR DESCRIPTION
This is for v1.7.0.

**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 
Update tzinfo to latest v2. The merit removes deprecated `thread_safe` gem dependency.
Here is the performance comparison.

- with v2

```
Warming up --------------------------------------
      timezone fixed   147.900k i/100ms
     timezone region   148.310k i/100ms
Calculating -------------------------------------
      timezone fixed      2.259M (± 2.7%) i/s -     11.388M in   5.045857s
     timezone region      2.312M (± 1.5%) i/s -     11.568M in   5.005012s
```

- with v1

```
Warming up --------------------------------------
      timezone fixed   150.174k i/100ms
     timezone region   151.443k i/100ms
Calculating -------------------------------------
      timezone fixed      2.324M (± 1.2%) i/s -     11.714M in   5.041740s
     timezone region      2.316M (± 2.9%) i/s -     11.661M in   5.040527s
```

tzinfo v2 is bit slower but acceptable.

```
require 'benchmark/ips'
require 'fluent/time'

formatter1 = Fluent::TimeFormatter.new("%Y%m%d %H%M%z", false, "+01:30")
formatter2 = Fluent::TimeFormatter.new("%Y%m%d %H%M%z", false, "Asia/Tokyo")
time = Fluent::EventTime.from_time(Time.new(2014, 9, 27, 0, 0, 0, 0))

Benchmark.ips do |x|
  x.report "timezone fixed" do
    formatter1.format(time)
  end

  x.report "timezone region" do
    formatter2.format(time)
  end
end
```

**Docs Changes**:
No need

**Release Note**: 
Update tzinfo dependency to v2.