### PR TITLE
Revive MsgpackPack for compat

### DIFF
--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -25,6 +25,9 @@ require 'fluent/plugin'
 
 module Fluent
   class EngineClass
+    # For compat. remove it in fluentd v2
+    include Fluent::MessagePackFactory::Mixin
+
     def initialize
       @root_agent = nil
       @default_loop = nil


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

no 

**What this PR does / why we need it**: 

Follow up https://github.com/fluent/fluentd/pull/2657
Revive `Engine.msgpack_*` for compat.

**Docs Changes**:

no need

**Release Note**: 

no need
