### PR TITLE
Change SocketCache to be shared between nodes

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -203,28 +203,23 @@ module Fluent::Plugin
         end
       end
 
+      socket_cache = @keepalive ? SocketCache.new(@keepalive_timeout, @log) : nil
+      @connection_manager = ConnectionManager.new(
+        log: @log,
+        secure: !!@security,
+        connection_factory: method(:create_transfer_socket),
+        socket_cache: socket_cache,
+      )
+
       @servers.each do |server|
         failure = FailureDetector.new(@heartbeat_interval, @hard_timeout, Time.now.to_i.to_f)
         name = server.name || "#{server.host}:#{server.port}"
 
-        socket_cache =
-          if @keepalive
-            SocketCache.new(@keepalive_timeout, @log)
-          else
-            nil
-          end
-        connection_manager = ConnectionManager.new(
-          log: @log,
-          secure: !!@security,
-          connection_factory: method(:create_transfer_socket),
-          socket_cache: socket_cache,
-        )
-
         log.info "adding forwarding server '#{name}'", host: server.host, port: server.port, weight: server.weight, plugin_id: plugin_id
         if @heartbeat_type == :none
-          @nodes << NoneHeartbeatNode.new(self, server, failure: failure, connection_manager: connection_manager)
+          @nodes << NoneHeartbeatNode.new(self, server, failure: failure, connection_manager: @connection_manager)
         else
-          node = Node.new(self, server, failure: failure, connection_manager: connection_manager)
+          node = Node.new(self, server, failure: failure, connection_manager: @connection_manager)
           begin
             node.validate_host_resolution!
           rescue => e
@@ -315,10 +310,15 @@ module Fluent::Plugin
         @usock.close rescue nil
       end
 
-      if @keepalive && @keepalive_timeout
-        @nodes.each(&:clear)
-      end
       super
+    end
+
+    def stop
+      super
+
+      if @keepalive
+        @connection_manager.stop
+      end
     end
 
     def write(chunk)
@@ -425,7 +425,7 @@ module Fluent::Plugin
     end
 
     def on_purge_obsolete_socks
-      @nodes.each(&:purge_obsolete_socks)
+      @connection_manager.purge_obsolete_socks
     end
 
     # return chunk id to be committed
@@ -668,14 +668,6 @@ module Fluent::Plugin
 
         heartbeat(false)
         nil
-      end
-
-      def clear
-        @connection_manager.stop
-      end
-
-      def purge_obsolete_socks
-        @connection_manager.purge_obsolete_socks
       end
 
       def close(sock)

--- a/lib/fluent/plugin/out_forward/socket_cache.rb
+++ b/lib/fluent/plugin/out_forward/socket_cache.rb
@@ -37,11 +37,11 @@ module Fluent::Plugin
           if tsock
             tsock.sock
           else
-            val = yield
-            new_tsock = TimedSocket.new(timeout, key, val)
+            sock = yield
+            new_tsock = TimedSocket.new(timeout, key, sock)
             @log.debug("connect new socket #{new_tsock}")
 
-            @inflight_sockets[val] = new_tsock
+            @inflight_sockets[sock] = new_tsock
             new_tsock.sock
           end
         end

--- a/lib/fluent/plugin/out_forward/socket_cache.rb
+++ b/lib/fluent/plugin/out_forward/socket_cache.rb
@@ -34,15 +34,16 @@ module Fluent::Plugin
         @mutex.synchronize do
           tsock = pick_socket(key)
 
-          unless tsock
+          if tsock
+            tsock.sock
+          else
             val = yield
             new_tsock = TimedSocket.new(timeout, key, val)
             @log.debug("connect new socket #{new_tsock}")
 
             @inflight_sockets[val] = new_tsock
-            return new_tsock.sock
+            new_tsock.sock
           end
-          tsock.sock
         end
       end
 

--- a/lib/fluent/plugin/out_forward/socket_cache.rb
+++ b/lib/fluent/plugin/out_forward/socket_cache.rb
@@ -87,7 +87,7 @@ module Fluent::Plugin
           @inactive_sockets.clear
         end
 
