### PR TITLE
in_tcp: Improve the performance for multiple events case

### DIFF
--- a/test/plugin/test_in_tcp.rb
+++ b/test/plugin/test_in_tcp.rb
@@ -162,4 +162,29 @@ class TcpInputTest < Test::Unit::TestCase
     assert event[1].is_a?(Fluent::EventTime)
     assert_equal address, event[2]['addr']
   end
+
+  sub_test_case '<extract>' do
+    test 'extract tag from record field' do
+      d = create_driver(BASE_CONFIG + %!
+        <parse>
+          @type json
+        </parse>
+        <extract>
+          tag_key tag
+        </extract>
+      !)
+      d.run(expect_records: 1) do
+        create_tcp_socket('127.0.0.1', PORT) do |sock|
+          data = {'msg' => 'hello', 'tag' => 'helper_test'}
+          sock.send("#{data.to_json}\n", 0)
+        end
+      end
+
+      assert_equal 1, d.events.size
+      event = d.events[0]
+      assert_equal 'helper_test', event[0]
+      assert event[1].is_a?(Fluent::EventTime)
+      assert_equal 'hello', event[2]['msg']
+    end
+  end
 end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 
Use `MultiEventStream` to improve the performance for multiple events in receive data.

**Docs Changes**:
No need.

**Release Note**: 
Same as title