### PR TITLE
Raise config error when using same file path in file_signle buffer

### DIFF
--- a/lib/fluent/plugin/buf_file_single.rb
+++ b/lib/fluent/plugin/buf_file_single.rb
@@ -88,14 +88,6 @@ module Fluent
           end
         end
 
-        type_of_owner = Plugin.lookup_type_from_class(@_owner.class)
-        if @@buffer_paths.has_key?(@path) && !called_in_test?
-          type_using_this_path = @@buffer_paths[@path]
-          raise Fluent::ConfigError, "Other '#{type_using_this_path}' plugin already uses same buffer path: type = #{type_of_owner}, buffer path = #{@path}"
-        end
-
-        @@buffer_paths[@path] = type_of_owner
-
         specified_directory_exists = File.exist?(@path) && File.directory?(@path)
         unexisting_path_for_directory = !File.exist?(@path) && !@path.include?('.*')
 
@@ -124,6 +116,13 @@ module Fluent
           @multi_workers_available = false
         end
 
+        type_of_owner = Plugin.lookup_type_from_class(@_owner.class)
+        if @@buffer_paths.has_key?(@path) && !called_in_test?
+          type_using_this_path = @@buffer_paths[@path]
+          raise Fluent::ConfigError, "Other '#{type_using_this_path}' plugin already uses same buffer path: type = #{type_of_owner}, buffer path = #{@path}"
+        end
+
+        @@buffer_paths[@path] = type_of_owner
         @dir_permission = if @dir_permission
                             @dir_permission.to_i(8)
                           else


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
none

**What this PR does / why we need it**: 
if user passes `/path/to/foo.*.baz` to single file buffer plugin as `path`
directive, single file buffer convert it into `/path/to/fsb.*.buf`.
in here. 
https://github.com/fluent/fluentd/blob/c7a825c7cad52f0c2a322ae88f7011e842b3d4fb/lib/fluent/plugin/buf_file_single.rb#L115-L117

When the user uses another single file buffer whose `path` is  `/path/to/` in the above situation,  single file buffer should raise an`ConfigError`, but not in present implementation.

**Docs Changes**:

no need

**Release Note**: 

same as the title
