### PR TITLE
Add title to have unique thread name

### DIFF
--- a/lib/fluent/plugin/in_monitor_agent.rb
+++ b/lib/fluent/plugin/in_monitor_agent.rb
@@ -208,7 +208,7 @@ module Fluent::Plugin
 
       log.debug "listening monitoring http server on http://#{@bind}:#{@port}/api/plugins for worker#{fluentd_worker_id}"
       api_handler = APIHandler.new(self)
-      create_http_server(addr: @bind, port: @port, logger: log, default_app: NotFoundJson) do |serv|
+      create_http_server(title: :in_monitor_http_server_helper, addr: @bind, port: @port, logger: log, default_app: NotFoundJson) do |serv|
         serv.get('/api/plugins') { |req| api_handler.plugins_ltsv(req) }
         serv.get('/api/plugins.json') { |req| api_handler.plugins_json(req) }
         serv.get('/api/config') { |req| api_handler.config_ltsv(req) }

--- a/lib/fluent/plugin/in_monitor_agent.rb
+++ b/lib/fluent/plugin/in_monitor_agent.rb
@@ -208,7 +208,7 @@ module Fluent::Plugin
 
       log.debug "listening monitoring http server on http://#{@bind}:#{@port}/api/plugins for worker#{fluentd_worker_id}"
       api_handler = APIHandler.new(self)
-      create_http_server(title: :in_monitor_http_server_helper, addr: @bind, port: @port, logger: log, default_app: NotFoundJson) do |serv|
+      create_http_server(:in_monitor_http_server_helper, addr: @bind, port: @port, logger: log, default_app: NotFoundJson) do |serv|
         serv.get('/api/plugins') { |req| api_handler.plugins_ltsv(req) }
         serv.get('/api/plugins.json') { |req| api_handler.plugins_json(req) }
         serv.get('/api/config') { |req| api_handler.config_ltsv(req) }

--- a/lib/fluent/plugin_helper/http_server.rb
+++ b/lib/fluent/plugin_helper/http_server.rb
@@ -34,11 +34,12 @@ module Fluent
       # close    : correct stopped threads
       # terminate: kill thread
 
+      # @param title [Symbol] the thread name. this value should be unique.
       # @param addr [String] Listen address
       # @param port [String] Listen port
       # @param logger [Logger] logger used in this server
       # @param default_app [Object] This method must have #call.
-      def create_http_server(addr:, port:, logger:, default_app: nil)
+      def create_http_server(title:, addr:, port:, logger:, default_app: nil)
         unless block_given?
           raise ArgumentError, 'BUG: callback not specified'
         end
@@ -48,7 +49,7 @@ module Fluent
         end
 
         _block_until_http_server_start do |notify|
-          thread_create(:plugin_helper_http_server) do
+          thread_create(title) do
             @_http_server.start(notify)
           end
         end

--- a/lib/fluent/plugin_helper/http_server.rb
+++ b/lib/fluent/plugin_helper/http_server.rb
@@ -39,7 +39,7 @@ module Fluent
       # @param port [String] Listen port
       # @param logger [Logger] logger used in this server
       # @param default_app [Object] This method must have #call.
-      def create_http_server(title:, addr:, port:, logger:, default_app: nil)
+      def create_http_server(title, addr:, port:, logger:, default_app: nil)
         unless block_given?
           raise ArgumentError, 'BUG: callback not specified'
         end

--- a/test/plugin_helper/test_http_server_helper.rb
+++ b/test/plugin_helper/test_http_server_helper.rb
@@ -50,7 +50,8 @@ class HtttpHelperTest < Test::Unit::TestCase
   %w[get head].each do |n|
     define_method(n) do |uri, header = {}|
       url = URI.parse(uri)
-      req = Net::HTTP.const_get(n.capitalize).new(url, header)
+      headers = { 'Content-Type' => 'application/x-www-form-urlencoded/' }.merge(header)
+      req = Net::HTTP.const_get(n.capitalize).new(url, headers)
       Net::HTTP.start(url.host, url.port) do |http|
         http.request(req)
       end
@@ -60,7 +61,8 @@ class HtttpHelperTest < Test::Unit::TestCase
   %w[post put patch delete options trace].each do |n|
     define_method(n) do |uri, body = '', header = {}|
       url = URI.parse(uri)
