### PR TITLE
server helper: Ignore ETIMEDOUT error in SSL_accept. fix #2592

### DIFF
--- a/lib/fluent/plugin_helper/server.rb
+++ b/lib/fluent/plugin_helper/server.rb
@@ -722,7 +722,7 @@ module Fluent
 
                 return true
               end
-            rescue Errno::EPIPE, Errno::ECONNRESET, OpenSSL::SSL::SSLError => e
+            rescue Errno::EPIPE, Errno::ECONNRESET, Errno::ETIMEDOUT, OpenSSL::SSL::SSLError => e
               @log.trace "unexpected error before accepting TLS connection", error: e
               close rescue nil
             end


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

**Which issue(s) this PR fixes**: 
Fixes #2548 #2592 

**What this PR does / why we need it**: 
I'm not sure when `SSL_accept` raises ETIMEDOUT but thread should not be died.
fluentd can't recover timedout socket so just ignore.

**Docs Changes**:
No need.

**Release Note**: 
Same as title.