### PR TITLE
Allow uncompressing buffer files during restore

### DIFF
--- a/lib/fluent/plugin/buf_file.rb
+++ b/lib/fluent/plugin/buf_file.rb
@@ -146,7 +146,7 @@ module Fluent
           end
 
           begin
-            chunk = Fluent::Plugin::Buffer::FileChunk.new(m, path, mode) # file chunk resumes contents of metadata
+            chunk = Fluent::Plugin::Buffer::FileChunk.new(m, path, mode, compress: @compress) # file chunk resumes contents of metadata
           rescue Fluent::Plugin::Buffer::FileChunk::FileChunkError => e
             handle_broken_files(path, mode, e)
             next


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #2619

**What this PR does / why we need it**: 

Chunks buffered via buf_file where not uncompressed on restore.
