### PR TITLE
Suppress warning about keyword argument introduced from ruby 2.7

### DIFF
--- a/lib/fluent/config/configure_proxy.rb
+++ b/lib/fluent/config/configure_proxy.rb
@@ -117,9 +117,9 @@ module Fluent
 
         merged = if self.root?
                    options[:root] = true
-                   self.class.new(other.name, options)
+                   self.class.new(other.name, **options)
                  else
-                   self.class.new(@name, options)
+                   self.class.new(@name, **options)
                  end
 
         # configured_in MUST be kept
@@ -172,9 +172,9 @@ module Fluent
 
         merged = if self.root?
                    options[:root] = true
-                   self.class.new(other.name, options)
+                   self.class.new(other.name, **options)
                  else
-                   self.class.new(@name, options)
+                   self.class.new(@name, **options)
                  end
 
         merged.configured_in_section = self.configured_in_section || other.configured_in_section

--- a/lib/fluent/plugin/buffer/chunk.rb
+++ b/lib/fluent/plugin/buffer/chunk.rb
@@ -202,7 +202,7 @@ module Fluent
             if kwargs[:compressed] == :gzip
               super
             else
-              super(kwargs) do |chunk_io|
+              super(**kwargs) do |chunk_io|
                 output_io = if chunk_io.is_a?(StringIO)
                               StringIO.new
                             else

--- a/lib/fluent/plugin/formatter_csv.rb
+++ b/lib/fluent/plugin/formatter_csv.rb
@@ -56,7 +56,7 @@ module Fluent
       end
 
       def format(tag, time, record)
-        csv = (@cache[Thread.current] ||= CSV.new("".force_encoding(Encoding::ASCII_8BIT), @generate_opts))
+        csv = (@cache[Thread.current] ||= CSV.new("".force_encoding(Encoding::ASCII_8BIT), **@generate_opts))
         line = (csv << record).string.dup
         # Need manual cleanup because CSV writer doesn't provide such method.
         csv.rewind
@@ -65,7 +65,7 @@ module Fluent
       end
 
       def format_with_nested_fields(tag, time, record)
-        csv = (@cache[Thread.current] ||= CSV.new("".force_encoding(Encoding::ASCII_8BIT), @generate_opts))
+        csv = (@cache[Thread.current] ||= CSV.new("".force_encoding(Encoding::ASCII_8BIT), **@generate_opts))
         values = @accessors.map { |a| a.call(record) }
         line = (csv << values).string.dup
         # Need manual cleanup because CSV writer doesn't provide such method.

--- a/lib/fluent/plugin_helper/child_process.rb
+++ b/lib/fluent/plugin_helper/child_process.rb
@@ -267,19 +267,19 @@ module Fluent
         end
 
         if mode.include?(:write)
-          writeio.set_encoding(external_encoding, internal_encoding, encoding_options)
+          writeio.set_encoding(external_encoding, internal_encoding, **encoding_options)
           writeio_in_use = true
         else
           writeio.reopen(IO::NULL) if writeio
         end
         if mode.include?(:read) || mode.include?(:read_with_stderr)
-          readio.set_encoding(external_encoding, internal_encoding, encoding_options)
+          readio.set_encoding(external_encoding, internal_encoding, **encoding_options)
           readio_in_use = true
         else
           readio.reopen(IO::NULL) if readio
         end
         if mode.include?(:stderr)
-          stderrio.set_encoding(external_encoding, internal_encoding, encoding_options)
+          stderrio.set_encoding(external_encoding, internal_encoding, **encoding_options)
           stderrio_in_use = true
         else
           stderrio.reopen(IO::NULL) if stderrio && stderr == :discard

--- a/lib/fluent/plugin_helper/extract.rb
+++ b/lib/fluent/plugin_helper/extract.rb
@@ -55,7 +55,7 @@ module Fluent
           config_param :time_type, :enum, list: [:float, :unixtime, :string], default: :float
 
           Fluent::TimeMixin::TIME_PARAMETERS.each do |name, type, opts|
-            config_param name, type, opts
+            config_param(name, type, **opts)
           end
         end
       end

--- a/lib/fluent/plugin_helper/inject.rb
+++ b/lib/fluent/plugin_helper/inject.rb
@@ -79,7 +79,7 @@ module Fluent
           config_param :time_type, :enum, list: [:float, :unixtime, :string], default: :float
 
           Fluent::TimeMixin::TIME_PARAMETERS.each do |name, type, opts|
