### PR TITLE
Remove bug label from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,6 @@
 ---
 name:  Bug Report
 about: Create a report to help us improve. If you have questions about Fluentd and plugins, please direct these to https://groups.google.com/forum/#!forum/fluentd
-labels: 'bug'
 
 ---
 


### PR DESCRIPTION
it's noisy to add bug label automatically even if it's not a bug.

cc @repeatedly 