### PR TITLE
Add HTTP output plugin

### DIFF
--- a/lib/fluent/plugin/out_http.rb
+++ b/lib/fluent/plugin/out_http.rb
@@ -130,17 +130,17 @@ module Fluent::Plugin
       when 'out_file', 'single_value', 'stdout', 'hash'
         'text/plain'
       else
-        raise Fluent::ConfigError, "can't determind Content-Type from formatter type. Set content_type parameter explicitly"
+        raise Fluent::ConfigError, "can't determine Content-Type from formatter type. Set content_type parameter explicitly"
       end
     end
 
     def setup_http_option
       use_ssl = URI.parse(@endpoint).scheme == 'https'
       opt = {
-        :open_timeout => @open_timeout,
-        :read_timeout => @read_timeout,
-        :ssl_timeout => @ssl_timeout,
-        :use_ssl => use_ssl
+        open_timeout: @open_timeout,
+        read_timeout: @read_timeout,
+        ssl_timeout: @ssl_timeout,
+        use_ssl: use_ssl
       }
 
       if use_ssl

--- a/lib/fluent/plugin/out_http.rb
+++ b/lib/fluent/plugin/out_http.rb
@@ -1,3 +1,19 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
 require 'net/http'
 require 'uri'
 require 'openssl'

--- a/lib/fluent/plugin/out_http.rb
+++ b/lib/fluent/plugin/out_http.rb
@@ -117,6 +117,8 @@ module Fluent::Plugin
       send_request(uri, req)
     end
 
+    private
+
     def setup_content_type
       case @formatter_configs.first[:@type]
       when 'json'
@@ -135,7 +137,7 @@ module Fluent::Plugin
     end
 
     def setup_http_option
