### PR TITLE
there is no reason calling mesgpacker_unapcker/packer from Fluent::Engine

### DIFF
--- a/lib/fluent/command/cat.rb
+++ b/lib/fluent/command/cat.rb
@@ -315,7 +315,7 @@ when 'msgpack'
   require 'fluent/engine'
 
   begin
-    u = Fluent::Engine.msgpack_factory.unpacker($stdin)
+    u = Fluent::MessagePackFactory.msgpack_unpacker($stdin)
     u.each {|record|
       w.write(record)
     }
@@ -340,4 +340,3 @@ else
   $stderr.puts "Unknown format '#{format}'"
   exit 1
 end
-

--- a/lib/fluent/compat/exec_util.rb
+++ b/lib/fluent/compat/exec_util.rb
@@ -85,7 +85,7 @@ module Fluent
 
       class MessagePackParser < Parser
         def call(io)
-          @u = Fluent::Engine.msgpack_factory.unpacker(io)
+          @u = Fluent::MessagePackFactory.msgpack_unpacker(io)
           begin
             @u.each(&@on_message)
           rescue EOFError

--- a/lib/fluent/counter/base_socket.rb
+++ b/lib/fluent/counter/base_socket.rb
@@ -20,14 +20,12 @@ require 'fluent/msgpack_factory'
 module Fluent
   module Counter
     class BaseSocket < Coolio::TCPSocket
-      include Fluent::MessagePackFactory::Mixin
-
       def packed_write(data)
         write pack(data)
       end
 
       def on_read(data)
-        msgpack_unpacker.feed_each(data) do |d|
+        Fluent::MessagePackFactory.msgpack_unpacker.feed_each(data) do |d|
           on_message d
         end
       end
@@ -39,7 +37,7 @@ module Fluent
       private
 
       def pack(data)
-        msgpack_packer.pack(data)
+        Fluent::MessagePackFactory.msgpack_packer.pack(data)
       end
     end
   end

--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -25,8 +25,6 @@ require 'fluent/plugin'
 
 module Fluent
   class EngineClass
-    include Fluent::MessagePackFactory::Mixin
-
     def initialize
       @root_agent = nil
       @default_loop = nil

--- a/lib/fluent/msgpack_factory.rb
+++ b/lib/fluent/msgpack_factory.rb
@@ -23,14 +23,23 @@ module Fluent
 
     module Mixin
       def msgpack_factory
+        if $log
+          $log.warn('Deprecated method: this method is going to be deleted. Use Fluent::MessagePackFactory.engine_factory')
+        end
         MessagePackFactory.engine_factory
       end
 
       def msgpack_packer(*args)
+        if $log
+          $log.warn('Deprecated method: this method is going to be deleted. Use Fluent::MessagePackFactory.msgpack_packer')
+        end
         MessagePackFactory.msgpack_packer(*args)
       end
 
       def msgpack_unpacker(*args)
+        if $log
+          $log.warn('Deprecated method: this method is going to be deleted. Use Fluent::MessagePackFactory.msgpack_unpacker')
+        end
         MessagePackFactory.msgpack_unpacker(*args)
       end
     end

--- a/lib/fluent/msgpack_factory.rb
+++ b/lib/fluent/msgpack_factory.rb
@@ -27,16 +27,24 @@ module Fluent
       end
 
       def msgpack_packer(*args)
-        msgpack_factory.packer(*args)
+        MessagePackFactory.msgpack_packer(*args)
       end
 
       def msgpack_unpacker(*args)
-        msgpack_factory.unpacker(*args)
+        MessagePackFactory.msgpack_unpacker(*args)
       end
     end
 
     def self.engine_factory
       @@engine_factory || factory
+    end
+
+    def self.msgpack_packer(*args)
+      engine_factory.packer(*args)
+    end
+
+    def self.msgpack_unpacker(*args)
+      engine_factory.unpacker(*args)
     end
 
     def self.factory

