### PR TITLE
remove unused variable

### DIFF
--- a/lib/fluent/command/plugin_config_formatter.rb
+++ b/lib/fluent/command/plugin_config_formatter.rb
@@ -174,9 +174,9 @@ class FluentPluginConfigFormatter
     end
     dumped << "\n"
     sections.each do |section_name, sub_section|
-      required = sub_section.delete(:required)
-      multi = sub_section.delete(:multi)
-      alias_name = sub_section.delete(:alias)
+      sub_section.delete(:required)
+      sub_section.delete(:multi)
+      sub_section.delete(:alias)
       sub_section.delete(:section)
       template = template_path("section.md.erb").read
       dumped <<


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
no

**What this PR does / why we need it**: 

I've noticed there is some unused variable while reading https://travis-ci.org/fluent/fluentd/jobs/600621297

/home/travis/build/fluent/fluentd/lib/fluent/command/plugin_config_formatter.rb:177: warning: assigned but unused variable - required
/home/travis/build/fluent/fluentd/lib/fluent/command/plugin_config_formatter.rb:178: warning: assigned but unused variable - multi
/home/travis/build/fluent/fluentd/lib/fluent/command/plugin_config_formatter.rb:179: warning: assigned but unused variable - alias_name


**Docs Changes**:

no need

**Release Note**: 

no need
