### PR TITLE
in_tail: Dump a file name in addition to a malformed line

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -436,7 +436,7 @@ module Fluent::Plugin
           end
         }
       rescue => e
-        log.warn line.dump, error: e.to_s
+        log.warn 'invalid line found', file: tail_watcher.path, line: line, error: e.to_s
         log.debug_backtrace(e.backtrace)
       end
     end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

This patch is based on a feature request from one of our customers.

Right now, in_tail emits the following warning message when it reads
a malformed line.

    2019-08-18 00:20:03 +0900 [warn]: #0 "a,b\",c" error="Illegal quoting in line 1."

However, since we use in_tail extensively (e.g. tracking lots of files
at once), it is sometimes not easy to determine WHICH file caused the
error just by seeing this message.

With this patch, in_tail shows:

    2019-08-18 00:27:42 +0900 [warn]: #0 invalid line found file="test.csv"
    line="a,b\",c" error="Illegal quoting in line 1."

... which should be useful for debugging.

**Docs Changes**:

No need to update the document.

**Release Note**: 

Use the PR title.