### PR TITLE
Implement new parser for parser_syslog

### DIFF
--- a/lib/fluent/plugin/parser_syslog.rb
+++ b/lib/fluent/plugin/parser_syslog.rb
@@ -38,6 +38,10 @@ module Fluent
       config_param :message_format, :enum, list: [:rfc3164, :rfc5424, :auto], default: :rfc3164
       desc 'Specify time format for event time for rfc5424 protocol'
       config_param :rfc5424_time_format, :string, default: "%Y-%m-%dT%H:%M:%S.%L%z"
+      desc 'The parser type used to parse syslog message'
+      config_param :parser_type, :enum, list: [:regexp, :string], default: :regexp
+      desc 'support colonless ident in string parser'
+      config_param :support_colonless_ident, :bool, default: true
 
       def initialize
         super
@@ -50,10 +54,17 @@ module Fluent
         @time_parser_rfc3164 = @time_parser_rfc5424 = nil
         @time_parser_rfc5424_without_subseconds = nil
         @support_rfc5424_without_subseconds = false
+        @regexp_parser = @parser_type == :regexp
         @regexp = case @message_format
                   when :rfc3164
-                    class << self
-                      alias_method :parse, :parse_plain
+                    if @regexp_parser
+                      class << self
+                        alias_method :parse, :parse_plain
+                      end
+                    else
+                      class << self
+                        alias_method :parse, :parse_rfc3164
+                      end
                     end
                     @with_priority ? REGEXP_WITH_PRI : REGEXP
                   when :rfc5424
@@ -88,11 +99,16 @@ module Fluent
           @regexp = @with_priority ? REGEXP_RFC5424_WITH_PRI : REGEXP_RFC5424
           @time_parser = @time_parser_rfc5424
           @support_rfc5424_without_subseconds = true
+          parse_plain(text, &block)
         else
           @regexp = @with_priority ? REGEXP_WITH_PRI : REGEXP
           @time_parser = @time_parser_rfc3164
+          if @regexp_parser
+            parse_plain(text, &block)
+          else
+            parse_rfc3164(text, &block)
+          end
         end
-        parse_plain(text, &block)
       end
 
       def parse_plain(text, &block)
@@ -134,6 +150,91 @@ module Fluent
         if @estimate_current_event
           time ||= Fluent::EventTime.now
         end
+
+        yield time, record
+      end
+
+      SPLIT_CHAR = ' '.freeze
+      PRI_START_CHAR = '<'.freeze
+
+      def parse_rfc3164(text, &block)
+        pri = nil
+        start = 0
+        if @with_priority
+          if text.start_with?(PRI_START_CHAR)
+            i = text.index('>'.freeze, 1)
+            pri = text.slice(1, i - 1).to_i
+            start = i + 1
+          else
+            yield nil, nil
+            return
+          end
+        end
+
+        # header part
+        diff = 15 # skip Mmm dd hh:mm:ss
+        time_end = text[start + diff]
+        if time_end == SPLIT_CHAR
+          time_str = text.slice(start, diff)
+          start += 16 # time + ' '
+        elsif time_end == '.'.freeze
+          # support subsecond time
+          i = text.index(SPLIT_CHAR, diff)
+          time_str = text.slice(start, i - start)
+          start = i + 1
+        else
+          yield nil, nil
+          return
+        end
+
+        i = text.index(SPLIT_CHAR, start)
+        if i.nil?
+          yield nil, nil
+          return
+        end
+        diff = i - start
+        host = text.slice(start, diff)
+        start += (diff + 1)
+
+        i = text.index(SPLIT_CHAR, start)
+        if i.nil?
+          yield nil, nil
+          return
+        end
+        diff = i - start
+
+        record = {'host' => host}
+        record['pri'] = pri if pri
+
+        # message part
+        msg = if text[i - 1] == ':'.freeze
+                if text[i - 2] == ']'.freeze
+                  j = text.index('['.freeze, start)
+                  record['ident'] = text.slice(start, j - start)
+                  record['pid'] = text.slice(j + 1, i - j - 3) # remove '[' / ']:'
+                else
+                  record['ident'] = text.slice(start, i - start - 1)
+                end
+                text.slice(i + 1, text.bytesize)
+              else
+                if @support_colonless_ident
+                  if text[i - 1] == ']'.freeze
+                    j = text.index('['.freeze, start)
+                    record['ident'] = text.slice(start, j - start)
+                    record['pid'] = text.slice(j + 1, i - j - 2) # remove '[' / ']'
+                  else
+                    record['ident'] = text.slice(start, i - start)
+                  end
+                  text.slice(i + 1, text.bytesize)
+                else
+                  text.slice(i - diff, text.bytesize)
+                end
+              end
+        msg.chomp!
+        record['message'] = msg
+
+        time = @time_parser.parse(time_str.squeeze(SPLIT_CHAR))
+        record['time'] = time_str if @keep_time_key
 
         yield time, record
       end

