### PR TITLE
Separate a connection with keepalive code from  normal connection

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -1095,7 +1095,8 @@ module Fluent::Plugin
         begin
           yield(socket, request_info)
         ensure
-          socket.close
+          socket.close_write rescue nil
+          socket.close rescue nil
         end
       end
 

--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -1100,17 +1100,17 @@ module Fluent::Plugin
           return [socket, request_info]
         end
 
-        ret =
-          begin
-            yield(socket, request_info)
-          rescue
-            @socket_cache.revoke
-            raise
-          else
-            unless require_ack
-              @socket_cache.dec_ref
-            end
+        ret = nil
+        begin
+          ret = yield(socket, request_info)
+        rescue
+          @socket_cache.revoke
+          raise
+        else
+          unless require_ack
+            @socket_cache.dec_ref
           end
+        end
 
         ret
       end

--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -901,7 +901,7 @@ module Fluent::Plugin
 
         case @sender.heartbeat_type
         when :transport
-          connect(dest_addr) do |sock|
+          connect(dest_addr) do |_ri, _sock|
             ## don't send any data to not cause a compatibility problem
             # sock.write FORWARD_TCP_HEARTBEAT_DATA
 


### PR DESCRIPTION
**What this PR does / why we need it**: 

I created a new method(`connect_keepalive`) to remove too many `if/unless @keepalive` since it's too complicated.
For the same reason as above, I changed send_data to use connect.

**Docs Changes**:
no needed

**Release Note**: 

no needed