-        while (s = sockets.pop)
+        sockets.each do |s|
           s.sock.close rescue nil
         end
       end
@@ -104,7 +104,7 @@ module Fluent::Plugin
           @inactive_sockets.clear
         end
 
-        while (s = sockets.pop)
+        sockets.each do |s|
           s.sock.close rescue nil
         end
       end

--- a/test/plugin/out_forward/test_connection_manager.rb
+++ b/test/plugin/out_forward/test_connection_manager.rb
@@ -82,7 +82,7 @@ class ConnectionManager < Test::Unit::TestCase
     sub_test_case 'when socket_cache exists' do
       test 'calls connect_keepalive' do
         cache = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
-        mock(cache).dec_ref.never
+        mock(cache).checkin('sock').never
 
         cm = Fluent::Plugin::ForwardOutput::ConnectionManager.new(
           log: $log,
@@ -100,7 +100,7 @@ class ConnectionManager < Test::Unit::TestCase
 
       test 'calls connect_keepalive and closes socket with block' do
         cache = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
-        mock(cache).dec_ref.once
+        mock(cache).checkin('sock').once
 
         cm = Fluent::Plugin::ForwardOutput::ConnectionManager.new(
           log: $log,
@@ -119,7 +119,7 @@ class ConnectionManager < Test::Unit::TestCase
 
       test 'does not call dec_ref when require_ack is true' do
         cache = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
-        mock(cache).dec_ref.never
+        mock(cache).checkin('sock').never
 
         cm = Fluent::Plugin::ForwardOutput::ConnectionManager.new(
           log: $log,

--- a/test/plugin/out_forward/test_socket_cache.rb
+++ b/test/plugin/out_forward/test_socket_cache.rb
@@ -5,13 +5,13 @@ require 'fluent/plugin/out_forward/socket_cache'
 class SocketCacheTest < Test::Unit::TestCase
   sub_test_case 'fetch_or' do
     test 'when gived key does not exist' do
-      c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, Logger.new(nil))
+      c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
       sock = mock!.open { 1 }.subject
       assert_equal(1, c.fetch_or { sock.open })
     end
 
     test 'when given key exists' do
-      c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, Logger.new(nil))
+      c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
       assert_equal(1, c.fetch_or { 1 })
 
       sock = dont_allow(mock!).open
@@ -19,7 +19,7 @@ class SocketCacheTest < Test::Unit::TestCase
     end
 
     test "when given key's value was expired" do
-      c = Fluent::Plugin::ForwardOutput::SocketCache.new(0, Logger.new(nil))
+      c = Fluent::Plugin::ForwardOutput::SocketCache.new(0, $log)
       assert_equal(1, c.fetch_or { 1 })
 
       sock = mock!.open { 1 }.subject
@@ -28,7 +28,7 @@ class SocketCacheTest < Test::Unit::TestCase
   end
 
   test 'revoke' do
-    c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, Logger.new(nil))
+    c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
     c.fetch_or { 1 }
     c.revoke
 
@@ -37,7 +37,7 @@ class SocketCacheTest < Test::Unit::TestCase
   end
 
   test 'revoke_by_value' do
-    c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, Logger.new(nil))
+    c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
     c.fetch_or { 1 }
     c.revoke_by_value(1)
 
@@ -47,7 +47,7 @@ class SocketCacheTest < Test::Unit::TestCase
 
   sub_test_case 'dec_ref' do
     test 'when value exists in active_socks' do
-      c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, Logger.new(nil))
+      c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
       c.fetch_or { 1 }
       c.dec_ref
 
@@ -55,7 +55,7 @@ class SocketCacheTest < Test::Unit::TestCase
     end
 
     test 'when value exists in inactive_socks' do
-      c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, Logger.new(nil))
+      c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
       c.fetch_or { 1 }
       c.revoke
       c.dec_ref