--- a/lib/fluent/plugin/parser_syslog.rb
+++ b/lib/fluent/plugin/parser_syslog.rb
@@ -175,14 +175,14 @@ module Fluent
         end
 
         # header part
-        time_diff = 15 # skip Mmm dd hh:mm:ss
-        time_end = text[cursor + time_diff]
+        time_size = 15 # skip Mmm dd hh:mm:ss
+        time_end = text[cursor + time_size]
         if time_end == SPLIT_CHAR
-          time_str = text.slice(cursor, time_diff)
+          time_str = text.slice(cursor, time_size)
           cursor += 16 # time + ' '
         elsif time_end == '.'.freeze
           # support subsecond time
-          i = text.index(SPLIT_CHAR, time_diff)
+          i = text.index(SPLIT_CHAR, time_size)
           time_str = text.slice(cursor, i - cursor)
           cursor = i + 1
         else
@@ -195,9 +195,9 @@ module Fluent
           yield nil, nil
           return
         end
-        host_diff = i - cursor
-        host = text.slice(cursor, host_diff)
-        cursor += (host_diff + 1)
+        host_size = i - cursor
+        host = text.slice(cursor, host_size)
+        cursor += host_size + 1
 
         record = {'host' => host}
         record['pri'] = pri if pri
@@ -210,9 +210,9 @@ module Fluent
               else
                 if text[i - 1] == ':'.freeze
                   if text[i - 2] == ']'.freeze
-                    j = text.index('['.freeze, cursor)
-                    record['ident'] = text.slice(cursor, j - cursor)
-                    record['pid'] = text.slice(j + 1, i - j - 3) # remove '[' / ']:'
+                    left_braket_pos = text.index('['.freeze, cursor)
+                    record['ident'] = text.slice(cursor, left_braket_pos - cursor)
+                    record['pid'] = text.slice(left_braket_pos + 1, i - left_braket_pos - 3) # remove '[' / ']:'
                   else
                     record['ident'] = text.slice(cursor, i - cursor - 1)
                   end
@@ -220,9 +220,9 @@ module Fluent
                 else
                   if @support_colonless_ident
                     if text[i - 1] == ']'.freeze
-                      j = text.index('['.freeze, cursor)
-                      record['ident'] = text.slice(cursor, j - cursor)
-                      record['pid'] = text.slice(j + 1, i - j - 2) # remove '[' / ']'
+                      left_braket_pos = text.index('['.freeze, cursor)
+                      record['ident'] = text.slice(cursor, left_braket_pos - cursor)
+                      record['pid'] = text.slice(left_braket_pos + 1, i - left_braket_pos - 2) # remove '[' / ']'
                     else
                       record['ident'] = text.slice(cursor, i - cursor)
                     end

--- a/lib/fluent/plugin/parser_syslog.rb
+++ b/lib/fluent/plugin/parser_syslog.rb
@@ -232,7 +232,7 @@ module Fluent
         msg.chomp!
         record['message'] = msg
 
-        time = @time_parser.parse(time_str.squeeze(SPLIT_CHAR))
+        time = @time_parser.parse(time_str)
         record['time'] = time_str if @keep_time_key
 
         yield time, record

--- a/lib/fluent/plugin/parser_syslog.rb
+++ b/lib/fluent/plugin/parser_syslog.rb
@@ -155,14 +155,17 @@ module Fluent
       end
 
       SPLIT_CHAR = ' '.freeze
-      PRI_START_CHAR = '<'.freeze
 
       def parse_rfc3164(text, &block)
         pri = nil
         cursor = 0
         if @with_priority
-          if text.start_with?(PRI_START_CHAR)
+          if text.start_with?('<'.freeze)
             i = text.index('>'.freeze, 1)
+            if i < 2
+              yield nil, nil
+              return
+            end
             pri = text.slice(1, i - 1).to_i
             cursor = i + 1
           else

--- a/lib/fluent/plugin/parser_syslog.rb
+++ b/lib/fluent/plugin/parser_syslog.rb
@@ -200,34 +200,33 @@ module Fluent
         record['pri'] = pri if pri
 
         i = text.index(SPLIT_CHAR, cursor)
