### PR TITLE
Increase minimum msgpack version

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.1'
 
-  gem.add_runtime_dependency("msgpack", [">= 0.7.0", "< 2.0.0"])
+  gem.add_runtime_dependency("msgpack", [">= 1.2.0", "< 2.0.0"])
   gem.add_runtime_dependency("yajl-ruby", ["~> 1.0"])
   gem.add_runtime_dependency("cool.io", [">= 1.4.5", "< 2.0.0"])
   gem.add_runtime_dependency("serverengine", [">= 2.0.4", "< 3.0.0"])


### PR DESCRIPTION
9aca889cd started using `MessagePack::Packer#full_pack`, which was introduced in msgpack 1.2.0.