@@ -65,7 +65,7 @@ class SocketCacheTest < Test::Unit::TestCase
 
   sub_test_case 'dec_ref_by_value' do
     test 'when value exists in active_socks' do
-      c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, Logger.new(nil))
+      c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
       c.fetch_or { 1 }
       c.dec_ref_by_value(1)
 
@@ -73,7 +73,7 @@ class SocketCacheTest < Test::Unit::TestCase
     end
 
     test 'when value exists in inactive_socks' do
-      c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, Logger.new(nil))
+      c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
       c.fetch_or { 1 }
       c.revoke
       c.dec_ref_by_value(1)
@@ -83,7 +83,7 @@ class SocketCacheTest < Test::Unit::TestCase
 
   sub_test_case 'clear' do
     test 'when value is in active_socks' do
-      c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, Logger.new(nil))
+      c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
       m = mock!.close { 'closed' }.subject
       c.fetch_or { m }
       assert_true(!c.instance_variable_get(:@active_socks).empty?)
@@ -93,7 +93,7 @@ class SocketCacheTest < Test::Unit::TestCase
     end
 
     test 'when value is in inactive_socks' do
-      c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, Logger.new(nil))
+      c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
       m = mock!.close { 'closed' }.subject
       c.fetch_or { m }
       c.revoke
@@ -106,7 +106,7 @@ class SocketCacheTest < Test::Unit::TestCase
 
   sub_test_case 'purge_obsolete_socks' do
     test 'delete key in inactive_socks' do
-      c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, Logger.new(nil))
+      c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
       m = mock!.close { 'closed' }.subject
       c.fetch_or { m }
       c.revoke
@@ -117,7 +117,7 @@ class SocketCacheTest < Test::Unit::TestCase
     end
 
     test 'move key from active_socks to inactive_socks' do
-      c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, Logger.new(nil))
+      c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
       m = dont_allow(mock!).close
       stub(m).inspect         # for log
       c.fetch_or { m }

--- a/test/plugin/out_forward/test_socket_cache.rb
+++ b/test/plugin/out_forward/test_socket_cache.rb
@@ -1,132 +1,139 @@
 require_relative '../../helper'
 
 require 'fluent/plugin/out_forward/socket_cache'
+require 'timecop'
 
 class SocketCacheTest < Test::Unit::TestCase
-  sub_test_case 'fetch_or' do
+  sub_test_case 'checkout_or' do
     test 'when gived key does not exist' do
       c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
-      sock = mock!.open { 1 }.subject
-      assert_equal(1, c.fetch_or { sock.open })
+      sock = mock!.open { 'socket' }.subject
+      assert_equal('socket', c.checkout_or('key') { sock.open })
     end
 
     test 'when given key exists' do
       c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
-      assert_equal(1, c.fetch_or { 1 })
+      socket = 'socket'
+      assert_equal(socket, c.checkout_or('key') { socket })
+      c.checkin(socket)
 
       sock = dont_allow(mock!).open
-      assert_equal(1, c.fetch_or { sock.open })
+      assert_equal(socket, c.checkout_or('key') { sock.open })
+    end
+
+    test 'when given key exists but used by other' do
+      c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
+      assert_equal(@sock, c.checkout_or('key') { @sock })
+
+      new_sock = 'new sock'
+      sock = mock!.open { new_sock }.subject
+      assert_equal(new_sock, c.checkout_or('key') { sock.open })
     end
 
     test "when given key's value was expired" do
       c = Fluent::Plugin::ForwardOutput::SocketCache.new(0, $log)
-      assert_equal(1, c.fetch_or { 1 })
+      assert_equal(@sock, c.checkout_or('key') { @sock })
 