-        if i.nil?
-          yield nil, nil
-          return
-        end
-        diff = i - cursor
 
         # message part
-        msg = if text[i - 1] == ':'.freeze
-                if text[i - 2] == ']'.freeze
-                  j = text.index('['.freeze, cursor)
-                  record['ident'] = text.slice(cursor, j - cursor)
-                  record['pid'] = text.slice(j + 1, i - j - 3) # remove '[' / ']:'
-                else
-                  record['ident'] = text.slice(cursor, i - cursor - 1)
-                end
-                text.slice(i + 1, text.bytesize)
+        msg = if i.nil?  # for 'only non-space content case'
+                text.slice(cursor, text.bytesize)
               else
-                if @support_colonless_ident
-                  if text[i - 1] == ']'.freeze
+                if text[i - 1] == ':'.freeze
+                  if text[i - 2] == ']'.freeze
                     j = text.index('['.freeze, cursor)
                     record['ident'] = text.slice(cursor, j - cursor)
-                    record['pid'] = text.slice(j + 1, i - j - 2) # remove '[' / ']'
+                    record['pid'] = text.slice(j + 1, i - j - 3) # remove '[' / ']:'
                   else
-                    record['ident'] = text.slice(cursor, i - cursor)
+                    record['ident'] = text.slice(cursor, i - cursor - 1)
                   end
                   text.slice(i + 1, text.bytesize)
                 else
-                  text.slice(cursor, text.bytesize)
+                  if @support_colonless_ident
+                    if text[i - 1] == ']'.freeze
+                      j = text.index('['.freeze, cursor)
+                      record['ident'] = text.slice(cursor, j - cursor)
+                      record['pid'] = text.slice(j + 1, i - j - 2) # remove '[' / ']'
+                    else
+                      record['ident'] = text.slice(cursor, i - cursor)
+                    end
+                    text.slice(i + 1, text.bytesize)
+                  else
+                    text.slice(cursor, text.bytesize)
+                  end
                 end
               end
         msg.chomp!

--- a/test/plugin/test_parser_syslog.rb
+++ b/test/plugin/test_parser_syslog.rb
@@ -116,19 +116,19 @@ class SyslogParserTest < ::Test::Unit::TestCase
       }
     end
 
-    data('regexp' => 'regexp', 'string' => 'string')
-    test "both parsers can't parse broken syslog message" do |param|
-      @parser.configure('parser_type' => param)
-      if param == 'string'
-        @parser.instance.parse("1990 Oct 22 10:52:01 TZ-6 scapegoat.dmz.example.org 10.1.2.32 sched[0]: That's All Folks!") { |time, record|
-          expected = {'host' => 'scapegoat.dmz.example.org', 'ident' => 'sched', 'pid' => '0', 'message' => "That's All Folks!"}
-          assert_not_equal(expected, record)
-        }
-      else
-        assert_raise(Fluent::TimeParser::TimeParseError) {
-          @parser.instance.parse("1990 Oct 22 10:52:01 TZ-6 scapegoat.dmz.example.org 10.1.2.32 sched[0]: That's All Folks!") { |time, record| }
-        }
-      end
+    test "string parsers can't parse broken syslog message and generate wrong record" do
+      @parser.configure('parser_type' => 'string')
+      @parser.instance.parse("1990 Oct 22 10:52:01 TZ-6 scapegoat.dmz.example.org 10.1.2.32 sched[0]: That's All Folks!") { |time, record|
+        expected = {'host' => 'scapegoat.dmz.example.org', 'ident' => 'sched', 'pid' => '0', 'message' => "That's All Folks!"}
+        assert_not_equal(expected, record)
+      }
+    end
+
+    test "regexp parsers can't parse broken syslog message and raises an error" do
+      @parser.configure('parser_type' => 'regexp')
+      assert_raise(Fluent::TimeParser::TimeParseError) {
+        @parser.instance.parse("1990 Oct 22 10:52:01 TZ-6 scapegoat.dmz.example.org 10.1.2.32 sched[0]: That's All Folks!") { |time, record| }
+      }
     end
 
     data('regexp' => 'regexp', 'string' => 'string')

--- a/test/plugin/test_parser_syslog.rb
+++ b/test/plugin/test_parser_syslog.rb
@@ -56,6 +56,15 @@ class SyslogParserTest < ::Test::Unit::TestCase
   end
 
   data('regexp' => 'regexp', 'string' => 'string')
