### PR TITLE
Fix a potential bug that ThreadError may occur on SIGUSR1

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -182,9 +182,9 @@ module Fluent
       if log = config[:logger_initializer]
         # Creating new thread due to mutex can't lock
         # in main thread during trap context
-        Thread.new {
+        Thread.new do
           log.reopen!
-        }.run
+        end
       end
 
       if config[:worker_pid]
@@ -721,7 +721,7 @@ module Fluent
     def flush_buffer
       # Creating new thread due to mutex can't lock
       # in main thread during trap context
-      Thread.new {
+      Thread.new do
         begin
           $log.debug "fluentd main process get SIGUSR1"
           $log.info "force flushing buffered events"
@@ -731,7 +731,7 @@ module Fluent
         rescue Exception => e
           $log.warn "flushing thread error: #{e}"
         end
-      }.run
+      end
     end
 
     def logging_with_console_output


### PR DESCRIPTION

<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 

None in GitHub issues, but it will fix the following bug report:

  * https://groups.google.com/d/msg/fluentd/Ten_apYLAX8/PD4jYk8KDwAJ

We ClearCode Inc. recently received same bug reports from our some customers.
Their fluentd is v0.12 but I think the same potential bug still exists in the latest version.

**What this PR does / why we need it**: 

This PR removes redundant `run` calls for some Thread objects.
It may cause the following error on SIGUSR1:

```
[error]: unexpected error error_class=ThreadError error=#<ThreadError: killed thread>
```

as reported in

  * https://groups.google.com/d/msg/fluentd/Ten_apYLAX8/PD4jYk8KDwAJ

because the new thread may finish before calling "run" method at main
thread.

In addition this PR also replaces `{ ... }` style blocks for them with `do ... end` style,
because the later style will clarify such mistakes.

**Docs Changes**:

None.

**Release Note**: 

Same as title