-      sock = mock!.open { 1 }.subject
-      assert_equal(1, c.fetch_or { sock.open })
+      new_sock = 'new sock'
+      sock = mock!.open { new_sock }.subject
+      assert_equal(new_sock, c.checkout_or('key') { sock.open })
+    end
+  end
+
+  sub_test_case 'checkin' do
+    test 'when value exists' do
+      c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
+      socket = 'socket'
+      c.checkout_or('key') { socket }
+      c.checkin(socket)
+
+      assert_equal(socket, c.instance_variable_get(:@available_sockets)['key'].first.sock)
+      assert_equal(1, c.instance_variable_get(:@available_sockets)['key'].size)
+      assert_equal(0, c.instance_variable_get(:@inflight_sockets).size)
+    end
+
+    test 'when value does not exist' do
+      c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
+      c.checkout_or('key') { 'sock' }
+      c.checkin('other sock')
+
+      assert_equal(0, c.instance_variable_get(:@available_sockets)['key'].size)
+      assert_equal(1, c.instance_variable_get(:@inflight_sockets).size)
     end
   end
 
   test 'revoke' do
     c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
-    c.fetch_or { 1 }
-    c.revoke
+    socket = 'socket'
+    c.checkout_or('key') { socket }
+    c.revoke(socket)
+
+    assert_equal(1, c.instance_variable_get(:@inactive_sockets).size)
+    assert_equal(0, c.instance_variable_get(:@inflight_sockets).size)
+    assert_equal(0, c.instance_variable_get(:@available_sockets)['key'].size)
 
     sock = mock!.open { 1 }.subject
-    assert_equal(1, c.fetch_or { sock.open })
-  end
-
-  test 'revoke_by_value' do
-    c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
-    c.fetch_or { 1 }
-    c.revoke_by_value(1)
-
-    sock = mock!.open { 1 }.subject
-    assert_equal(1, c.fetch_or { sock.open })
-  end
-
-  sub_test_case 'dec_ref' do
-    test 'when value exists in active_socks' do
-      c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
-      c.fetch_or { 1 }
-      c.dec_ref
-
-      assert_equal(0, c.instance_variable_get(:@active_socks)[Thread.current.object_id].ref)
-    end
-
-    test 'when value exists in inactive_socks' do
-      c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
-      c.fetch_or { 1 }
-      c.revoke
-      c.dec_ref
-      assert_equal(-1, c.instance_variable_get(:@inactive_socks)[Thread.current.object_id].ref)
-    end
-  end
-
-  sub_test_case 'dec_ref_by_value' do
-    test 'when value exists in active_socks' do
-      c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
-      c.fetch_or { 1 }
-      c.dec_ref_by_value(1)
-
-      assert_equal(0, c.instance_variable_get(:@active_socks)[Thread.current.object_id].ref)
-    end
-
-    test 'when value exists in inactive_socks' do
-      c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
-      c.fetch_or { 1 }
-      c.revoke
-      c.dec_ref_by_value(1)
-      assert_equal(-1, c.instance_variable_get(:@inactive_socks)[Thread.current.object_id].ref)
-    end
+    assert_equal(1, c.checkout_or('key') { sock.open })
   end
 
   sub_test_case 'clear' do
-    test 'when value is in active_socks' do
+    test 'when value is in available_sockets' do
       c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
       m = mock!.close { 'closed' }.subject
-      c.fetch_or { m }
-      assert_true(!c.instance_variable_get(:@active_socks).empty?)
+      m2 = mock!.close { 'closed' }.subject
+      m3 = mock!.close { 'closed' }.subject
+      c.checkout_or('key') { m }
+      c.revoke(m)
+      c.checkout_or('key') { m2 }
+      c.checkin(m2)
+      c.checkout_or('key2') { m3 }
+
+      assert_equal(1, c.instance_variable_get(:@inflight_sockets).size)
+      assert_equal(1, c.instance_variable_get(:@available_sockets)['key'].size)
+      assert_equal(1, c.instance_variable_get(:@inactive_sockets).size)
 
       c.clear
