### PR TITLE
validate if timkey is less than equal 0

### DIFF
--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -310,6 +310,9 @@ module Fluent
             Fluent::Timezone.validate!(@buffer_config.timekey_zone)
             @timekey_zone = @buffer_config.timekey_use_utc ? '+0000' : @buffer_config.timekey_zone
             @timekey = @buffer_config.timekey
+            if @timekey <= 0
+              raise Fluent::ConfigError, "timekey should be greater than 0. current timekey: #{@timekey}"
+            end
             @timekey_use_utc = @buffer_config.timekey_use_utc
             @offset = Fluent::Timezone.utc_offset(@timekey_zone)
             @calculate_offset = @offset.respond_to?(:call) ? @offset : nil

--- a/test/plugin/test_output.rb
+++ b/test/plugin/test_output.rb
@@ -868,6 +868,23 @@ class OutputTest < Test::Unit::TestCase
     end
   end
 
+  test 'raises an error if timekey is less than equal 0' do
+    i = create_output(:delayed)
+    assert_raise Fluent::ConfigError.new('timekey should be greater than 0. current timekey: 0.0') do
+      i.configure(config_element('ROOT','',{},[config_element('buffer', 'time', { "timekey" => nil })]))
+    end
+
+    i = create_output(:delayed)
+    assert_raise Fluent::ConfigError.new('timekey should be greater than 0. current timekey: 0.0') do
+      i.configure(config_element('ROOT','',{},[config_element('buffer', 'time', { "timekey" => 0 })]))
+    end
+
+    i = create_output(:delayed)
+    assert_raise Fluent::ConfigError.new('timekey should be greater than 0. current timekey: -1.0') do
+      i.configure(config_element('ROOT','',{},[config_element('buffer', 'time', { "timekey" => -1 })]))
+    end
+  end
+
   sub_test_case 'sync output feature' do
     setup do
       @i = create_output(:sync)


### PR DESCRIPTION
Signed-off-by: Yuta Iwama <ganmacs@gmail.com>

<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes https://github.com/fluent/fluentd/issues/2607

**What this PR does / why we need it**: 

I made a change to raise an error when a user specifies `timekey`  less than equal 0.
when `timekey` is 0, fluentd will raise `ZeroDivisionError` at [here](https://github.com/fluent/fluentd/blob/master/lib/fluent/plugin/output.rb#L1379).

**Docs Changes**:

no need

**Release Note**: 

same as the title
