### PR TITLE
Add buf_file_single plugin

### DIFF
--- a/lib/fluent/plugin/buf_file_single.rb
+++ b/lib/fluent/plugin/buf_file_single.rb
@@ -70,6 +70,8 @@ module Fluent
         else
           if owner.chunk_key_tag
             raise Fluent::ConfigError, "chunk keys must be tag or one field"
+          elsif owner.chunk_keys.size > 1
+            raise Fluent::ConfigError, "2 or more chunk keys is not allowed"
           else
             @key_in_path = owner.chunk_keys.first.to_sym
           end
@@ -110,8 +112,9 @@ module Fluent
           @multi_workers_available = true
         else # specified path is file path
           if File.basename(@path).include?('.*.')
-            log.warn "file_single doesn't allow user specified 'prefix.*.suffix' style path. Use 'fsb.*#{PATH_SUFFIX}' instead: #{@path}"
-            @path = "fsb.*#{PATH_SUFFIX}"
+            new_path = File.join(File.dirname(@path), "fsb.*#{PATH_SUFFIX}")
+            log.warn "file_single doesn't allow user specified 'prefix.*.suffix' style path. Use '#{new_path}' for file instead: #{@path}"
+            @path = new_path
           elsif File.basename(@path).end_with?('.*')
             @path = @path + PATH_SUFFIX
           else
@@ -131,7 +134,7 @@ module Fluent
       # This method is called only when multi worker is configured
       def multi_workers_ready?
         unless @multi_workers_available
-          log.error "file buffer with multi workers should be configured to use directory 'path', or system root_dir and plugin id"
+          log.error "file_single buffer with multi workers should be configured to use directory 'path', or system root_dir and plugin id"
         end
         @multi_workers_available
       end

--- a/lib/fluent/plugin/buf_file_single.rb
+++ b/lib/fluent/plugin/buf_file_single.rb
@@ -43,8 +43,10 @@ module Fluent
       config_set_default :chunk_limit_size, DEFAULT_CHUNK_LIMIT_SIZE
       config_set_default :total_limit_size, DEFAULT_TOTAL_LIMIT_SIZE
 
+      desc 'The permission of chunk file. If no specified, <system> setting or 0644 is used'
       config_param :file_permission, :string, default: nil # '0644'
-      config_param :dir_permission,  :string, default: nil # '0755'
+      desc 'The permission of chunk directory. If no specified, <system> setting or 0644 is used'
+      config_param :dir_permission, :string, default: nil # '0755'
 
       @@buffer_paths = {}
 

--- a/lib/fluent/plugin/buf_file_single.rb
+++ b/lib/fluent/plugin/buf_file_single.rb
@@ -70,7 +70,7 @@ module Fluent
         using_plugin_root_dir = false
         unless @path
           if root_dir = owner.plugin_root_dir
-            @path = File.join(root_dir, 'fsb')
+            @path = File.join(root_dir, 'buffer')
             using_plugin_root_dir = true # plugin_root_dir path contains worker id
           else
             raise Fluent::ConfigError, "buffer path is not configured. specify 'path' in <buffer>"
@@ -102,7 +102,7 @@ module Fluent
         else # specified path is file path
           if File.basename(@path).include?('.*.')
             # valid file path
-            log.warn "file_single doesn't allow user specified 'prefix.*.suffix' style path. Use 'fsb.*#{PATH_SUFFIX}' instead: #{path}"
+            log.warn "file_single doesn't allow user specified 'prefix.*.suffix' style path. Use 'fsb.*#{PATH_SUFFIX}' instead: #{@path}"
             @path = "fsb.*#{PATH_SUFFIX}"
           elsif File.basename(@path).end_with?('.*')
             @path = @path + PATH_SUFFIX

--- a/lib/fluent/plugin/buf_file_single.rb
+++ b/lib/fluent/plugin/buf_file_single.rb
@@ -73,8 +73,7 @@ module Fluent
           end
         end
 
-        multi_workers_configured = owner.system_config.workers > 1 ? true : false
-
+        multi_workers_configured = owner.system_config.workers > 1
         using_plugin_root_dir = false
         unless @path
           if root_dir = owner.plugin_root_dir
@@ -88,7 +87,7 @@ module Fluent
         type_of_owner = Plugin.lookup_type_from_class(@_owner.class)
         if @@buffer_paths.has_key?(@path) && !called_in_test?
           type_using_this_path = @@buffer_paths[@path]
-          raise ConfigError, "Other '#{type_using_this_path}' plugin already use same buffer path: type = #{type_of_owner}, buffer path = #{@path}"
+          raise Fluent::ConfigError, "Other '#{type_using_this_path}' plugin already uses same buffer path: type = #{type_of_owner}, buffer path = #{@path}"
         end
 
         @@buffer_paths[@path] = type_of_owner
@@ -109,7 +108,6 @@ module Fluent
           @multi_workers_available = true
         else # specified path is file path
           if File.basename(@path).include?('.*.')
-            # valid file path
             log.warn "file_single doesn't allow user specified 'prefix.*.suffix' style path. Use 'fsb.*#{PATH_SUFFIX}' instead: #{@path}"
             @path = "fsb.*#{PATH_SUFFIX}"
           elsif File.basename(@path).end_with?('.*')

--- a/lib/fluent/plugin/buf_file_single.rb
+++ b/lib/fluent/plugin/buf_file_single.rb
@@ -44,9 +44,9 @@ module Fluent
       config_set_default :total_limit_size, DEFAULT_TOTAL_LIMIT_SIZE
 
       desc 'The permission of chunk file. If no specified, <system> setting or 0644 is used'
-      config_param :file_permission, :string, default: nil # '0644'
-      desc 'The permission of chunk directory. If no specified, <system> setting or 0644 is used'
-      config_param :dir_permission, :string, default: nil # '0755'
+      config_param :file_permission, :string, default: nil
+      desc 'The permission of chunk directory. If no specified, <system> setting or 0755 is used'
+      config_param :dir_permission, :string, default: nil
 
       @@buffer_paths = {}
 

--- a/lib/fluent/plugin/buf_file_single.rb
+++ b/lib/fluent/plugin/buf_file_single.rb
@@ -1,0 +1,200 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'fileutils'
+
+require 'fluent/plugin/buffer'
+require 'fluent/plugin/buffer/file_single_chunk'
+require 'fluent/system_config'
+
+module Fluent
+  module Plugin
+    class FileSingleBuffer < Fluent::Plugin::Buffer
+      Plugin.register_buffer('file_single', self)
+
+      include SystemConfig::Mixin
+
+      DEFAULT_CHUNK_LIMIT_SIZE = 256 * 1024 * 1024        # 256MB
+      DEFAULT_TOTAL_LIMIT_SIZE =  64 * 1024 * 1024 * 1024 #  64GB
+
+      PATH_SUFFIX = ".#{Fluent::Plugin::Buffer::FileSingleChunk::PATH_EXT}"
+      DIR_PERMISSION = 0755
+
+      desc 'The path where buffer chunks are stored.'
+      config_param :path, :string, default: nil
+
+      config_set_default :chunk_limit_size, DEFAULT_CHUNK_LIMIT_SIZE
+      config_set_default :total_limit_size, DEFAULT_TOTAL_LIMIT_SIZE
+
+      config_param :file_permission, :string, default: nil # '0644'
+      config_param :dir_permission,  :string, default: nil # '0755'
+
+      @@buffer_paths = {}
+
+      def initialize
+        super
+
+        @multi_workers_available = false
+        @additional_resume_path = nil
+      end
+
+      def configure(conf)
+        super
+
+        @key_in_path = nil
+        if owner.chunk_keys.empty?
+          log.debug "use event tag for buffer key"
+        else
+          if owner.chunk_key_tag
+            raise Fluent::ConfigError, "chunk keys must be tag or one field"
+          else
+            @key_in_path = owner.chunk_keys.first.to_sym
+          end
+        end
+
+        multi_workers_configured = owner.system_config.workers > 1 ? true : false
+
+        using_plugin_root_dir = false
+        unless @path
+          if root_dir = owner.plugin_root_dir
+            @path = File.join(root_dir, 'fsb')
+            using_plugin_root_dir = true # plugin_root_dir path contains worker id
+          else
+            raise Fluent::ConfigError, "buffer path is not configured. specify 'path' in <buffer>"
+          end
+        end
+
+        type_of_owner = Plugin.lookup_type_from_class(@_owner.class)
+        if @@buffer_paths.has_key?(@path) && !called_in_test?
+          type_using_this_path = @@buffer_paths[@path]
+          raise ConfigError, "Other '#{type_using_this_path}' plugin already use same buffer path: type = #{type_of_owner}, buffer path = #{@path}"
+        end
+
+        @@buffer_paths[@path] = type_of_owner
+
+        specified_directory_exists = File.exist?(@path) && File.directory?(@path)
+        unexisting_path_for_directory = !File.exist?(@path) && !@path.include?('.*')
+
+        if specified_directory_exists || unexisting_path_for_directory # directory
+          if using_plugin_root_dir || !multi_workers_configured
+            @path = File.join(@path, "fsb.*#{PATH_SUFFIX}")
+          else
+            @path = File.join(@path, "worker#{fluentd_worker_id}", "fsb.*#{PATH_SUFFIX}")
+            if fluentd_worker_id == 0
+              # worker 0 always checks unflushed buffer chunks to be resumed (might be created while non-multi-worker configuration)
+              @additional_resume_path = File.join(File.expand_path("../../", @path), "fsb.*#{PATH_SUFFIX}")
+            end
+          end
+          @multi_workers_available = true
+        else # specified path is file path
+          if File.basename(@path).include?('.*.')
+            # valid file path
+            log.warn "file_single doesn't allow user specified 'prefix.*.suffix' style path. Use 'fsb.*#{PATH_SUFFIX}' instead: #{path}"
+            @path = "fsb.*#{PATH_SUFFIX}"
+          elsif File.basename(@path).end_with?('.*')
+            @path = @path + PATH_SUFFIX
+          else
+            # existing file will be ignored
+            @path = @path + ".*#{PATH_SUFFIX}"
+          end
+          @multi_workers_available = false
+        end
+
+        @dir_permission = if @dir_permission
+                            @dir_permission.to_i(8)
+                          else
+                            system_config.dir_permission || DIR_PERMISSION
+                          end
+      end
+
+      # This method is called only when multi worker is configured
+      def multi_workers_ready?
+        unless @multi_workers_available
+          log.error "file buffer with multi workers should be configured to use directory 'path', or system root_dir and plugin id"
+        end
+        @multi_workers_available
+      end
+
+      def start
+        FileUtils.mkdir_p(File.dirname(@path), mode: @dir_permission)
+
+        super
+      end
+
+      def persistent?
+        true
+      end
+
+      def resume
+        stage = {}
+        queue = []
+
+        patterns = [@path]
+        patterns.unshift @additional_resume_path if @additional_resume_path
+        Dir.glob(patterns) do |path|
+          next unless File.file?(path)
+
+          log.debug { "restoring buffer file: path = #{path}" }
+
+          m = new_metadata() # this metadata will be overwritten by resuming .meta file content
+                             # so it should not added into @metadata_list for now
+          mode = Fluent::Plugin::Buffer::FileSingleChunk.assume_chunk_state(path)
+          if mode == :unknown
+            log.debug "unknown state chunk found", path: path
+            next
+          end
+
+          begin
+            chunk = Fluent::Plugin::Buffer::FileSingleChunk.new(m, path, mode, @key_in_path) # file chunk resumes contents of metadata
+          rescue Fluent::Plugin::Buffer::FileSingleChunk::FileChunkError => e
+            handle_broken_files(path, mode, e)
+            next
+          end
+
+          case chunk.state
+          when :staged
+            stage[chunk.metadata] = chunk
+          when :queued
+            queue << chunk
+          end
+        end
+
+        queue.sort_by! { |chunk| chunk.modified_at }
+
+        return stage, queue
+      end
+
+      def generate_chunk(metadata)
+        # FileChunk generates real path with unique_id
+        if @file_permission
+          chunk = Fluent::Plugin::Buffer::FileSingleChunk.new(metadata, @path, :create, @key_in_path, perm: @file_permission, compress: @compress)
+        else
+          chunk = Fluent::Plugin::Buffer::FileSingleChunk.new(metadata, @path, :create, @key_in_path, compress: @compress)
+        end
+
+        log.debug "Created new chunk", chunk_id: dump_unique_id_hex(chunk.unique_id), metadata: metadata
+
+        chunk
+      end
+
+      def handle_broken_files(path, mode, e)
+        log.error "found broken chunk file during resume. Delete corresponding files:", :path => path, :mode => mode, :err_msg => e.message
+        # After support 'backup_dir' feature, these files are moved to backup_dir instead of unlink.
+        File.unlink(path) rescue nil
+      end
+    end
+  end
+end

