### PR TITLE
Support logrotate on Windows correctly. Fix #2446

### DIFF
--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -312,7 +312,6 @@ exit 0 if early_exit
 require 'fluent/supervisor'
 if opts[:supervise]
   if Fluent.windows?
-
     if opts[:log_path] && opts[:log_path] != "-"
       if opts[:log_rotate_age] || opts[:log_rotate_size]
         require 'pathname'

--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -311,6 +311,17 @@ exit 0 if early_exit
 
 require 'fluent/supervisor'
 if opts[:supervise]
+  if Fluent.windows?
+
+    if opts[:log_path] && opts[:log_path] != "-"
+      if opts[:log_rotate_age] || opts[:log_rotate_size]
+        require 'pathname'
+
+        log_path = Pathname(opts[:log_path]).sub_ext("-supervisor#{Pathname(opts[:log_path]).extname}").to_s
+        opts[:log_path] = log_path
+      end
+    end
+  end
   Fluent::Supervisor.new(opts).run_supervisor
 else
   if opts[:standalone_worker] && opts[:workers] && opts[:workers] > 1

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -354,13 +354,21 @@ module Fluent
         @log_rotate_size = log_rotate_size
       end
 
+      def worker_id_suffixed_path(worker_id, path)
+        require 'pathname'
+
+        Pathname(path).sub_ext("-#{worker_id}#{Pathname(path).extname}").to_s
+      end
+
       def init(process_type, worker_id)
         @opts[:process_type] = process_type
         @opts[:worker_id] = worker_id
 
         if @path && @path != "-"
           @logdev = if @log_rotate_age || @log_rotate_size
-                     Fluent::LogDeviceIO.new(@path, shift_age: @log_rotate_age, shift_size: @log_rotate_size)
+                     Fluent::LogDeviceIO.new(Fluent.windows? ?
+                                               worker_id_suffixed_path(worker_id, @path) : @path,
+                                             shift_age: @log_rotate_age, shift_size: @log_rotate_size)
                    else
                      File.open(@path, "a")
                    end


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>

<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #2446

**What this PR does / why we need it**: 

In Windows multi-process environment, we cannot rename a file which is opened by another process.

Then, we should do this:

* Separate log file for each process on Windows

**Docs Changes**:

I'll add a note in https://docs.fluentd.org/deployment/logging#log-rotation-setting.

**Release Note**: 

Same as title.