### PR TITLE
Replace in_tail with a faster implementation.

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -700,7 +700,14 @@ module Fluent::Plugin
 
         def next_line
           idx = @buffer.index(@eol)
-          convert(@buffer.slice!(0, idx + 1)) unless idx.nil?
+
+          unless idx.nil?
+            # Using freeze and slice is faster than slice!
+            @buffer.freeze
+            rbuf = @buffer.slice(0, idx + 1)
+            @buffer = @buffer.slice(idx + 1, @buffer.size)
+            convert(rbuf)
+          end
         end
 
         def bytesize

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -698,15 +698,17 @@ module Fluent::Plugin
           s.encode!(@encoding, @from_encoding, :invalid => :replace, :undef => :replace)
         end
 
-        def next_line
+        def read_lines(lines)
           idx = @buffer.index(@eol)
 
-          unless idx.nil?
+          until idx.nil?
             # Using freeze and slice is faster than slice!
+            # See https://github.com/fluent/fluentd/pull/2527
             @buffer.freeze
             rbuf = @buffer.slice(0, idx + 1)
             @buffer = @buffer.slice(idx + 1, @buffer.size)
-            convert(rbuf)
+            idx = @buffer.index(@eol)
+            lines << convert(rbuf)
           end
         end
 
@@ -740,9 +742,7 @@ module Fluent::Plugin
                 begin
                   while true
                     @fifo << io.readpartial(8192, @iobuf)
-                    while (line = @fifo.next_line)
-                      @lines << line
-                    end
+                    @fifo.read_lines(@lines)
                     if @lines.size >= @watcher.read_lines_limit
                       # not to use too much memory in case the file is very large
                       read_more = true


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
no

**What this PR does / why we need it**: 

`slice!` is very slow. so I replaced in_tail implementation with `slice` + `freeze`.
This change makes FIFO of in_tail about 100x faster in ruby 2.6's simple benchmark.

benchmark script & result: https://gist.github.com/ganmacs/3f517c79881f56547cde305ae7a86b35

**Docs Changes**:

no

**Release Note**: 

Replace in_tail with faster implementation.
