### PR TITLE
Load certificates from windows certstore

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |gem|
     gem.add_runtime_dependency("win32-ipc", ["~> 0.6.1"])
     gem.add_runtime_dependency("win32-event", ["~> 0.6.1"])
     gem.add_runtime_dependency("windows-pr", ["~> 1.2.5"])
+    gem.add_runtime_dependency("certstore_c", ["~> 0.1.2"])
   end
 
   gem.add_development_dependency("rake", ["~> 11.0"])

--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -111,6 +111,8 @@ module Fluent::Plugin
     config_param :tls_cert_thumbprint, :string, default: nil, secret: true
     desc 'The certificate logical store name on Windows system certstore.'
     config_param :tls_cert_logical_store_name, :string, default: nil
+    desc 'Enable to use certificate enterprise store on Windows system certstore.'
+    config_param :tls_cert_use_enterprise_store, :bool, default: true
     desc "Enable keepalive connection."
     config_param :keepalive, :bool, default: false
     desc "Expired time of keepalive. Default value is nil, which means to keep connection as long as possible"
@@ -361,6 +363,7 @@ module Fluent::Plugin
           private_key_passphrase: @tls_client_private_key_passphrase,
           cert_thumbprint: @tls_cert_thumbprint,
           cert_logical_store_name: @tls_cert_logical_store_name,
+          cert_use_enterprise_store: @tls_cert_use_enterprise_store,
 
           # Enabling SO_LINGER causes data loss on Windows
           # https://github.com/fluent/fluentd/issues/1968

--- a/lib/fluent/plugin_helper/socket.rb
+++ b/lib/fluent/plugin_helper/socket.rb
@@ -100,7 +100,8 @@ module Fluent
           version: TLS_DEFAULT_VERSION, ciphers: CIPHERS_DEFAULT, insecure: false, verify_fqdn: true, fqdn: nil,
           enable_system_cert_store: true, allow_self_signed_cert: false, cert_paths: nil,
           cert_path: nil, private_key_path: nil, private_key_passphrase: nil,
-          cert_thumbprint: nil, cert_store_name: nil, cert_logical_store_name: nil, **kwargs, &block)
+          cert_thumbprint: nil, cert_logical_store_name: nil, cert_use_enterprise_store: true,
+          **kwargs, &block)
 
         host_is_ipaddress = IPAddr.new(host) rescue false
         fqdn ||= host unless host_is_ipaddress
@@ -119,7 +120,8 @@ module Fluent
             if enable_system_cert_store
               if Fluent.windows? && cert_logical_store_name
                 log.trace "loading Windows system certificate store"
-                loader = Certstore::OpenSSL::Loader.new(log, cert_store, cert_logical_store_name)
+                loader = Certstore::OpenSSL::Loader.new(log, cert_store, cert_logical_store_name,
+                                                        enterprise: cert_use_enterprise_store)
                 loader.load_cert_store
                 cert_store = loader.cert_store
                 context.cert = loader.get_certificate(cert_thumbprint) if cert_thumbprint


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
None.

**What this PR does / why we need it**: 
Currently, Fluentd does not refer Windows Certstore as OpenSSL certificates store.
This PR makes to be able to refer it and import certificates which are stored in Windows certstore.

**Docs Changes**:
~~Add `Load certificates from windows certstore` article in out_forward document. I will send a patch later.~~
https://github.com/fluent/fluentd-docs-gitbook/pull/102

**Release Note**: 
Same as a title.