### PR TITLE
Set system config variables explicitly

### DIFF
--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -320,11 +320,16 @@ if opts[:supervise]
       end
     end
   end
-  Fluent::Supervisor.new(opts).run_supervisor
+
+  supervisor = Fluent::Supervisor.new(opts)
+  supervisor.configure(supervisor: true)
+  supervisor.run_supervisor
 else
   if opts[:standalone_worker] && opts[:workers] && opts[:workers] > 1
     puts "Error: multi workers is not supported with --no-supervisor"
     exit 2
   end
-  Fluent::Supervisor.new(opts).run_worker
+  worker = Fluent::Supervisor.new(opts)
+  worker.configure
+  worker.run_worker
 end

--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -309,7 +309,6 @@ end
 
 exit 0 if early_exit
 
-require 'fluent/supervisor'
 if opts[:supervise]
   if Fluent.windows?
     if opts[:log_path] && opts[:log_path] != "-"

--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -120,6 +120,7 @@ module Fluent
     end
 
     def add_plugin_dir(dir)
+      $log.warn('Deprecated method: this method is going to be deleted. Use Fluent::Plugin.add_plugin_dir')
       Plugin.add_plugin_dir(dir)
     end
 

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -444,7 +444,6 @@ module Fluent
 
     def initialize(opt)
       @daemonize = opt[:daemonize]
-      @supervise = opt[:supervise]
       @standalone_worker= opt[:standalone_worker]
       @config_path = opt[:config_path]
       @inline_config = opt[:inline_config]

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -816,7 +816,7 @@ module Fluent
       @plugin_dirs.each {|dir|
         if Dir.exist?(dir)
           dir = File.expand_path(dir)
-          Fluent::Engine.add_plugin_dir(dir)
+          Fluent::Plugin.add_plugin_dir(dir)
         end
       }
 

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -475,8 +475,6 @@ module Fluent
     end
 
     def run_supervisor
-      $log.info :supervisor, "parsing config file is succeeded", path: @config_path
-
       if @system_config.workers < 1
         raise Fluent::ConfigError, "invalid number of workers (must be > 0):#{@system_config.workers}"
       end
@@ -561,6 +559,8 @@ module Fluent
 
       @log.level = @system_config.log_level
       @log.apply_options(format: @system_config.log.format, time_format: @system_config.log.time_format)
+
+      $log.info :supervisor, 'parsing config file is succeeded', path: @config_path
     end
 
     private

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -400,9 +400,9 @@ module Fluent
         self
       end
 
-      def apply_options(opts)
-        $log.format = opts[:format] if opts[:format]
-        $log.time_format = opts[:time_format] if opts[:time_format]
+      def apply_options(format: nil, time_format: nil)
+        $log.format = format if format
+        $log.time_format = time_format if time_format
       end
 
       def level=(level)

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -463,6 +463,7 @@ module Fluent
       @signame = opt[:signame]
 
       @cl_opt = opt
