### PR TITLE
fix typo of service_discovery

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -240,7 +240,7 @@ module Fluent::Plugin
         configs << { type: @service_discovery[i][:@type], conf: c }
       end
 
-      service_disovery_create_manager(
+      service_discovery_create_manager(
         :out_forward_service_discovery_watcher,
         configurations: configs,
         load_balancer: LoadBalancer.new(log),

--- a/lib/fluent/plugin_helper/service_discovery.rb
+++ b/lib/fluent/plugin_helper/service_discovery.rb
@@ -49,7 +49,7 @@ module Fluent
       # @param configurations [Hash] hash which must has discivery_service type and its configuration like `{ type: :static, conf: <Fluent::Config::Element> }`
       # @param load_balancer [Object] object which has two methods #rebalance and #select_service
       # @param custom_build_method [Proc]
-      def service_disovery_create_manager(title, configurations:, load_balancer: nil, custom_build_method: nil, interval: 3)
+      def service_discovery_create_manager(title, configurations:, load_balancer: nil, custom_build_method: nil, interval: 3)
         @_plugin_helper_service_discovery_title = title
         @_plugin_helper_service_discovery_iterval = interval
 

--- a/test/plugin_helper/test_service_discovery.rb
+++ b/test/plugin_helper/test_service_discovery.rb
@@ -11,7 +11,7 @@ class ServiceDiscoveryHelper < Test::Unit::TestCase
     helpers :service_discovery
 
     # Make these mehtod public
-    def service_disovery_create_manager(title, configurations:, load_balancer: nil, custom_build_method: nil, interval: 3)
+    def service_discovery_create_manager(title, configurations:, load_balancer: nil, custom_build_method: nil, interval: 3)
       super
     end
 
@@ -38,7 +38,7 @@ class ServiceDiscoveryHelper < Test::Unit::TestCase
   test 'start discovery manager' do
     d = @d = Dummy.new
 
-    d.service_disovery_create_manager(
+    d.service_discovery_create_manager(
       :service_discovery_helper_test,
       configurations: [{ type: :static, conf:  config_element('root', '', {}, [config_element('service', '', { 'host' => '127.0.0.1', 'port' => '1234' })]) }],
     )
@@ -59,7 +59,7 @@ class ServiceDiscoveryHelper < Test::Unit::TestCase
   test 'call timer_execute if dynamic configuration' do
     d = @d = Dummy.new
 
-    d.service_disovery_create_manager(
+    d.service_discovery_create_manager(
       :service_discovery_helper_test,
       configurations: [{ type: :file, conf: config_element('file_config', '', { 'path' => File.join(@sd_file_dir, 'config.yml') }) }],
     )


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
None.

**What this PR does / why we need it**: 
Fix typo.

service_disovery_create_manager -> 
service_dis"c"overy_create_manager

**Docs Changes**:
None 

**Release Note**: 
None