### PR TITLE
OneEvent isn't always empty

### DIFF
--- a/lib/fluent/event.rb
+++ b/lib/fluent/event.rb
@@ -87,6 +87,10 @@ module Fluent
       OneEventStream.new(@time, @record.dup)
     end
 
+    def empty?
+      false
+    end
+
     def size
       1
     end


### PR DESCRIPTION
Signed-off-by: Yuta Iwama <ganmacs@gmail.com>

<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

```rb
require 'benchmark/ips'

class A
  def empty?
    size == 0
  end
end

class B < A
  def size
    1
  end
end

class C < A
  def empty?
    false
  end
end


b = B.new
c = C.new

Benchmark.ips do |x|
  x.report("b") do
    b.empty?
  end

  x.report("c") do
    c.empty?
  end
end
```

```
Warming up --------------------------------------
                   b   437.425k i/100ms
                   c   454.017k i/100ms
Calculating -------------------------------------
                   b     16.370M (± 6.5%) i/s -     81.798M in   5.021556s
                   c     22.938M (± 3.4%) i/s -    114.866M in   5.013438s
```

**Docs Changes**:

no need

**Release Note**: 

same as title