-      req = Net::HTTP.const_get(n.capitalize).new(url, header)
+      headers = { 'Content-Type' => 'application/x-www-form-urlencoded/' }.merge(header)
+      req = Net::HTTP.const_get(n.capitalize).new(url, headers)
       req.body = body
       Net::HTTP.start(url.host, url.port) do |http|
         http.request(req)

--- a/test/plugin_helper/test_http_server_helper.rb
+++ b/test/plugin_helper/test_http_server_helper.rb
@@ -73,7 +73,7 @@ class HtttpHelperTest < Test::Unit::TestCase
   sub_test_case 'Create a HTTP server' do
     test 'monunt given path' do
       on_driver do |driver|
-        driver.create_http_server(title: :http_server_helper_test, addr: '127.0.0.1', port: PORT, logger: NULL_LOGGER) do |s|
+        driver.create_http_server(:http_server_helper_test, addr: '127.0.0.1', port: PORT, logger: NULL_LOGGER) do |s|
           s.get('/example/hello') { [200, { 'Content-Type' => 'text/plain' }, 'hello get'] }
           s.post('/example/hello') { [200, { 'Content-Type' => 'text/plain' }, 'hello post'] }
           s.head('/example/hello') { [200, { 'Content-Type' => 'text/plain' }, 'hello head'] }
@@ -108,7 +108,7 @@ class HtttpHelperTest < Test::Unit::TestCase
 
     test 'when path does not start with `/` or ends with `/`' do
       on_driver do |driver|
-        driver.create_http_server(title: :http_server_helper_test, addr: '127.0.0.1', port: PORT, logger: NULL_LOGGER) do |s|
+        driver.create_http_server(:http_server_helper_test, addr: '127.0.0.1', port: PORT, logger: NULL_LOGGER) do |s|
           s.get('example/hello') { [200, { 'Content-Type' => 'text/plain' }, 'hello get'] }
           s.get('/example/hello2/') { [200, { 'Content-Type' => 'text/plain' }, 'hello get'] }
         end
@@ -123,7 +123,7 @@ class HtttpHelperTest < Test::Unit::TestCase
 
     test 'when error raised' do
       on_driver do |driver|
-        driver.create_http_server(title: :http_server_helper_test, addr: '127.0.0.1', port: PORT, logger: NULL_LOGGER) do |s|
+        driver.create_http_server(:http_server_helper_test, addr: '127.0.0.1', port: PORT, logger: NULL_LOGGER) do |s|
           s.get('/example/hello') { raise 'error!' }
         end
 
@@ -134,7 +134,7 @@ class HtttpHelperTest < Test::Unit::TestCase
 
     test 'when path is not found' do
       on_driver do |driver|
-        driver.create_http_server(title: :http_server_helper_test, addr: '127.0.0.1', port: PORT, logger: NULL_LOGGER) do |s|
+        driver.create_http_server(:http_server_helper_test, addr: '127.0.0.1', port: PORT, logger: NULL_LOGGER) do |s|
           s.get('/example/hello') { [200, { 'Content-Type' => 'text/plain' }, 'hello get'] }
         end
 
@@ -145,7 +145,7 @@ class HtttpHelperTest < Test::Unit::TestCase
 
     test 'params and body' do
       on_driver do |driver|
-        driver.create_http_server(title: :http_server_helper_test, addr: '127.0.0.1', port: PORT, logger: NULL_LOGGER) do |s|
+        driver.create_http_server(:http_server_helper_test, addr: '127.0.0.1', port: PORT, logger: NULL_LOGGER) do |s|
           s.get('/example/hello') do |req|
             assert_equal(req.query_string, nil)
             assert_equal(req.body, nil)
@@ -195,7 +195,7 @@ class HtttpHelperTest < Test::Unit::TestCase
         end
 
         stub(Fluent::PluginHelper::HttpServer::Server).new(anything) { server }
-        driver.create_http_server(title: :http_server_helper_test, addr: '127.0.0.1', port: PORT, logger: NULL_LOGGER) do
+        driver.create_http_server(:http_server_helper_test, addr: '127.0.0.1', port: PORT, logger: NULL_LOGGER) do
           # nothing
         end
         driver.stop