-      use_ssl = URI.parse(@endpoint).scheme == 'https'
+      use_ssl = @endpoint.start_with?('https')
       opt = {
         open_timeout: @open_timeout,
         read_timeout: @read_timeout,
@@ -154,7 +156,7 @@ module Fluent::Plugin
         end
         if @tls_private_key_path
           raise Fluent::ConfigError, "tls_private_key_path is wrong: #{@tls_private_key_path}" unless File.file?(@tls_private_key_path)
-          opt[:key] = OpenSSL::PKey::read(File.read(@tls_private_key_path), @tls_private_key_passphrase)
+          opt[:key] = OpenSSL::PKey.read(File.read(@tls_private_key_path), @tls_private_key_passphrase)
         end
         opt[:verify_mode] = case @tls_verify_mode
                             when :none

--- a/lib/fluent/plugin/out_http.rb
+++ b/lib/fluent/plugin/out_http.rb
@@ -1,0 +1,205 @@
+require 'net/http'
+require 'uri'
+require 'openssl'
+require 'fluent/plugin/output'
+require 'fluent/plugin_helper/socket'
+
+module Fluent::Plugin
+  class HTTPOutput < Output
+    Fluent::Plugin.register_output('http', self)
+
+    helpers :formatter
+
+    desc 'The endpoint for HTTP request, e.g. http://example.com/api'
+    config_param :endpoint, :string
+    desc 'The method for HTTP request'
+    config_param :http_method, :enum, list: [:put, :post], default: :post
+    desc 'The proxy for HTTP request'
+    config_param :proxy, :string, default: ENV['HTTP_PROXY'] || ENV['http_proxy']
+    desc 'Content-Type for HTTP request'
+    config_param :content_type, :string, default: nil
+    desc 'Additional headers for HTTP request'
+    config_param :headers, :hash, default: nil
+
+    desc 'The connection open timeout in seconds'
+    config_param :open_timeout, :integer, default: nil
+    desc 'The read timeout in seconds'
+    config_param :read_timeout, :integer, default: nil
+    desc 'The TLS timeout in seconds'
+    config_param :ssl_timeout, :integer, default: nil
+
+    desc 'The CA certificate path for TLS'
+    config_param :tls_ca_cert_path, :string, default: nil
+    desc 'The client certificate path for TLS'
+    config_param :tls_client_cert_path, :string, default: nil
+    desc 'The client private key path for TLS'
+    config_param :tls_private_key_path, :string, default: nil
+    desc 'The client private key passphrase for TLS'
+    config_param :tls_private_key_passphrase, :string, default: nil, secret: true
+    desc 'The verify mode of TLS'
+    config_param :tls_verify_mode, :enum, list: [:none, :peer], default: :peer
+    desc 'The default version of TLS'
+    config_param :tls_version, :enum, list: Fluent::PluginHelper::Socket::TLS_SUPPORTED_VERSIONS, default: Fluent::PluginHelper::Socket::TLS_DEFAULT_VERSION
+    desc 'The cipher configuration of TLS'
+    config_param :tls_ciphers, :string, default: Fluent::PluginHelper::Socket::CIPHERS_DEFAULT
+
+    desc 'Raise UnrecoverableError when the response is non success, 4xx/5xx'
+    config_param :error_response_as_unrecoverable, :bool, default: true
+
+    config_section :format do
+      config_set_default :@type, 'json'
+    end
+
+    config_section :auth, required: false, multi: false do
+      desc 'The method for HTTP authentication'
+      config_param :method, :enum, list: [:basic], default: :basic
+      desc 'The username for basic authentication'
+      config_param :username, :string, default: nil
+      desc 'The password for basic authentication'
+      config_param :password, :string, default: nil, secret: true
+    end
+
+    def initialize
+      super
+
+      @uri = nil
+      @proxy_uri = nil
+      @formatter = nil
+    end
+
+    def configure(conf)
+      super
+
+      @http_opt = setup_http_option
+      @proxy_uri = URI.parse(@proxy) if @proxy
+      @formatter = formatter_create
+      @content_type = setup_content_type unless @content_type
+    end
+
+    def multi_workers_ready?
+      true
+    end
+
+    def formatted_to_msgpack_binary?
+      @formatter_configs.first[:@type] == 'msgpack'
+    end
+
+    def format(tag, time, record)
+      @formatter.format(tag, time, record)
+    end
+
+    def write(chunk)
+      uri = parse_endpoint(chunk)
+      req = create_request(chunk, uri)
+
+      log.debug { "#{@http_method.capitalize} data to #{uri.to_s} with chunk(#{dump_unique_id_hex(chunk.unique_id)})" }
+
+      send_request(uri, req)
+    end
+
+    def setup_content_type
+      case @formatter_configs.first[:@type]
+      when 'json'
+        'application/x-ndjson'
+      when 'csv'
+        'text/csv'
+      when 'tsv', 'ltsv'
+        'text/tab-separated-values'
+      when 'msgpack'
+        'application/x-msgpack'
+      when 'out_file', 'single_value', 'stdout', 'hash'
+        'text/plain'
+      else
+        raise Fluent::ConfigError, "can't determind Content-Type from formatter type. Set content_type parameter explicitly"
+      end
+    end
+
+    def setup_http_option
+      use_ssl = URI.parse(@endpoint).scheme == 'https'
+      opt = {
+        :open_timeout => @open_timeout,
+        :read_timeout => @read_timeout,
+        :ssl_timeout => @ssl_timeout,
+        :use_ssl => use_ssl
+      }
+
+      if use_ssl
+        if @tls_ca_cert_path
+          raise Fluent::ConfigError, "tls_ca_cert_path is wrong: #{@tls_ca_cert_path}" unless File.file?(@tls_ca_cert_path)
+          opt[:ca_file] = @tls_ca_cert_path
+        end
+        if @tls_client_cert_path
+          raise Fluent::ConfigError, "tls_client_cert_path is wrong: #{@tls_client_cert_path}" unless File.file?(@tls_client_cert_path)
+          opt[:cert] = OpenSSL::X509::Certificate.new(File.read(@tls_client_cert_path))
+        end
+        if @tls_private_key_path
+          raise Fluent::ConfigError, "tls_private_key_path is wrong: #{@tls_private_key_path}" unless File.file?(@tls_private_key_path)
+          opt[:key] = OpenSSL::PKey::read(File.read(@tls_private_key_path), @tls_private_key_passphrase)
+        end
+        opt[:verify_mode] = case @tls_verify_mode
+                            when :none
+                              OpenSSL::SSL::VERIFY_NONE
+                            when :peer
+                              OpenSSL::SSL::VERIFY_PEER
+                            end
+        opt[:ciphers] = @tls_ciphers
+        opt[:ssl_version] = @tls_version
+      end
+
+      opt
+    end
+
+    def parse_endpoint(chunk)
+      endpoint = extract_placeholders(@endpoint, chunk)    
+      URI.parse(endpoint)
+    end
+
+    def set_headers(req)
+      if @headers
+        @headers.each do |k, v|
+          req[k] = v
+        end
+      end
+      req['Content-Type'] = @content_type
+    end
+
+    def create_request(chunk, uri)
+      req = case @http_method
+            when :post
+              Net::HTTP::Post.new(uri.request_uri)
+            when :put
+              Net::HTTP::Put.new(uri.request_uri)
+            end
+      if @auth
+        req.basic_auth(@auth.username, @auth.password)
+      end
+      set_headers(req)
+      req.body = chunk.read
+      req
+    end
+
+    def send_request(uri, req)
+      res = if @proxy_uri
+              Net::HTTP.start(uri.host, uri.port, @proxy_uri.host, @proxy_uri.port, @proxy_uri.user, @proxy_uri.password, @http_opt) { |http|
+                http.request(req)
+              }
+            else
+              Net::HTTP.start(uri.host, uri.port, @http_opt) { |http|
+                http.request(req)
+              }
+            end
+
+      if res.is_a?(Net::HTTPSuccess)
+        log.debug { "#{res.code} #{res.message} #{res.body}" }
+      else
+        msg = "#{res.code} #{res.message} #{res.body}"
+
+        if @error_response_as_unrecoverable
+          raise Fluent::UnrecoverableError, msg
+        else
+          log.error "got error response from '#{@http_method.capitalize} #{uri.to_s}' : #{msg}"
+        end
+      end
+    end
+  end
+end

--- a/test/plugin/test_out_http.rb
+++ b/test/plugin/test_out_http.rb
@@ -82,7 +82,9 @@ class HTTPOutputTest < Test::Unit::TestCase
         }
       when 'text/plain'
         # Use single_value in this test
