### PR TITLE
Set encoding

### DIFF
--- a/test/plugin/test_buffer_file_chunk.rb
+++ b/test/plugin/test_buffer_file_chunk.rb
@@ -855,6 +855,7 @@ class BufferFileChunkTest < Test::Unit::TestCase
       assert_equal @gzipped_src, c.read(compressed: :gzip)
 
       io = StringIO.new
+      io.set_encoding(Encoding::ASCII_8BIT)
       c.write_to(io, compressed: :gzip)
       assert_equal @gzipped_src, io.string
     end

--- a/test/plugin/test_buffer_file_single_chunk.rb
+++ b/test/plugin/test_buffer_file_single_chunk.rb
@@ -613,6 +613,7 @@ class BufferFileSingleChunkTest < Test::Unit::TestCase
       assert_equal @gzipped_src, c.read(compressed: :gzip)
 
       io = StringIO.new
+      io.set_encoding(Encoding::ASCII_8BIT)
       c.write_to(io, compressed: :gzip)
       assert_equal @gzipped_src, io.string
     end

--- a/test/plugin/test_buffer_memory_chunk.rb
+++ b/test/plugin/test_buffer_memory_chunk.rb
@@ -331,6 +331,7 @@ class BufferMemoryChunkTest < Test::Unit::TestCase
       assert_equal @gzipped_src, c.read(compressed: :gzip)
 
       io = StringIO.new
+      io.set_encoding(Encoding::ASCII_8BIT)
       c.write_to(io, compressed: :gzip)
       assert_equal @gzipped_src, io.string
     end


### PR DESCRIPTION

<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 

none

**What this PR does / why we need it**: 

for the env which `Encoding.default_external` returns not `ASCII-8BIT`

```rb
s = StringIO.new
p s.external_encoding # => #<Encoding:UTF-8>
s.write('text'.force_encoding(Encoding::ASCII_8BIT))
p s.string.encoding # => #<Encoding:UTF-8>

s = StringIO.new('text'.force_encoding(Encoding::ASCII_8BIT))
p s.external_encoding # => #<Encoding:ASCII-8BIT>
p s.string.encoding # => #<Encoding:ASCII-8BIT>
```

**Docs Changes**:

no need

**Release Note**: 

no need


cc. @repeatedly 