### PR TITLE
Use Object.__send__ to avoid conflicting method name

### DIFF
--- a/lib/fluent/plugin/multi_output.rb
+++ b/lib/fluent/plugin/multi_output.rb
@@ -94,7 +94,7 @@ module Fluent
         @outputs.each do |o|
           begin
             log.debug "calling #{method_name} on output plugin dynamically created", type: Fluent::Plugin.lookup_type_from_class(o.class), plugin_id: o.plugin_id
-            o.send(method_name) unless o.send(checker_name)
+            o.__send__(method_name) unless o.__send__(checker_name)
           rescue Exception => e
             log.warn "unexpected error while calling #{method_name} on output plugin dynamically created", plugin: o.class, plugin_id: o.plugin_id, error: e
             log.warn_backtrace

--- a/lib/fluent/plugin_helper/formatter.rb
+++ b/lib/fluent/plugin_helper/formatter.rb
@@ -103,7 +103,7 @@ module Fluent
       def formatter_operate(method_name, &block)
         @_formatters.each_pair do |usage, formatter|
           begin
-            formatter.send(method_name)
+            formatter.__send__(method_name)
             block.call(formatter) if block_given?
           rescue => e
             log.error "unexpected error while #{method_name}", usage: usage, formatter: formatter, error: e

--- a/lib/fluent/plugin_helper/parser.rb
+++ b/lib/fluent/plugin_helper/parser.rb
@@ -103,7 +103,7 @@ module Fluent
       def parser_operate(method_name, &block)
         @_parsers.each_pair do |usage, parser|
           begin
-            parser.send(method_name)
+            parser.__send__(method_name)
             block.call(parser) if block_given?
           rescue => e
             log.error "unexpected error while #{method_name}", usage: usage, parser: parser, error: e

--- a/lib/fluent/plugin_helper/storage.rb
+++ b/lib/fluent/plugin_helper/storage.rb
@@ -138,7 +138,7 @@ module Fluent
         @_storages.each_pair do |usage, s|
           begin
             block.call(s) if block_given?
-            s.storage.send(method_name)
+            s.storage.__send__(method_name)
           rescue => e
             log.error "unexpected error while #{method_name}", usage: usage, storage: s.storage, error: e
           end

--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -240,7 +240,7 @@ module Fluent
         lifecycle do |instance, kind|
           begin
             log.debug "calling #{method} on #{kind} plugin", type: Plugin.lookup_type_from_class(instance.class), plugin_id: instance.plugin_id
-            instance.send(method) unless instance.send(checker)
+            instance.__send__(method) unless instance.__send__(checker)
           rescue Exception => e
             log.warn "unexpected error while calling #{method} on #{kind} plugin", plugin: instance.class, plugin_id: instance.plugin_id, error: e
             log.warn_backtrace
@@ -270,17 +270,17 @@ module Fluent
                 operation = "preparing shutdown" # for logging
                 log.debug "#{operation} #{kind} plugin", type: Plugin.lookup_type_from_class(instance.class), plugin_id: instance.plugin_id
                 begin
-                  instance.send(:before_shutdown) unless instance.send(:before_shutdown?)
+                  instance.__send__(:before_shutdown) unless instance.__send__(:before_shutdown?)
                 rescue Exception => e
                   log.warn "unexpected error while #{operation} on #{kind} plugin", plugin: instance.class, plugin_id: instance.plugin_id, error: e
                   log.warn_backtrace
                 end
                 operation = "shutting down"
                 log.info "#{operation} #{kind} plugin", type: Plugin.lookup_type_from_class(instance.class), plugin_id: instance.plugin_id
-                instance.send(:shutdown) unless instance.send(:shutdown?)
+                instance.__send__(:shutdown) unless instance.__send__(:shutdown?)
               else
                 log.debug "#{operation} #{kind} plugin", type: Plugin.lookup_type_from_class(instance.class), plugin_id: instance.plugin_id
-                instance.send(method) unless instance.send(checker)
+                instance.__send__(method) unless instance.__send__(checker)
               end
             rescue Exception => e
               log.warn "unexpected error while #{operation} on #{kind} plugin", plugin: instance.class, plugin_id: instance.plugin_id, error: e

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -136,7 +136,7 @@ module Fluent
             supervisor_value = instance_variable_get("@#{param}")
             next if supervisor_value.nil? # it's not configured by command line options
 
-            system.send("#{param}=", supervisor_value)
+            system.__send__("#{param}=", supervisor_value)
           end
         end
       }
@@ -179,7 +179,7 @@ module Fluent
           @_system_config = (defined?($_system_config) && $_system_config ? $_system_config : Fluent::Engine.system_config).dup
         end
         opts.each_pair do |key, value|
-          @_system_config.send(:"#{key.to_s}=", value)
+          @_system_config.__send__(:"#{key.to_s}=", value)
         end
       end
     end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes https://github.com/fluent/fluentd/issues/2613

**What this PR does / why we need it**: 

Use `Object.__send__` to avoid conflicting method name

**Docs Changes**:

no need

**Release Note**: 

same as the title
