### PR TITLE
Improve stats method

### DIFF
--- a/lib/fluent/plugin/buffer.rb
+++ b/lib/fluent/plugin/buffer.rb
@@ -741,6 +741,17 @@ module Fluent
         retry
       end
 
+      STATS_KEYS = [
+        'stage_length',
+        'stage_byte_size',
+        'queue_length',
+        'queue_byte_size',
+        'available_buffer_space_ratios',
+        'total_queued_size',
+        'oldest_timekey',
+        'newest_timekey'
+      ]
+
       def statistics
         stage_size, queue_size = @stage_size, @queue_size
         buffer_space = 1.0 - ((stage_size + queue_size * 1.0) / @total_limit_size).round

--- a/lib/fluent/plugin/buffer.rb
+++ b/lib/fluent/plugin/buffer.rb
@@ -742,14 +742,15 @@ module Fluent
       end
 
       def statistics
-        buffer_space = 1.0 - ((@stage_size + @queue_size * 1.0) / @total_limit_size).round
+        stage_size, queue_size = @stage_size, @queue_size
+        buffer_space = 1.0 - ((stage_size + queue_size * 1.0) / @total_limit_size).round
         stats = {
           'stage_length' => @stage.size,
-          'stage_byte_size' => @stage_size,
+          'stage_byte_size' => stage_size,
           'queue_length' => @queue.size,
-          'queue_byte_size' => @queue_size,
+          'queue_byte_size' => queue_size,
           'available_buffer_space_ratios' => buffer_space * 100,
-          'total_queued_size' => @stage_size + @queue_size,
+          'total_queued_size' => stage_size + queue_size,
         }
 
         if (m = timekeys.min)

--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -16,6 +16,7 @@
 
 require 'fluent/error'
 require 'fluent/plugin/base'
+require 'fluent/plugin/buffer'
 require 'fluent/plugin_helper/record_accessor'
 require 'fluent/log'
 require 'fluent/plugin_id'
@@ -1466,6 +1467,11 @@ module Fluent
         end
       end
 
+      BUFFER_STATS_KEYS = {}
+      Fluent::Plugin::Buffer::STATS_KEYS.each { |key|
+        BUFFER_STATS_KEYS[key] = "buffer_#{key}"
+      }
+
       def statistics
         stats = {
           'emit_records' => @emit_records,
@@ -1481,7 +1487,7 @@ module Fluent
 
         if @buffer && @buffer.respond_to?(:statistics)
           (@buffer.statistics['buffer'] || {}).each do |k, v|
-            stats["buffer_#{k}"] = v
+            stats[BUFFER_STATS_KEYS[k]] = v
           end
         end
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Follow up of #2450 

**What this PR does / why we need it**: 
- `queus_size` / `stage_size` are updated by other thread so assigning these values to local variable is better
- `buffer_` prefix keys are static so avoid dynamic allocation for these keys.

**Docs Changes**:
No need

**Release Note**: 
Improve the resource usage of `Output/Buffer`'s statistics method