### PR TITLE
formatter_csv: Improve the performance.  2x faster

### DIFF
--- a/test/plugin/test_formatter_csv.rb
+++ b/test/plugin/test_formatter_csv.rb
@@ -108,4 +108,20 @@ class CsvFormatterTest < ::Test::Unit::TestCase
     d = create_driver('fields' => data)
     assert_equal %w(one two three), d.instance.fields
   end
+
+  def test_format_with_multiple_records
+    d = create_driver("fields" => "message,message2")
+    r = {'message' => 'hello', 'message2' => 'fluentd'}
+
+    formatted = d.instance.format(tag, @time, r)
+    assert_equal("\"hello\",\"fluentd\"\n", formatted)
+
+    r = {'message' => 'hey', 'message2' => 'ho'}
+    formatted = d.instance.format(tag, @time, r)
+    assert_equal("\"hey\",\"ho\"\n", formatted)
+
+    r = {'message' => 'longer message', 'message2' => 'longer longer message'}
+    formatted = d.instance.format(tag, @time, r)
+    assert_equal("\"longer message\",\"longer longer message\"\n", formatted)
+  end
 end


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 
Improve the performance by avoiding creating CSV object per format call.
In ruby 2.6.3, 2x faster than before.

```
Warming up --------------------------------------
                 now     4.627k i/100ms
                 new     9.692k i/100ms
Calculating -------------------------------------
                 now     49.484k (± 2.1%) i/s -    249.858k in   5.051491s
                 new     98.117k (± 8.4%) i/s -    494.292k in   5.091679s
```

```
require 'benchmark/ips'
require 'csv'

class CF
  def initialize
    @fields = ["key1","key2","ke,y3","ke y4","key5","key6","key7","key8"]
    @generate_opts1 = {col_sep: ',', force_quotes: true}
    @generate_opts2 = {col_sep: ',', force_quotes: true, headers: @fields,
                       row_sep: @add_newline ? :auto : "".force_encoding(Encoding::ASCII_8BIT)}

    @cache = {}
  end

  def format1(tag, time, record)
    row = @fields.map do |key|
      record[key]
    end
    line = CSV.generate_line(row, @generate_opts1)
    line.chomp! unless @add_newline
    line
  end

  def format2(tag, time, record)
    csv = (@cache[Thread.current] ||= CSV.new("".force_encoding(Encoding::UTF_8), @generate_opts2))
    line = (csv << record).string.dup
    csv.rewind
    csv.truncate(0)
    line
  end
end

keys = ["key1","key2","ke,y3","ke y4","key5","key6","key7","key8"]
record = {}
keys.each { |key|
  record[key] = "valueeeeee1"
}

cf = CF.new

Benchmark.ips do |x|
  x.report('now') do
    cf.format1(nil, nil, record)
  end

  x.report('new') do
    cf.format2(nil, nil, record)
  end
end
```

**Docs Changes**:
No need

**Release Note**: 
Same as title.