+      @conf = nil
 
       log_opts = { suppress_repeated_stacktrace: opt[:suppress_repeated_stacktrace] }
       @log = LoggerInitializer.new(

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -620,22 +620,24 @@ module Fluent
 
       $log.info "spawn command to main: ", cmdline: fluentd_spawn_cmd
 
-      params['main_cmd'] = fluentd_spawn_cmd
-      params['daemonize'] = @daemonize
-      params['inline_config'] = @inline_config
-      params['log_path'] = @log_path
-      params['log_rotate_age'] = @log_rotate_age
-      params['log_rotate_size'] = @log_rotate_size
-      params['chuser'] = @chuser
-      params['chgroup'] = @chgroup
-      params['use_v1_config'] = @use_v1_config
-      params['conf_encoding'] = @conf_encoding
-      params['signame'] = @signame
+      params = {
+        'main_cmd' => fluentd_spawn_cmd,
+        'daemonize' => @daemonize,
+        'inline_config' => @inline_config,
+        'log_path' => @log_path,
+        'log_rotate_age' => @log_rotate_age,
+        'log_rotate_size' => @log_rotate_size,
+        'chuser' => @chuser,
+        'chgroup' => @chgroup,
+        'use_v1_config' => @use_v1_config,
+        'conf_encoding' => @conf_encoding,
+        'signame' => @signame,
 
-      params['workers'] = @system_config.workers
-      params['root_dir'] = @system_config.root_dir
-      params['log_level'] = @system_config.log_level
-      params['suppress_repeated_stacktrace'] = @system_config.suppress_repeated_stacktrace
+        'workers' => @system_config.workers,
+        'root_dir' => @system_config.root_dir,
+        'log_level' => @system_config.log_level,
+        'suppress_repeated_stacktrace' => @system_config.suppress_repeated_stacktrace,
+      }
 
       se = ServerEngine.create(ServerModule, WorkerModule){
         Fluent::Supervisor.load_config(@config_path, params)

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -464,7 +464,8 @@ module Fluent
       @log_level = opt[:log_level]
       @log_rotate_age = opt[:log_rotate_age]
       @log_rotate_size = opt[:log_rotate_size]
-      @suppress_interval = opt[:suppress_interval]
+      # for system_config
+      @emit_error_log_interval = @suppress_interval = opt[:suppress_interval]
       @suppress_config_dump = opt[:suppress_config_dump]
       @log_event_verbose = opt[:log_event_verbose]
       @without_source = opt[:without_source]

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -620,7 +620,6 @@ module Fluent
 
       $log.info "spawn command to main: ", cmdline: fluentd_spawn_cmd
 
-      params = {}
       params['main_cmd'] = fluentd_spawn_cmd
       params['daemonize'] = @daemonize
       params['inline_config'] = @inline_config
@@ -631,13 +630,12 @@ module Fluent
       params['chgroup'] = @chgroup
       params['use_v1_config'] = @use_v1_config
       params['conf_encoding'] = @conf_encoding
+      params['signame'] = @signame
 
-      # system config parameters
       params['workers'] = @system_config.workers
       params['root_dir'] = @system_config.root_dir
       params['log_level'] = @system_config.log_level
       params['suppress_repeated_stacktrace'] = @system_config.suppress_repeated_stacktrace
-      params['signame'] = @signame
 
       se = ServerEngine.create(ServerModule, WorkerModule){
         Fluent::Supervisor.load_config(@config_path, params)

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -115,29 +115,12 @@ module Fluent
       s
     end
 
-    def attach(supervisor)
-      system = self
-      supervisor.instance_eval {
-        SYSTEM_CONFIG_PARAMETERS.each do |param|
-          case param
-          when :rpc_endpoint, :enable_get_dump, :process_name, :file_permission, :dir_permission, :counter_server, :counter_client
-            next # doesn't exist in command line options
-          when :log_level
-            ll_value = instance_variable_get("@log_level")
-            # info level can't be specified via command line option.
-            # log_level is info here, it is default value and <system>'s log_level should be applied if exists.
-            if ll_value != Fluent::Log::LEVEL_INFO
-              system.log_level = ll_value
-            end
-          else
-            next unless instance_variable_defined?("@#{param}")
-            supervisor_value = instance_variable_get("@#{param}")
-            next if supervisor_value.nil? # it's not configured by command line options
-
-            system.__send__("#{param}=", supervisor_value)
-          end
+    def overwrite_variables(**opt)
+      SYSTEM_CONFIG_PARAMETERS.each do |param|
+        if opt.key?(param) && !opt[param].nil? && instance_variable_defined?("@#{param}")
+          instance_variable_set("@#{param}", opt[param])
         end
-      }
+      end
     end
 
     def apply(supervisor)

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -122,8 +122,6 @@ module Fluent
           case param
           when :rpc_endpoint, :enable_get_dump, :process_name, :file_permission, :dir_permission, :counter_server, :counter_client
             next # doesn't exist in command line options
-          when :emit_error_log_interval
-            system.emit_error_log_interval = @suppress_interval if @suppress_interval
           when :log_level
             ll_value = instance_variable_get("@log_level")
             # info level can't be specified via command line option.

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -123,25 +123,6 @@ module Fluent
       end
     end
 
-    def apply(supervisor)
-      system = self
-      supervisor.instance_eval {
-        SYSTEM_CONFIG_PARAMETERS.each do |param|
-          param_value = system.__send__(param)
-          next if param_value.nil?
-
-          case param
-          when :log_level
-            @log.level = @log_level = param_value
-          else
-            instance_variable_set("@#{param}", param_value)
-          end
-        end
-        #@counter_server = system.counter_server unless system.counter_server.nil?
-        #@counter_client = system.counter_client unless system.counter_client.nil?
-      }
-    end
-
     module Mixin
       def system_config
         require 'fluent/engine'

--- a/test/plugin/test_in_monitor_agent.rb
+++ b/test/plugin/test_in_monitor_agent.rb
@@ -171,7 +171,7 @@ EOC
         s = Fluent::Supervisor.new(opts.merge(config_path: filepath))
         s.configure
       ensure
-        FileUtils.rm_r(CONFIG_DIR) rescue StandardError
+        FileUtils.rm_r(CONFIG_DIR) rescue _
       end
 
       expected_opts = {
@@ -309,7 +309,7 @@ EOC
         @supervisor = Fluent::Supervisor.new(Fluent::Supervisor.default_options.merge(config_path: @filepath))
         @supervisor.configure
       ensure
-        FileUtils.rm_r(CONFIG_DIR) rescue StandardError
+        FileUtils.rm_r(CONFIG_DIR) rescue _
       end
     end
 

--- a/test/plugin/test_in_monitor_agent.rb
+++ b/test/plugin/test_in_monitor_agent.rb
@@ -12,6 +12,8 @@ require_relative '../test_plugin_classes'
 class MonitorAgentInputTest < Test::Unit::TestCase
   include FuzzyAssert
 
+  CONFIG_DIR = File.expand_path('../tmp/in_monitor_agent', __dir__)
+
   def setup
     Fluent::Test.setup
   end
@@ -160,9 +162,20 @@ EOC
     test "fluentd opts" do
       d = create_driver
       opts = Fluent::Supervisor.default_options
-      Fluent::Supervisor.new(opts)
+
+      filepath = nil
+      begin
+        FileUtils.mkdir_p(CONFIG_DIR)
+        filepath = File.expand_path('fluentd.conf', CONFIG_DIR)
+        FileUtils.touch(filepath)
+        s = Fluent::Supervisor.new(opts.merge(config_path: filepath))
+        s.configure
+      ensure
+        FileUtils.rm_r(CONFIG_DIR) rescue StandardError
+      end
+
       expected_opts = {
-        "config_path" => "/etc/fluent/fluent.conf",
+        "config_path" => filepath,
         "pid_file"    => nil,
         "plugin_dirs" => ["/etc/fluent/plugin"],
         "log_path"    => nil,
@@ -279,11 +292,25 @@ EOC
   </match>
 </label>
 EOC
-      @ra = Fluent::RootAgent.new(log: $log)
-      stub(Fluent::Engine).root_agent { @ra }
-      @ra = configure_ra(@ra, conf)
-      # store Supervisor instance to avoid collected by GC
-      @supervisor = Fluent::Supervisor.new(Fluent::Supervisor.default_options)
+
+
+      begin
+        @ra = Fluent::RootAgent.new(log: $log)
+        stub(Fluent::Engine).root_agent { @ra }
+        @ra = configure_ra(@ra, conf)
+        # store Supervisor instance to avoid collected by GC
+
+        FileUtils.mkdir_p(CONFIG_DIR)
+        @filepath = File.expand_path('fluentd.conf', CONFIG_DIR)
+        File.open(@filepath, 'w') do |v|
+          v.puts(conf)
+        end
+
+        @supervisor = Fluent::Supervisor.new(Fluent::Supervisor.default_options.merge(config_path: @filepath))
+        @supervisor.configure
+      ensure
+        FileUtils.rm_r(CONFIG_DIR) rescue StandardError
+      end
     end
 
     test "/api/plugins" do
@@ -469,8 +496,7 @@ plugin_id:test_filter\tplugin_category:filter\ttype:test_filter\toutput_plugin:f
   tag monitor
 ")
       d.instance.start
-      expected_response_regex = /pid:\d+\tppid:\d+\tconfig_path:\/etc\/fluent\/fluent.conf\tpid_file:\tplugin_dirs:\/etc\/fluent\/plugin\tlog_path:/
-
+      expected_response_regex = %r{pid:\d+\tppid:\d+\tconfig_path:#{@filepath}\tpid_file:\tplugin_dirs:/etc/fluent/plugin\tlog_path:}
       assert_match(expected_response_regex,
                    get("http://127.0.0.1:#{@port}/api/config").body)
     end
@@ -484,7 +510,7 @@ plugin_id:test_filter\tplugin_category:filter\ttype:test_filter\toutput_plugin:f
 ")
       d.instance.start
       res = JSON.parse(get("http://127.0.0.1:#{@port}/api/config.json").body)
-      assert_equal("/etc/fluent/fluent.conf", res["config_path"])
+      assert_equal(@filepath, res["config_path"])
       assert_nil(res["pid_file"])
       assert_equal(["/etc/fluent/plugin"], res["plugin_dirs"])
       assert_nil(res["log_path"])

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -30,14 +30,6 @@ class SupervisorTest < ::Test::Unit::TestCase
     File.open(path, "w") {|f| f.write data }
   end
 
-  def test_initialize
-    opts = Fluent::Supervisor.default_options
-    sv = Fluent::Supervisor.new(opts)
-    opts.each { |k, v|
-      assert_equal v, sv.instance_variable_get("@#{k}")
-    }
-  end
-
   def test_read_config
     create_info_dummy_logger
 
@@ -61,10 +53,8 @@ class SupervisorTest < ::Test::Unit::TestCase
 
     sv.instance_variable_set(:@config_path, tmp_dir)
     sv.instance_variable_set(:@use_v1_config, use_v1_config)
-    sv.send(:read_config)
 
-    conf = sv.instance_variable_get(:@conf)
-
+    conf = sv.__send__(:read_config)
     elem = conf.elements.find { |e| e.name == 'source' }
     assert_equal "forward", elem['@type']
     assert_equal "forward_input", elem['@id']
@@ -108,9 +98,8 @@ class SupervisorTest < ::Test::Unit::TestCase
 
     sv.instance_variable_set(:@config_path, tmp_path)
     sv.instance_variable_set(:@use_v1_config, use_v1_config)
-    sv.send(:read_config)
 
-    conf = sv.instance_variable_get(:@conf)
+    conf = sv.__send__(:read_config)
     label = conf.elements.detect {|e| e.name == "label" }
     filter = label.elements.detect {|e| e.name == "filter" }
     record_transformer = filter.elements.detect {|e| e.name = "record_transformer" }
@@ -148,9 +137,7 @@ class SupervisorTest < ::Test::Unit::TestCase
 </system>
     EOC
     conf = Fluent::Config.parse(conf_data, "(test)", "(test_dir)", true)
-    sv.instance_variable_set(:@conf, conf)
-    sv.send(:set_system_config)
-    sys_conf = sv.instance_variable_get(:@system_config)
+    sys_conf = sv.__send__(:build_system_config, conf)
 
     assert_equal '127.0.0.1:24445', sys_conf.rpc_endpoint
     assert_equal true, sys_conf.suppress_repeated_stacktrace
@@ -229,9 +216,7 @@ class SupervisorTest < ::Test::Unit::TestCase
   </system>
     EOC
     conf = Fluent::Config.parse(conf_data, "(test)", "(test_dir)", true)
-    sv.instance_variable_set(:@conf, conf)
-    sv.send(:set_system_config)
-    sys_conf = sv.instance_variable_get(:@system_config)
+    sys_conf = sv.__send__(:build_system_config, conf)
 
     server = DummyServer.new
     server.rpc_endpoint = sys_conf.rpc_endpoint


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Ref #2624 

**What this PR does / why we need it**: 

Use `@system_config` explicitly so that supervisor doesn't need to expose all context to system_config.  the current implementation is hard to understand since there are too many states.

**Docs Changes**:

no need

**Release Note**: 

no need
