### PR TITLE
Reuse same hash object after calling purge_obsolete_socks

### DIFF
--- a/lib/fluent/plugin/out_forward/socket_cache.rb
+++ b/lib/fluent/plugin/out_forward/socket_cache.rb
@@ -81,7 +81,9 @@ module Fluent::Plugin
               end
             end
           end
-          @available_sockets = @available_sockets.select { |_, v| !v.empty? }
+
+          # reuse same object (@available_sockets)
+          @available_sockets.reject! { |_, v| v.empty? }
 
           sockets += @inactive_sockets
           @inactive_sockets.clear

--- a/test/plugin/out_forward/test_socket_cache.rb
+++ b/test/plugin/out_forward/test_socket_cache.rb
@@ -38,6 +38,16 @@ class SocketCacheTest < Test::Unit::TestCase
       sock = mock!.open { new_sock }.subject
       assert_equal(new_sock, c.checkout_or('key') { sock.open })
     end
+
+    test 'reuse same hash object after calling purge_obsolete_socks' do
+      c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
+      c.checkout_or('key') { 'socket' }
+      c.purge_obsolete_socks
+
+      assert_nothing_raised(NoMethodError) do
+        c.checkout_or('key') { 'new socket' }
+      end
+    end
   end
 
   sub_test_case 'checkin' do


### PR DESCRIPTION
since @available_sockets is initialized with
`Hash.new { |obj, k| obj[k] = [] }` at https://github.com/fluent/fluentd/blob/v1.7.1/lib/fluent/plugin/out_forward/socket_cache.rb#L27

**Which issue(s) this PR fixes**: 
Fixes https://github.com/fluent/fluentd/issues/2626

**What this PR does / why we need it**: 

to avoid  NoMethodError after calling purge_obsolete_socks 

**Docs Changes**:

no need

**Release Note**: 

same as title