### PR TITLE
Not to call Parser#configure is called twice

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -97,6 +97,10 @@ module Fluent::Plugin
     desc 'Ignore repeated permission error logs'
     config_param :ignore_repeated_permission_error, :bool, default: false
 
+    config_section :parse, required: false, multi: true, init: true, param_name: :parser_configs do
+      config_argument :usage, :string, default: 'in_tail_parser'
+    end
+
     attr_reader :paths
 
     @@pos_file_paths = {}
@@ -148,7 +152,8 @@ module Fluent::Plugin
                            method(:parse_singleline)
                          end
       @file_perm = system_config.file_permission || FILE_PERMISSION
-      @parser = parser_create(conf: parser_config)
+      # parser is already created by parser helper
+      @parser = parser_create(usage: parser_config['usage'] || @parser_configs.first.usage)
     end
 
     def configure_tag


### PR DESCRIPTION
Signed-off-by: Yuta Iwama <ganmacs@gmail.com>

<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes https://github.com/fluent/fluentd/issues/2555

**What this PR does / why we need it**: 

First time is in parser helper
https://github.com/fluent/fluentd/blob/5a7d94941371dddcb7150a73ddbe142102a68964/lib/fluent/plugin_helper/parser.rb#L82 (and the `localtime` is set in the first time. https://github.com/fluent/fluentd/issues/2555#issuecomment-521802165)
Second time is parser_create in TailInput
https://github.com/fluent/fluentd/blob/5a7d94941371dddcb7150a73ddbe142102a68964/lib/fluent/plugin/in_tail.rb#L151


**Docs Changes**:

**Release Note**: 

same as title