-        data = req.body.lines(chomp: true)
+        req.body.each_line { |line|
+          data << line.chomp
+        }
       else
         data << req.body
       end

--- a/test/plugin/test_out_http.rb
+++ b/test/plugin/test_out_http.rb
@@ -1,0 +1,351 @@
+# coding: utf-8
+require_relative "../helper"
+require 'fluent/test/driver/output'
+require 'fluent/plugin/out_http'
+
+require 'webrick'
+require 'webrick/https'
+require 'net/http'
+require 'uri'
+require 'json'
+
+# WEBrick's ProcHandler doesn't handle PUT by default
+module WEBrick::HTTPServlet
+  class ProcHandler < AbstractServlet
+    alias do_PUT  do_GET
+  end
+end
+
+class HTTPOutputTest < Test::Unit::TestCase
+  include Fluent::Test::Helpers
+
+  TMP_DIR = File.join(__dir__, "../tmp/out_http#{ENV['TEST_ENV_NUMBER']}")
+  DEFAULT_LOGGER = ::WEBrick::Log.new(::STDOUT, ::WEBrick::BasicLog::FATAL)
+
+  class << self
+    # Use class variable to reduce server start/shutdown time
+    def startup
+      @@result = nil
+      @@auth_handler = nil
+      @@http_server_thread = nil
+    end
+
+    def shutdown
+      @@http_server_thread.kill
+      @@http_server_thread.join
+    rescue
+    end
+  end
+
+  def server_port
+    19880
+  end
+
+  def base_endpoint
+    "http://127.0.0.1:#{server_port}"
+  end
+
+  def server_config
+    config = {:BindAddress => '127.0.0.1', :Port => server_port}
+    # Suppress webrick logs
+    config[:Logger] = DEFAULT_LOGGER
+    config[:AccessLog] = []
+    config
+  end
+
+  def http_client(**opts, &block)
+    opts = opts.merge(open_timeout: 1, read_timeout: 1)
+    if block_given?
+      Net::HTTP.start('127.0.0.1', server_port, **opts, &block)
+    else
+      Net::HTTP.start('127.0.0.1', server_port, **opts)
+    end
+  end
+
+  def run_http_server
+    server = ::WEBrick::HTTPServer.new(server_config)
+    server.mount_proc('/test') { |req, res|
+      if @@auth_handler
+        @@auth_handler.call(req, res)
+      end
+
+      @@result.method = req.request_method
+      @@result.content_type = req.content_type
+      req.each do |key, value|
+        @@result.headers[key] = value
+      end
+
+      data = []
+      case req.content_type
+      when 'application/x-ndjson'
+        req.body.each_line { |l|
+          data << JSON.parse(l)
+        }
+      when 'text/plain'
+        # Use single_value in this test
+        data = req.body.lines(chomp: true)
+      else
+        data << req.body
+      end
+      @@result.data = data
+
+      res.status = 200
+      res.body = "success"
+    }
+    server.mount_proc('/503') { |_, res|
+      res.status = 503
+      res.body = 'Service Unavailable'
+    }
+    server.mount_proc('/404') { |_, res|
+      res.status = 404
+      res.body = 'Not Found'
+    }
+    # For start check
+    server.mount_proc('/') { |_, res|
+      res.status = 200
+      res.body = 'Hello Fluentd!'
+    }
+    server.start
+  ensure
+    server.shutdown rescue nil
+  end
+
+  Result = Struct.new("Result", :method, :content_type, :headers, :data)
+
+  setup do
+    Fluent::Test.setup
+    FileUtils.rm_rf(TMP_DIR)
+
+    @@result = Result.new(nil, nil, {}, nil)    
+    @@http_server_thread ||= Thread.new do
+      run_http_server
+    end
+
+    now = Time.now
+    started = false
+    until started
+      raise "Server not started" if (now - Time.now > 10.0)
+      begin
+        http_client { |c| c.request_get('/') }
+        started = true
+      rescue
+        sleep 0.5
+      end
+    end
+  end
+
+  teardown do
+    @@result = nil
+    @@auth_handler = nil
+  end
+
+  def create_driver(conf)
+    Fluent::Test::Driver::Output.new(Fluent::Plugin::HTTPOutput).configure(conf)
+  end
+
+  def config
+    %[
+      endpoint #{base_endpoint}/test
+    ]
+  end
+
+  def test_events
+    [
+      {"message" => "hello", "num" => 10, "bool" => true},
+      {"message" => "hello", "num" => 11, "bool" => false}
+    ]
+  end
+
+  def test_configure
+    d = create_driver(config)
+    assert_equal "http://127.0.0.1:#{server_port}/test", d.instance.endpoint
+    assert_equal :post, d.instance.http_method
+    assert_equal 'application/x-ndjson', d.instance.content_type
+    assert_equal [503], d.instance.retryable_response_codes
+    assert_true d.instance.error_response_as_unrecoverable
+    assert_nil d.instance.proxy
+    assert_nil d.instance.headers
+  end
+
+  data('json' => ['json', 'application/x-ndjson'],
+       'ltsv' => ['ltsv', 'text/tab-separated-values'],
+       'msgpack' => ['msgpack', 'application/x-msgpack'],
+       'single_value' => ['single_value', 'text/plain'])
+  def test_configure_content_type(types)
+    format_type, content_type = types
+    d = create_driver(config + %[
+      <format>
+        @type #{format_type}
+      </format>
+    ])
+    assert_equal content_type, d.instance.content_type
+  end
+
+  data('PUT' => 'put', 'POST' => 'post')
+  def test_write_with_method(method)
+    d = create_driver(config + "http_method #{method}")
+    d.run(default_tag: 'test.http') do
+      test_events.each { |event|
+        d.feed(event)
+      }
+    end
+
+    result = @@result
+    assert_equal method.upcase, result.method
+    assert_equal 'application/x-ndjson', result.content_type
+    assert_equal test_events, result.data
+    assert_not_empty result.headers
+  end
+
+  def test_write_with_single_value_format
+    d = create_driver(config + %[
+      <format>
+        @type single_value
+      </format>
+    ])
+    d.run(default_tag: 'test.http') do
+      test_events.each { |event|
+        d.feed(event)
+      }
+    end
+
+    result = @@result
+    assert_equal 'text/plain', result.content_type
+    assert_equal (test_events.map { |e| e['message'] }), result.data
+    assert_not_empty result.headers
+  end
+
+  def test_write_with_headers
+    d = create_driver(config + 'headers {"test_header":"fluentd!"}')
+    d.run(default_tag: 'test.http') do
+      test_events.each { |event|
+        d.feed(event)
+      }
+    end
+
+    result = @@result
+    assert_true result.headers.has_key?('test_header')
+    assert_equal "fluentd!", result.headers['test_header']
+  end
+
+  def test_write_with_retryable_response
+    d = create_driver("endpoint #{base_endpoint}/503")
+    assert_raise(Fluent::Plugin::HTTPOutput::RetryableResponse) do
+      d.run(default_tag: 'test.http', shutdown: false) do
+        test_events.each { |event|
+          d.feed(event)
+        }
+      end
+    end
+    d.instance_shutdown
+  end
+
+  # basic auth test includes "error_response_as_unrecoverable true" case
+  def test_write_with_disabled_unrecoverable
+    d = create_driver(%[
+      endpoint #{base_endpoint}/404
+      error_response_as_unrecoverable false
+    ])
+    d.run(default_tag: 'test.http', shutdown: false) do
+      test_events.each { |event|
+        d.feed(event)
+      }
+    end
+    assert_match(/got error response from.*404 Not Found Not Found/, d.instance.log.out.logs.first)
+    d.instance_shutdown
+  end
+
+  sub_test_case 'basie auth' do
+    setup do
+      FileUtils.mkdir_p(TMP_DIR)
+      htpd = WEBrick::HTTPAuth::Htpasswd.new(File.join(TMP_DIR, 'dot.htpasswd'))
+      htpd.set_passwd(nil, 'test', 'hey')
+      authenticator = WEBrick::HTTPAuth::BasicAuth.new(:UserDB => htpd, :Realm => 'test', :Logger => DEFAULT_LOGGER)
+      @@auth_handler = Proc.new { |req, res| authenticator.authenticate(req, res) }
+    end
+
+    teardown do
+      FileUtils.rm_rf(TMP_DIR)
+    end
+
+    def server_port
+      19881
+    end
+
+    def test_basic_auth
+      d = create_driver(config + %[
+        <auth>
+          method basic
+          username test
+          password hey
+        </auth>
+      ])
+      d.run(default_tag: 'test.http') do
+        test_events.each { |event|
+          d.feed(event)
+        }
+      end
+
+      result = @@result
+      assert_equal 'POST', result.method
+      assert_equal 'application/x-ndjson', result.content_type
+      assert_equal test_events, result.data
+      assert_not_empty result.headers
+    end
+
+    def test_basic_auth_with_invalid_auth
+      d = create_driver(config + %[
+        <auth>
+          method basic
+          username ayaya
+          password hello?
+        </auth>
+      ])
+      d.run(default_tag: 'test.http', shutdown: false) do
+        test_events.each { |event|
+          d.feed(event)
+        }
+      end
+      assert_match(/got unrecoverable error/, d.instance.log.out.logs.first)
+
+      d.instance_shutdown
+    end
+  end
+
+  sub_test_case 'HTTPS' do
+    def server_port
+      19882
+    end
+
+    def server_config
+      config = super
+      # WEBrick supports self-generated self-signed certificate
+      config[:SSLEnable] = true
+      config[:SSLCertName] = [["CN", WEBrick::Utils::getservername]]
+      config
+    end
+
+    def http_client(&block)
+      super(use_ssl: true, verify_mode: OpenSSL::SSL::VERIFY_NONE, &block)
+    end
+
+    def test_write_with_https
+      d = create_driver(%[
+        endpoint https://127.0.0.1:#{server_port}/test
+        tls_verify_mode none
+        ssl_timeout 2s
+      ])
+      d.run(default_tag: 'test.http') do
+        test_events.each { |event|
+          d.feed(event)
+        }
+      end
+
+      result = @@result
+      assert_equal 'POST', result.method
+      assert_equal 'application/x-ndjson', result.content_type
+      assert_equal test_events, result.data
+      assert_not_empty result.headers
+    end
+  end
+end

