### PR TITLE
child_process helper: fix stderr blocking for discard case. fix #2609

### DIFF
--- a/lib/fluent/plugin_helper/child_process.rb
+++ b/lib/fluent/plugin_helper/child_process.rb
@@ -257,7 +257,8 @@ module Fluent
         readio = writeio = stderrio = wait_thread = nil
         readio_in_use = writeio_in_use = stderrio_in_use = false
 
-        if !mode.include?(:stderr) && !mode.include?(:read_with_stderr) && stderr != :discard # connect
+        if !mode.include?(:stderr) && !mode.include?(:read_with_stderr)
+          spawn_opts[:err] = IO::NULL if stderr == :discard
           writeio, readio, wait_thread = *Open3.popen2(*spawn_args, spawn_opts)
         elsif mode.include?(:read_with_stderr)
           writeio, readio, wait_thread = *Open3.popen2e(*spawn_args, spawn_opts)
@@ -281,7 +282,7 @@ module Fluent
           stderrio.set_encoding(external_encoding, internal_encoding, encoding_options)
           stderrio_in_use = true
         else
-          stderrio.reopen(IO::NULL) if stderrio && stderrio == :discard
+          stderrio.reopen(IO::NULL) if stderrio && stderr == :discard
         end
 
         pid = wait_thread.pid # wait_thread => Process::Waiter

--- a/test/plugin_helper/test_child_process.rb
+++ b/test/plugin_helper/test_child_process.rb
@@ -147,9 +147,13 @@ class ChildProcessTest < Test::Unit::TestCase
         end
         m.unlock
       end
-      sleep TEST_WAIT_INTERVAL_FOR_BLOCK_RUNNING until m.locked? || ran
-      m.lock
-      m.unlock
+      begin
+        sleep TEST_WAIT_INTERVAL_FOR_BLOCK_RUNNING until m.locked? || ran
+        m.lock
+      rescue
+      ensure
+        m.unlock
+      end
     end
 
     assert_equal [], @d.log.out.logs


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

**Which issue(s) this PR fixes**: 
Fixes #2609 

**What this PR does / why we need it**: 
reopen with IO::NULL is not correct way to discard message.
It replaces ruby side IO object, not process. Thanks nurse-san!
Need to specify IO::NULL when launch the process.

**Docs Changes**:
No need

**Release Note**: 
Same as title