### PR TITLE
Improve unused parameter warning messages from sections used at least once

### DIFF
--- a/lib/fluent/config/element.rb
+++ b/lib/fluent/config/element.rb
@@ -31,7 +31,7 @@ module Fluent
         @unused = unused || attrs.keys
         @v1_config = false
         @corresponding_proxies = [] # some plugins use flat parameters, e.g. in_http doesn't provide <format> section for parser.
-        @unused_in = false # if this element is not used in plugins, correspoing plugin name and parent element name is set, e.g. [source, plugin class].
+        @unused_in = nil # if this element is not used in plugins, correspoing plugin name and parent element name is set, e.g. [source, plugin class].
 
         # it's global logger, not plugin logger: deprecated message should be global warning, not plugin level.
         @logger = defined?($log) ? $log : nil
@@ -110,13 +110,13 @@ module Fluent
       end
 
       def has_key?(key)
-        @unused_in = false # some sections, e.g. <store> in copy, is not defined by config_section so clear unused flag for better warning message in check_not_fetched.
+        @unused_in = [] # some sections, e.g. <store> in copy, is not defined by config_section so clear unused flag for better warning message in check_not_fetched.
         @unused.delete(key)
         super
       end
 
       def [](key)
-        @unused_in = false # ditto
+        @unused_in = [] # ditto
         @unused.delete(key)
 
         if RESERVED_PARAMETERS.include?(key) && !has_key?(key) && has_key?(RESERVED_PARAMETERS_COMPAT[key])

--- a/lib/fluent/config/section.rb
+++ b/lib/fluent/config/section.rb
@@ -207,8 +207,11 @@ module Fluent
         elems = conf.respond_to?(:elements) ? conf.elements : []
         elems.each { |e|
           next if plugin_class.nil? && Fluent::Config::V1Parser::ELEM_SYMBOLS.include?(e.name) # skip pre-defined non-plugin elements because it doens't have proxy section
+          next if e.unused_in && e.unused_in.empty? # the section is used at least once
 
-          unless proxy.sections.any? { |name, subproxy| e.name == subproxy.name.to_s || e.name == subproxy.alias.to_s }
+          if proxy.sections.any? { |name, subproxy| e.name == subproxy.name.to_s || e.name == subproxy.alias.to_s }
+            e.unused_in = []
+          else
             parent_name = if conf.arg.empty?
                             conf.name
                           else

--- a/test/config/test_configurable.rb
+++ b/test/config/test_configurable.rb
@@ -192,10 +192,17 @@ module ConfigurableSpec
   class ExampleWithCustomSection
     include Fluent::Configurable
     config_param :name_param, :string
+    config_section :normal_section  do
+      config_param :normal_section_param, :string
+    end
 
     class CustomSection
       include Fluent::Configurable
       config_param :custom_section_param, :string
+    end
+
+    class AnotherElement
+      include Fluent::Configurable
     end
 
     def configure(conf)
@@ -1338,7 +1345,7 @@ module Fluent::Config
         }
       end
 
-      test 'get false when the section is defined without using config_section' do
+      test 'get an empty array when the section is defined without using config_section' do
         conf = config_element('ROOT', '',
                               {
                                 'name_param' => 'name',
@@ -1347,7 +1354,21 @@ module Fluent::Config
         example = ConfigurableSpec::ExampleWithCustomSection.new
         example.configure(conf)
         conf.elements.each { |e|
-          assert_equal(false, e.unused_in)
+          assert_equal([], e.unused_in)
+        }
+      end
+
+      test 'get an empty array when the configuration is used in another element without any sections' do
+        conf = config_element('ROOT', '',
+                              {
+                                'name_param' => 'name',
+                              },
+                              [config_element('normal_section', '', {'normal_section_param' => 'normal'} )])
+        example = ConfigurableSpec::ExampleWithCustomSection.new
+        example.configure(conf)
+        ConfigurableSpec::ExampleWithCustomSection::AnotherElement.new.configure(conf)
+        conf.elements.each { |e|
+          assert_equal([], e.unused_in)
         }
       end
     end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #2572

**What this PR does / why we need it**: 

This PR improves warning messages using the following configuration:

```
<match debug.**>
  @type s3
  s3_bucket dummy
  <buffer>
    unused_key 1
  </buffer>
</match>
```

* Before
    ```
    2019-08-16 23:17:26 +0900 [warn]: section <buffer> is not used in <match debug.**>
    ```
* After
    ```
    2019-08-18 00:31:03 +0900 [warn]: parameter 'unused_key' in <buffer>
      unused_key 1
    </buffer> is not used.
    ```

**Docs Changes**:
no need

**Release Note**: 
same as tile