### PR TITLE
Accept tzinfo not only 2.x but also 1.x

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("serverengine", [">= 2.0.4", "< 3.0.0"])
   gem.add_runtime_dependency("http_parser.rb", [">= 0.5.1", "< 0.7.0"])
   gem.add_runtime_dependency("sigdump", ["~> 0.2.2"])
-  gem.add_runtime_dependency("tzinfo", ["~> 2.0"])
+  gem.add_runtime_dependency("tzinfo", [">= 1.0", "< 3.0"])
   gem.add_runtime_dependency("tzinfo-data", ["~> 1.0"])
   gem.add_runtime_dependency("strptime", [">= 0.2.2", "< 1.0.0"])
   gem.add_runtime_dependency("dig_rb", ["~> 1.0.0"])


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #2634

**What this PR does / why we need it**: 
The pull request #2479 enforces using tzinfo ~> 2.0 but it conflicts
with plugins which depend on activesupport such as fluent-plugin-sql
since it requires tzinfo ~> 1.1.
Until activesupport upgrades it, it would be better to accept also
tzinfo 1.x to keep availability of such plugins. Fluentd can accept
both versions of tzinfo since #2479 absorb the difference of their
API.

**Docs Changes**:
None

**Release Note**: 
None