--- a/lib/fluent/plugin/buffer/file_single_chunk.rb
+++ b/lib/fluent/plugin/buffer/file_single_chunk.rb
@@ -17,7 +17,6 @@
 require 'uri'
 require 'fluent/plugin/buffer/chunk'
 require 'fluent/unique_id'
-require 'fluent/msgpack_factory'
 
 module Fluent
   module Plugin
@@ -30,7 +29,6 @@ module Fluent
         ## state: b/q - 'b'(on stage), 'q'(enqueued)
 
         include SystemConfig::Mixin
-        include MessagePackFactory::Mixin
 
         PATH_EXT = 'buf'
         PATH_SUFFIX = ".#{PATH_EXT}"
@@ -166,8 +164,8 @@ module Fluent
           res = PATH_REGEXP =~ base
           return nil unless res
 
-          key = base[4..res - 1]  # remove 'fsb.' and '.'
-          hex_id = base[res + 2..-5] # remove '.' and '.buf'
+          key = base[4..res - 1] # remove 'fsb.' and '.'
+          hex_id = $2            # remove '.' and '.buf'
           unique_id = hex_id.scan(/../).map {|x| x.to_i(16) }.pack('C*')
           [unique_id, key]
         end
@@ -306,7 +304,7 @@ module Fluent
 
           @state = :queued
           @bytesize = @chunk.size
-          @commit_position = @chunk.size
+          @commit_position = @chunk.pos
         end
       end
     end

--- a/lib/fluent/plugin/buffer/file_single_chunk.rb
+++ b/lib/fluent/plugin/buffer/file_single_chunk.rb
@@ -1,0 +1,313 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'uri'
+require 'fluent/plugin/buffer/chunk'
+require 'fluent/unique_id'
+
+module Fluent
+  module Plugin
+    class Buffer
+      class FileSingleChunk < Chunk
+        class FileChunkError < StandardError; end
+
+        ## buffer path user specified : /path/to/directory
+        ## buffer chunk path          : /path/to/directory/sfb.b513b61c9791029c2513b61c9791029c2.buf
+        ## state: b/q - 'b'(on stage), 'q'(enqueued)
+
+        include SystemConfig::Mixin
+
+        PATH_EXT = 'buf'
+        PATH_SUFFIX = ".#{PATH_EXT}"
+        PATH_REGEXP = /\.(b|q)([0-9a-f]+)\.#{PATH_EXT}*\Z/n
+        FILE_PERMISSION = 0644
+
+        attr_reader :path, :permission
+
+        def initialize(metadata, path, mode, key, perm: system_config.file_permission || FILE_PERMISSION, compress: :text)
+          super(metadata, compress: compress)
+          @key = key
+          @permission = perm.is_a?(String) ? perm.to_i(8) : perm
+          @bytesize = @size = @adding_bytes = @adding_size = 0
+
+          case mode
+          when :create then create_new_chunk(path, metadata, @permission)
+          when :staged then load_existing_staged_chunk(path)
+          when :queued then load_existing_enqueued_chunk(path)
+          else
+            raise ArgumentError, "Invalid file chunk mode: #{mode}"
+          end
+        end
+
+        def concat(bulk, bulk_size)
+          raise "BUG: concatenating to unwritable chunk, now '#{self.state}'" unless self.writable?
+
+          bulk.force_encoding(Encoding::ASCII_8BIT)
+          @chunk.write(bulk)
+          @adding_bytes += bulk.bytesize
+          @adding_size += bulk_size
+          true
+        end
+
+        def commit
+          @commit_position = @chunk.pos
+          @size += @adding_size
+          @bytesize += @adding_bytes
+          @adding_bytes = @adding_size = 0
+          @modified_at = Fluent::Clock.real_now
+
+          true
+        end
+
+        def rollback
+          if @chunk.pos != @commit_position
+            @chunk.seek(@commit_position, IO::SEEK_SET)
+            @chunk.truncate(@commit_position)
+          end
+          @adding_bytes = @adding_size = 0
+          true
+        end
+
+        def bytesize
+          @bytesize + @adding_bytes
+        end
+
+        def size
+          @size + @adding_size
+        end
+
+        def empty?
+          @bytesize.zero?
+        end
+
+        def enqueued!
+          return unless self.staged?
+
+          new_chunk_path = self.class.generate_queued_chunk_path(@path, @unique_id)
+
+          begin
+            file_rename(@chunk, @path, new_chunk_path, ->(new_io) { @chunk = new_io })
+          rescue => e
+            begin
+              file_rename(@chunk, new_chunk_path, @path, ->(new_io) { @chunk = new_io }) if File.exist?(new_chunk_path)
+            rescue => re
+              # In this point, restore buffer state is hard because previous `file_rename` failed by resource problem.
+              # Retry is one possible approach but it may cause livelock under limited resources or high load environment.
+              # So we ignore such errors for now and log better message instead.
+              # "Too many open files" should be fixed by proper buffer configuration and system setting.
+              raise "can't enqueue buffer file and failed to restore. This may causes inconsistent state: path = #{@path}, error = '#{e}', retry error = '#{re}'"
+            else
+              raise "can't enqueue buffer file: path = #{@path}, error = '#{e}'"
+            end
+          end
+
+          @path = new_chunk_path
+
+          super
+        end
+
+        def close
+          super
+          size = @chunk.size
+          @chunk.close
+          if size == 0
+            File.unlink(@path)
+          end
+        end
+
+        def purge
+          super
+          @chunk.close
+          @bytesize = @size = @adding_bytes = @adding_size = 0
+          File.unlink(@path)
+        end
+
+        def read(**kwargs)
+          @chunk.seek(0, IO::SEEK_SET)
+          @chunk.read
+        end
+
+        def open(**kwargs, &block)
+          @chunk.seek(0, IO::SEEK_SET)
+          val = yield @chunk
+          @chunk.seek(0, IO::SEEK_END) if self.staged?
+          val
+        end
+
+        def self.assume_chunk_state(path)
+          return :unknown unless path.end_with?(".#{PATH_EXT}")
+
+          if  /\.(b|q)([0-9a-f]+)\.#{PATH_EXT}*\Z/n =~ path # //n switch means explicit 'ASCII-8BIT' pattern
+            $1 == 'b' ? :staged : :queued
+          else
+            # files which matches to glob of buffer file pattern
+            # it includes files which are created by out_file
+            :unknown
+          end
+        end
+
+        def self.unique_id_and_key_from_path(path)
+          base = File.basename(path)
+          res = /\.(b|q)([0-9a-f]+)\.buf\Z/n =~ base # //n switch means explicit 'ASCII-8BIT' pattern
+          return nil unless res
+
+          key = base[4..res - 1]  # remove 'sfb.' and '.'
+          hex_id = base[res + 2..-5] # remove '.' and '.bug' 
+          unique_id = hex_id.scan(/../).map {|x| x.to_i(16) }.pack('C*')
+          [unique_id, key]
+        end
+
+        def self.unique_id_from_path(path)
+          if /\.(b|q)([0-9a-f]+)\.#{PATH_EXT}*\Z/n =~ path # //n switch means explicit 'ASCII-8BIT' pattern
+            return $2.scan(/../).map{|x| x.to_i(16) }.pack('C*')
+          end
+          nil
+        end
+
+        def self.generate_stage_chunk_path(path, key, unique_id)
+          pos = path.index('.*.')
+          raise "BUG: buffer chunk path on stage MUST have '.*.'" unless pos
+
+          prefix = path[0...pos]
+          suffix = path[(pos + 3)..-1]
+
+          chunk_id = Fluent::UniqueId.hex(unique_id)
+          state = 'b'
+          "#{prefix}.#{key}.#{state}#{chunk_id}.#{suffix}"
+        end
+
+        def self.generate_queued_chunk_path(path, unique_id)
+          chunk_id = Fluent::UniqueId.hex(unique_id)
+          staged_path = ".b#{chunk_id}."
+          if path.index(staged_path)
+            path.sub(staged_path, ".q#{chunk_id}.")
+          else # for unexpected cases (ex: users rename files while opened by fluentd)
+            path + ".q#{chunk_id}.chunk"
+          end
+        end
+
+        def restore_metadata
+          if res = self.class.unique_id_and_key_from_path(@path)
+            @unique_id = res.first
+            key = decode_key(res.last)
+            if @key
+              @metadata.variables = {@key => key}
+            else
+              @metadata.tag = key
+            end
+          else
+            raise FileChunkError, "Invalid chunk found. unique_id and key not exist: #{@path}"
+          end
+          @size = 0
+
+          stat = File.stat(@path)
+          @created_at = stat.ctime.to_i
+          @modified_at = stat.mtime.to_i
+        end
+
+        def restore_size
+
+        end
+
+        def file_rename(file, old_path, new_path, callback = nil)
+          pos = file.pos
+          if Fluent.windows?
+            file.close
+            File.rename(old_path, new_path)
+            file = File.open(new_path, 'rb', @permission)
+          else
+            File.rename(old_path, new_path)
+            file.reopen(new_path, 'rb')
+          end
+          file.set_encoding(Encoding::ASCII_8BIT)
+          file.sync = true
+          file.binmode
+          file.pos = pos
+          callback.call(file) if callback
+        end
+
+        URI_PARSER = URI::Parser.new
+        ESCAPE_REGEXP = /[^-_.a-zA-Z0-9]/n
+
+        def encode_key(metadata)
+          k = @key ? metadata.variables[@key] : metadata.tag
+          k ||= ''
+          URI_PARSER.escape(k, ESCAPE_REGEXP) # //n switch means exp
+        end
+
+        def decode_key(key)
+          URI_PARSER.unescape(key)
+        end
+
+        def create_new_chunk(path, metadata, perm)
+          @path = self.class.generate_stage_chunk_path(path, encode_key(metadata), @unique_id)
+          begin
+            @chunk = File.open(@path, 'wb+', perm)
+            @chunk.set_encoding(Encoding::ASCII_8BIT)
+            @chunk.sync = true
+            @chunk.binmode
+          rescue => e
+            # Here assumes "Too many open files" like recoverable error so raising BufferOverflowError.
+            # If other cases are possible, we will change erorr handling with proper classes.
+            raise BufferOverflowError, "can't create buffer file for #{path}. Stop creating buffer files: error = #{e}"
+          end
+          
+          @state = :unstaged
+          @bytesize = 0
+          @commit_position = @chunk.pos # must be 0
+          @adding_bytes = 0
+          @adding_size = 0
+        end
+
+        def load_existing_staged_chunk(path)
+          @path = path
+
+          # staging buffer chunk without metadata is classic buffer chunk file
+          # and it should be enqueued immediately
+          @chunk = File.open(@path, 'rb+')
+          @chunk.set_encoding(Encoding::ASCII_8BIT)
+          @chunk.sync = true
+          @chunk.binmode
+          @chunk.seek(0, IO::SEEK_END)
+
+          restore_metadata
+
+          @state = :staged
+          @bytesize = @chunk.size
+          @commit_position = @chunk.pos
+          @adding_bytes = 0
+          @adding_size = 0
+        end
+
+        def load_existing_enqueued_chunk(path)
+          @path = path
+          raise FileChunkError, "enqueued file chunk is empty" if File.size(@path).zero?
+
+          @chunk = File.open(@path, 'rb')
+          @chunk.set_encoding(Encoding::ASCII_8BIT)
+          @chunk.binmode
+          @chunk.seek(0, IO::SEEK_SET)
+
+          restore_metadata
+
+          @state = :queued
+          @bytesize = @chunk.size
+          @commit_position = @chunk.size
+        end
+      end
+    end
+  end
+end

