### PR TITLE
support DNS SRV record by RFC2782

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -889,9 +889,9 @@ module Fluent::Plugin
       def switch_original_host!
         @srv_host_mutex.synchronize do
           if @using_srv
-          @host = @original_host
-          @port = @original_port
-          @using_srv = false
+            @host = @original_host
+            @port = @original_port
+            @using_srv = false
           end
         end
       end

--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -620,6 +620,69 @@ EOL
     assert{ logs.any?{|log| log.include?("no response from node. regard it as unavailable.") } }
   end
 
+
+  test 'enable_dns_srv is disabled in default' do
+    @d = d = create_driver(CONFIG)
+    node = d.instance.nodes.first
+    assert_false node.enable_dns_srv
+  end
+
+  test 'enable_dns_srv can be enabled' do
+    @d = d = create_driver(%[
+      <server>
+        enable_dns_srv true
+        host #{TARGET_HOST}
+        port #{TARGET_PORT}
+      </server>
+    ])
+    node = d.instance.nodes.first
+    assert_true node.enable_dns_srv
+  end
+
+  test 'srv_service_name is default fluentd' do
+    @d = d = create_driver(CONFIG)
+    node = d.instance.nodes.first
+    assert_equal 'fluentd', node.srv_service_name
+  end
+
+  test 'srv_service_name is can be change' do
+    @d = d = create_driver(%[
+      <server>
+        enable_dns_srv true
+        srv_service_name in_forward
+        host #{TARGET_HOST}
+        port #{TARGET_PORT}
+      </server>
+    ])
+    node = d.instance.nodes.first
+    assert_equal 'in_forward', node.srv_service_name
+  end
+
+  test 'srv_service_protocol is default tcp' do
+    @d = d = create_driver(%[
+      <server>
+        host #{TARGET_HOST}
+        port #{TARGET_PORT}
+      </server>
+    ])
+    node = d.instance.nodes.first
+    assert_equal 'tcp', node.srv_service_protocol
+  end
+
+  test 'srv_service_protocol is can be change' do
+    @d = d = create_driver(%[
+      <server>
+        srv_service_name in_forward
+        srv_service_protocol udp
+        host #{TARGET_HOST}
+        port #{TARGET_PORT}
+      </server>
+    ])
+    node = d.instance.nodes.first
+    assert_equal 'udp', node.srv_service_protocol
+  end
+
+  
   test 'authentication_with_shared_key' do
     input_conf = TARGET_CONFIG + %[
                    <security>


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes  : None

**What this PR does / why we need it**: 
https://groups.google.com/forum/#!topic/fluentd/Lxx0-rVtsfo

Support for RFC2782 in out_forward allows for more flexible fluentd operations
Specifically, public cloud service discovery

**Docs Changes**:
It will be necessary when this request is merged.
I will send a pull request to the document separately.

**Release Note**: 


**To the reviewer**
SRV#available? may be a better implementation.
For example, `fluent/compat/socket_util` might seem like a smarter way to implement it, but fluentd's code is too complex for my technical capabilities to figure out how to do it.
I will correct the code better if you give me advice.
