### PR TITLE
solve issue when messages contain UTF-8 (CJK)

### DIFF
--- a/lib/fluent/plugin/out_exec_filter.rb
+++ b/lib/fluent/plugin/out_exec_filter.rb
@@ -284,6 +284,7 @@ module Fluent::Plugin
     end
 
     def run(io)
+      io.set_encoding(Encoding::ASCII_8BIT)
       case
       when @parser.implement?(:parse_io)
         @parser.parse_io(io, &method(:on_record))


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
fix encoding problem

from:
    "msg\":\"\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\"
to:
    "msg":"你好"

**Docs Changes**:

**Release Note**: 
