### PR TITLE
Fix warning printed when chunk key placeholder not replaced

### DIFF
--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -758,7 +758,7 @@ module Fluent
             rvalue = rvalue.gsub(CHUNK_KEY_PLACEHOLDER_PATTERN, hash)
           end
           if rvalue =~ CHUNK_KEY_PLACEHOLDER_PATTERN
-            log.warn "chunk key placeholder '#{$1}' not replaced. template:#{str}"
+            log.warn "chunk key placeholder '#{$&}' not replaced. template:#{str}"
           end
           rvalue.sub(CHUNK_ID_PLACEHOLDER_PATTERN) {
             if chunk_passed


### PR DESCRIPTION
This used `$1` to print the key name.  However, there are no capture groups in `CHUNK_KEY_PLACEHOLDER_PATTERN`, so `$1` would not be set.  According to the Ruby docs I looked up, `$&` can be used to get the part of the string that matched, which I think will give the correct output in this case.
