### PR TITLE
Add flag for waiting for the peer closes its socket

### DIFF
--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -293,6 +293,9 @@ module Fluent
 
       lifecycle_safe_sequence.call(:stop, :stopped?)
 
+      # Wait close sequence by client side
+      sleep Fluent::Engine.system_config.delay_enter_shutdown
+
       # before_shutdown does force_flush for output plugins: it should block, so it's unsafe operation
       lifecycle_unsafe_sequence.call(:shutdown, :shutdown?)
 

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -40,6 +40,7 @@ module Fluent
     config_param :rpc_endpoint,    :string, default: nil
     config_param :enable_get_dump, :bool, default: nil
     config_param :process_name,    :string, default: nil
+    config_param :delay_enter_shutdown, :time, default: 0
     config_param :file_permission, default: nil do |v|
       v.to_i(8)
     end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
ref https://github.com/fluent/fluentd/issues/1985

**What this PR does / why we need it**: 

https://github.com/fluent/fluent-logger-ruby/compare/master...ganmacs:call-read_nonblock-before-write?expand=1

**Docs Changes**:

Needed

**Release Note**: 

same as tittle
