### PR TITLE
reenable gitlab ci failures

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,6 @@ stages:
 2-1-10:
   image: "ruby:2.1.10"
   stage: build
-  allow_failure: true
   extends: .install-template 
   script:
     - bundle install --jobs=3 --retry=3
@@ -20,7 +19,6 @@ stages:
 2-2-10:
   image: "ruby:2.2.10"
   stage: build
-  allow_failure: true
   extends: .install-template 
   script:
     - bundle install --jobs=3 --retry=3
@@ -31,7 +29,6 @@ stages:
 2-4-5:
   image: "ruby:2.4.5"
   stage: build
-  allow_failure: true
   extends: .install-template 
   script:
     - bundle install --jobs=3 --retry=3
@@ -42,7 +39,6 @@ stages:
 2-5-5:
   image: "ruby:2.5.5"
   stage: build
-  allow_failure: true
   extends: .install-template 
   script:
     - bundle install --jobs=3 --retry=3
@@ -53,7 +49,6 @@ stages:
 2-6-3:
   image: "ruby:2.6.3"
   stage: build
-  allow_failure: true
   extends: .install-template 
   script:
     - bundle install --jobs=3 --retry=3
@@ -64,7 +59,6 @@ stages:
 rubyhead:
   image: "ruby:latest"
   stage: build
-  allow_failure: true
   extends: .install-template 
   script:
     - bundle install --jobs=3 --retry=3
@@ -76,7 +70,6 @@ rubyhead:
 2-1-10-test:
   image: "ruby:2.1.10"
   stage: tests
-  allow_failure: true
   extends: .test-template
   script:
     - bundle exec rake test
@@ -88,7 +81,6 @@ rubyhead:
 2-2-10-test:
   image: "ruby:2.2.10"
   stage: tests
-  allow_failure: true
   extends: .test-template
   script:
     - bundle exec rake test
@@ -100,7 +92,6 @@ rubyhead:
 2-4-5-test:
   image: "ruby:2.4.5"
   stage: tests
-  allow_failure: true
   extends: .test-template
   script:
     - bundle exec rake test
@@ -112,7 +103,6 @@ rubyhead:
 2-5-5-test:
   image: "ruby:2.5.5"
   stage: tests
-  allow_failure: true
   extends: .test-template
   script:
     - bundle exec rake test
@@ -124,7 +114,6 @@ rubyhead:
 2-6-3-test:
   image: "ruby:2.6.3"
   stage: tests
-  allow_failure: true
   extends: .test-template
   script:
     - bundle exec rake test
@@ -136,7 +125,6 @@ rubyhead:
 rubyhead-test:
   image: "ruby:latest"
   stage: tests
-  allow_failure: true
   extends: .test-template
   script:
     - bundle exec rake test


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #2542

**What this PR does / why we need it**: 
This lets the Gitlab CI Jobs fail if tests do not pass.
Failing tests in the existing test suite indicate problems and should not be ignored.