### PR TITLE
formatter_csv: support nested fields. fix #2630

### DIFF
--- a/lib/fluent/plugin_helper/record_accessor.rb
+++ b/lib/fluent/plugin_helper/record_accessor.rb
@@ -31,6 +31,10 @@ module Fluent
         Accessor.new(param)
       end
 
+      def record_accessor_nested?(param)
+        Accessor.parse_parameter(param).is_a?(Array)
+      end
+
       class Accessor
         attr_reader :keys
 

--- a/test/plugin/test_formatter_csv.rb
+++ b/test/plugin/test_formatter_csv.rb
@@ -54,6 +54,15 @@ class CsvFormatterTest < ::Test::Unit::TestCase
     assert_equal("\"awesome\",\"awesome2\"\n", formatted)
   end
 
+  def test_format_with_nested_fields
+    d = create_driver("fields" => "message,$.nest.key")
+    formatted = d.instance.format(tag, @time, {
+                                    'message' => 'awesome',
+                                    'nest' => {'key' => 'awesome2'}
+                                  })
+    assert_equal("\"awesome\",\"awesome2\"\n", formatted)
+  end
+
   def test_format_without_newline
     d = create_driver("fields" => "message,message2", "add_newline" => false)
     formatted = d.instance.format(tag, @time, {


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

**Which issue(s) this PR fixes**: 
Fixes #2630 

**What this PR does / why we need it**: 
Support nested fields via `record_accessor`.

**Docs Changes**:
Add note for nested fields to `fields` parameter.

**Release Note**: 
same as title