### PR TITLE
Move MessgePackFactory.init outside of Engine

### DIFF
--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -69,8 +69,6 @@ module Fluent
 
       @root_agent = RootAgent.new(log: log, system_config: @system_config)
 
-      MessagePackFactory.init
-
       self
     end
 

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -25,6 +25,7 @@ require 'fluent/log'
 require 'fluent/plugin'
 require 'fluent/rpc'
 require 'fluent/system_config'
+require 'fluent/msgpack_factory'
 require 'serverengine'
 
 if Fluent.windows?
@@ -546,6 +547,7 @@ module Fluent
       main_process do
         create_socket_manager if @standalone_worker
         change_privilege if @standalone_worker
+        MessagePackFactory.init
         init_engine
         run_configure
         run_engine
@@ -577,6 +579,7 @@ module Fluent
       begin
         Fluent::Engine.dry_run_mode = true
         change_privilege
+        MessagePackFactory.init
         init_engine
         run_configure
       rescue Fluent::ConfigError => e


### PR DESCRIPTION
Signed-off-by: Yuta Iwama <ganmacs@gmail.com>

<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Ref https://github.com/fluent/fluentd/pull/2647

**What this PR does / why we need it**: 

`MessagePackFactory.init` does not need to be call in Engine class.

**Docs Changes**:

no need

**Release Note**: 

no need