--- a/lib/fluent/plugin/buffer/file_chunk.rb
+++ b/lib/fluent/plugin/buffer/file_chunk.rb
@@ -38,7 +38,6 @@ module Fluent
         # path_suffix: path suffix string, like '.log' (or any other user specified)
 
         include SystemConfig::Mixin
-        include MessagePackFactory::Mixin
 
         FILE_PERMISSION = 0644
 
@@ -221,7 +220,7 @@ module Fluent
 
           unless data
             # old type of restore
-            data = msgpack_unpacker(symbolize_keys: true).feed(bindata).read rescue {}
+            data = Fluent::MessagePackFactory.msgpack_unpacker(symbolize_keys: true).feed(bindata).read rescue {}
           end
 
           now = Fluent::Clock.real_now
@@ -403,7 +402,7 @@ module Fluent
           if chunk.slice(0, 2) == BUFFER_HEADER
             size = chunk.slice(2, 4).unpack('N').first
             if size
-              return msgpack_unpacker(symbolize_keys: true).feed(chunk.slice(6, size)).read rescue nil
+              return Fluent::MessagePackFactory.msgpack_unpacker(symbolize_keys: true).feed(chunk.slice(6, size)).read rescue nil
             end
           end
 

--- a/lib/fluent/plugin/buffer/file_single_chunk.rb
+++ b/lib/fluent/plugin/buffer/file_single_chunk.rb
@@ -30,7 +30,6 @@ module Fluent
         ## state: b/q - 'b'(on stage), 'q'(enqueued)
 
         include SystemConfig::Mixin
-        include MessagePackFactory::Mixin
 
         PATH_EXT = 'buf'
         PATH_SUFFIX = ".#{PATH_EXT}"
