### PR TITLE
parser_csv: Improve the performance for typical cases

### DIFF
--- a/lib/fluent/plugin/parser_csv.rb
+++ b/lib/fluent/plugin/parser_csv.rb
@@ -33,10 +33,11 @@ module Fluent
       def configure(conf)
         super
 
-        @quote_char = '"'
-        @escape_pattern = Regexp.compile(@quote_char * 2)
 
         if @parser_type == :fast
+          @quote_char = '"'
+          @escape_pattern = Regexp.compile(@quote_char * 2)
+
           m = method(:parse_fast)
           self.singleton_class.module_eval do
             define_method(:parse, m)

--- a/lib/fluent/plugin/parser_csv.rb
+++ b/lib/fluent/plugin/parser_csv.rb
@@ -27,12 +27,73 @@ module Fluent
       config_param :keys, :array, value_type: :string
       desc 'The delimiter character (or string) of CSV values'
       config_param :delimiter, :string, default: ','
+      desc 'The parser type used to parse CSV line'
+      config_param :parser_type, :enum, list: [:normal, :fast], default: :normal
+
+      def configure(conf)
+        super
+
+        @quote_char = '"'
+        if @parser_type == :fast
+          m = method(:parse_fast)
+          self.singleton_class.module_eval do
+            define_method(:parse, m)
+          end
+        end
+      end
 
       def parse(text, &block)
         values = CSV.parse_line(text, col_sep: @delimiter)
         r = Hash[@keys.zip(values)]
         time, record = convert_values(parse_time(r), r)
         yield time, record
+      end
+
+      def parse_fast(text, &block)
+        r = parse_fast_internal(text)
+        time, record = convert_values(parse_time(r), r)
+        yield time, record
+      end
+
+      # CSV.parse_line is too slow due to initialize lots of object and
+      # CSV module doesn't provide the efficient method for parsing single line.
+      # This method avoids the overhead of CSV.parse_line for typical patterns
+      def parse_fast_internal(text)
+        record = {}
+        text.chomp!
+
+        return record if text.empty?
+
+        # use while because while is now faster than each_with_index
+        columns = text.split(@delimiter, -1)
+        num_columns = columns.size
+        i = 0
+        j = 0
+        while j < num_columns
+          column = columns[j]
+          if column.empty?
+            column = nil
+          else
+            num_quote = column.count(@quote_char)
+            if num_quote == 1 && column.start_with?(@quote_char)
+              to_merge = [column]
+              j += 1
+              while j < num_columns
+                merged_col = columns[j]
+                to_merge << merged_col
+                break if merged_col.end_with?(@quote_char)
+                j += 1
+              end
+              column = to_merge.join(@delimiter)[1..-2]
+            elsif num_quote == 2 && column.start_with?(@quote_char) && column.end_with?(@quote_char)
+              column = column[1..-2]
+            end
+          end
+          record[@keys[i]] = column
+          j += 1
+          i += 1
+        end
+        record
       end
     end
   end

--- a/test/plugin/test_parser_csv.rb
+++ b/test/plugin/test_parser_csv.rb
@@ -149,5 +149,38 @@ class CSVParserTest < ::Test::Unit::TestCase
         assert_equal expected, record
       end
     end
+
+    def test_incompatibility_between_normal_and_fast_parser
+      normal = create_driver(
+        'keys' => 'key1,key2',
+        'parser_type' => 'normal'
+      )
+      fast = create_driver(
+        'keys' => 'key1,key2',
+        'parser_type' => 'fast'
+      )
+
+      # unexpected quote position
+      text = 'a"b,"a"""c"'
+      assert_raise(CSV::MalformedCSVError) {
+        normal.instance.parse(text) { |t, r| }
+      } 
+      assert_nothing_raised {
+        # generate broken record
+        fast.instance.parse(text) { |t, r| }
+      }
+
+      # incorrect the number of column
+      text = 'a,b,c'
+      expected = {"key1" => 'a', "key2" => 'b'}
+      normal.instance.parse(text) { |t, r|
+        assert_equal expected, r
+      }
+      fast.instance.parse(text) { |t, r|
+        assert_not_equal expected, r
+      }
+
+      # And more...
+    end
   end
 end

--- a/test/plugin/test_parser_csv.rb
+++ b/test/plugin/test_parser_csv.rb
@@ -139,6 +139,15 @@ class CSVParserTest < ::Test::Unit::TestCase
         assert_equal(event_time("28/Feb/2013:12:00:00 +0900", format: '%d/%b/%Y:%H:%M:%S %z'), time)
         assert_equal expected, record
       end