+  def test_parse_with_empty_priority(param)
+    @parser.configure('with_priority' => true, 'parser_type' => param)
+    @parser.instance.parse('<>Feb 28 12:00:00 192.168.0.1 fluentd[11111]: [error] Syslog test') { |time, record|
+      assert_nil time
+      assert_nil record
+    }
+  end
+
+  data('regexp' => 'regexp', 'string' => 'string')
   def test_parse_without_colon(param)
     @parser.configure({'parser_type' => param})
     @parser.instance.parse('Feb 28 12:00:00 192.168.0.1 fluentd[11111] [error] Syslog test') { |time, record|

--- a/test/plugin/test_parser_syslog.rb
+++ b/test/plugin/test_parser_syslog.rb
@@ -143,6 +143,21 @@ class SyslogParserTest < ::Test::Unit::TestCase
         end
       }
     end
+
+    data('regexp' => 'regexp', 'string' => 'string')
+    test "Only no whitespace content in MSG causes different result" do |param|
+      @parser.configure('parser_type' => param)
+      @parser.instance.parse('Aug 10 12:00:00 127.0.0.1 value1,value2,value3,value4') { |time, record|
+        # 'message' is correct but regexp set it as 'ident'
+        if param == 'string'
+          expected = {'host' => '127.0.0.1', 'message' => 'value1,value2,value3,value4'}
+          assert_equal(expected, record)
+        else
+          expected = {'host' => '127.0.0.1', 'ident' => 'value1,value2,value3,value4', 'message' => ''}
+          assert_equal(expected, record)
+        end
+      }
+    end
   end
 
   class TestRFC5424Regexp < self

--- a/test/plugin/test_parser_syslog.rb
+++ b/test/plugin/test_parser_syslog.rb
@@ -14,8 +14,9 @@ class SyslogParserTest < ::Test::Unit::TestCase
     }
   end
 
