### PR TITLE
in_syslog: add 'emit_unmatched_lines' option

### DIFF
--- a/test/plugin/test_in_syslog.rb
+++ b/test/plugin/test_in_syslog.rb
@@ -361,4 +361,31 @@ EOS
       msgs
     end
   end
+
+  def test_emit_unmatched_lines
+    d = create_driver([CONFIG, 'emit_unmatched_lines true'].join("\n"))
+    tests = [
+      # valid message
+      {'msg' => '<6>Sep 10 00:00:00 localhost logger: xxx', 'expected' => {'host'=>'localhost', 'ident'=>'logger', 'message'=>'xxx'}},
+      # missing priority
+      {'msg' => 'hello world', 'expected' => {'unmatched_line' => 'hello world'}},
+      # timestamp parsing failure
+      {'msg' => '<6>ZZZ 99 99:99:99 localhost logger: xxx', 'expected' => {'unmatched_line' => '<6>ZZZ 99 99:99:99 localhost logger: xxx'}},
+    ]
+
+    d.run(expect_emits: 3) do
+      u = UDPSocket.new
+      u.do_not_reverse_lookup = false
+      u.connect('127.0.0.1', PORT)
+      tests.each {|test|
+        u.send(test['msg'], 0)
+      }
+    end
+
+    assert_equal tests.size, d.events.size
+    tests.size.times do |i|
+      assert_equal tests[i]['expected'], d.events[i][2]
+      assert_equal 'syslog.unmatched', d.events[i][0] unless i==0
+    end
+  end
 end


### PR DESCRIPTION
Fixes #2497

Signed-off-by: Brian Candler <b.candler@pobox.com>

**What this PR does / why we need it**: 

Many devices emit syslog messages which don't match expected format, and are otherwise thrown away.  Add `emit_unmatched_lines` as per the [equivalent in_tail option](https://github.com/fluent/fluentd-docs-gitbook/blob/1.0/plugins/input/tail.md#emit_unmatched_lines).

**Docs Changes**:

Add new parameter to https://github.com/fluent/fluentd-docs-gitbook/blob/1.0/plugins/input/syslog.md

**Release Note**: 

```
### Enhancement

* in_syslog: Add `emit_unmatched_lines` to capture lines which don't parse
```
