### PR TITLE
Semantic Status Code - modify on_request response from 200 to 204 in plugin/in_http

### DIFF
--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -152,7 +152,7 @@ module Fluent::Plugin
           if @respond_with_empty_img
             return ["200 OK", {'Content-Type'=>'image/gif; charset=utf-8'}, EMPTY_GIF_IMAGE]
           else
-            return ["200 OK", {'Content-Type'=>'text/plain'}, ""]
+            return ["204 No Content", {}]
           end
         end
 
@@ -219,7 +219,7 @@ module Fluent::Plugin
       if @respond_with_empty_img
         return ["200 OK", {'Content-Type'=>'image/gif; charset=utf-8'}, EMPTY_GIF_IMAGE]
       else
-        return ["200 OK", {'Content-Type'=>'text/plain'}, ""]
+        return ["204 No Content", {}]
       end
     end
 

--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -140,7 +140,7 @@ module Fluent::Plugin
       super
     end
 
-    def on_request(path_info, params)
+    def on_request(path_info, params, use_204_response=false)
       begin
         path = path_info[1..-1]  # remove /
         tag = path.split('/').join('.')
@@ -152,7 +152,11 @@ module Fluent::Plugin
           if @respond_with_empty_img
             return ["200 OK", {'Content-Type'=>'image/gif; charset=utf-8'}, EMPTY_GIF_IMAGE]
           else
-            return ["204 No Content", {}]
+            if use_204_response
+              return  ["204 No Content", {}]
+            else
+              return ["200 OK", {'Content-Type'=>'text/plain'}, ""]
+            end
           end
         end
 
@@ -219,7 +223,11 @@ module Fluent::Plugin
       if @respond_with_empty_img
         return ["200 OK", {'Content-Type'=>'image/gif; charset=utf-8'}, EMPTY_GIF_IMAGE]
       else
-        return ["204 No Content", {}]
+        if use_204_response
+          return  ["204 No Content", {}]
+        else
+          return ["200 OK", {'Content-Type'=>'text/plain'}, ""]
+        end
       end
     end
 

--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -58,6 +58,8 @@ module Fluent::Plugin
     config_param :cors_allow_origins, :array, default: nil
     desc 'Respond with empty gif image of 1x1 pixel.'
     config_param :respond_with_empty_img, :bool, default: false
+    desc 'Respond status code with 204.'
+    config_param :use_204_response, :bool, default: false
 
     config_section :parse do
       config_set_default :@type, 'in_http'
@@ -140,7 +142,7 @@ module Fluent::Plugin
       super
     end
 
-    def on_request(path_info, params, use_204_response=false)
+    def on_request(path_info, params)
       begin
         path = path_info[1..-1]  # remove /
         tag = path.split('/').join('.')
@@ -152,7 +154,7 @@ module Fluent::Plugin
           if @respond_with_empty_img
             return ["200 OK", {'Content-Type'=>'image/gif; charset=utf-8'}, EMPTY_GIF_IMAGE]
           else
-            if use_204_response
+            if @use_204_response
               return  ["204 No Content", {}]
             else
               return ["200 OK", {'Content-Type'=>'text/plain'}, ""]
@@ -223,7 +225,7 @@ module Fluent::Plugin
       if @respond_with_empty_img
         return ["200 OK", {'Content-Type'=>'image/gif; charset=utf-8'}, EMPTY_GIF_IMAGE]
       else
-        if use_204_response
+        if @use_204_response
           return  ["204 No Content", {}]
         else
           return ["200 OK", {'Content-Type'=>'text/plain'}, ""]

--- a/test/plugin/test_in_http.rb
+++ b/test/plugin/test_in_http.rb
@@ -596,7 +596,7 @@ class HttpInputTest < Test::Unit::TestCase
         res_codes << res.code
       end
     end
-    assert_equal ["204", "204"], res_codes
+    assert_equal ["200", "200"], res_codes
     assert_equal [], res_bodies
     assert_equal events, d.events
     assert_equal_event_time time, d.events[0][1]


### PR DESCRIPTION
**The reason about this PR**: 

I used fluentd service and figured that 200 response with empty string is a little bit not precise.
According to [rfc7231](https://tools.ietf.org/html/rfc7231#section-6.3.5), 204 is more proper status code.
> a 204 status code is commonly used with document editing interfaces corresponding to a "save" action


**What this PR does / why we need it**: 

- For more semantic status code
- Add test for this change in test_in_http
- Fix typo in test_in_http