### PR TITLE
Avoid zero division error when there are no available nodes

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -428,6 +428,12 @@ module Fluent::Plugin
       end
 
       weight_array = []
+      if regular_nodes.empty?
+        log.warn('No nodes are available')
+        @weight_array = weight_array
+        return @weight_array
+      end
+
       gcd = regular_nodes.map {|n| n.weight }.inject(0) {|r,w| r.gcd(w) }
       regular_nodes.each {|n|
         (n.weight / gcd).times {

--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -1010,6 +1010,20 @@ EOL
     end
   end
 
+  test 'if no available node' do
+    # do not create output driver
+    d = create_driver(%[
+    <server>
+      name test
+      standby
+      host #{TARGET_HOST}
+      port #{TARGET_PORT}
+    </server>
+    ])
+    d.instance_start
+    assert_nothing_raised { d.run }
+  end
+
   sub_test_case 'keepalive' do
     test 'Do not create connection per send_data' do
       target_input_driver = create_target_input_driver(conf: TARGET_CONFIG)


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
no

**What this PR does / why we need it**: 

I added checking of the size of `regular_nodes` to avoid to raise ZeroDivisionError when there are no available nodes.

https://github.com/fluent/fluentd/blob/2ec546695a843a5751a1456ed6cdcdf22b300b8f/lib/fluent/plugin/out_forward.rb#L439


**Docs Changes**:

No need

**Release Note**: 

No need