-            config_param name, type, opts
+            config_param(name, type, **opts)
           end
         end
       end

--- a/lib/fluent/plugin_helper/server.rb
+++ b/lib/fluent/plugin_helper/server.rb
@@ -690,9 +690,9 @@ module Fluent
           end
 
           if RUBY_VERSION.to_f >= 2.3
-            NONBLOCK_ARG = {exception: false}
+            NONBLOCK_ARG = { exception: false }
             def try_handshake
-              @_handler_socket.accept_nonblock(NONBLOCK_ARG)
+              @_handler_socket.accept_nonblock(**NONBLOCK_ARG)
             end
           else
             def try_handshake

--- a/lib/fluent/test/driver/base_owned.rb
+++ b/lib/fluent/test/driver/base_owned.rb
@@ -53,13 +53,26 @@ module Fluent
           @section_name = ''
         end
 
-        def configure(conf, syntax: :v1)
+        def configure(conf)
           if conf.is_a?(Fluent::Config::Element)
             @config = conf
           elsif conf.is_a?(Hash)
             @config = Fluent::Config::Element.new(@section_name, "", Hash[conf.map{|k,v| [k.to_s, v]}], [])
           else
-            @config = Fluent::Config.parse(conf, @section_name, "", syntax: syntax)
+            @config = Fluent::Config.parse(conf, @section_name, "", syntax: :v1)
+          end
+          @instance.configure(@config)
+          self
+        end
+
+        # this is special method for v0 and should be deleted
+        def configure_v0(conf)
+          if conf.is_a?(Fluent::Config::Element)
+            @config = conf
+          elsif conf.is_a?(Hash)
+            @config = Fluent::Config::Element.new(@section_name, "", Hash[conf.map{|k,v| [k.to_s, v]}], [])
+          else
+            @config = Fluent::Config.parse(conf, @section_name, "", syntax: :v0)
           end
           @instance.configure(@config)
           self

--- a/lib/fluent/time.rb
+++ b/lib/fluent/time.rb
@@ -147,7 +147,7 @@ module Fluent
     module TimeParameters
       include Fluent::Configurable
       TIME_FULL_PARAMETERS.each do |name, type, opts|
-        config_param name, type, opts
+        config_param(name, type, **opts)
       end
 
       def configure(conf)

--- a/test/counter/test_client.rb
+++ b/test/counter/test_client.rb
@@ -128,7 +128,8 @@ class CounterClientTest < ::Test::Unit::TestCase
     test 'raise an error when @scope is nil' do
       @client.instance_variable_set(:@scope, nil)
       assert_raise 'Call `establish` method to get a `scope` before calling this method' do
-        @client.init(name: 'key1', reset_interval: 10).get
+        params = { name: 'key1', reset_interval: 10 }
+        @client.init(params).get
       end
     end
 
@@ -151,7 +152,8 @@ class CounterClientTest < ::Test::Unit::TestCase
       ]
     )
     test 'return an error object' do |(param, expected_error)|
-      @client.init(:name => 'key1', :reset_interval => 10).get
+      params = { name: 'key1', reset_interval: 10 }
+      @client.init(params).get
       response = @client.init(param).get
       errors = response.errors.first
 
@@ -164,7 +166,8 @@ class CounterClientTest < ::Test::Unit::TestCase
     end
 
     test 'return an existing value when passed key already exists and ignore option is true' do
-      res1 = @client.init(name: 'key1', reset_interval: 10).get
+      params = { name: 'key1', reset_interval: 10 }
+      res1 = @client.init(params).get
       res2 = nil
       assert_nothing_raised do
         res2 = @client.init({ name: 'key1', reset_interval: 10 }, options: { ignore: true }).get
@@ -312,7 +315,8 @@ class CounterClientTest < ::Test::Unit::TestCase
     test 'raise an error when @scope is nil' do
       @client.instance_variable_set(:@scope, nil)
       assert_raise 'Call `establish` method to get a `scope` before calling this method' do
-        @client.inc(name: 'name', value: 1).get
+        params = { name: 'name', value: 1 }
+        @client.inc(params).get
       end
     end
 


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
 no

**What this PR does / why we need it**: 

For https://bugs.ruby-lang.org/issues/14183

there are a vast number of warnings in https://travis-ci.org/fluent/fluentd/jobs/602120485 which is tested in ruby 2.7 preview2.

See also https://www.ruby-lang.org/en/news/2019/10/22/ruby-2-7-0-preview2-released/
**Docs Changes**:

no need

**Release Note**: 

no need
