### PR TITLE
Add hash method to metadata to speed up comparing it in a hash key

### DIFF
--- a/lib/fluent/plugin/buffer.rb
+++ b/lib/fluent/plugin/buffer.rb
@@ -133,6 +133,15 @@ module Fluent
               cmp_variables(variables, variables2)
           end
         end
+
+        # This is an optimization code. Current Struct's implementation is comparing all data.
+        # https://github.com/ruby/ruby/blob/0623e2b7cc621b1733a760b72af246b06c30cf96/struct.c#L1200-L1203
+        # Actually this overhead is very small but this class is generated *per chunk* (and used in hash object).
+        # This means that this class is one of the most called object in Fluentd.
+        # See https://github.com/fluent/fluentd/pull/2560
+        def hash
+          timekey.object_id
+        end
       end
 
       # for tests


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 

no

**What this PR does / why we need it**: 

Object#hash  is called when using an object as the hash key or reference value from a hash object with the object.
Current `Struct`'s implementation is comparing all inner variables. 
https://github.com/ruby/ruby/blob/0623e2b7cc621b1733a760b72af246b06c30cf96/struct.c#L1200-L1203

This impl is a bit redundant. Especially in fluentd, it can be overhead.
e.g. [Output#handle_stream_simple](https://github.com/fluent/fluentd/blob/785fe3df5df76ae7110ea226c506131d8e607aa6/lib/fluent/plugin/output.rb#L999) creates a hash object using an object as a key. this method is called per `emit`(one of the most called methods in fluentd). 

benchmark

```rb
require 'benchmark/ips'

A = Struct.new(:l, :c, :r)

B = Struct.new(:l, :c, :r) do
  def hash
    l
  end
end

a = A.new(1, 2, 3)
b = B.new(1, 2, 3)

Benchmark.ips do |x|
  x.report("not hash defined") do
    { a => 1 }
  end

  x.report("hash defined") do
    { b => 1 }
  end
end

aa = { a => 1 }
bb = { b => 1 }

Benchmark.ips do |x|
  x.report("not hash defined ref") do
    aa[a]
  end

  x.report("hash defined ref") do
    bb[b]
  end
end

a2 = A.new(1, 2, 4)
b2 = B.new(1, 2, 4)

Benchmark.ips do |x|
  x.report("not hash defined ref not exist") do
    aa[a2]
  end

  x.report("hash defined ref not exist") do
    bb[b2]
  end
end

```

```
Warming up --------------------------------------
    not hash defined    95.271k i/100ms
        hash defined   213.133k i/100ms
Calculating -------------------------------------
    not hash defined      1.121M (± 6.8%) i/s -      5.621M in   5.040657s
        hash defined      3.320M (± 6.6%) i/s -     16.624M in   5.030596s
Warming up --------------------------------------
not hash defined ref    90.976k i/100ms
    hash defined ref   212.802k i/100ms
Calculating -------------------------------------
not hash defined ref      1.207M (± 6.0%) i/s -      6.095M in   5.071473s
    hash defined ref      4.270M (± 2.0%) i/s -     21.493M in   5.035820s
Warming up --------------------------------------
not hash defined ref not exist
                        96.979k i/100ms
hash defined ref not exist
                       166.564k i/100ms
Calculating -------------------------------------
not hash defined ref not exist
                          1.215M (± 2.2%) i/s -      6.110M in   5.029940s
hash defined ref not exist
                          2.463M (± 1.8%) i/s -     12.326M in   5.005410s
```

**Docs Changes**:

no need

**Release Note**: 

same as title