-      assert_true(c.instance_variable_get(:@active_socks).empty?)
-    end
-
-    test 'when value is in inactive_socks' do
-      c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
-      m = mock!.close { 'closed' }.subject
-      c.fetch_or { m }
-      c.revoke
-      assert_true(!c.instance_variable_get(:@inactive_socks).empty?)
-
-      c.clear
-      assert_true(c.instance_variable_get(:@active_socks).empty?)
+      assert_equal(0, c.instance_variable_get(:@inflight_sockets).size)
+      assert_equal(0, c.instance_variable_get(:@available_sockets)['key'].size)
+      assert_equal(0, c.instance_variable_get(:@inactive_sockets).size)
     end
   end
 
   sub_test_case 'purge_obsolete_socks' do
     test 'delete key in inactive_socks' do
       c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
-      m = mock!.close { 'closed' }.subject
-      c.fetch_or { m }
-      c.revoke
-      assert_true(!c.instance_variable_get(:@inactive_socks).empty?)
+      sock = mock!.close { 'closed' }.subject
+      c.checkout_or('key') { sock }
+      c.revoke(sock)
+      assert_false(c.instance_variable_get(:@inactive_sockets).empty?)
 
       c.purge_obsolete_socks
-      assert_true(c.instance_variable_get(:@active_socks).empty?)
+      assert_true(c.instance_variable_get(:@inactive_sockets).empty?)
     end
 
-    test 'move key from active_socks to inactive_socks' do
+    test 'move key from available_sockets to inactive_sockets' do
+      Timecop.freeze(Time.parse('2016-04-13 14:00:00 +0900'))
+
       c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
-      m = dont_allow(mock!).close
-      stub(m).inspect         # for log
-      c.fetch_or { m }
-      assert_true(!c.instance_variable_get(:@active_socks).empty?)
-      assert_true(c.instance_variable_get(:@inactive_socks).empty?)
+      sock = mock!.close { 'closed' }.subject
+      sock2 = dont_allow(mock!).close
+      stub(sock).inspect
+      stub(sock2).inspect
+
+      c.checkout_or('key') { sock }
+      c.checkin(sock)
+
+      # wait timeout
+      Timecop.freeze(Time.parse('2016-04-13 14:20:00 +0900'))
+      c.checkout_or('key') { sock2 }
+
+      assert_equal(1, c.instance_variable_get(:@inflight_sockets).size)
+      assert_equal(sock2, c.instance_variable_get(:@inflight_sockets).values.first.sock)
 
       c.purge_obsolete_socks
-      assert_true(!c.instance_variable_get(:@active_socks).empty?)
-      assert_true(c.instance_variable_get(:@inactive_socks).empty?)
+
+      assert_equal(1, c.instance_variable_get(:@inflight_sockets).size)
+      assert_equal(sock2, c.instance_variable_get(:@inflight_sockets).values.first.sock)
     end
   end
 end

--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -1052,7 +1052,7 @@ EOL
     end
 
     sub_test_case 'with require_ack_response' do
-      test 'Do not create connection per send_data' do
+      test 'Create connection per send_data' do
         target_input_driver = create_target_input_driver(conf: TARGET_CONFIG)
         output_conf = CONFIG + %[
           require_ack_response true
@@ -1064,7 +1064,7 @@ EOL
 
         begin
           chunk = Fluent::Plugin::Buffer::MemoryChunk.new(Fluent::Plugin::Buffer::Metadata.new(nil, nil, nil))
-          mock.proxy(d.instance).socket_create_tcp(TARGET_HOST, TARGET_PORT, anything) { |sock| mock(sock).close.once; sock }.once
+          mock.proxy(d.instance).socket_create_tcp(TARGET_HOST, TARGET_PORT, anything) { |sock| mock(sock).close.once; sock }.twice
 
           target_input_driver.run(timeout: 15) do
             d.run(shutdown: false) do


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 

no

**What this PR does / why we need it**: 

Old SocketCache isn't shared between other nodes since node's `port` and `host` is fixed at start time. 
In the situation nodes' port and host change dynamically, sharing SocketCache between nodes makes more efficient. 
And recent refactoring can make SocketCache more simple.

**Docs Changes**:

no need

**Release Note**: 

no need
