### PR TITLE
socket: Support all private keys OpenSSL supports

### DIFF
--- a/lib/fluent/command/ca_generate.rb
+++ b/lib/fluent/command/ca_generate.rb
@@ -91,7 +91,7 @@ HELP
     def self.generate_server_pair(opts={})
       key = OpenSSL::PKey::RSA.generate(opts[:private_key_length])
 
-      ca_key = OpenSSL::PKey::RSA.new(File.read(opts[:ca_key_path]), opts[:ca_key_passphrase])
+      ca_key = OpenSSL::PKey::read(File.read(opts[:ca_key_path]), opts[:ca_key_passphrase])
       ca_cert = OpenSSL::X509::Certificate.new(File.read(opts[:ca_cert_path]))
       issuer = ca_cert.issuer
 

--- a/lib/fluent/plugin_helper/cert_option.rb
+++ b/lib/fluent/plugin_helper/cert_option.rb
@@ -76,7 +76,7 @@ module Fluent
       end
 
       def cert_option_load(cert_path, private_key_path, private_key_passphrase)
-        key = OpenSSL::PKey::RSA.new(File.read(private_key_path), private_key_passphrase)
+        key = OpenSSL::PKey::read(File.read(private_key_path), private_key_passphrase)
         certs = cert_option_certificates_from_file(cert_path)
         cert = certs.shift
         return cert, key, certs
@@ -137,7 +137,7 @@ module Fluent
       end
 
       def cert_option_generate_server_pair_by_ca(ca_cert_path, ca_key_path, ca_key_passphrase, generate_opts)
-        ca_key = OpenSSL::PKey::RSA.new(File.read(ca_key_path), ca_key_passphrase)
+        ca_key = OpenSSL::PKey::read(File.read(ca_key_path), ca_key_passphrase)
         ca_cert = OpenSSL::X509::Certificate.new(File.read(ca_cert_path))
         cert, key = cert_option_generate_pair(generate_opts, ca_cert.subject)
         raise "BUG: certificate digest algorithm not set" unless generate_opts[:digest]

--- a/lib/fluent/plugin_helper/socket.rb
+++ b/lib/fluent/plugin_helper/socket.rb
@@ -133,7 +133,7 @@ module Fluent
           context.cert_store = cert_store
           context.verify_hostname = true if verify_fqdn && fqdn && context.respond_to?(:verify_hostname=)
           context.cert = OpenSSL::X509::Certificate.new(File.read(cert_path)) if cert_path
-          context.key = OpenSSL::PKey::RSA.new(File.read(private_key_path), private_key_passphrase) if private_key_path
+          context.key = OpenSSL::PKey::read(File.read(private_key_path), private_key_passphrase) if private_key_path
         end
 
         tcpsock = socket_create_tcp(host, port, **kwargs)


### PR DESCRIPTION
When creating a TLS socket, the helpers only attempted to parse an RSA
key with `OpenSSL::PKey::RSA.new`. By using the higher level
`OpenSSL::PKey::read`, OpenSSL will determine and parse the proper key
type, adding support for EC and DSA keys.

Signed-off-by: Matthew Mussomele <matt@nefeli.io>

**Which issue(s) this PR fixes**: 
Fixes #2486

**What this PR does / why we need it**: 

This adds support for using any private keys that OpenSSL supports to the socket helper. I looked for existing tests around the TLS socket to augment, but failed to find any, but offline tested that the changes snippet properly loads other key types.

**Docs Changes**:
None

**Release Note**: 