-  def test_parse
-    @parser.configure({})
+  data('regexp' => 'regexp', 'string' => 'string')
+  def test_parse(param)
+    @parser.configure({'parser_type' => param})
     @parser.instance.parse('Feb 28 12:00:00 192.168.0.1 fluentd[11111]: [error] Syslog test') { |time, record|
       assert_equal(event_time('Feb 28 12:00:00', format: '%b %d %H:%M:%S'), time)
       assert_equal(@expected, record)
@@ -24,8 +25,9 @@ class SyslogParserTest < ::Test::Unit::TestCase
     assert_equal("%b %d %H:%M:%S", @parser.instance.patterns['time_format'])
   end
 
-  def test_parse_with_time_format
-    @parser.configure('time_format' => '%b %d %M:%S:%H')
+  data('regexp' => 'regexp', 'string' => 'string')
+  def test_parse_with_time_format(param)
+    @parser.configure('time_format' => '%b %d %M:%S:%H', 'parser_type' => param)
     @parser.instance.parse('Feb 28 00:00:12 192.168.0.1 fluentd[11111]: [error] Syslog test') { |time, record|
       assert_equal(event_time('Feb 28 12:00:00', format: '%b %d %H:%M:%S'), time)
       assert_equal(@expected, record)
@@ -33,8 +35,9 @@ class SyslogParserTest < ::Test::Unit::TestCase
     assert_equal('%b %d %M:%S:%H', @parser.instance.patterns['time_format'])
   end
 
-  def test_parse_with_priority
-    @parser.configure('with_priority' => true)
+  data('regexp' => 'regexp', 'string' => 'string')
+  def test_parse_with_priority(param)
+    @parser.configure('with_priority' => true, 'parser_type' => param)
     @parser.instance.parse('<6>Feb 28 12:00:00 192.168.0.1 fluentd[11111]: [error] Syslog test') { |time, record|
       assert_equal(event_time('Feb 28 12:00:00', format: '%b %d %H:%M:%S'), time)
       assert_equal(@expected.merge('pri' => 6), record)
@@ -43,8 +46,9 @@ class SyslogParserTest < ::Test::Unit::TestCase
     assert_equal("%b %d %H:%M:%S", @parser.instance.patterns['time_format'])
   end
 
-  def test_parse_without_colon
-    @parser.configure({})
+  data('regexp' => 'regexp', 'string' => 'string')
+  def test_parse_without_colon(param)
+    @parser.configure({'parser_type' => param})
     @parser.instance.parse('Feb 28 12:00:00 192.168.0.1 fluentd[11111] [error] Syslog test') { |time, record|
       assert_equal(event_time('Feb 28 12:00:00', format: '%b %d %H:%M:%S'), time)
       assert_equal(@expected, record)
@@ -53,10 +57,12 @@ class SyslogParserTest < ::Test::Unit::TestCase
     assert_equal("%b %d %H:%M:%S", @parser.instance.patterns['time_format'])
   end
 
-  def test_parse_with_keep_time_key
+  data('regexp' => 'regexp', 'string' => 'string')
+  def test_parse_with_keep_time_key(param)
     @parser.configure(
                       'time_format' => '%b %d %M:%S:%H',
                       'keep_time_key'=>'true',
+                      'parser_type' => param
                       )
     text = 'Feb 28 00:00:12 192.168.0.1 fluentd[11111]: [error] Syslog test'
     @parser.instance.parse(text) do |time, record|
@@ -64,18 +70,20 @@ class SyslogParserTest < ::Test::Unit::TestCase
     end
   end
 
-  def test_parse_various_characters_for_tag
+  data('regexp' => 'regexp', 'string' => 'string')
+  def test_parse_various_characters_for_tag(param)
     ident = '~!@#$%^&*()_+=-`]{};"\'/?\\,.<>'
-    @parser.configure({})
+    @parser.configure({'parser_type' => param})
     @parser.instance.parse("Feb 28 12:00:00 192.168.0.1 #{ident}[11111]: [error] Syslog test") { |time, record|
       assert_equal(event_time('Feb 28 12:00:00', format: '%b %d %H:%M:%S'), time)
       assert_equal(@expected.merge('ident' => ident), record)
     }
   end
 
-  def test_parse_various_characters_for_tag_with_priority
+  data('regexp' => 'regexp', 'string' => 'string')
+  def test_parse_various_characters_for_tag_with_priority(param)
     ident = '~!@#$%^&*()_+=-`]{};"\'/?\\,.<>'
-    @parser.configure('with_priority' => true)
+    @parser.configure('with_priority' => true, 'parser_type' => param)
     @parser.instance.parse("<6>Feb 28 12:00:00 192.168.0.1 #{ident}[11111]: [error] Syslog test") { |time, record|
       assert_equal(event_time('Feb 28 12:00:00', format: '%b %d %H:%M:%S'), time)
       assert_equal(@expected.merge('pri' => 6, 'ident' => ident), record)
@@ -273,10 +281,12 @@ class SyslogParserTest < ::Test::Unit::TestCase
   end
 
   class TestAutoRegexp < self
-    def test_auto_with_legacy_syslog_message
+    data('regexp' => 'regexp', 'string' => 'string')
+    def test_auto_with_legacy_syslog_message(param)
       @parser.configure(
                         'time_format' => '%b %d %M:%S:%H',
                         'message_format' => 'auto',
+                        'parser_type' => param
                         )
       text = 'Feb 28 00:00:12 192.168.0.1 fluentd[11111]: [error] Syslog test'
       @parser.instance.parse(text) do |time, record|
@@ -286,11 +296,13 @@ class SyslogParserTest < ::Test::Unit::TestCase
       assert_equal(Fluent::Plugin::SyslogParser::REGEXP, @parser.instance.patterns['format'])
     end
 
-    def test_auto_with_legacy_syslog_priority_message
+    data('regexp' => 'regexp', 'string' => 'string')
+    def test_auto_with_legacy_syslog_priority_message(param)
       @parser.configure(
                         'time_format' => '%b %d %M:%S:%H',
                         'with_priority' => true,
                         'message_format' => 'auto',
+                        'parser_type' => param
                         )
       text = '<6>Feb 28 12:00:00 192.168.0.1 fluentd[11111]: [error] Syslog test'
       @parser.instance.parse(text) do |time, record|
@@ -300,11 +312,13 @@ class SyslogParserTest < ::Test::Unit::TestCase
       assert_equal(Fluent::Plugin::SyslogParser::REGEXP_WITH_PRI, @parser.instance.patterns['format'])
     end
 
-    def test_parse_with_rfc5424_message
+    data('regexp' => 'regexp', 'string' => 'string')
+    def test_parse_with_rfc5424_message(param)
       @parser.configure(
                         'time_format' => '%Y-%m-%dT%H:%M:%S.%L%z',
                         'message_format' => 'auto',
                         'with_priority' => true,
+                        'parser_type' => param
                         )
       text = '<16>1 2017-02-06T13:14:15.003Z 192.168.0.1 fluentd - - - Hi, from Fluentd!'
       @parser.instance.parse(text) do |time, record|
@@ -318,11 +332,13 @@ class SyslogParserTest < ::Test::Unit::TestCase
                    @parser.instance.patterns['format'])
     end
 
-    def test_parse_with_rfc5424_structured_message
+    data('regexp' => 'regexp', 'string' => 'string')
+    def test_parse_with_rfc5424_structured_message(param)
       @parser.configure(
                         'time_format' => '%Y-%m-%dT%H:%M:%S.%L%z',
                         'message_format' => 'auto',
                         'with_priority' => true,
+                        'parser_type' => param
                         )
       text = '<16>1 2017-02-06T13:14:15.003Z 192.168.0.1 fluentd 11111 ID24224 [exampleSDID@20224 iut="3" eventSource="Application" eventID="11211"] Hi, from Fluentd!'
       @parser.instance.parse(text) do |time, record|
@@ -337,12 +353,14 @@ class SyslogParserTest < ::Test::Unit::TestCase
                    @parser.instance.patterns['format'])
     end
 
-    def test_parse_with_both_message_type
+    data('regexp' => 'regexp', 'string' => 'string')
+    def test_parse_with_both_message_type(param)
       @parser.configure(
         'time_format' => '%b %d %M:%S:%H',
         'rfc5424_time_format' => '%Y-%m-%dT%H:%M:%S.%L%z',
         'message_format' => 'auto',
         'with_priority' => true,
+        'parser_type' => param
       )
       text = '<1>Feb 28 12:00:00 192.168.0.1 fluentd[11111]: [error] Syslog test'
       @parser.instance.parse(text) do |time, record|
@@ -382,12 +400,14 @@ class SyslogParserTest < ::Test::Unit::TestCase
                    @parser.instance.patterns['format'])
     end
 
-    def test_parse_with_both_message_type_and_priority
+    data('regexp' => 'regexp', 'string' => 'string')
+    def test_parse_with_both_message_type_and_priority(param)
       @parser.configure(
                         'time_format' => '%b %d %M:%S:%H',
                         'rfc5424_time_format' => '%Y-%m-%dT%H:%M:%S.%L%z',
                         'with_priority' => true,
                         'message_format' => 'auto',
+                        'parser_type' => param
                         )
       text = '<6>Feb 28 12:00:00 192.168.0.1 fluentd[11111]: [error] Syslog test'
       @parser.instance.parse(text) do |time, record|


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

**Which issue(s) this PR fixes**: 
Fixes #2585 

**What this PR does / why we need it**: 
Changing regexp is difficult because it may break existing user environment, so
add non-regexp based parser to support more syslog message. 
This parser is also 2x faster.

```
require 'benchmark/ips'
require 'fluent/engine'
require_relative 'lib/fluent/plugin/parser_syslog'

parser = Fluent::Plugin::SyslogParser.new
parser.configure(Fluent::Config::Element.new('ROOT', '', {'keep_time_key' => true}, []))
log = 'Feb 28 12:00:00 192.168.0.1 fluentd[11111]: [error] Syslog test'
parser2 = Fluent::Plugin::SyslogParser.new
parser2.configure(Fluent::Config::Element.new('ROOT', '', {'with_priority' => true, 'keep_time_key' => true}, []))
log2 = '<1>Feb 28 12:00:00 192.168.0.1 fluentd[11111]: [error] Syslog test'

Benchmark.ips do |x|
  x.report "regexp" do
    parser.parse_plain(log) { |t, r| }
  end
  x.report "string" do
    parser.parse_rfc3164(log) { |t, r| }
  end
  x.report "regexp with pri" do
    parser2.parse_plain(log2) { |t, r| }
  end
  x.report "string with pri" do
    parser2.parse_rfc3164(log2) { |t, r| }
  end
end

Warming up --------------------------------------
              regexp    20.246k i/100ms
              string    42.531k i/100ms
     regexp with pri    18.060k i/100ms
     string with pri    37.281k i/100ms
Calculating -------------------------------------
              regexp    218.482k (± 1.7%) i/s -      1.093M in   5.005516s
              string    488.549k (± 1.5%) i/s -      2.467M in   5.050341s
     regexp with pri    195.467k (± 2.1%) i/s -    993.300k in   5.083917s
     string with pri    408.422k (± 3.7%) i/s -      2.050M in   5.028522s
```

**Docs Changes**:
Add new parameters and log example.

**Release Note**: 
Same as title.