### PR TITLE
plugin_config_formatter: update new doc URL

### DIFF
--- a/lib/fluent/command/plugin_config_formatter.rb
+++ b/lib/fluent/command/plugin_config_formatter.rb
@@ -32,8 +32,8 @@ class FluentPluginConfigFormatter
     "buffer", "parser", "formatter", "storage"
   ]
 
-  DOCS_BASE_URL = "https://docs.fluentd.org/v1.0/articles/quickstart"
-  DOCS_ARTICLE_BASE_URL = "https://docs.fluentd.org/v1.0/articles/"
+  DOCS_BASE_URL = "https://docs.fluentd.org/v/1.0"
+  DOCS_PLUGIN_HELPER_BASE_URL = "#{DOCS_BASE_URL}/plugin-helper-overview/"
 
   def initialize(argv = ARGV)
     @argv = argv
@@ -198,7 +198,7 @@ class FluentPluginConfigFormatter
   end
 
   def plugin_helper_url(plugin_helper)
-    "#{DOCS_ARTICLE_BASE_URL}api-plugin-helper-#{plugin_helper}"
+    "#{DOCS_PLUGIN_HELPER_BASE_URL}api-plugin-helper-#{plugin_helper}"
   end
 
   def plugin_helper_markdown_link(plugin_helper)
@@ -207,7 +207,7 @@ class FluentPluginConfigFormatter
 
   def plugin_overview_url(class_name)
     plugin_type = class_name.slice(/::(\w+)\z/, 1).downcase
-    "#{DOCS_ARTICLE_BASE_URL}#{plugin_type}-plugin-overview"
+    "#{DOCS_BASE_URL}/#{plugin_type}#overview"
   end
 
   def plugin_overview_markdown_link(class_name)

--- a/test/command/test_plugin_config_formatter.rb
+++ b/test/command/test_plugin_config_formatter.rb
@@ -180,10 +180,10 @@ TEXT
       expected = <<TEXT
 ## Plugin helpers
 
-* [inject](https://docs.fluentd.org/v1.0/articles/api-plugin-helper-inject)
-* [compat_parameters](https://docs.fluentd.org/v1.0/articles/api-plugin-helper-compat_parameters)
+* [inject](https://docs.fluentd.org/v/1.0/plugin-helper-overview/api-plugin-helper-inject)
+* [compat_parameters](https://docs.fluentd.org/v/1.0/plugin-helper-overview/api-plugin-helper-compat_parameters)
 
-* See also: [Input Plugin Overview](https://docs.fluentd.org/v1.0/articles/input-plugin-overview)
+* See also: [Input Plugin Overview](https://docs.fluentd.org/v/1.0/input#overview)
 
 ## TestFluentPluginConfigFormatter::SimpleInput
 
@@ -203,10 +203,10 @@ TEXT
       expected = <<TEXT
 ## Plugin helpers
 
-* [inject](https://docs.fluentd.org/v1.0/articles/api-plugin-helper-inject)
-* [compat_parameters](https://docs.fluentd.org/v1.0/articles/api-plugin-helper-compat_parameters)
+* [inject](https://docs.fluentd.org/v/1.0/plugin-helper-overview/api-plugin-helper-inject)
+* [compat_parameters](https://docs.fluentd.org/v/1.0/plugin-helper-overview/api-plugin-helper-compat_parameters)
 
-* See also: [Output Plugin Overview](https://docs.fluentd.org/v1.0/articles/output-plugin-overview)
+* See also: [Output Plugin Overview](https://docs.fluentd.org/v/1.0/output#overview)
 
 ## TestFluentPluginConfigFormatter::ComplexOutput
 


### PR DESCRIPTION
Signed-off-by: Takahiro YAMASHITA <nokute78@gmail.com>

<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 
`fluent-plugin-config-format` outputs old style URLs. (not gitbook style)

This PR is to make `fluent-plugin-config-format` supporting gitbook style URLs.

Old output is
```
[taka@localhost fluentd]$ bundle exec bin/fluent-plugin-config-format input syslog
## Plugin helpers

* [parser](https://docs.fluentd.org/v1.0/articles/api-plugin-helper-parser)
* [compat_parameters](https://docs.fluentd.org/v1.0/articles/api-plugin-helper-compat_parameters)
* [server](https://docs.fluentd.org/v1.0/articles/api-plugin-helper-server)

* See also: [Input Plugin Overview](https://docs.fluentd.org/v1.0/articles/input-plugin-overview)
```

New output is
```
[taka@localhost fluentd]$ bundle exec bin/fluent-plugin-config-format input syslog
## Plugin helpers

* [parser](https://docs.fluentd.org/v/1.0/plugin-helper-overview/api-plugin-helper-parser)
* [compat_parameters](https://docs.fluentd.org/v/1.0/plugin-helper-overview/api-plugin-helper-compat_parameters)
* [server](https://docs.fluentd.org/v/1.0/plugin-helper-overview/api-plugin-helper-server)

* See also: [Input Plugin Overview](https://docs.fluentd.org/v/1.0/input#overview)
```

**Docs Changes**:
None 

**Release Note**: 
plugin_config_formatter: support gitbook URLs.
