### PR TITLE
Properly show class names

### DIFF
--- a/lib/fluent/time.rb
+++ b/lib/fluent/time.rb
@@ -292,7 +292,7 @@ module Fluent
 
     def parse_unixtime(value)
       unless value.is_a?(String) || value.is_a?(Numeric)
-        raise TimeParseError, "value must be a string or a number: #{value}(value.class)"
+        raise TimeParseError, "value must be a string or a number: #{value}(#{value.class})"
       end
 
       if @cache1_key == value
@@ -323,7 +323,7 @@ module Fluent
     ## parse_by_to_r  (msec): 28.232856 sec
     def parse_float(value)
       unless value.is_a?(String) || value.is_a?(Numeric)
-        raise TimeParseError, "value must be a string or a number: #{value}(value.class)"
+        raise TimeParseError, "value must be a string or a number: #{value}(#{value.class})"
       end
 
       if @cache1_key == value


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

None

**What this PR does / why we need it**: 
We recently encountered a weird error showing that:

`value must be a string or a number: (value.class)"`

After digging into the source code, I finally realized that I passed `nil` into the parser but the message was quite confusing.

From my perspective, I thought `(value.class)` should actually be `(#{value.class})`, which showed the class name of the value. In my case, it will be `(NilClass)`, which should be clear for users to understand.

**Docs Changes**:

None

**Release Note**: 

None