### PR TITLE
fix data lost on decompression

### DIFF
--- a/lib/fluent/plugin/compressable.rb
+++ b/lib/fluent/plugin/compressable.rb
@@ -64,9 +64,11 @@ module Fluent
           unused = gz.unused
           gz.finish
 
-          break if unused.nil?
-          adjust = unused.length
-          io.pos -= adjust
+          unless unused.nil?
+            adjust = unused.length
+            input.pos -= adjust
+          end
+          break if io.eof?
         end
 
         out
@@ -80,9 +82,11 @@ module Fluent
           unused = gz.unused
           gz.finish
 
-          break if unused.nil?
-          adjust = unused.length
-          input.pos -= adjust
+          unless unused.nil?
+            adjust = unused.length
+            input.pos -= adjust
+          end
+          break if input.eof?
         end
 
         output

--- a/lib/fluent/plugin/compressable.rb
+++ b/lib/fluent/plugin/compressable.rb
@@ -66,7 +66,7 @@ module Fluent
 
           unless unused.nil?
             adjust = unused.length
-            input.pos -= adjust
+            io.pos -= adjust
           end
           break if io.eof?
         end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #2546

in `string_decompress()`, `gz.read` loop break when `unused.nil?`,  
but `unused.nil?` does not show end of stream.
It cause data lost.

loop shoud be break when eof.