### PR TITLE
Set thread title

### DIFF
--- a/lib/fluent/plugin_helper/thread.rb
+++ b/lib/fluent/plugin_helper/thread.rb
@@ -92,7 +92,7 @@ module Fluent
           end
         end
         thread.abort_on_exception = true
-        thread.name = title.to_s
+        thread.name = title.to_s if thread.respond_to?(:name)
         @_threads_mutex.synchronize do
           @_threads[thread.object_id] = thread
         end

--- a/lib/fluent/plugin_helper/thread.rb
+++ b/lib/fluent/plugin_helper/thread.rb
@@ -92,7 +92,7 @@ module Fluent
           end
         end
         thread.abort_on_exception = true
-        thread.name = title
+        thread.name = title.to_s
         @_threads_mutex.synchronize do
           @_threads[thread.object_id] = thread
         end

--- a/lib/fluent/plugin_helper/thread.rb
+++ b/lib/fluent/plugin_helper/thread.rb
@@ -92,6 +92,7 @@ module Fluent
           end
         end
         thread.abort_on_exception = true
+        thread.name = title
         @_threads_mutex.synchronize do
           @_threads[thread.object_id] = thread
         end


### PR DESCRIPTION
This helps understand thread usage with commands like `top -H` and `ps -e -T`

Before this change the thread name shows up as `thread.rb:70`. After, it may show up as whatever title was given. The exact behavior will depend on the implementation of Ruby's `native_set_another_thread_name`.