@@ -216,7 +215,7 @@ module Fluent
           count = 0
           File.open(@path, 'rb') { |f|
             if chunk_format == :msgpack
-              msgpack_unpacker(f).each { |d| count += 1 }
+              Fluent::MessagePackFactory.msgpack_unpacker(f).each { |d| count += 1 }
             else
               f.each_line { |l| count += 1 }
             end

--- a/lib/fluent/plugin/in_forward.rb
+++ b/lib/fluent/plugin/in_forward.rb
@@ -256,7 +256,7 @@ module Fluent::Plugin
             serializer = :to_json.to_proc
             feeder = ->(d){ parser << d }
           else # msgpack
-            parser = Fluent::Engine.msgpack_factory.unpacker
+            parser = Fluent::MessagePackFactory.msgpack_unpacker
             serializer = :to_msgpack.to_proc
             feeder = ->(d){
               parser.feed_each(d){|obj|

--- a/lib/fluent/plugin/in_unix.rb
+++ b/lib/fluent/plugin/in_unix.rb
@@ -143,7 +143,7 @@ module Fluent
           @y.on_parse_complete = @on_message
         else
           m = method(:on_read_msgpack)
-          @u = Fluent::Engine.msgpack_factory.unpacker
+          @u = Fluent::MessagePackFactory.msgpack_unpacker
         end
 
         singleton_class.module_eval do

--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -543,7 +543,7 @@ module Fluent::Plugin
           username: server.username,
         )
 
-        @unpacker = Fluent::Engine.msgpack_unpacker
+        @unpacker = Fluent::MessagePackFactory.msgpack_unpacker
 
         @resolved_host = nil
         @resolved_time = 0

--- a/lib/fluent/plugin/out_forward/ack_handler.rb
+++ b/lib/fluent/plugin/out_forward/ack_handler.rb
@@ -34,7 +34,7 @@ module Fluent::Plugin
         @timeout = timeout
         @log = log
         @read_length = read_length
-        @unpacker = Fluent::Engine.msgpack_unpacker
+        @unpacker = Fluent::MessagePackFactory.msgpack_unpacker
       end
 
       def collect_response(select_interval)

--- a/lib/fluent/plugin/out_stream.rb
+++ b/lib/fluent/plugin/out_stream.rb
@@ -68,7 +68,7 @@ module Fluent
         chain = NullOutputChain.instance
         chunk.open {|io|
           # TODO use MessagePackIoEventStream
-          u = Fluent::Engine.msgpack_factory.unpacker(io)
+          u = Fluent::MessagePackFactory.msgpack_unpacker(io)
           begin
             u.each {|(tag,entries)|
               es = MultiEventStream.new

--- a/test/plugin/out_forward/test_handshake_protocol.rb
+++ b/test/plugin/out_forward/test_handshake_protocol.rb
@@ -16,7 +16,7 @@ class HandshakeProtocolTest < Test::Unit::TestCase
       handshake.invoke(sock, ri, ['HELO', {}])
 
       assert_equal(ri.state, :pingpong)
-      Fluent::Engine.msgpack_factory.unpacker.feed_each(sock.string) do |ping|
+      Fluent::MessagePackFactory.msgpack_unpacker.feed_each(sock.string) do |ping|
         assert_equal(ping.size, 6)
         assert_equal(ping[0], 'PING')
         assert_equal(ping[1], hostname)
@@ -38,7 +38,7 @@ class HandshakeProtocolTest < Test::Unit::TestCase
       handshake.invoke(sock, ri, ['HELO', { 'auth' => 'auth' }])
 
       assert_equal(ri.state, :pingpong)
-      Fluent::Engine.msgpack_factory.unpacker.feed_each(sock.string) do |ping|
+      Fluent::MessagePackFactory.msgpack_unpacker.feed_each(sock.string) do |ping|
         assert_equal(ping.size, 6)
         assert_equal(ping[0], 'PING')
         assert_equal(ping[1], hostname)

--- a/test/plugin/test_in_forward.rb
+++ b/test/plugin/test_in_forward.rb
@@ -538,7 +538,7 @@ class ForwardInputTest < Test::Unit::TestCase
       chunk = ["tag1", entries, { 'compressed' => 'gzip' }].to_msgpack
 
       d.run do
-        Fluent::Engine.msgpack_factory.unpacker.feed_each(chunk) do |obj|
+        Fluent::MessagePackFactory.msgpack_unpacker.feed_each(chunk) do |obj|
           option = d.instance.send(:on_message, obj, chunk.size, DUMMY_SOCK)
           assert_equal 'gzip', option['compressed']
         end
@@ -568,7 +568,7 @@ class ForwardInputTest < Test::Unit::TestCase
       mock(Fluent::CompressedMessagePackEventStream).new(entries, nil, 0)
 
       d.run do
-        Fluent::Engine.msgpack_factory.unpacker.feed_each(chunk) do |obj|
+        Fluent::MessagePackFactory.msgpack_unpacker.feed_each(chunk) do |obj|
           option = d.instance.send(:on_message, obj, chunk.size, DUMMY_SOCK)
           assert_equal 'gzip', option['compressed']
         end
@@ -592,7 +592,7 @@ class ForwardInputTest < Test::Unit::TestCase
       assert chunk.size < (32 * 1024 * 1024)
 
       d.run(shutdown: false) do
-        Fluent::Engine.msgpack_factory.unpacker.feed_each(chunk) do |obj|
+        Fluent::MessagePackFactory.msgpack_unpacker.feed_each(chunk) do |obj|
           d.instance.send(:on_message, obj, chunk.size, DUMMY_SOCK)
         end
       end
@@ -624,7 +624,7 @@ class ForwardInputTest < Test::Unit::TestCase
       chunk = [ "test.tag", (0...16).map{|i| [time + i, {"data" => str}] } ].to_msgpack
 
       d.run(shutdown: false) do
-        Fluent::Engine.msgpack_factory.unpacker.feed_each(chunk) do |obj|
+        Fluent::MessagePackFactory.msgpack_unpacker.feed_each(chunk) do |obj|
           d.instance.send(:on_message, obj, chunk.size, DUMMY_SOCK)
         end
       end
@@ -654,7 +654,7 @@ class ForwardInputTest < Test::Unit::TestCase
 
       # d.run => send_data
       d.run(shutdown: false) do
-        Fluent::Engine.msgpack_factory.unpacker.feed_each(chunk) do |obj|
+        Fluent::MessagePackFactory.msgpack_unpacker.feed_each(chunk) do |obj|
           d.instance.send(:on_message, obj, chunk.size, DUMMY_SOCK)
         end
       end
@@ -1004,11 +1004,11 @@ class ForwardInputTest < Test::Unit::TestCase
   end
 
   def packer(*args)
-    Fluent::Engine.msgpack_factory.packer(*args)
+    Fluent::MessagePackFactory.msgpack_packer(*args)
   end
 
   def unpacker
-    Fluent::Engine.msgpack_factory.unpacker
+    Fluent::MessagePackFactory.msgpack_unpacker
   end
 
   # res
@@ -1158,9 +1158,9 @@ class ForwardInputTest < Test::Unit::TestCase
       execute_test_with_source_hostname_key(*keys) { |events|
         entries = ''
         events.each { |tag, time, record|
-          Fluent::Engine.msgpack_factory.packer(entries).write([time, record]).flush
+          Fluent::MessagePackFactory.msgpack_packer(entries).write([time, record]).flush
         }
-        send_data Fluent::Engine.msgpack_factory.packer.write(["tag1", entries]).to_s
+        send_data Fluent::MessagePackFactory.msgpack_packer.write(["tag1", entries]).to_s
       }
     end
   end

--- a/test/plugin/test_in_unix.rb
+++ b/test/plugin/test_in_unix.rb
@@ -18,7 +18,7 @@ module StreamInputTest
 
     d.run do
       d.expected_emits.each {|tag,_time,record|
-        send_data Fluent::Engine.msgpack_factory.packer.write([tag, 0, record]).to_s
+        send_data Fluent::MessagePackFactory.msgpack_packer.write([tag, 0, record]).to_s
       }
     end
   end
@@ -33,7 +33,7 @@ module StreamInputTest
 
     d.run do
       d.expected_emits.each {|tag,_time,record|
-        send_data Fluent::Engine.msgpack_factory.packer.write([tag, _time, record]).to_s
+        send_data Fluent::MessagePackFactory.msgpack_packer.write([tag, _time, record]).to_s
       }
     end
   end
@@ -51,7 +51,7 @@ module StreamInputTest
       d.expected_emits.each {|tag,_time,record|
         entries << [_time, record]
       }
-      send_data Fluent::Engine.msgpack_factory.packer.write(["tag1", entries]).to_s
+      send_data Fluent::MessagePackFactory.msgpack_packer.write(["tag1", entries]).to_s
     end
   end
 
@@ -66,9 +66,9 @@ module StreamInputTest
     d.run do
       entries = ''
       d.expected_emits.each {|tag,_time,record|
-        Fluent::Engine.msgpack_factory.packer(entries).write([_time, record]).flush
+        Fluent::MessagePackFactory.msgpack_packer(entries).write([_time, record]).flush
       }
-      send_data Fluent::Engine.msgpack_factory.packer.write(["tag1", entries]).to_s
+      send_data Fluent::MessagePackFactory.msgpack_packer.write(["tag1", entries]).to_s
     end
   end
 

--- a/test/plugin/test_out_stream.rb
+++ b/test/plugin/test_out_stream.rb
@@ -31,10 +31,10 @@ module StreamOutputTest
     d.emit({"a"=>2}, time)
 
     expect = ["test",
-        Fluent::Engine.msgpack_factory.packer.write([time,{"a"=>1}]).to_s +
-        Fluent::Engine.msgpack_factory.packer.write([time,{"a"=>2}]).to_s
+        Fluent::MessagePackFactory.msgpack_packer.write([time,{"a"=>1}]).to_s +
+        Fluent::MessagePackFactory.msgpack_packer.write([time,{"a"=>2}]).to_s
       ]
-    expect = Fluent::Engine.msgpack_factory.packer.write(expect).to_s
+    expect = Fluent::MessagePackFactory.msgpack_packer.write(expect).to_s
 
     result = d.run
     assert_equal(expect, result)

--- a/test/test_event.rb
+++ b/test/test_event.rb
@@ -74,7 +74,7 @@ module EventTest
 
     test 'to_msgpack_stream' do
       stream = @es.to_msgpack_stream
-      Fluent::Engine.msgpack_factory.unpacker.feed_each(stream) { |time, record|
+      Fluent::MessagePackFactory.msgpack_unpacker.feed_each(stream) { |time, record|
         assert_equal @time, time
         assert_equal @record, record
       }
@@ -82,7 +82,7 @@ module EventTest
 
     test 'to_msgpack_stream with time_int argument' do
       stream = @es.to_msgpack_stream(time_int: true)
-      Fluent::Engine.msgpack_factory.unpacker.feed_each(stream) { |time, record|
+      Fluent::MessagePackFactory.msgpack_unpacker.feed_each(stream) { |time, record|
         assert_equal @time.to_i, time
         assert_equal @record, record
       }
@@ -90,7 +90,7 @@ module EventTest
 
     test 'to_compressed_msgpack_stream' do
       stream = @es.to_compressed_msgpack_stream
-      Fluent::Engine.msgpack_factory.unpacker.feed_each(decompress(stream)) { |time, record|
+      Fluent::MessagePackFactory.msgpack_unpacker.feed_each(decompress(stream)) { |time, record|
         assert_equal @time, time
         assert_equal @record, record
       }
@@ -98,7 +98,7 @@ module EventTest
 
     test 'to_compressed_msgpack_stream with time_int argument' do
       stream = @es.to_compressed_msgpack_stream(time_int: true)
-      Fluent::Engine.msgpack_factory.unpacker.feed_each(decompress(stream)) { |time, record|
+      Fluent::MessagePackFactory.msgpack_unpacker.feed_each(decompress(stream)) { |time, record|
         assert_equal @time.to_i, time
         assert_equal @record, record
       }
@@ -174,7 +174,7 @@ module EventTest
     test 'to_msgpack_stream' do
       i = 0
       stream = @es.to_msgpack_stream
-      Fluent::Engine.msgpack_factory.unpacker.feed_each(stream) { |time, record|
+      Fluent::MessagePackFactory.msgpack_unpacker.feed_each(stream) { |time, record|
         assert_equal @times[i], time
         assert_equal @records[i], record
         i += 1
@@ -185,7 +185,7 @@ module EventTest
       i = 0
       compressed_stream = @es.to_compressed_msgpack_stream
       stream = decompress(compressed_stream)
-      Fluent::Engine.msgpack_factory.unpacker.feed_each(stream) { |time, record|
+      Fluent::MessagePackFactory.msgpack_unpacker.feed_each(stream) { |time, record|
         assert_equal @times[i], time
         assert_equal @records[i], record
         i += 1
@@ -196,7 +196,7 @@ module EventTest
       i = 0
       compressed_stream = @es.to_compressed_msgpack_stream(time_int: true)
       stream = decompress(compressed_stream)
-      Fluent::Engine.msgpack_factory.unpacker.feed_each(stream) { |time, record|
+      Fluent::MessagePackFactory.msgpack_unpacker.feed_each(stream) { |time, record|
         assert_equal @times[i].to_i, time
         assert_equal @records[i], record
         i += 1
@@ -276,7 +276,7 @@ module EventTest
     test 'to_msgpack_stream' do
       i = 0
       stream = @es.to_msgpack_stream
-      Fluent::Engine.msgpack_factory.unpacker.feed_each(stream) { |time, record|
+      Fluent::MessagePackFactory.msgpack_unpacker.feed_each(stream) { |time, record|
         assert_equal @times[i], time
         assert_equal @records[i], record
         i += 1
@@ -287,7 +287,7 @@ module EventTest
       i = 0
       compressed_stream = @es.to_compressed_msgpack_stream
       stream = decompress(compressed_stream)
-      Fluent::Engine.msgpack_factory.unpacker.feed_each(stream) { |time, record|
+      Fluent::MessagePackFactory.msgpack_unpacker.feed_each(stream) { |time, record|
         assert_equal @times[i], time
         assert_equal @records[i], record
         i += 1
@@ -298,7 +298,7 @@ module EventTest
       i = 0
       compressed_stream = @es.to_compressed_msgpack_stream(time_int: true)
       stream = decompress(compressed_stream)
-      Fluent::Engine.msgpack_factory.unpacker.feed_each(stream) { |time, record|
+      Fluent::MessagePackFactory.msgpack_unpacker.feed_each(stream) { |time, record|
         assert_equal @times[i].to_i, time
         assert_equal @records[i], record
         i += 1
@@ -312,7 +312,7 @@ module EventTest
     include Fluent::Plugin::Compressable
 
     def setup
-      pk = Fluent::Engine.msgpack_factory.packer
+      pk = Fluent::MessagePackFactory.msgpack_packer
       time = Engine.now
       @times = [Fluent::EventTime.new(time.sec), Fluent::EventTime.new(time.sec + 1)]
       @records = [{'k' => 'v1', 'n' => 1}, {'k' => 'v2', 'n' => 2}]
@@ -384,7 +384,7 @@ module EventTest
     test 'to_msgpack_stream' do
       i = 0
       stream = @es.to_msgpack_stream
-      Fluent::Engine.msgpack_factory.unpacker.feed_each(stream) { |time, record|
+      Fluent::MessagePackFactory.msgpack_unpacker.feed_each(stream) { |time, record|
         assert_equal @times[i], time
         assert_equal @records[i], record
         i += 1
@@ -395,7 +395,7 @@ module EventTest
       i = 0
       compressed_stream = @es.to_compressed_msgpack_stream
       stream = decompress(compressed_stream)
-      Fluent::Engine.msgpack_factory.unpacker.feed_each(stream) { |time, record|
+      Fluent::MessagePackFactory.msgpack_unpacker.feed_each(stream) { |time, record|
         assert_equal @times[i], time
         assert_equal @records[i], record
         i += 1
@@ -490,7 +490,7 @@ module EventTest
       stream = nil
       ensure_data_is_decompressed { stream = @es.to_msgpack_stream }
 
-      Fluent::Engine.msgpack_factory.unpacker.feed_each(stream) { |time, record|
+      Fluent::MessagePackFactory.msgpack_unpacker.feed_each(stream) { |time, record|
         assert_equal @times[i], time
         assert_equal @records[i], record
         i += 1
@@ -505,7 +505,7 @@ module EventTest
       assert_equal @entries, @es.instance_variable_get(:@data)
 
       stream = decompress(compressed_stream)
-      Fluent::Engine.msgpack_factory.unpacker.feed_each(stream) { |time, record|
+      Fluent::MessagePackFactory.msgpack_unpacker.feed_each(stream) { |time, record|
         assert_equal @times[i], time
         assert_equal @records[i], record
         i += 1


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Ref  https://github.com/fluent/fluentd/issues/2624

**What this PR does / why we need it**: 

Remove redundant dependency from Fluent::Engine.
Fluent::Engine has too many states. it's a blocker of new reload feature.
Also, MessagePackFactory::Mixin is used for just reducing types. So I removed `include MessagePackFactory::Mixin` expression and made these methods deprecated.

**Docs Changes**:
no need

**Release Note**: 

no need