### PR TITLE
in_syslog: add option 'original_message_key'

### DIFF
--- a/lib/fluent/plugin/in_syslog.rb
+++ b/lib/fluent/plugin/in_syslog.rb
@@ -95,6 +95,8 @@ module Fluent::Plugin
     config_param :priority_key, :string, default: nil
     desc 'The field name of the facility.'
     config_param :facility_key, :string, default: nil
+    desc 'The field name of the entire original message.'
+    config_param :original_message_key, :string, default: nil
 
     desc "The max bytes of message"
     config_param :message_length_limit, :size, default: 2048
@@ -232,6 +234,7 @@ module Fluent::Plugin
         record[@facility_key] = facility if @facility_key
         record[@source_address_key] = sock.remote_addr if @source_address_key
         record[@source_hostname_key] = sock.remote_host if @source_hostname_key
+        record[@original_message_key] = text if @original_message_key
 
         tag = "#{@tag}.#{facility}.#{priority}"
         emit(tag, time, record)

--- a/test/plugin/test_in_syslog.rb
+++ b/test/plugin/test_in_syslog.rb
@@ -388,4 +388,23 @@ EOS
       assert('syslog.unmatched' == d.events[i][0]) unless i==0
     end
   end
+
+  def test_original_message_key
+    d = create_driver([CONFIG, 'original_message_key raw'].join("\n"))
+    tests = create_test_case
+
+    d.run(expect_emits: 2) do
+      u = UDPSocket.new
+      u.connect('127.0.0.1', PORT)
+      tests.each {|test|
+        u.send(test['msg'], 0)
+      }
+    end
+
+    assert(d.events.size > 0)
+    d.events.each_index do |i|
+      assert_equal(tests[i]['expected'], d.events[i][2]['message'])
+      assert_equal(tests[i]['msg'], d.events[i][2]['raw'] + "\n")
+    end
+  end
 end


### PR DESCRIPTION
(Note: this applies on top of PR #2499 )

**Which issue(s) this PR fixes**: 

N/A

**What this PR does / why we need it**: 

Some log systems like [loki](https://github.com/grafana/loki) natively work on raw text lines, and are more natural to use in this form as opposed to a JSON collection of parsed fields.

Loki can accept certain parsed fields out-of-band as tags, but only if low-cardinality.  syslog parsing can generate high cardinality values, in particular `pid`, so all these values cannot be mapped to tags.  But if they are not mapped to tags, and the original line is not kept, then these values are lost.

I think it would also be useful with out_file to record the entire original syslog line.

**Docs Changes**:

Add new setting to https://github.com/fluent/fluentd-docs-gitbook/blob/1.0/plugins/input/syslog.md

**Release Note**: 

```
### Enhancement

in_syslog: add `original_message_key` to retain the entire original message
```
