### PR TITLE
Use teardown instead of shutdown in CounterStoreTest

### DIFF
--- a/test/counter/test_store.rb
+++ b/test/counter/test_store.rb
@@ -14,7 +14,7 @@ class CounterStoreTest < ::Test::Unit::TestCase
     @now = Fluent::EventTime.now
   end
 
-  shutdown do
+  teardown do
     Timecop.return
   end
 


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
No issues

**What this PR does / why we need it**: 

`Timecop.return` is never called because `CounterStoreTest#shutdown` is never called.
We shuould define `CounterStoreTest.shutdown` or `CounterStoreTest#teardown`.
cf. https://github.com/test-unit/test-unit/blob/3.2.8/lib/test/unit.rb#L462-L473

As you can see, this PR corrects the elapsed time from -90938190.322263 seconds to 0.013861 seconds.

Before

```
% bundle exec rake TEST=test/counter/test_store.rb
/Users/arabiki/.anyenv/envs/rbenv/versions/2.6.2/bin/ruby -w -I"lib:test" -Eascii-8bit:ascii-8bit -I"/Users/arabiki/.anyenv/envs/rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/rake-11.3.0/lib" "/Users/arabiki/.anyenv/envs/rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/rake-11.3.0/lib/rake/rake_test_loader.rb" "test/counter/test_store.rb"
/Users/arabiki/.anyenv/envs/rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/rake-11.3.0/lib/rake/thread_pool.rb:106: warning: mismatched indentations at 'rescue' with 'def' at 94
Loaded suite /Users/arabiki/.anyenv/envs/rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/rake-11.3.0/lib/rake/rake_test_loader
Started
..................
Finished in -90938190.322263 seconds.
----------------------------------------------------------------------------------------------------
18 tests, 53 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------
-0.00 tests/s, -0.00 assertions/s
fluentd 1.6.3 built to pkg/fluentd-1.6.3.gem.
```

After

```
% bundle exec rake TEST=test/counter/test_store.rb
/Users/arabiki/.anyenv/envs/rbenv/versions/2.6.2/bin/ruby -w -I"lib:test" -Eascii-8bit:ascii-8bit -I"/Users/arabiki/.anyenv/envs/rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/rake-11.3.0/lib" "/Users/arabiki/.anyenv/envs/rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/rake-11.3.0/lib/rake/rake_test_loader.rb" "test/counter/test_store.rb"
/Users/arabiki/.anyenv/envs/rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/rake-11.3.0/lib/rake/thread_pool.rb:106: warning: mismatched indentations at 'rescue' with 'def' at 94
Loaded suite /Users/arabiki/.anyenv/envs/rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/rake-11.3.0/lib/rake/rake_test_loader
Started
..................
Finished in 0.013861 seconds.
----------------------------------------------------------------------------------------------------
18 tests, 53 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------
1298.61 tests/s, 3823.68 assertions/s
fluentd 1.6.3 built to pkg/fluentd-1.6.3.gem.
```

**Docs Changes**:

**Release Note**: 
