### PR TITLE
already resolved_host in L688

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -706,7 +706,7 @@ module Fluent::Plugin
             heartbeat(true)
           end
         when :udp
-          @usock.send "\0", 0, Socket.pack_sockaddr_in(@port, resolved_host)
+          @usock.send "\0", 0, Socket.pack_sockaddr_in(@port, dest_addr)
           nil
         when :none # :none doesn't use this class
           raise "BUG: heartbeat_type none must not use Node"


### PR DESCRIPTION
Signed-off-by: Yuta Iwama <ganmacs@gmail.com>

<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
no

**What this PR does / why we need it**: 

#resolved_host is already called in L688

https://github.com/fluent/fluentd/blob/58fd5276e6458a5de75d5beaa64a5ca574f9e09c/lib/fluent/plugin/out_forward.rb#L688

**Docs Changes**:

no needed

**Release Note**: 
no needed