--- a/test/plugin/test_out_http.rb
+++ b/test/plugin/test_out_http.rb
@@ -241,7 +241,6 @@ class HTTPOutputTest < Test::Unit::TestCase
     d.instance_shutdown
   end
 
-  # basic auth test includes "error_response_as_unrecoverable true" case
   def test_write_with_disabled_unrecoverable
     d = create_driver(%[
       endpoint #{base_endpoint}/404
@@ -294,6 +293,7 @@ class HTTPOutputTest < Test::Unit::TestCase
       assert_not_empty result.headers
     end
 
+    # This test includes `error_response_as_unrecoverable true` behaviour check
     def test_basic_auth_with_invalid_auth
       d = create_driver(config + %[
         <auth>

--- a/test/plugin/test_out_http.rb
+++ b/test/plugin/test_out_http.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 require_relative "../helper"
 require 'fluent/test/driver/output'
 require 'fluent/plugin/out_http'
@@ -12,7 +11,7 @@ require 'json'
 # WEBrick's ProcHandler doesn't handle PUT by default
 module WEBrick::HTTPServlet
   class ProcHandler < AbstractServlet
-    alias do_PUT  do_GET
+    alias do_PUT do_GET
   end
 end
 
@@ -46,7 +45,7 @@ class HTTPOutputTest < Test::Unit::TestCase
   end
 
   def server_config
-    config = {:BindAddress => '127.0.0.1', :Port => server_port}
+    config = {BindAddress: '127.0.0.1', Port: server_port}
     # Suppress webrick logs
     config[:Logger] = DEFAULT_LOGGER
     config[:AccessLog] = []
@@ -255,7 +254,7 @@ class HTTPOutputTest < Test::Unit::TestCase
     d.instance_shutdown
   end
 
-  sub_test_case 'basie auth' do
+  sub_test_case 'basic auth' do
     setup do
       FileUtils.mkdir_p(TMP_DIR)
       htpd = WEBrick::HTTPAuth::Htpasswd.new(File.join(TMP_DIR, 'dot.htpasswd'))


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 
Add HTTP output plugin for v1.7. I got several requests from different users in kubecon. Users have the endpoint to accept logs via HTTP/HTTPs. So generic HTTP output plugin is useful for typical usecases.

Discussion point:
- Support in_http format. fluentd has forward protocol so out_http -> in_http usecase is very rare. I think no need for now
- Support `[{}, {},..., {}]` like json/msgpack. Current implementation uses ndjson. I'm not sure one large array payload is useful or not.

**Docs Changes**:
Need to add article to output section. I will write it after ready to merge.

**Release Note**: 
Add `http` output plugin