### PR TITLE
Use faster way to get sec and nsec

### DIFF
--- a/lib/fluent/clock.rb
+++ b/lib/fluent/clock.rb
@@ -43,6 +43,10 @@ module Fluent
       Process.clock_gettime(CLOCK_ID)
     end
 
+    def self.real_now(unit = :second)
+      Process.clock_gettime(Process::CLOCK_REALTIME, unit)
+    end
+
     def self.dst_clock_from_time(time)
       diff_sec = Time.now - time
       now_raw - diff_sec

--- a/lib/fluent/plugin/buffer/chunk.rb
+++ b/lib/fluent/plugin/buffer/chunk.rb
@@ -57,13 +57,31 @@ module Fluent
           @state = :unstaged
 
           @size = 0
-          @created_at = Time.now
-          @modified_at = Time.now
+          @created_at = Fluent::Clock.real_now
+          @modified_at = Fluent::Clock.real_now
 
           extend Decompressable if compress == :gzip
         end
 
-        attr_reader :unique_id, :metadata, :created_at, :modified_at, :state
+        attr_reader :unique_id, :metadata, :state
+
+        def raw_create_at
+          @created_at
+        end
+
+        def raw_modified_at
+          @modified_at
+        end
+
+        # for compatibility
+        def created_at
+          @created_at_object ||= Time.at(@created_at)
+        end
+
+        # for compatibility
+        def modified_at
+          @modified_at_object ||= Time.at(@modified_at)
+        end
 
         # data is array of formatted record string
         def append(data, **kwargs)

--- a/lib/fluent/plugin/buffer/memory_chunk.rb
+++ b/lib/fluent/plugin/buffer/memory_chunk.rb
@@ -43,7 +43,8 @@ module Fluent
           @chunk_bytes += @adding_bytes
 
           @adding_bytes = @adding_size = 0
-          @modified_at = Time.now
+          @modified_at = Fluent::Clock.real_now
+          @modified_at_object = nil
           true
         end
 

--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -1376,7 +1376,7 @@ module Fluent
                 # This block should be done by integer values.
                 # If both of flush_interval & flush_thread_interval are 1s, expected actual flush timing is 1.5s.
                 # If we use integered values for this comparison, expected actual flush timing is 1.0s.
-                @buffer.enqueue_all{ |metadata, chunk| chunk.created_at.to_i + flush_interval <= now_int }
+                @buffer.enqueue_all{ |metadata, chunk| chunk.raw_create_at + flush_interval <= now_int }
               end
 
               if @chunk_key_time

--- a/lib/fluent/time.rb
+++ b/lib/fluent/time.rb
@@ -111,7 +111,8 @@ module Fluent
     end
 
     def self.now
-      now = Fluent::Clock.real_now(:nanosecond)
+      # This method is called many time. so call Process.clock_gettime directly instead of Fluent::Clock.real_now
+      now = Process.clock_gettime(Process::CLOCK_REALTIME, :nanosecond)
       Fluent::EventTime.new(now / 1_000_000_000, now % 1_000_000_000)
     end
 

--- a/lib/fluent/time.rb
+++ b/lib/fluent/time.rb
@@ -111,7 +111,8 @@ module Fluent
     end
 
     def self.now
-      from_time(Time.now)
+      now = Fluent::Clock.real_now(:nanosecond)
+      Fluent::EventTime.new(now / 1_000_000_000, now % 1_000_000_000)
     end
 
     def self.parse(*args)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -50,6 +50,7 @@ require 'fluent/msgpack_factory'
 require 'fluent/time'
 require 'serverengine'
 require 'helpers/fuzzy_assert'
+require 'helpers/process_extenstion'
 
 module Fluent
   module Plugin

--- a/test/helpers/process_extenstion.rb
+++ b/test/helpers/process_extenstion.rb
@@ -1,0 +1,33 @@
+require 'timecop'
+
+module Process
+  class << self
+    alias_method :clock_gettime_original, :clock_gettime
+
+    def clock_gettime(clock_id, unit = :float_second)
+      # now only support CLOCK_REALTIME
+      if Process::CLOCK_REALTIME == clock_id
+        t = Time.now
+
+        case unit
+        when :float_second
+          t.to_i + t.nsec / 1_000_000_000.0
+        when :float_millisecond
+          t.to_i * 1_000 + t.nsec / 1_000_000.0
+        when :float_microsecond
+          t.to_i * 1_000_000 + t.nsec / 1_000.0
+        when :second
+          t.to_i
+        when :millisecond
+          t.to_i * 1000 + t.nsec / 1_000_000
+        when :microsecond
+          t.to_i * 1_000_000 + t.nsec / 1_000
+        when :nanosecond
+          t.to_i * 1_000_000_000 + t.nsec
+        end
+      else
+        Process.clock_gettime_original(clock_id, unit)
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
no

**What this PR does / why we need it**: 

`Process.clock_gettime` is faster than `Time.now` if getting sec and nsec.
and `Time.now` is called in `EventTime.now`.
EventTime.now is called per data in [parser_none](https://github.com/fluent/fluentd/blob/785fe3df5df76ae7110ea226c506131d8e607aa6/lib/fluent/plugin/parser_none.rb#L31) and per [chunk creation](https://github.com/fluent/fluentd/blob/785fe3df5df76ae7110ea226c506131d8e607aa6/lib/fluent/plugin/buffer/chunk.rb#L60-L61). so it's better to replace them with faster version's method.

```ruby
def now1
  now = Process.clock_gettime(Process::CLOCK_REALTIME, :nanosecond)
  sec = now / 1_000_000_000
  nsec = now % 1_000_000_000
  [sec, nsec]
end

def now2
  t = Time.now
  sec = t.to_i
  nsec = t.nsec
  [sec, nsec]
end

require 'benchmark/ips'

Benchmark.ips do |x|
  x.report("Time.now") do
    now2
  end

  x.report("Process.clock_gettime") do
    now1
  end
end
```

```
Warming up --------------------------------------
            Time.now   191.241k i/100ms
Process.clock_gettime
                       291.915k i/100ms
Calculating -------------------------------------
            Time.now      2.956M (± 1.9%) i/s -     14.917M in   5.047422s
Process.clock_gettime
                          5.563M (± 4.5%) i/s -     28.024M in   5.047899s
```

**Docs Changes**:

no need

**Release Note**: 

same as title