--- a/lib/fluent/plugin/buffer/file_single_chunk.rb
+++ b/lib/fluent/plugin/buffer/file_single_chunk.rb
@@ -26,7 +26,7 @@ module Fluent
         class FileChunkError < StandardError; end
 
         ## buffer path user specified : /path/to/directory
-        ## buffer chunk path          : /path/to/directory/sfb.b513b61c9791029c2513b61c9791029c2.buf
+        ## buffer chunk path          : /path/to/directory/fsb.key.b513b61c9791029c2513b61c9791029c2.buf
         ## state: b/q - 'b'(on stage), 'q'(enqueued)
 
         include SystemConfig::Mixin
@@ -166,8 +166,8 @@ module Fluent
           res = PATH_REGEXP =~ base
           return nil unless res
 
-          key = base[4..res - 1]  # remove 'sfb.' and '.'
-          hex_id = base[res + 2..-5] # remove '.' and '.bug' 
+          key = base[4..res - 1]  # remove 'fsb.' and '.'
+          hex_id = base[res + 2..-5] # remove '.' and '.buf'
           unique_id = hex_id.scan(/../).map {|x| x.to_i(16) }.pack('C*')
           [unique_id, key]
         end
@@ -180,8 +180,7 @@ module Fluent
           suffix = path[(pos + 3)..-1]
 
           chunk_id = Fluent::UniqueId.hex(unique_id)
-          state = 'b'
-          "#{prefix}.#{key}.#{state}#{chunk_id}.#{suffix}"
+          "#{prefix}.#{key}.b#{chunk_id}.#{suffix}"
         end
 
         def self.generate_queued_chunk_path(path, unique_id)

--- a/lib/fluent/plugin/buffer/file_single_chunk.rb
+++ b/lib/fluent/plugin/buffer/file_single_chunk.rb
@@ -17,6 +17,7 @@
 require 'uri'
 require 'fluent/plugin/buffer/chunk'
 require 'fluent/unique_id'
+require 'fluent/msgpack_factory'
 
 module Fluent
   module Plugin
@@ -29,6 +30,7 @@ module Fluent
         ## state: b/q - 'b'(on stage), 'q'(enqueued)
 
         include SystemConfig::Mixin
+        include MessagePackFactory::Mixin
 
         PATH_EXT = 'buf'
         PATH_SUFFIX = ".#{PATH_EXT}"

--- a/test/plugin/test_buf_file_single.rb
+++ b/test/plugin/test_buf_file_single.rb
@@ -44,14 +44,15 @@ class FileSingleBufferTest < Test::Unit::TestCase
 
   setup do
     Fluent::Test.setup
-    @d = nil
 
+    @d = nil
     @bufdir = PATH
     FileUtils.rm_r(@bufdir) rescue nil
     FileUtils.mkdir_p(@bufdir)
   end
 
   teardown do
+    FileUtils.rm_r(@bufdir) rescue nil
   end
 
   def create_driver(conf = TAG_CONF)
@@ -157,14 +158,12 @@ class FileSingleBufferTest < Test::Unit::TestCase
       ])
       @p = @d.instance.buffer
 
-      FileUtils.rm_r bufdir if File.exist?(@bufdir)
+      FileUtils.rm_r(@bufdir) if File.exist?(@bufdir)
       assert !File.exist?(@bufdir)
 
       @p.start
       assert File.exist?(@bufdir)
       assert { File.stat(@bufdir).mode.to_s(8).end_with?('700') }
-
-      FileUtils.rm_r(@bufdir)
     end
 
     test '#start creates directory for buffer chunks with specified permission via system config' do
@@ -181,8 +180,6 @@ class FileSingleBufferTest < Test::Unit::TestCase
         @p.start
         assert File.exist?(@bufdir)
         assert { File.stat(@bufdir).mode.to_s(8).end_with?('700') }
-
-        FileUtils.rm_r @bufdir
       end
     end
 
@@ -418,7 +415,7 @@ class FileSingleBufferTest < Test::Unit::TestCase
       assert_equal 3, queue[1].size
     end
 
