### PR TITLE
Fix dry run mode

### DIFF
--- a/lib/fluent/agent.rb
+++ b/lib/fluent/agent.rb
@@ -62,7 +62,9 @@ module Fluent
 
       # initialize <match> and <filter> elements
       conf.elements('filter', 'match').each { |e|
-        next if e.for_another_worker?
+        if !Fluent::Engine.supervisor_mode && e.for_another_worker?
+          next
+        end
         pattern = e.arg.empty? ? '**' : e.arg
         type = e['@type']
         raise ConfigError, "Missing '@type' parameter on <#{e.name}> directive" unless type

--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -323,7 +323,7 @@ if opts[:supervise]
 
   supervisor = Fluent::Supervisor.new(opts)
   supervisor.configure(supervisor: true)
-  supervisor.run_supervisor
+  supervisor.run_supervisor(dry_run: opts[:dry_run])
 else
   if opts[:standalone_worker] && opts[:workers] && opts[:workers] > 1
     puts "Error: multi workers is not supported with --no-supervisor"

--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -47,12 +47,12 @@ module Fluent
 
     MAINLOOP_SLEEP_INTERVAL = 0.3
 
-    attr_reader :root_agent, :system_config, :supervisor_mode
-    attr_accessor :dry_run_mode
+    attr_reader :root_agent, :system_config, :supervisor_mode, :dry_run_mode
 
-    def init(system_config, supervisor_mode: false)
+    def init(system_config, supervisor_mode: false, dry_run_mode: false)
       @system_config = system_config
       @supervisor_mode = supervisor_mode
+      @dry_run_mode = dry_run_mode
 
       @suppress_config_dump = system_config.suppress_config_dump unless system_config.suppress_config_dump.nil?
       @without_source = system_config.without_source unless system_config.without_source.nil?

--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -79,38 +79,27 @@ module Fluent
 
     def run_configure(conf)
       configure(conf)
-      conf.check_not_fetched { |key, e|
+      conf.check_not_fetched do |key, e|
         parent_name, plugin_name = e.unused_in
-        if parent_name
-          message = if plugin_name
-                      "section <#{e.name}> is not used in <#{parent_name}> of #{plugin_name} plugin"
-                    else
-                      "section <#{e.name}> is not used in <#{parent_name}>"
-                    end
+        message = if parent_name && plugin_name
+                    "section <#{e.name}> is not used in <#{parent_name}> of #{plugin_name} plugin"
+                  elsif parent_name
+                    "section <#{e.name}> is not used in <#{parent_name}>"
+                  elsif e.name != 'system' && !(@without_source && e.name == 'source')
+                    "parameter '#{key}' in #{e.to_s.strip} is not used."
+                  else
+                    nil
+                  end
+        next if message.nil?
 
-          if @dry_run_mode && @supervisor_mode
-            $log.warn :supervisor, message
-          elsif e.for_every_workers?
-            $log.warn :worker0, message
-          elsif e.for_this_worker?
-            $log.warn message
-          end
-          next
+        if @dry_run_mode && @supervisor_mode
+          $log.warn :supervisor, message
+        elsif e.for_every_workers?
+          $log.warn :worker0, message
+        elsif e.for_this_worker?
+          $log.warn message
         end
-
-        unless e.name == 'system'
-          unless @without_source && e.name == 'source'
-            message = "parameter '#{key}' in #{e.to_s.strip} is not used."
-            if @dry_run_mode && @supervisor_mode
-              $log.warn :supervisor, message
-            elsif e.for_every_workers?
-              $log.warn :worker0, message
-            elsif e.for_this_worker?
-              $log.warn message
-            end
-          end
-        end
-      }
+      end
     end
 
     def configure(conf)

--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -41,18 +41,16 @@ module Fluent
       @fluent_log_event_router = nil
       @system_config = SystemConfig.new
 
-      @dry_run_mode = false
       @supervisor_mode = false
     end
 
     MAINLOOP_SLEEP_INTERVAL = 0.3
 
-    attr_reader :root_agent, :system_config, :supervisor_mode, :dry_run_mode
+    attr_reader :root_agent, :system_config, :supervisor_mode
 
-    def init(system_config, supervisor_mode: false, dry_run_mode: false)
+    def init(system_config, supervisor_mode: false)
       @system_config = system_config
       @supervisor_mode = supervisor_mode
-      @dry_run_mode = dry_run_mode
 
       @suppress_config_dump = system_config.suppress_config_dump unless system_config.suppress_config_dump.nil?
       @without_source = system_config.without_source unless system_config.without_source.nil?
@@ -77,7 +75,7 @@ module Fluent
       end
     end
 
-    def run_configure(conf)
+    def run_configure(conf, dry_run: false)
       configure(conf)
       conf.check_not_fetched do |key, e|
         parent_name, plugin_name = e.unused_in
@@ -92,7 +90,7 @@ module Fluent
                   end
         next if message.nil?
 
-        if @dry_run_mode && @supervisor_mode
+        if dry_run && @supervisor_mode
           $log.warn :supervisor, message
         elsif e.for_every_workers?
           $log.warn :worker0, message

--- a/lib/fluent/plugin/base.rb
+++ b/lib/fluent/plugin/base.rb
@@ -52,7 +52,7 @@ module Fluent
       end
 
       def configure(conf)
-        if conf.respond_to?(:for_this_worker?) && conf.for_this_worker?
+        if Fluent::Engine.supervisor_mode || (conf.respond_to?(:for_this_worker?) && conf.for_this_worker?)
           workers = if conf.target_worker_ids && !conf.target_worker_ids.empty?
                       conf.target_worker_ids.size
                     else

--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -89,7 +89,7 @@ module Fluent
               raise Fluent::ConfigError, "worker id #{target_worker_id} specified by <worker> directive is not allowed. Available worker id is between 0 and #{(Fluent::Engine.system_config.workers - 1)}"
             end
             available_worker_ids.delete(target_worker_id) if available_worker_ids.include?(target_worker_id)
-            if used_worker_ids.include?(target_worker_id) && !Fluent::Engine.dry_run_mode
+            if used_worker_ids.include?(target_worker_id)
               raise Fluent::ConfigError, "specified worker_id<#{worker_id}> collisions is detected on <worker> directive. Available worker id(s): #{available_worker_ids}"
             end
             used_worker_ids << target_worker_id
@@ -100,9 +100,6 @@ module Fluent
               end
             end
 
-            # On dry_run mode, all worker sections have to be configured on supervisor (recognized as worker_id = 0).
-            target_worker_ids = [0] if Fluent::Engine.dry_run_mode
-
             unless target_worker_ids.empty?
               e.set_target_worker_ids(target_worker_ids.uniq)
             end
@@ -112,9 +109,6 @@ module Fluent
           if target_worker_id < 0 || target_worker_id > (Fluent::Engine.system_config.workers - 1)
             raise Fluent::ConfigError, "worker id #{target_worker_id} specified by <worker> directive is not allowed. Available worker id is between 0 and #{(Fluent::Engine.system_config.workers - 1)}"
           end
-
-          ## On dry_run mode, all worker sections have to be configured on supervisor (recognized as worker_id = 0).
-          target_worker_id = 0 if Fluent::Engine.dry_run_mode
 
           e.elements.each do |elem|
             unless ['source', 'match', 'filter', 'label'].include?(elem.name)
@@ -132,7 +126,9 @@ module Fluent
       # initialize <label> elements before configuring all plugins to avoid 'label not found' in input, filter and output.
       label_configs = {}
       conf.elements(name: 'label').each { |e|
-        next if e.for_another_worker?
+        if !Fluent::Engine.supervisor_mode && e.for_another_worker?
+          next
+        end
         name = e.arg
         raise ConfigError, "Missing symbol argument on <label> directive" if name.empty?
 
@@ -154,7 +150,9 @@ module Fluent
         log.info :worker0, "'--without-source' is applied. Ignore <source> sections"
       else
         conf.elements(name: 'source').each { |e|
-          next if e.for_another_worker?
+          if !Fluent::Engine.supervisor_mode && e.for_another_worker?
+            next
+          end
           type = e['@type']
           raise ConfigError, "Missing '@type' parameter on <source> directive" unless type
           add_source(type, e)

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -603,7 +603,7 @@ module Fluent
         Fluent::Engine.dry_run_mode = true
         ServerEngine::Privilege.change(@chuser, @chgroup)
         MessagePackFactory.init
-        Fluent::Engine.init(@system_config)
+        Fluent::Engine.init(@system_config, supervisor: true)
         Fluent::Engine.run_configure(@conf)
       rescue Fluent::ConfigError => e
         $log.error "config error", file: @config_path, error: e

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -450,7 +450,6 @@ module Fluent
       @use_v1_config = opt[:use_v1_config]
       @conf_encoding = opt[:conf_encoding]
       @log_path = opt[:log_path]
-      @dry_run = opt[:dry_run]
       @show_plugin_config = opt[:show_plugin_config]
       @libs = opt[:libs]
       @plugin_dirs = opt[:plugin_dirs]
@@ -473,8 +472,8 @@ module Fluent
       @finished = false
     end
 
-    def run_supervisor
-      if @dry_run
+    def run_supervisor(dry_run: false)
+      if dry_run
         $log.info "starting fluentd-#{Fluent::VERSION} as dry run mode", ruby: RUBY_VERSION
       end
 
@@ -500,15 +499,15 @@ module Fluent
       begin
         ServerEngine::Privilege.change(@chuser, @chgroup)
         MessagePackFactory.init
-        Fluent::Engine.init(@system_config, supervisor_mode: true, dry_run_mode: @dry_run)
-        Fluent::Engine.run_configure(@conf)
+        Fluent::Engine.init(@system_config, supervisor_mode: true)
+        Fluent::Engine.run_configure(@conf, dry_run: dry_run)
       rescue Fluent::ConfigError => e
         $log.error 'config error', file: @config_path, error: e
         $log.debug_backtrace
         exit!(1)
       end
 
-      if @dry_run
+      if dry_run
         $log.info 'finsihed dry run mode'
         exit 0
       else

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -590,7 +590,6 @@ module Fluent
 
     def dry_run_cmd
       $log.info "starting fluentd-#{Fluent::VERSION} as dry run mode", ruby: RUBY_VERSION
-      @system_config.suppress_config_dump = true
       dry_run
       exit 0
     rescue => e

--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -625,7 +625,8 @@ CONF
   workers 2
 </system>
 <source>
-  @type single
+  @type dummy
+  tag dummy
   @id single
   @label @dummydata
 </source>
@@ -669,7 +670,8 @@ EOC
   workers 2
 </system>
 <source>
-  @type single
+  @type dummy
+  tag dummy
   @id single
   @label @dummydata
 </source>
@@ -793,7 +795,7 @@ CONF
     @id   blackhole
     <buffer>
       @type file
-      path #{File.join(@root_path, "buf", "file.*.log")}
+      path #{File.join(@root_path, "buf")}
     </buffer>
   </match>
 </worker>
@@ -863,6 +865,7 @@ module Fluent::Plugin
   class FakeInput < Input
     Fluent::Plugin.register_input('fake', self)
     config_param :secret, :string, secret: true
+    def multi_workers_ready?; true; end
   end
 end
 EOC


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
ref #2624

**What this PR does / why we need it**: 

#### Show better log

<details>

Example config
```
<system>
  workers 2
</system>

<worker 0>
  <source>
    @type fake
    secret very-secret-string0
    test 1
  </source>

  <match>
    @type null
  </match>
</worker>

<worker 1>
  <source>
    @type fake
    secret very-secret-string1
  </source>
  <match>
    @type null
  </match>
</worker>
```

#### normal mode

```
$ fluentd -c example/debug/secret.conf --dry-run
```

Before (supervisor and worker show same log about `@type fake`)

```
2019-10-15 15:16:44 +0900 [info]: parsing config file is succeeded path="example/debug/secret.conf"
2019-10-15 15:16:44 +0900 [info]: adding match pattern="**" type="null"
2019-10-15 15:16:44 +0900 [info]: adding match pattern="**" type="null"
2019-10-15 15:16:44 +0900 [info]: adding source type="fake"
2019-10-15 15:16:44 +0900 [info]: adding source type="fake"
2019-10-15 15:16:44 +0900 [info]: using configuration file: <ROOT>
  <system>
    workers 2
  </system>
  <worker 0>
    <source>
      @type fake
      secret xxxxxx
      test 1
    </source>
    <match>
      @type null
    </match>
  </worker>
  <worker 1>
    <source>
      @type fake
      secret xxxxxx
    </source>
    <match>
      @type null
    </match>
  </worker>
</ROOT>
2019-10-15 15:16:44 +0900 [warn]: parameter 'test' in <source>
  @type fake
  secret xxxxxx
  test 1
</source> is not used.
2019-10-15 15:16:44 +0900 [info]: starting fluentd-1.7.3 pid=91300 ruby="2.6.3"
2019-10-15 15:16:44 +0900 [info]: spawn command to main:  cmdline=["/Users/yuta.iwama/.rbenv/versions/2.6.3/bin/ruby", "-Eascii-8bit:ascii-8bit", "-rbundler/setup", "bin/fluentd", "-c", "example/debug/secret.conf", "-p", "plugins", "--under-supervisor"]
2019-10-15 15:16:45 +0900 [info]: #1 adding match pattern="**" type="null"
2019-10-15 15:16:45 +0900 [info]: gem 'fluentd' version '1.7.3'
2019-10-15 15:16:45 +0900 [info]: #0 adding match pattern="**" type="null"
2019-10-15 15:16:45 +0900 [info]: #0 adding source type="fake"
2019-10-15 15:16:45 +0900 [warn]: #0 parameter 'test' in <source>
  @type fake
  secret xxxxxx
  test 1
</source> is not used.
```

After(Removed duplicated log)

```
2019-10-15 15:16:44 +0900 [info]: parsing config file is succeeded path="example/debug/secret.conf"
2019-10-15 15:16:44 +0900 [info]: adding match pattern="**" type="null"
2019-10-15 15:16:44 +0900 [info]: adding match pattern="**" type="null"
2019-10-15 15:16:44 +0900 [info]: adding source type="fake"
2019-10-15 15:16:44 +0900 [info]: adding source type="fake"
2019-10-15 15:16:44 +0900 [info]: using configuration file: <ROOT>
  <system>
    workers 2
  </system>
  <worker 0>
    <source>
      @type fake
      secret xxxxxx
      test 1
    </source>
    <match>
      @type null
    </match>
  </worker>
  <worker 1>
    <source>
      @type fake
      secret xxxxxx
    </source>
    <match>
      @type null
    </match>
  </worker>
</ROOT>
2019-10-15 15:16:44 +0900 [warn]: parameter 'test' in <source>
  @type fake
  secret xxxxxx
  test 1
</source> is not used.
```

#### dry-run mode

```
$ fluentd -c example/debug/secret.conf --dry-run
```

Before

```
2019-10-15 15:16:07 +0900 [info]: parsing config file is succeeded path="example/debug/secret.conf"
2019-10-15 15:16:07 +0900 [info]: starting fluentd-1.7.3 as dry run mode ruby="2.6.3"
2019-10-15 15:16:07 +0900 [info]: adding match pattern="**" type="null"
2019-10-15 15:16:07 +0900 [info]: adding match pattern="**" type="null"
2019-10-15 15:16:07 +0900 [info]: adding source type="fake"
2019-10-15 15:16:07 +0900 [info]: adding source type="fake"
2019-10-15 15:16:07 +0900 [warn]: parameter 'test' in <source>
  @type fake
  secret xxxxxx
  test 1
</source> is not used.
```

After(show config)

```
2019-10-15 15:15:23 +0900 [info]: parsing config file is succeeded path="example/debug/secret.conf"
2019-10-15 15:15:23 +0900 [info]: starting fluentd-1.7.3 as dry run mode ruby="2.6.3"
2019-10-15 15:15:23 +0900 [info]: adding match pattern="**" type="null"
2019-10-15 15:15:23 +0900 [info]: adding source type="fake"
2019-10-15 15:15:23 +0900 [info]: using configuration file: <ROOT>
  <system>
    workers 2
  </system>
  <worker 0>
    <source>
      @type fake
      secret xxxxxx
      test 1
    </source>
    <match>
      @type null
    </match>
  </worker>
  <worker 1>
    <source>
      @type fake
      secret xxxxxx
    </source>
    <match>
      @type null
    </match>
  </worker>
</ROOT>
2019-10-15 15:15:23 +0900 [warn]: parameter 'test' in <source>
  @type fake
  secret xxxxxx
  test 1
</source> is not used.
```

</details>

#### when config has an error

<details>
Example config

```
<system>
  workers 2
</system>

<worker 0-1>
  <source>
    @type fake
    secret very-secret-string0
    test 1
  </source>

  <match>
    @type null
  </match>
</worker>

<worker 0-1>
  <source>
    @type fake
    secret very-secret-string1
  </source>

  <match>
    @type null
  </match>
</worker>
```

#### Before

```
2019-10-15 15:25:41 +0900 [info]: parsing config file is succeeded path="example/debug/secret.conf"
2019-10-15 15:25:41 +0900 [info]: starting fluentd-1.7.3 as dry run mode ruby="2.6.3"
2019-10-15 15:25:41 +0900 [info]: adding match pattern="**" type="null"
2019-10-15 15:25:41 +0900 [info]: adding match pattern="**" type="null"
2019-10-15 15:25:41 +0900 [info]: adding source type="fake"
2019-10-15 15:25:41 +0900 [info]: adding source type="fake"
2019-10-15 15:25:41 +0900 [warn]: parameter 'test' in <source>
  @type fake
  secret xxxxxx
  test 1
</source> is not used.
```

#### After(be able to detect an error when dry-run)


```
2019-10-15 15:25:37 +0900 [info]: parsing config file is succeeded path="example/debug/secret.conf"
2019-10-15 15:25:37 +0900 [info]: starting fluentd-1.7.3 as dry run mode ruby="2.6.3"
2019-10-15 15:25:37 +0900 [error]: config error file="example/debug/secret.conf" error_class=Fluent::ConfigError error="specified worker_id<0> collisions is detected on <worker> directive. Available worker id(s): []"
```
</details>

**Docs Changes**:

no need

**Release Note**: 

Make starting log better and seal dumped config