--- a/test/plugin_helper/test_http_server_helper.rb
+++ b/test/plugin_helper/test_http_server_helper.rb
@@ -71,7 +71,7 @@ class HtttpHelperTest < Test::Unit::TestCase
   sub_test_case 'Create a HTTP server' do
     test 'monunt given path' do
       on_driver do |driver|
-        driver.create_http_server(addr: '127.0.0.1', port: PORT, logger: NULL_LOGGER) do |s|
+        driver.create_http_server(title: :http_server_helper_test, addr: '127.0.0.1', port: PORT, logger: NULL_LOGGER) do |s|
           s.get('/example/hello') { [200, { 'Content-Type' => 'text/plain' }, 'hello get'] }
           s.post('/example/hello') { [200, { 'Content-Type' => 'text/plain' }, 'hello post'] }
           s.head('/example/hello') { [200, { 'Content-Type' => 'text/plain' }, 'hello head'] }
@@ -106,7 +106,7 @@ class HtttpHelperTest < Test::Unit::TestCase
 
     test 'when path does not start with `/` or ends with `/`' do
       on_driver do |driver|
-        driver.create_http_server(addr: '127.0.0.1', port: PORT, logger: NULL_LOGGER) do |s|
+        driver.create_http_server(title: :http_server_helper_test, addr: '127.0.0.1', port: PORT, logger: NULL_LOGGER) do |s|
           s.get('example/hello') { [200, { 'Content-Type' => 'text/plain' }, 'hello get'] }
           s.get('/example/hello2/') { [200, { 'Content-Type' => 'text/plain' }, 'hello get'] }
         end
@@ -121,7 +121,7 @@ class HtttpHelperTest < Test::Unit::TestCase
 
     test 'when error raised' do
       on_driver do |driver|
-        driver.create_http_server(addr: '127.0.0.1', port: PORT, logger: NULL_LOGGER) do |s|
+        driver.create_http_server(title: :http_server_helper_test, addr: '127.0.0.1', port: PORT, logger: NULL_LOGGER) do |s|
           s.get('/example/hello') { raise 'error!' }
         end
 
@@ -132,7 +132,7 @@ class HtttpHelperTest < Test::Unit::TestCase
 
     test 'when path is not found' do
       on_driver do |driver|
-        driver.create_http_server(addr: '127.0.0.1', port: PORT, logger: NULL_LOGGER) do |s|
+        driver.create_http_server(title: :http_server_helper_test, addr: '127.0.0.1', port: PORT, logger: NULL_LOGGER) do |s|
           s.get('/example/hello') { [200, { 'Content-Type' => 'text/plain' }, 'hello get'] }
         end
 
@@ -143,7 +143,7 @@ class HtttpHelperTest < Test::Unit::TestCase
 
     test 'params and body' do
       on_driver do |driver|
-        driver.create_http_server(addr: '127.0.0.1', port: PORT, logger: NULL_LOGGER) do |s|
+        driver.create_http_server(title: :http_server_helper_test, addr: '127.0.0.1', port: PORT, logger: NULL_LOGGER) do |s|
           s.get('/example/hello') do |req|
             assert_equal(req.query_string, nil)
             assert_equal(req.body, nil)
@@ -193,7 +193,7 @@ class HtttpHelperTest < Test::Unit::TestCase
         end
 
         stub(Fluent::PluginHelper::HttpServer::Server).new(anything) { server }
-        driver.create_http_server(addr: '127.0.0.1', port: PORT, logger: NULL_LOGGER) do
+        driver.create_http_server(title: :http_server_helper_test, addr: '127.0.0.1', port: PORT, logger: NULL_LOGGER) do
           # nothing
         end
         driver.stop


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
no

**What this PR does / why we need it**: 

According to https://docs.fluentd.org/plugin-helper-overview/api-plugin-helper-thread#methods, create_thread receives `title` which must be unique as an argument and http_server_helper uses thread_helper internally.
There are no problems now since http_server is used only by in_monitor plugin.
But we need to change http_server can change their name to have a unique name.

**Docs Changes**:

yes. need to add the description about `title`.

**Release Note**: 

no