+
+      # escaped
+      text = '28/Feb/2013:12:00:00 +0900,"message","mes""sage","""message""",,""""""'
+      expected = {'key1' => 'message', 'key2' => 'mes"sage', 'key3' => '"message"',
+                  'key4' => nil, 'key5' => '""'}
+      d.instance.parse(text) do |time, record|
+        assert_equal(event_time("28/Feb/2013:12:00:00 +0900", format: '%d/%b/%Y:%H:%M:%S %z'), time)
+        assert_equal expected, record
+      end
     end
   end
 end


### PR DESCRIPTION
Add parser_type parameter to switch the parser.

Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 
Parser version try of https://github.com/fluent/fluentd/pull/2529.
I implemented original method because CSV module doesn't provide the way to parse single line without recreate CSV object.
This fast implementation supports typical patterns so it is useful. See test case for supported patterns: https://github.com/fluent/fluentd/blob/8b1cb4a6899f556ddad19aa1e8b5863825313ae9/test/plugin/test_parser_csv.rb#L107

Here is the benchmark result:

```
non quote: value1,value1,value1,value1,value1,value1,value1,value1
quoted   : "fo,o","fo,o","fo,o","fo,o","fo,o","fo,o","fo,o","fo,o"
escaped  : "aa","b""b""b","c"," ",e,f,"""""",
Warming up --------------------------------------
  now with non quote     1.388k i/100ms
  new with non quote    30.281k i/100ms
     now with quoted     1.175k i/100ms
     new with quoted    10.304k i/100ms
     now with escape     1.142k i/100ms
     new with escape    11.327k i/100ms
Calculating -------------------------------------
  now with non quote     14.631k (± 2.2%) i/s -     73.564k in   5.030352s
  new with non quote    329.169k (± 3.2%) i/s -      1.665M in   5.065852s
     now with quoted     11.950k (± 2.8%) i/s -     59.925k in   5.019060s
     new with quoted    103.813k (± 7.2%) i/s -    525.504k in   5.096997s
     now with escape     11.920k (± 2.5%) i/s -     60.526k in   5.080920s
     new with escape    117.268k (± 1.9%) i/s -    589.004k in   5.024571s
```

- benchmark code

```
require 'benchmark/ips'
require 'csv'

class CP
  def initialize
    @keys = $keys.dup
    @delimiter = ','
    @quote_char = '"'
    @escape_pattern = Regexp.compile(@quote_char * 2)
  end

  def parse1(text, &block)
    values = CSV.parse_line(text, col_sep: @delimiter)
    r = Hash[@keys.zip(values)]
    yield r
  end

  def parse2(text, &block)
    r = fast_parse(text)
    yield r
  end

  def fast_parse(text)
    record = {}
    text.chomp!

    return record if text.empty?

    # use while because while is now faster than each_with_index
    columns = text.split(@delimiter, -1)
    num_columns = columns.size
    i = 0
    j = 0
    while j < num_columns
      column = columns[j]

      case column.count(@quote_char)
      when 0
        if column.empty?
          column = nil
        end
      when 1
        if column.start_with?(@quote_char)
          to_merge = [column]
          j += 1
          while j < num_columns
            merged_col = columns[j]
            to_merge << merged_col
            break if merged_col.end_with?(@quote_char)
            j += 1
          end
          column = to_merge.join(@delimiter)[1..-2]
        end
      when 2
        if column.start_with?(@quote_char) && column.end_with?(@quote_char)
          column = column[1..-2]
        end
      else
        if column.start_with?(@quote_char) && column.end_with?(@quote_char)
          column = column[1..-2]
        end
        column.gsub!(@escape_pattern, @quote_char)
      end

      record[@keys[i]] = column
      j += 1
      i += 1
    end
    record
  end
end

$keys = ["key1","key2","ke,y3","ke y4","key5","key6","key7","key8"]
keys = $keys.dup
text1 = keys.size.times.map { "value1" }.join(",")
text2 = keys.size.times.map { '"fo,o"' }.join(",")
text3 = '"aa","b""b""b","c"," ",e,f,"""""",'

puts "Ruby version: #{RUBY_VERSION}"

cp = CP.new

puts "non quote: #{text1}"
puts "quoted   : #{text2}"
puts "escaped  : #{text3}"

Benchmark.ips do |x|
  x.report('now with non quote') do
    cp.parse1(text1) { |r| }
  end

  x.report('new with non quote') do
    cp.parse2(text1) { |r| }
  end

  x.report('now with quoted') do
    cp.parse1(text2) { |r| }
  end

  x.report('new with quoted') do
    cp.parse2(text2) { |r| }
  end

  x.report('now with escape') do
    cp.parse1(text3) { |r| }
  end

  x.report('new with escape') do
    cp.parse2(text3) { |r| }
  end
end
```

**Docs Changes**:
Add `parser_type` to `parser_csv` article

**Release Note**: 
Same as title