### PR TITLE
buf_file/buf_file_single: fix to ignore placeholder based path. fix #2582

### DIFF
--- a/lib/fluent/plugin/buf_file.rb
+++ b/lib/fluent/plugin/buf_file.rb
@@ -132,7 +132,7 @@ module Fluent
 
         patterns = [@path]
         patterns.unshift @additional_resume_path if @additional_resume_path
-        Dir.glob(patterns) do |path|
+        Dir.glob(escaped_patterns(patterns)) do |path|
           next unless File.file?(path)
 
           log.debug { "restoring buffer file: path = #{path}" }
@@ -182,6 +182,15 @@ module Fluent
         log.error "found broken chunk file during resume. Deleted corresponding files:", :path => path, :mode => mode, :err_msg => e.message
         # After support 'backup_dir' feature, these files are moved to backup_dir instead of unlink.
         File.unlink(path, path + '.meta') rescue nil
+      end
+
+      private
+
+      def escaped_patterns(patterns)
+        patterns.map { |pattern|
+          # '{' '}' are special character in Dir.glob
+          pattern.gsub(/[\{\}]/) { |c| "\\#{c}" }
+        }
       end
     end
   end

--- a/lib/fluent/plugin/buf_file_single.rb
+++ b/lib/fluent/plugin/buf_file_single.rb
@@ -155,7 +155,7 @@ module Fluent
 
         patterns = [@path]
         patterns.unshift @additional_resume_path if @additional_resume_path
-        Dir.glob(patterns) do |path|
+        Dir.glob(escaped_patterns(patterns)) do |path|
           next unless File.file?(path)
 
           log.debug { "restoring buffer file: path = #{path}" }
@@ -205,6 +205,15 @@ module Fluent
         log.error "found broken chunk file during resume. Delete corresponding files:", path: path, mode: mode, err_msg: e.message
         # After support 'backup_dir' feature, these files are moved to backup_dir instead of unlink.
         File.unlink(path) rescue nil
+      end
+
+      private
+
+      def escaped_patterns(patterns)
+        patterns.map { |pattern|
+          # '{' '}' are special character in Dir.glob
+          pattern.gsub(/[\{\}]/) { |c| "\\#{c}" }
+        }
       end
     end
   end

--- a/test/plugin/test_buf_file_single.rb
+++ b/test/plugin/test_buf_file_single.rb
@@ -502,6 +502,54 @@ class FileSingleBufferTest < Test::Unit::TestCase
     end
   end
 
+  sub_test_case 'there are some existing file chunks with placeholders path' do
+    setup do
+      @buf_ph_dir = File.expand_path('../../tmp/buffer_${test}_file_single_dir', __FILE__)
+      FileUtils.rm_rf(@buf_ph_dir)
+      FileUtils.mkdir_p(@buf_ph_dir)
+
+      @c1id = Fluent::UniqueId.generate
+      p1 = File.join(@buf_ph_dir, "fsb.testing.q#{Fluent::UniqueId.hex(@c1id)}.buf")
+      File.open(p1, 'wb') do |f|
+        f.write ["t1.test", event_time('2016-04-17 13:58:15 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+      end
+      t = Time.now - 50000
+      File.utime(t, t, p1)
+
+      @c2id = Fluent::UniqueId.generate
+      p2 = File.join(@buf_ph_dir, "fsb.testing.b#{Fluent::UniqueId.hex(@c2id)}.buf")
+      File.open(p2, 'wb') do |f|
+        f.write ["t1.test", event_time('2016-04-17 14:00:15 -0700').to_i, {"message" => "yay"}].to_json + "\n"
+      end
+    end
+
+    teardown do
+      if @p
+        @p.stop unless @p.stopped?
+        @p.before_shutdown unless @p.before_shutdown?
+        @p.shutdown unless @p.shutdown?
+        @p.after_shutdown unless @p.after_shutdown?
+        @p.close unless @p.closed?
+        @p.terminate unless @p.terminated?
+      end
+      FileUtils.rm_rf(@buf_ph_dir)
+    end
+
+    test '#resume returns staged/queued chunks with metadata' do
+      @d = create_driver(%[
+        <buffer tag>
+          @type file_single
+          path #{@buf_ph_dir}
+        </buffer>
+      ])
+      @p = @d.instance.buffer
+      @p.start
+
+      assert_equal 1, @p.stage.size
+      assert_equal 1, @p.queue.size
+    end
+  end
+
   sub_test_case 'there are some existing msgpack file chunks' do
     setup do
       packer = Fluent::MessagePackFactory.packer


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

**Which issue(s) this PR fixes**: 
Fixes #2582 

**What this PR does / why we need it**: 
fluentd uses `{` and `}` for placeholders and these characters are special in `Dir.glob`.
Should be escaped before call `Dir.glob`.

**Docs Changes**:
No need.

**Release Note**: 
Same as title.