-    test '#resume returns staged/queued chunks but skip size calculation by calc_num_records' do
+    test '#resume returns staged/queued chunks but skips size calculation by calc_num_records' do
       @d = create_driver(%[
         <buffer tag>
          @type file_single

--- a/test/plugin/test_buf_file_single.rb
+++ b/test/plugin/test_buf_file_single.rb
@@ -1,0 +1,556 @@
+require_relative '../helper'
+require 'fluent/plugin/buf_file_single'
+require 'fluent/plugin/output'
+require 'fluent/unique_id'
+require 'fluent/system_config'
+require 'fluent/env'
+require 'fluent/test/driver/output'
+
+require 'msgpack'
+
+module FluentPluginFileSingleBufferTest
+  class DummyOutputPlugin < Fluent::Plugin::Output
+    Fluent::Plugin.register_output('buf_file_single_test', self)
+    config_section :buffer do
+      config_set_default :@type, 'file_single'
+    end
+    def multi_workers_ready?
+      true
+    end
+    def write(chunk)
+      # drop
+    end
+  end
+end
+
+class FileSingleBufferTest < Test::Unit::TestCase
+  def metadata(timekey: nil, tag: 'testing', variables: nil)
+    Fluent::Plugin::Buffer::Metadata.new(timekey, tag, variables)
+  end
+
+  PATH = File.expand_path('../../tmp/buffer_file_single_dir', __FILE__)
+  TAG_CONF = %[
+    <buffer tag>
+      @type file_single
+      path #{PATH}
+    </buffer>
+  ]
+  FIELD_CONF = %[
+    <buffer k>
+      @type file_single
+      path #{PATH}
+    </buffer>
+  ]
+
+  setup do
+    Fluent::Test.setup
+    @d = nil
+
+    @bufdir = PATH
+    FileUtils.rm_r(@bufdir) rescue nil
+    FileUtils.mkdir_p(@bufdir)
+  end
+
+  teardown do
+  end
+
+  def create_driver(conf = TAG_CONF)
+    Fluent::Test::Driver::Output.new(FluentPluginFileSingleBufferTest::DummyOutputPlugin).configure(conf)
+  end
+
+  sub_test_case 'non configured buffer plugin instance' do
+    test 'path has "fsb" prefix and "buf" suffix' do
+      @d = create_driver
+      p = @d.instance.buffer
+      assert_equal File.join(@bufdir, 'fsb.*.buf'), p.path
+    end
+  end
+
+  sub_test_case 'buffer configurations and workers' do
+    setup do
+      @d = FluentPluginFileSingleBufferTest::DummyOutputPlugin.new
+    end
+
+    test 'enables multi worker configuration with unexisting directory path' do
+      FileUtils.rm_rf(@bufdir)
+      buf_conf = config_element('buffer', '', {'path' => @bufdir})
+      assert_nothing_raised do
+        Fluent::SystemConfig.overwrite_system_config('root_dir' => @bufdir, 'workers' => 4) do
+          @d.configure(config_element('ROOT', '', {}, [buf_conf]))
+        end
+      end
+    end
+
+    test 'enables multi worker configuration with existing directory path' do
+      FileUtils.mkdir_p @bufdir
+      buf_conf = config_element('buffer', '', {'path' => @bufdir})
+      assert_nothing_raised do
+        Fluent::SystemConfig.overwrite_system_config('root_dir' => @bufdir, 'workers' => 4) do
+          @d.configure(config_element('ROOT', '', {}, [buf_conf]))
+        end
+      end
+    end
+
+    test 'enables multi worker configuration with root dir' do
+      buf_conf = config_element('buffer', '')
+      assert_nothing_raised do
+        Fluent::SystemConfig.overwrite_system_config('root_dir' => @bufdir, 'workers' => 4) do
+          @d.configure(config_element('ROOT', '', {'@id' => 'dummy_output_with_buf'}, [buf_conf]))
+        end
+      end
+    end
+  end
+
+  sub_test_case 'buffer plugin configured only with path' do
+    setup do
+      @bufpath = File.join(@bufdir, 'testbuf.*.buf')
+      FileUtils.rm_r(@bufdir) if File.exist?(@bufdir)
+
+      @d = create_driver
+      @p = @d.instance.buffer
+    end
+
+    teardown do
+      if @p
+        @p.stop unless @p.stopped?
+        @p.before_shutdown unless @p.before_shutdown?
+        @p.shutdown unless @p.shutdown?
+        @p.after_shutdown unless @p.after_shutdown?
+        @p.close unless @p.closed?
+        @p.terminate unless @p.terminated?
+      end
+      if @bufdir
+        Dir.glob(File.join(@bufdir, '*')).each do |path|
+          next if ['.', '..'].include?(File.basename(path))
+          File.delete(path)
+        end
+      end
+    end
+
+    test 'this is persistent plugin' do
+      assert @p.persistent?
+    end
+
+    test '#start creates directory for buffer chunks' do
+      @d = create_driver
+      @p = @d.instance.buffer
+
+      FileUtils.rm_r(@bufdir) if File.exist?(@bufdir)
+      assert !File.exist?(@bufdir)
+
+      @p.start
+      assert File.exist?(@bufdir)
+      assert { File.stat(@bufdir).mode.to_s(8).end_with?('755') }
+
+      FileUtils.rm_r(@bufdir)
+    end
+
+    test '#start creates directory for buffer chunks with specified permission' do
+      omit "NTFS doesn't support UNIX like permissions" if Fluent.windows?
+
+      @d = create_driver(%[
+        <buffer tag>
+          @type file_single
+          path #{PATH}
+          dir_permission 700
+        </buffer>
+      ])
+      @p = @d.instance.buffer
+
+      FileUtils.rm_r bufdir if File.exist?(@bufdir)
+      assert !File.exist?(@bufdir)
+
+      @p.start
+      assert File.exist?(@bufdir)
+      assert { File.stat(@bufdir).mode.to_s(8).end_with?('700') }
+
+      FileUtils.rm_r(@bufdir)
+    end
+
+    test '#start creates directory for buffer chunks with specified permission via system config' do
+      omit "NTFS doesn't support UNIX like permissions" if Fluent.windows?
+
+      sysconf = {'dir_permission' => '700'}
+      Fluent::SystemConfig.overwrite_system_config(sysconf) do
+        @d = create_driver
+        @p = @d.instance.buffer
+
+        FileUtils.rm_r @bufdir if File.exist?(@bufdir)
+        assert !File.exist?(@bufdir)
+
+        @p.start
+        assert File.exist?(@bufdir)
+        assert { File.stat(@bufdir).mode.to_s(8).end_with?('700') }
+
+        FileUtils.rm_r @bufdir
+      end
+    end
+
+    test '#generate_chunk generates blank file chunk on path with unique_id' do
+      FileUtils.mkdir_p(@bufdir) unless File.exist?(@bufdir)
+
+      m1 = metadata()
+      c1 = @p.generate_chunk(m1)
+      assert c1.is_a? Fluent::Plugin::Buffer::FileSingleChunk
+      assert_equal m1, c1.metadata
+      assert c1.empty?
+      assert_equal :unstaged, c1.state
+      assert_equal Fluent::Plugin::Buffer::FileSingleChunk::FILE_PERMISSION, c1.permission
+      assert_equal File.join(@bufdir, "fsb.testing.b#{Fluent::UniqueId.hex(c1.unique_id)}.buf"), c1.path
+      assert{ File.stat(c1.path).mode.to_s(8).end_with?('644') }
+
+      m2 = metadata(timekey: event_time('2016-04-17 11:15:00 -0700').to_i)
+      c2 = @p.generate_chunk(m2)
+      assert c2.is_a? Fluent::Plugin::Buffer::FileSingleChunk
+      assert_equal m2, c2.metadata
+      assert c2.empty?
+      assert_equal :unstaged, c2.state
+      assert_equal Fluent::Plugin::Buffer::FileSingleChunk::FILE_PERMISSION, c2.permission
+      assert_equal File.join(@bufdir, "fsb.testing.b#{Fluent::UniqueId.hex(c2.unique_id)}.buf"), c2.path
+      assert { File.stat(c2.path).mode.to_s(8).end_with?('644') }
+
+      c1.purge
+      c2.purge
+      FileUtils.rm_rf(@bufdir)
+    end
+
+    test '#generate_chunk generates blank file chunk with specified permission' do
+      omit "NTFS doesn't support UNIX like permissions" if Fluent.windows?
+
+      @d = create_driver(%[
+        <buffer tag>
+          @type file_single
+          path #{PATH}
+          file_permission 600
+        </buffer>
+      ])
+      @p = @d.instance.buffer
+
+      FileUtils.rm_r @bufdir if File.exist?(@bufdir)
+      assert !File.exist?(@bufdir)
+
+      @p.start
+
+      m = metadata()
+      c = @p.generate_chunk(m)
+      assert c.is_a? Fluent::Plugin::Buffer::FileSingleChunk
+      assert_equal m, c.metadata
+      assert c.empty?
+      assert_equal :unstaged, c.state
+      assert_equal 0600, c.permission
+      assert_equal File.join(@bufdir, "fsb.testing.b#{Fluent::UniqueId.hex(c.unique_id)}.buf"), c.path
+      assert{ File.stat(c.path).mode.to_s(8).end_with?('600') }
+
+      c.purge
+      FileUtils.rm_r(@bufdir)
+    end
+  end
+
+  sub_test_case 'configured with system root directory and plugin @id' do
+    setup do
+      @root_dir = File.expand_path('../../tmp/buffer_file_single_root', __FILE__)
+      FileUtils.rm_rf(@root_dir)
+
+      @d = FluentPluginFileSingleBufferTest::DummyOutputPlugin.new
+      @p = nil
+    end
+
+    teardown do
+      if @p
+        @p.stop unless @p.stopped?
+        @p.before_shutdown unless @p.before_shutdown?
+        @p.shutdown unless @p.shutdown?
+        @p.after_shutdown unless @p.after_shutdown?
+        @p.close unless @p.closed?
+        @p.terminate unless @p.terminated?
+      end
+    end
+
+    test '#start creates directory for buffer chunks' do
+      Fluent::SystemConfig.overwrite_system_config('root_dir' => @root_dir) do
+        @d.configure(config_element('ROOT', '', {'@id' => 'dummy_output_with_buf'}, [config_element('buffer', '', {})]))
+        @p = @d.buffer
+      end
+
+      expected_buffer_path = File.join(@root_dir, 'worker0', 'dummy_output_with_buf', 'buffer', "fsb.*.buf")
+      expected_buffer_dir = File.dirname(expected_buffer_path)
+      assert_equal expected_buffer_path, @d.buffer.path
+      assert_false Dir.exist?(expected_buffer_dir)
+
+      @p.start
+      assert Dir.exist?(expected_buffer_dir)
+    end
+  end
+
+  sub_test_case 'there are no existing file chunks' do
+    setup do
+      FileUtils.rm_r(@bufdir) if File.exist?(@bufdir)
+
+      @d = create_driver
+      @p = @d.instance.buffer
+      @p.start
+    end
+    teardown do
+      if @p
+        @p.stop unless @p.stopped?
+        @p.before_shutdown unless @p.before_shutdown?
+        @p.shutdown unless @p.shutdown?
+        @p.after_shutdown unless @p.after_shutdown?
+        @p.close unless @p.closed?
+        @p.terminate unless @p.terminated?
+      end
+      if @bufdir
+        Dir.glob(File.join(@bufdir, '*')).each do |path|
+          next if ['.', '..'].include?(File.basename(path))
+          File.delete(path)
+        end
+      end
+    end
+
+    test '#resume returns empty buffer state' do
+      ary = @p.resume
+      assert_equal({}, ary[0])
+      assert_equal([], ary[1])
+    end
+  end
+
+  sub_test_case 'there are some existing file chunks' do
+    setup do
+      @c1id = Fluent::UniqueId.generate
+      p1 = File.join(@bufdir, "fsb.testing.q#{Fluent::UniqueId.hex(@c1id)}.buf")
+      File.open(p1, 'wb') do |f|
+        f.write ["t1.test", event_time('2016-04-17 13:58:15 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+        f.write ["t2.test", event_time('2016-04-17 13:58:17 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+        f.write ["t3.test", event_time('2016-04-17 13:58:21 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+        f.write ["t4.test", event_time('2016-04-17 13:58:22 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+      end
+      t = Time.now - 50000
+      File.utime(t, t, p1)
+
+      @c2id = Fluent::UniqueId.generate
+      p2 = File.join(@bufdir, "fsb.testing.q#{Fluent::UniqueId.hex(@c2id)}.buf")
+      File.open(p2, 'wb') do |f|
+        f.write ["t1.test", event_time('2016-04-17 13:59:15 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+        f.write ["t2.test", event_time('2016-04-17 13:59:17 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+        f.write ["t3.test", event_time('2016-04-17 13:59:21 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+      end
+      t = Time.now - 40000
+      File.utime(t, t, p2)
+
+      @c3id = Fluent::UniqueId.generate
+      p3 = File.join(@bufdir, "fsb.testing.b#{Fluent::UniqueId.hex(@c3id)}.buf")
+      File.open(p3, 'wb') do |f|
+        f.write ["t1.test", event_time('2016-04-17 14:00:15 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+        f.write ["t2.test", event_time('2016-04-17 14:00:17 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+        f.write ["t3.test", event_time('2016-04-17 14:00:21 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+        f.write ["t4.test", event_time('2016-04-17 14:00:28 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+      end
+
+      @c4id = Fluent::UniqueId.generate
+      p4 = File.join(@bufdir, "fsb.foo.b#{Fluent::UniqueId.hex(@c4id)}.buf")
+      File.open(p4, 'wb') do |f|
+        f.write ["t1.test", event_time('2016-04-17 14:01:15 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+        f.write ["t2.test", event_time('2016-04-17 14:01:17 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+        f.write ["t3.test", event_time('2016-04-17 14:01:21 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+      end
+
+      @d = create_driver
+      @p = @d.instance.buffer
+      @p.start
+    end
+
+    teardown do
+      if @p
+        @p.stop unless @p.stopped?
+        @p.before_shutdown unless @p.before_shutdown?
+        @p.shutdown unless @p.shutdown?
+        @p.after_shutdown unless @p.after_shutdown?
+        @p.close unless @p.closed?
+        @p.terminate unless @p.terminated?
+      end
+      if @bufdir
+        Dir.glob(File.join(@bufdir, '*')).each do |path|
+          next if ['.', '..'].include?(File.basename(path))
+          File.delete(path)
+        end
+      end
+    end
+
+    test '#resume returns staged/queued chunks with metadata' do
+      assert_equal 2, @p.stage.size
+      assert_equal 2, @p.queue.size
+
+      stage = @p.stage
+
+      m3 = metadata()
+      assert_equal @c3id, stage[m3].unique_id
+      assert_equal 0, stage[m3].size
+      assert_equal :staged, stage[m3].state
+
+      m4 = metadata(tag: 'foo')
+      assert_equal @c4id, stage[m4].unique_id
+      assert_equal 0, stage[m4].size
+      assert_equal :staged, stage[m4].state
+    end
+
+    test '#resume returns queued chunks ordered by last modified time (FIFO)' do
+      assert_equal 2, @p.stage.size
+      assert_equal 2, @p.queue.size
+
+      queue = @p.queue
+
+      assert{ queue[0].modified_at <= queue[1].modified_at }
+
+      assert_equal @c1id, queue[0].unique_id
+      assert_equal :queued, queue[0].state
+      assert_equal 'testing', queue[0].metadata.tag
+      assert_nil queue[0].metadata.variables
+      assert_equal 0, queue[0].size
+
+      assert_equal @c2id, queue[1].unique_id
+      assert_equal :queued, queue[1].state
+      assert_equal 'testing', queue[1].metadata.tag
+      assert_nil queue[1].metadata.variables
+      assert_equal 0, queue[1].size
+    end
+  end
+
+  sub_test_case 'there are some existing file chunks, both in specified path and per-worker directory under specified path, configured as multi workers' do
+    setup do
+      @worker0_dir = File.join(@bufdir, "worker0")
+      @worker1_dir = File.join(@bufdir, "worker1")
+      FileUtils.rm_rf(@bufdir)
+      FileUtils.mkdir_p(@worker0_dir)
+      FileUtils.mkdir_p(@worker1_dir)
+
+      @bufdir_chunk_1 = Fluent::UniqueId.generate
+      bc1 = File.join(@bufdir, "fsb.testing.q#{Fluent::UniqueId.hex(@bufdir_chunk_1)}.buf")
+      File.open(bc1, 'wb') do |f|
+        f.write ["t1.test", event_time('2016-04-17 13:58:15 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+        f.write ["t2.test", event_time('2016-04-17 13:58:17 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+        f.write ["t3.test", event_time('2016-04-17 13:58:21 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+        f.write ["t4.test", event_time('2016-04-17 13:58:22 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+      end
+
+      @bufdir_chunk_2 = Fluent::UniqueId.generate
+      bc2 = File.join(@bufdir, "fsb.testing.q#{Fluent::UniqueId.hex(@bufdir_chunk_2)}.buf")
+      File.open(bc2, 'wb') do |f|
+        f.write ["t1.test", event_time('2016-04-17 13:58:15 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+        f.write ["t2.test", event_time('2016-04-17 13:58:17 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+        f.write ["t3.test", event_time('2016-04-17 13:58:21 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+        f.write ["t4.test", event_time('2016-04-17 13:58:22 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+      end
+
+      @worker_dir_chunk_1 = Fluent::UniqueId.generate
+      wc0_1 = File.join(@worker0_dir, "fsb.testing.q#{Fluent::UniqueId.hex(@worker_dir_chunk_1)}.buf")
+      wc1_1 = File.join(@worker1_dir, "fsb.testing.q#{Fluent::UniqueId.hex(@worker_dir_chunk_1)}.buf")
+      [wc0_1, wc1_1].each do |chunk_path|
+        File.open(chunk_path, 'wb') do |f|
+          f.write ["t1.test", event_time('2016-04-17 13:59:15 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+          f.write ["t2.test", event_time('2016-04-17 13:59:17 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+          f.write ["t3.test", event_time('2016-04-17 13:59:21 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+        end
+      end
+
+      @worker_dir_chunk_2 = Fluent::UniqueId.generate
+      wc0_2 = File.join(@worker0_dir, "fsb.testing.b#{Fluent::UniqueId.hex(@worker_dir_chunk_2)}.buf")
+      wc1_2 = File.join(@worker1_dir, "fsb.foo.b#{Fluent::UniqueId.hex(@worker_dir_chunk_2)}.buf")
+      [wc0_2, wc1_2].each do |chunk_path|
+        File.open(chunk_path, 'wb') do |f|
+          f.write ["t1.test", event_time('2016-04-17 14:00:15 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+          f.write ["t2.test", event_time('2016-04-17 14:00:17 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+          f.write ["t3.test", event_time('2016-04-17 14:00:21 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+          f.write ["t4.test", event_time('2016-04-17 14:00:28 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+        end
+      end
+
+      @worker_dir_chunk_3 = Fluent::UniqueId.generate
+      wc0_3 = File.join(@worker0_dir, "fsb.bar.b#{Fluent::UniqueId.hex(@worker_dir_chunk_3)}.buf")
+      wc1_3 = File.join(@worker1_dir, "fsb.baz.b#{Fluent::UniqueId.hex(@worker_dir_chunk_3)}.buf")
+      [wc0_3, wc1_3].each do |chunk_path|
+        File.open(chunk_path, 'wb') do |f|
+          f.write ["t1.test", event_time('2016-04-17 14:01:15 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+          f.write ["t2.test", event_time('2016-04-17 14:01:17 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+          f.write ["t3.test", event_time('2016-04-17 14:01:21 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+        end
+      end
+    end
+
+    teardown do
+      if @p
+        @p.stop unless @p.stopped?
+        @p.before_shutdown unless @p.before_shutdown?
+        @p.shutdown unless @p.shutdown?
+        @p.after_shutdown unless @p.after_shutdown?
+        @p.close unless @p.closed?
+        @p.terminate unless @p.terminated?
+      end
+    end
+
+    test 'worker(id=0) #resume returns staged/queued chunks with metadata, not only in worker dir, including the directory specified by path' do
+      ENV['SERVERENGINE_WORKER_ID'] = '0'
+
+      buf_conf = config_element('buffer', '', {'path' => @bufdir})
+      @d = FluentPluginFileSingleBufferTest::DummyOutputPlugin.new
+      with_worker_config(workers: 2, worker_id: 0) do
+        @d.configure(config_element('output', '', {}, [buf_conf]))
+      end
+
+      @d.start
+      @p = @d.buffer
+
+      assert_equal 2, @p.stage.size
+      assert_equal 3, @p.queue.size
+
+      stage = @p.stage
+
+      m1 = metadata(tag: 'testing')
+      assert_equal @worker_dir_chunk_2, stage[m1].unique_id
+      assert_equal 0, stage[m1].size
+      assert_equal :staged, stage[m1].state
+
+      m2 = metadata(tag: 'bar')
+      assert_equal @worker_dir_chunk_3, stage[m2].unique_id
+      assert_equal 0, stage[m2].size
+      assert_equal :staged, stage[m2].state
+
+      queue = @p.queue
+
+      assert_equal [@bufdir_chunk_1, @bufdir_chunk_2, @worker_dir_chunk_1].sort, queue.map(&:unique_id).sort
+      assert_equal [0, 0, 0], queue.map(&:size).sort
+      assert_equal [:queued, :queued, :queued], queue.map(&:state)
+    end
+
+    test 'worker(id=1) #resume returns staged/queued chunks with metadata, only in worker dir' do
+      buf_conf = config_element('buffer', '', {'path' => @bufdir})
+      @d = FluentPluginFileSingleBufferTest::DummyOutputPlugin.new
+      with_worker_config(workers: 2, worker_id: 1) do
+        @d.configure(config_element('output', '', {}, [buf_conf]))
+      end
+
+      @d.start
+      @p = @d.buffer
+
+      assert_equal 2, @p.stage.size
+      assert_equal 1, @p.queue.size
+
+      stage = @p.stage
+
+      m1 = metadata(tag: 'foo')
+      assert_equal @worker_dir_chunk_2, stage[m1].unique_id
+      assert_equal 0, stage[m1].size
+      assert_equal :staged, stage[m1].state
+
+      m2 = metadata(tag: 'baz')
+      assert_equal @worker_dir_chunk_3, stage[m2].unique_id
+      assert_equal 0, stage[m2].size
+      assert_equal :staged, stage[m2].state
+
+      queue = @p.queue
+
+      assert_equal @worker_dir_chunk_1, queue[0].unique_id
+      assert_equal 0, queue[0].size
+      assert_equal :queued, queue[0].state
+    end
+  end
+end

--- a/test/plugin/test_buf_file_single.rb
+++ b/test/plugin/test_buf_file_single.rb
@@ -83,7 +83,7 @@ class FileSingleBufferTest < Test::Unit::TestCase
     end
 
     data('text based chunk' => [FluentPluginFileSingleBufferTest::DummyOutputPlugin, :text],
-        'msgpack based chunk' => [FluentPluginFileSingleBufferTest::DummyOutputMPPlugin, :msgpack])
+         'msgpack based chunk' => [FluentPluginFileSingleBufferTest::DummyOutputMPPlugin, :msgpack])
     test 'detect chunk_format' do |param|
       klass, expected = param
       @d = create_driver(TAG_CONF, klass)

--- a/test/plugin/test_buffer_file_single_chunk.rb
+++ b/test/plugin/test_buffer_file_single_chunk.rb
@@ -400,6 +400,9 @@ class BufferFileSingleChunkTest < Test::Unit::TestCase
       assert_nil @c.metadata.variables
       assert_equal 0, @c.size
       assert_equal @d, @c.read
+
+      @c.restore_size(:text)
+      assert_equal 4, @c.size
     end
 
     test 'can be enqueued' do
@@ -420,6 +423,9 @@ class BufferFileSingleChunkTest < Test::Unit::TestCase
 
       assert_equal 0, @c.size
       assert_equal @d, File.read(@c.path)
+
+      @c.restore_size(:text)
+      assert_equal 4, @c.size
     end
 
     test '#file_rename can rename chunk files even in windows, and call callback with file size' do
@@ -491,6 +497,9 @@ class BufferFileSingleChunkTest < Test::Unit::TestCase
       assert_equal @d.bytesize, @c.bytesize
       assert_equal @d, @c.read
 
+      @c.restore_size(:text)
+      assert_equal 4, @c.size
+
       assert_raise RuntimeError.new("BUG: concatenating to unwritable chunk, now 'queued'") do
         @c.append(["queued chunk is read only"])
       end
@@ -522,7 +531,7 @@ class BufferFileSingleChunkTest < Test::Unit::TestCase
       File.unlink(@chunk_path) if File.exist?(@chunk_path)
     end
 
-    test 'can load as queued chunk from file without metadata' do
+    test 'can load as queued chunk' do
       assert @c
       assert_equal :queued, @c.state
       assert_equal @chunk_id, @c.unique_id

--- a/test/plugin/test_buffer_file_single_chunk.rb
+++ b/test/plugin/test_buffer_file_single_chunk.rb
@@ -1,0 +1,612 @@
+require_relative '../helper'
+require 'fluent/plugin/buffer/file_single_chunk'
+require 'fluent/plugin/compressable'
+require 'fluent/unique_id'
+
+require 'fileutils'
+require 'msgpack'
+require 'time'
+require 'timecop'
+
+class BufferFileSingleChunkTest < Test::Unit::TestCase
+  include Fluent::Plugin::Compressable
+
+  setup do
+    @klass = Fluent::Plugin::Buffer::FileSingleChunk
+    @chunkdir = File.expand_path('../../tmp/buffer_file_single_chunk', __FILE__)
+    FileUtils.rm_r(@chunkdir) rescue nil
+    FileUtils.mkdir_p(@chunkdir)
+  end
+
+  teardown do
+    Timecop.return
+  end
+
+  Metadata = Struct.new(:timekey, :tag, :variables)
+  def gen_metadata(timekey: nil, tag: 'testing', variables: nil)
+    Metadata.new(timekey, tag, variables)
+  end
+
+  def gen_path(path)
+    File.join(@chunkdir, path)
+  end
+
+  def gen_test_chunk_id
+    now = Time.parse('2016-04-07 14:31:33 +0900')
+    u1 = ((now.to_i * 1000 * 1000 + now.usec) << 12 | 1725) # 1725 is one of `rand(0xfff)`
+    u3 = 2979763054 # one of rand(0xffffffff)
+    u4 = 438020492  # ditto
+    [u1 >> 32, u1 & 0xffffffff, u3, u4].pack('NNNN')
+    # unique_id.unpack('N*').map{|n| n.to_s(16)}.join => "52fde6425d7406bdb19b936e1a1ba98c"
+  end
+
+  def hex_id(id)
+    id.unpack('N*').map { |n| n.to_s(16) }.join
+  end
+
+  sub_test_case 'classmethods' do
+    data(
+      correct_staged: ['/mydir/mypath/fsb.b00ff.buf', :staged],
+      correct_queued: ['/mydir/mypath/fsb.q00ff.buf', :queued],
+      incorrect_staged: ['/mydir/mypath/fsb.b00ff.buf/unknown', :unknown],
+      incorrect_queued: ['/mydir/mypath/fsb.q00ff.buf/unknown', :unknown],
+      output_file: ['/mydir/mypath/fsb.20160716.buf', :unknown],
+    )
+    test 'can .assume_chunk_state' do |data|
+      path, expected = data
+      assert_equal expected, @klass.assume_chunk_state(path)
+    end
+
+    test '.generate_stage_chunk_path generates path with staged mark & chunk unique_id' do
+      assert_equal gen_path("fsb.foo.b52fde6425d7406bdb19b936e1a1ba98c.buf"), @klass.generate_stage_chunk_path(gen_path("fsb.*.buf"), 'foo', gen_test_chunk_id)
+      assert_raise RuntimeError.new("BUG: buffer chunk path on stage MUST have '.*.'") do
+        @klass.generate_stage_chunk_path(gen_path("fsb.buf"), 'foo', gen_test_chunk_id)
+      end
+      assert_raise RuntimeError.new("BUG: buffer chunk path on stage MUST have '.*.'") do
+        @klass.generate_stage_chunk_path(gen_path("fsb.*"), 'foo', gen_test_chunk_id)
+      end
+      assert_raise RuntimeError.new("BUG: buffer chunk path on stage MUST have '.*.'") do
+        @klass.generate_stage_chunk_path(gen_path("*.buf"), 'foo', gen_test_chunk_id)
+      end
+    end
+
+    test '.generate_queued_chunk_path generates path with enqueued mark for staged chunk path' do
+      assert_equal(
+        gen_path("fsb.q52fde6425d7406bdb19b936e1a1ba98c.buf"),
+        @klass.generate_queued_chunk_path(gen_path("fsb.b52fde6425d7406bdb19b936e1a1ba98c.buf"), gen_test_chunk_id)
+      )
+    end
+
+    test '.generate_queued_chunk_path generates special path with chunk unique_id for non staged chunk path' do
+      assert_equal(
+        gen_path("fsb.buf.q52fde6425d7406bdb19b936e1a1ba98c.chunk"),
+        @klass.generate_queued_chunk_path(gen_path("fsb.buf"), gen_test_chunk_id)
+      )
+      assert_equal(
+        gen_path("fsb.q55555555555555555555555555555555.buf.q52fde6425d7406bdb19b936e1a1ba98c.chunk"),
+        @klass.generate_queued_chunk_path(gen_path("fsb.q55555555555555555555555555555555.buf"), gen_test_chunk_id)
+      )
+    end
+
+    test '.unique_id_and_key_from_path recreates unique_id and key from file path' do
+      assert_equal [gen_test_chunk_id, 'test.log'], @klass.unique_id_and_key_from_path(gen_path("fsb.test.log.q52fde6425d7406bdb19b936e1a1ba98c.buf"))
+    end
+  end
+
+  sub_test_case 'newly created chunk' do
+    setup do
+      @path_conf = File.join(@chunkdir, 'fsb.*.buf')
+      @chunk_path = File.join(@chunkdir, "fsb.testing.b#{hex_id(gen_test_chunk_id)}.buf")
+      @c = Fluent::Plugin::Buffer::FileSingleChunk.new(gen_metadata, @path_conf, :create, nil)
+    end
+
+    def gen_chunk_path(prefix, unique_id)
+      File.join(@chunkdir, "fsb.testing.#{prefix}#{Fluent::UniqueId.hex(unique_id)}.buf")
+    end
+
+    teardown do
+      if @c
+        @c.purge rescue nil
+      end
+      if File.exist?(@chunk_path)
+        File.unlink(@chunk_path)
+      end
+    end
+
+    test 'creates new files for chunk and metadata with specified path & permission' do
+      assert { @c.unique_id.size == 16 }
+      assert_equal gen_chunk_path('b', @c.unique_id), @c.path
+
+      assert File.exist?(gen_chunk_path('b', @c.unique_id))
+      assert { File.stat(gen_chunk_path('b', @c.unique_id)).mode.to_s(8).end_with?(@klass.const_get('FILE_PERMISSION').to_s(8)) }
+
+      assert_equal :unstaged, @c.state
+      assert @c.empty?
+    end
+
+    test 'can #append, #commit and #read it' do
+      assert @c.empty?
+
+      d1 = {"f1" => 'v1', "f2" => 'v2', "f3" => 'v3'}
+      d2 = {"f1" => 'vv1', "f2" => 'vv2', "f3" => 'vv3'}
+      data = [d1.to_json + "\n", d2.to_json + "\n"]
+      @c.append(data)
+      @c.commit
+
+      ds = @c.read.split("\n").select { |d| !d.empty? }
+      assert_equal 2, ds.size
+      assert_equal d1, JSON.parse(ds[0])
+      assert_equal d2, JSON.parse(ds[1])
+
+      d3 = {"f1" => 'x', "f2" => 'y', "f3" => 'z'}
+      d4 = {"f1" => 'a', "f2" => 'b', "f3" => 'c'}
+      @c.append([d3.to_json + "\n", d4.to_json + "\n"])
+      @c.commit
+
+      ds = @c.read.split("\n").select{|d| !d.empty? }
+      assert_equal 4, ds.size
+      assert_equal d1, JSON.parse(ds[0])
+      assert_equal d2, JSON.parse(ds[1])
+      assert_equal d3, JSON.parse(ds[2])
+      assert_equal d4, JSON.parse(ds[3])
+    end
+
+    test 'can #concat, #commit and #read it' do
+      assert @c.empty?
+
+      d1 = {"f1" => 'v1', "f2" => 'v2', "f3" => 'v3'}
+      d2 = {"f1" => 'vv1', "f2" => 'vv2', "f3" => 'vv3'}
+      data = [d1.to_json + "\n", d2.to_json + "\n"].join
+      @c.concat(data, 2)
+      @c.commit
+
+      ds = @c.read.split("\n").select{|d| !d.empty? }
+      assert_equal 2, ds.size
+      assert_equal d1, JSON.parse(ds[0])
+      assert_equal d2, JSON.parse(ds[1])
+
+      d3 = {"f1" => 'x', "f2" => 'y', "f3" => 'z'}
+      d4 = {"f1" => 'a', "f2" => 'b', "f3" => 'c'}
+      @c.concat([d3.to_json + "\n", d4.to_json + "\n"].join, 2)
+      @c.commit
+
+      ds = @c.read.split("\n").select { |d| !d.empty? }
+      assert_equal 4, ds.size
+      assert_equal d1, JSON.parse(ds[0])
+      assert_equal d2, JSON.parse(ds[1])
+      assert_equal d3, JSON.parse(ds[2])
+      assert_equal d4, JSON.parse(ds[3])
+    end
+
+    test 'has its contents in binary (ascii-8bit)' do
+      data1 = "aaa bbb ccc".force_encoding('utf-8')
+      @c.append([data1])
+      @c.commit
+      assert_equal Encoding::ASCII_8BIT, @c.instance_eval{ @chunk.external_encoding }
+      assert_equal Encoding::ASCII_8BIT, @c.read.encoding
+    end
+
+    test 'has #bytesize and #size' do
+      assert @c.empty?
+
+      d1 = {"f1" => 'v1', "f2" => 'v2', "f3" => 'v3'}
+      d2 = {"f1" => 'vv1', "f2" => 'vv2', "f3" => 'vv3'}
+      data = [d1.to_json + "\n", d2.to_json + "\n"]
+      @c.append(data)
+
+      assert_equal (d1.to_json + "\n" + d2.to_json + "\n").bytesize, @c.bytesize
+      assert_equal 2, @c.size
+
+      @c.commit
+
+      assert_equal (d1.to_json + "\n" + d2.to_json + "\n").bytesize, @c.bytesize
+      assert_equal 2, @c.size
+
+      first_bytesize = @c.bytesize
+      d3 = {"f1" => 'x', "f2" => 'y', "f3" => 'z'}
+      d4 = {"f1" => 'a', "f2" => 'b', "f3" => 'c'}
+      @c.append([d3.to_json + "\n", d4.to_json + "\n"])
+
+      assert_equal first_bytesize + (d3.to_json + "\n" + d4.to_json + "\n").bytesize, @c.bytesize
+      assert_equal 4, @c.size
+
+      @c.commit
+
+      assert_equal first_bytesize + (d3.to_json + "\n" + d4.to_json + "\n").bytesize, @c.bytesize
+      assert_equal 4, @c.size
+    end
+
+    test 'can #rollback to revert non-committed data' do
+      assert @c.empty?
+
+      d1 = {"f1" => 'v1', "f2" => 'v2', "f3" => 'v3'}
+      d2 = {"f1" => 'vv1', "f2" => 'vv2', "f3" => 'vv3'}
+      data = [d1.to_json + "\n", d2.to_json + "\n"]
+      @c.append(data)
+
+      assert_equal (d1.to_json + "\n" + d2.to_json + "\n").bytesize, @c.bytesize
+      assert_equal 2, @c.size
+
+      @c.rollback
+
+      assert @c.empty?
+      assert_equal '', File.read(@c.path)
+
+      d1 = {"f1" => 'v1', "f2" => 'v2', "f3" => 'v3'}
+      d2 = {"f1" => 'vv1', "f2" => 'vv2', "f3" => 'vv3'}
+      data = [d1.to_json + "\n", d2.to_json + "\n"]
+      @c.append(data)
+      @c.commit
+
+      assert_equal (d1.to_json + "\n" + d2.to_json + "\n").bytesize, @c.bytesize
+      assert_equal 2, @c.size
+
+      first_bytesize = @c.bytesize
+      d3 = {"f1" => 'x', "f2" => 'y', "f3" => 'z'}
+      d4 = {"f1" => 'a', "f2" => 'b', "f3" => 'c'}
+      @c.append([d3.to_json + "\n", d4.to_json + "\n"])
+
+      assert_equal first_bytesize + (d3.to_json + "\n" + d4.to_json + "\n").bytesize, @c.bytesize
+      assert_equal 4, @c.size
+
+      @c.rollback
+
+      assert_equal first_bytesize, @c.bytesize
+      assert_equal 2, @c.size
+      assert_equal (d1.to_json + "\n" + d2.to_json + "\n"), File.read(@c.path)
+    end
+
+    test 'can #rollback to revert non-committed data from #concat' do
+      assert @c.empty?
+
+      d1 = {"f1" => 'v1', "f2" => 'v2', "f3" => 'v3'}
+      d2 = {"f1" => 'vv1', "f2" => 'vv2', "f3" => 'vv3'}
+      data = [d1.to_json + "\n", d2.to_json + "\n"].join
+      @c.concat(data, 2)
+
+      assert_equal (d1.to_json + "\n" + d2.to_json + "\n").bytesize, @c.bytesize
+      assert_equal 2, @c.size
+
+      @c.rollback
+
+      assert @c.empty?
+      assert_equal '', File.read(@c.path)
+
+      d1 = {"f1" => 'v1', "f2" => 'v2', "f3" => 'v3'}
+      d2 = {"f1" => 'vv1', "f2" => 'vv2', "f3" => 'vv3'}
+      data = [d1.to_json + "\n", d2.to_json + "\n"]
+      @c.append(data)
+      @c.commit
+
+      assert_equal (d1.to_json + "\n" + d2.to_json + "\n").bytesize, @c.bytesize
+      assert_equal 2, @c.size
+
+      first_bytesize = @c.bytesize
+      d3 = {"f1" => 'x', "f2" => 'y', "f3" => 'z'}
+      d4 = {"f1" => 'a', "f2" => 'b', "f3" => 'c'}
+      @c.concat([d3.to_json + "\n", d4.to_json + "\n"].join, 2)
+
+      assert_equal first_bytesize + (d3.to_json + "\n" + d4.to_json + "\n").bytesize, @c.bytesize
+      assert_equal 4, @c.size
+
+      @c.rollback
+
+      assert_equal first_bytesize, @c.bytesize
+      assert_equal 2, @c.size
+      assert_equal (d1.to_json + "\n" + d2.to_json + "\n"), File.read(@c.path)
+    end
+
+    test 'can store its data by #close' do
+      d1 = {"f1" => 'v1', "f2" => 'v2', "f3" => 'v3'}
+      d2 = {"f1" => 'vv1', "f2" => 'vv2', "f3" => 'vv3'}
+      data = [d1.to_json + "\n", d2.to_json + "\n"]
+      @c.append(data)
+      @c.commit
+      d3 = {"f1" => 'x', "f2" => 'y', "f3" => 'z'}
+      d4 = {"f1" => 'a', "f2" => 'b', "f3" => 'c'}
+      @c.append([d3.to_json + "\n", d4.to_json + "\n"])
+      @c.commit
+      content = @c.read
+      @c.close
+
+      assert_equal content, File.read(@c.path)
+    end
+
+    test 'deletes all data by #purge' do
+      d1 = {"f1" => 'v1', "f2" => 'v2', "f3" => 'v3'}
+      d2 = {"f1" => 'vv1', "f2" => 'vv2', "f3" => 'vv3'}
+      data = [d1.to_json + "\n", d2.to_json + "\n"]
+      @c.append(data)
+      @c.commit
+      d3 = {"f1" => 'x', "f2" => 'y', "f3" => 'z'}
+      d4 = {"f1" => 'a', "f2" => 'b', "f3" => 'c'}
+      @c.append([d3.to_json + "\n", d4.to_json + "\n"])
+      @c.commit
+      @c.purge
+
+      assert @c.empty?
+      assert_equal 0, @c.bytesize
+      assert_equal 0, @c.size
+      assert !File.exist?(@c.path)
+    end
+
+    test 'can #open its contents as io' do
+      d1 = {"f1" => 'v1', "f2" => 'v2', "f3" => 'v3'}
+      d2 = {"f1" => 'vv1', "f2" => 'vv2', "f3" => 'vv3'}
+      data = [d1.to_json + "\n", d2.to_json + "\n"]
+      @c.append(data)
+      @c.commit
+      d3 = {"f1" => 'x', "f2" => 'y', "f3" => 'z'}
+      d4 = {"f1" => 'a', "f2" => 'b', "f3" => 'c'}
+      @c.append([d3.to_json + "\n", d4.to_json + "\n"])
+      @c.commit
+
+      lines = []
+      @c.open do |io|
+        assert io
+        io.readlines.each do |l|
+          lines << l
+        end
+      end
+
+      assert_equal d1.to_json + "\n", lines[0]
+      assert_equal d2.to_json + "\n", lines[1]
+      assert_equal d3.to_json + "\n", lines[2]
+      assert_equal d4.to_json + "\n", lines[3]
+    end
+
+    test 'can refer system config for file permission' do
+      omit "NTFS doesn't support UNIX like permissions" if Fluent.windows?
+
+      chunk_path = File.join(@chunkdir, 'fsb.*.buf')
+      Fluent::SystemConfig.overwrite_system_config("file_permission" => "600") do
+        c = Fluent::Plugin::Buffer::FileSingleChunk.new(gen_metadata, chunk_path, :create, nil)
+        assert{ File.stat(c.path).mode.to_s(8).end_with?('600') }
+      end
+    end
+  end
+
+  sub_test_case 'chunk with file for staged chunk' do
+    setup do
+      @chunk_id = gen_test_chunk_id
+      @staged_path = File.join(@chunkdir, "fsb.testing.b#{hex_id(@chunk_id)}.buf")
+      @enqueued_path = File.join(@chunkdir, "fsb.testing.q#{hex_id(@chunk_id)}.buf")
+
+      @d1 = {"k" => "x", "f1" => 'v1', "f2" => 'v2', "f3" => 'v3'}
+      @d2 = {"k" => "x", "f1" => 'vv1', "f2" => 'vv2', "f3" => 'vv3'}
+      @d3 = {"k" => "x", "f1" => 'x', "f2" => 'y', "f3" => 'z'}
+      @d4 = {"k" => "x", "f1" => 'a', "f2" => 'b', "f3" => 'c'}
+      @d = [@d1, @d2, @d3, @d4].map{ |d| d.to_json + "\n" }.join
+      File.write(@staged_path, @d, :mode => 'wb')
+
+      @c = Fluent::Plugin::Buffer::FileSingleChunk.new(gen_metadata, @staged_path, :staged, nil)
+    end
+
+    teardown do
+      if @c
+        @c.purge rescue nil
+      end
+      [@staged_path, @enqueued_path].each do |path|
+        File.unlink(path) if File.exist?(path)
+      end
+    end
+
+    test 'can load as staged chunk from file with metadata' do
+      assert_equal @staged_path, @c.path
+      assert_equal :staged, @c.state
+
+      assert_nil @c.metadata.timekey
+      assert_equal 'testing', @c.metadata.tag
+      assert_nil @c.metadata.variables
+      assert_equal 0, @c.size
+      assert_equal @d, @c.read
+    end
+
+    test 'can be enqueued' do
+      stage_path = @c.path
+      queue_path = @enqueued_path
+      assert File.exist?(stage_path)
+      assert !File.exist?(queue_path)
+
+      @c.enqueued!
+
+      assert_equal queue_path, @c.path
+      assert !File.exist?(stage_path)
+      assert File.exist?(queue_path)
+
+      assert_nil @c.metadata.timekey
+      assert_equal 'testing', @c.metadata.tag
+      assert_nil @c.metadata.variables
+
+      assert_equal 0, @c.size
+      assert_equal @d, File.read(@c.path)
+    end
+
+    test '#file_rename can rename chunk files even in windows, and call callback with file size' do
+      data = "aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbccccccccccccccccccccccccccccc"
+
+      testing_file1 = gen_path('rename1.test')
+      testing_file2 = gen_path('rename2.test')
+      f = File.open(testing_file1, 'wb', @c.permission)
+      f.set_encoding(Encoding::ASCII_8BIT)
+      f.sync = true
+      f.binmode
+      f.write data
+      pos = f.pos
+
+      assert f.binmode?
+      assert f.sync
+      assert_equal data.bytesize, f.size
+
+      io = nil
+      @c.file_rename(f, testing_file1, testing_file2, ->(new_io){ io = new_io })
+      assert io
+      if Fluent.windows?
+        assert { f != io }
+      else
+        assert_equal f, io
+      end
+      assert_equal Encoding::ASCII_8BIT, io.external_encoding
+      assert io.sync
+      assert io.binmode?
+      assert_equal data.bytesize, io.size
+      assert_equal pos, io.pos
+      assert_equal '', io.read
+
+      io.rewind
+      assert_equal data, io.read
+    end
+  end
+
+  sub_test_case 'chunk with file for enqueued chunk' do
+    setup do
+      @chunk_id = gen_test_chunk_id
+      @enqueued_path = File.join(@chunkdir, "fsb.testing.q#{hex_id(@chunk_id)}.buf")
+
+      @d1 = {"k" => "x", "f1" => 'v1', "f2" => 'v2', "f3" => 'v3'}
+      @d2 = {"k" => "x", "f1" => 'vv1', "f2" => 'vv2', "f3" => 'vv3'}
+      @d3 = {"k" => "x", "f1" => 'x', "f2" => 'y', "f3" => 'z'}
+      @d4 = {"k" => "x", "f1" => 'a', "f2" => 'b', "f3" => 'c'}
+      @d = [@d1, @d2, @d3, @d4].map { |d| d.to_json + "\n" }.join
+      File.write(@enqueued_path, @d, :mode => 'wb')
+
+      @c = Fluent::Plugin::Buffer::FileSingleChunk.new(gen_metadata, @enqueued_path, :queued, nil)
+    end
+
+    teardown do
+      if @c
+        @c.purge rescue nil
+      end
+      File.unlink(@enqueued_path) if File.exist?(@enqueued_path)
+    end
+
+    test 'can load as queued chunk (read only) with metadata' do
+      assert @c
+      assert_equal @chunk_id, @c.unique_id
+      assert_equal :queued, @c.state
+      stat = File.stat(@enqueued_path)
+      assert_equal stat.ctime.to_i, @c.created_at.to_i
+      assert_equal stat.mtime.to_i, @c.modified_at.to_i
+      assert_equal 0, @c.size
+      assert_equal @d.bytesize, @c.bytesize
+      assert_equal @d, @c.read
+
+      assert_raise RuntimeError.new("BUG: concatenating to unwritable chunk, now 'queued'") do
+        @c.append(["queued chunk is read only"])
+      end
+      assert_raise IOError do
+        @c.instance_eval{ @chunk }.write "chunk io is opened as read only"
+      end
+    end
+  end
+
+  sub_test_case 'chunk with queued chunk file' do
+    setup do
+      @chunk_id = gen_test_chunk_id
+      @chunk_path = File.join(@chunkdir, "fsb.testing.q#{hex_id(@chunk_id)}.buf")
+
+      @d1 = {"k" => "x", "f1" => 'v1', "f2" => 'v2', "f3" => 'v3'}
+      @d2 = {"k" => "x", "f1" => 'vv1', "f2" => 'vv2', "f3" => 'vv3'}
+      @d3 = {"k" => "x", "f1" => 'x', "f2" => 'y', "f3" => 'z'}
+      @d4 = {"k" => "x", "f1" => 'a', "f2" => 'b', "f3" => 'c'}
+      @d = [@d1, @d2, @d3, @d4].map { |d| d.to_json + "\n" }.join
+      File.write(@chunk_path, @d, :mode => 'wb')
+
+      @c = Fluent::Plugin::Buffer::FileSingleChunk.new(gen_metadata, @chunk_path, :queued, nil)
+    end
+
+    teardown do
+      if @c
+        @c.purge rescue nil
+      end
+      File.unlink(@chunk_path) if File.exist?(@chunk_path)
+    end
+
+    test 'can load as queued chunk from file without metadata' do
+      assert @c
+      assert_equal :queued, @c.state
+      assert_equal @chunk_id, @c.unique_id
+      assert_equal gen_metadata, @c.metadata
+      assert_equal @d.bytesize, @c.bytesize
+      assert_equal 0, @c.size
+      assert_equal @d, @c.read
+
+      assert_raise RuntimeError.new("BUG: concatenating to unwritable chunk, now 'queued'") do
+        @c.append(["queued chunk is read only"])
+      end
+      assert_raise IOError do
+        @c.instance_eval{ @chunk }.write "chunk io is opened as read only"
+      end
+    end
+  end
+
+  sub_test_case 'compressed buffer' do
+    setup do
+      @src = 'text data for compressing' * 5
+      @gzipped_src = compress(@src)
+    end
+
+    test '#append with compress option writes  compressed data to chunk when compress is gzip' do
+      c = @klass.new(gen_metadata, File.join(@chunkdir,'fsb.*.buf'), :create, nil, compress: :gzip)
+      c.append([@src, @src], compress: :gzip)
+      c.commit
+
+      # check chunk is compressed
+      assert c.read(compressed: :gzip).size < [@src, @src].join("").size
+
+      assert_equal @src + @src, c.read
+    end
+
+    test '#open passes io object having decompressed data to a block when compress is gzip' do
+      c = @klass.new(gen_metadata, File.join(@chunkdir,'fsb.*.buf'), :create, nil, compress: :gzip)
+      c.concat(@gzipped_src, @src.size)
+      c.commit
+
+      decomressed_data = c.open do |io|
+        v = io.read
+        assert_equal @src, v
+        v
+      end
+      assert_equal @src, decomressed_data
+    end
+
+    test '#open with compressed option passes io object having decompressed data to a block when compress is gzip' do
+      c = @klass.new(gen_metadata, File.join(@chunkdir,'fsb.*.buf'), :create, nil, compress: :gzip)
+      c.concat(@gzipped_src, @src.size)
+      c.commit
+
+      comressed_data = c.open(compressed: :gzip) do |io|
+        v = io.read
+        assert_equal @gzipped_src, v
+        v
+      end
+      assert_equal @gzipped_src, comressed_data
+    end
+
+    test '#write_to writes decompressed data when compress is gzip' do
+      c = @klass.new(gen_metadata, File.join(@chunkdir,'fsb.*.buf'), :create, nil, compress: :gzip)
+      c.concat(@gzipped_src, @src.size)
+      c.commit
+
+      assert_equal @src, c.read
+      assert_equal @gzipped_src, c.read(compressed: :gzip)
+
+      io = StringIO.new
+      c.write_to(io)
+      assert_equal @src, io.string
+    end
+
+    test '#write_to with compressed option writes compressed data when compress is gzip' do
+      c = @klass.new(gen_metadata, File.join(@chunkdir,'fsb.*.buf'), :create, nil, compress: :gzip)
+      c.concat(@gzipped_src, @src.size)
+      c.commit
+
+      assert_equal @src, c.read
+      assert_equal @gzipped_src, c.read(compressed: :gzip)
+
+      io = StringIO.new
+      c.write_to(io, compressed: :gzip)
+      assert_equal @gzipped_src, io.string
+    end
+  end
+end

--- a/test/plugin/test_buffer_file_single_chunk.rb
+++ b/test/plugin/test_buffer_file_single_chunk.rb
@@ -83,8 +83,12 @@ class BufferFileSingleChunkTest < Test::Unit::TestCase
       )
     end
 
-    test '.unique_id_and_key_from_path recreates unique_id and key from file path' do
-      assert_equal [gen_test_chunk_id, 'test.log'], @klass.unique_id_and_key_from_path(gen_path("fsb.test.log.q52fde6425d7406bdb19b936e1a1ba98c.buf"))
+    data('1 word tag' => 'foo',
+         '2 words tag' => 'test.log',
+         'empty' => '')
+    test '.unique_id_and_key_from_path recreates unique_id and key from file path' do |key|
+      path = @klass.unique_id_and_key_from_path(gen_path("fsb.#{key}.q52fde6425d7406bdb19b936e1a1ba98c.buf"))
+      assert_equal [gen_test_chunk_id, key], path
     end
   end
 

--- a/test/plugin/test_buffer_file_single_chunk.rb
+++ b/test/plugin/test_buffer_file_single_chunk.rb
@@ -6,7 +6,6 @@ require 'fluent/unique_id'
 require 'fileutils'
 require 'msgpack'
 require 'time'
-require 'timecop'
 
 class BufferFileSingleChunkTest < Test::Unit::TestCase
   include Fluent::Plugin::Compressable
@@ -16,10 +15,6 @@ class BufferFileSingleChunkTest < Test::Unit::TestCase
     @chunkdir = File.expand_path('../../tmp/buffer_file_single_chunk', __FILE__)
     FileUtils.rm_r(@chunkdir) rescue nil
     FileUtils.mkdir_p(@chunkdir)
-  end
-
-  teardown do
-    Timecop.return
   end
 
   Metadata = Struct.new(:timekey, :tag, :variables)
@@ -114,7 +109,7 @@ class BufferFileSingleChunkTest < Test::Unit::TestCase
     end
 
     test 'creates new files for chunk and metadata with specified path & permission' do
-      assert { @c.unique_id.size == 16 }
+      assert_equal 16, @c.unique_id.size
       assert_equal gen_chunk_path('b', @c.unique_id), @c.path
 
       assert File.exist?(gen_chunk_path('b', @c.unique_id))


### PR DESCRIPTION

**Which issue(s) this PR fixes**: 
Ref https://github.com/fluent/fluentd/issues/2153

**What this PR does / why we need it**: 
`buf_file` works fine for typical cases, e.g. `in_tail`/`in_forward`, but it is not good for lots of small emit cases. It issues lots of IO operation.
So to reduce IO tps on high traffic environment, introduce `buf_file_single`. This is similar to v0.12 buf_file and this is lightweight. 

`buf_file_single` has one limitation that supports only tag or one field chunk key, `<buffer tag>` or `<buffer key>`. This limitation will be relaxed by supporting metadata header in the file.

**Docs Changes**:
Add `buf_file_single` article. Will send a patch later.

**Release Note**: 
Same as title