### PR TITLE
Make config values more strictly and enable to set nil or default

### DIFF
--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -131,6 +131,10 @@ op.on('--use-v0-config', "Use v0 configuration format", TrueClass) {|b|
   opts[:use_v1_config] = !b
 }
 
+op.on('--strict-config-value', "Parse config values strictly", TrueClass) {|b|
+  opts[:strict_config_value] = b
+}
+
 op.on('-v', '--verbose', "increase verbose level (-v: debug, -vv: trace)", TrueClass) {|b|
   if b
     opts[:log_level] = [opts[:log_level] - 1, Fluent::Log::LEVEL_TRACE].max

--- a/lib/fluent/config/element.rb
+++ b/lib/fluent/config/element.rb
@@ -182,24 +182,27 @@ module Fluent
         false
       end
 
-      def options(key)
-        return {} if @corresponding_proxies.empty?
+      def param_type(key)
+        return nil if @corresponding_proxies.empty?
 
         param_key = key.to_sym
         proxy = @corresponding_proxies.detect do |_proxy|
           _proxy.params.has_key?(param_key)
         end
-        return {} unless proxy
+        return nil unless proxy
         _block, opts = proxy.params[param_key]
-        opts
-      end
-
-      def param_type(key)
-        options(key)[:type]
+        opts[:type]
       end
 
       def default_value(key)
-        options(key)[:default]
+        return nil if @corresponding_proxies.empty?
+
+        param_key = key.to_sym
+        proxy = @corresponding_proxies.detect do |_proxy|
+          _proxy.params.has_key?(param_key)
+        end
+        return nil unless proxy
+        proxy.defaults[param_key]
       end
 
       def dump_value(k, v, nindent)

--- a/lib/fluent/config/element.rb
+++ b/lib/fluent/config/element.rb
@@ -142,7 +142,7 @@ module Fluent
         indent = "  " * nest
         nindent = "  " * (nest + 1)
         out = ""
-        if @arg.empty?
+        if @arg.nil? || @arg.empty?
           out << "#{indent}<#{@name}>\n"
         else
           out << "#{indent}<#{@name} #{@arg}>\n"

--- a/lib/fluent/config/error.rb
+++ b/lib/fluent/config/error.rb
@@ -24,9 +24,9 @@ module Fluent
   class ObsoletedParameterError < ConfigError
   end
 
-  class SetNil < ConfigError
+  class SetNil < Exception
   end
 
-  class SetDefault < ConfigError
+  class SetDefault < Exception
   end
 end

--- a/lib/fluent/config/error.rb
+++ b/lib/fluent/config/error.rb
@@ -23,4 +23,7 @@ module Fluent
 
   class ObsoletedParameterError < ConfigError
   end
+
+  class SetNil < ConfigError
+  end
 end

--- a/lib/fluent/config/error.rb
+++ b/lib/fluent/config/error.rb
@@ -26,4 +26,7 @@ module Fluent
 
   class SetNil < ConfigError
   end
+
+  class SetDefault < ConfigError
+  end
 end

--- a/lib/fluent/config/literal_parser.rb
+++ b/lib/fluent/config/literal_parser.rb
@@ -52,6 +52,16 @@ module Fluent
       def initialize(strscan, eval_context)
         super(strscan)
         @eval_context = eval_context
+        unless @eval_context.respond_to?(:use_nil)
+          def @eval_context.use_nil
+            raise SetNil
+          end
+        end
+        unless @eval_context.respond_to?(:use_default)
+          def @eval_context.use_default
+            raise SetDefault
+          end
+        end
       end
 
       def parse_literal(string_boundary_charset = LINE_END)

--- a/lib/fluent/config/literal_parser.rb
+++ b/lib/fluent/config/literal_parser.rb
@@ -81,7 +81,11 @@ module Fluent
         string = []
         while true
           if skip(/\"/)
-            return string.join
+            if string.include?(nil)
+              return nil
+            else
+              return string.join
+            end
           elsif check(/[^"]#{LINE_END_WITHOUT_SPACING_AND_COMMENT}/)
             if s = check(/[^\\]#{LINE_END_WITHOUT_SPACING_AND_COMMENT}/)
               string << s
@@ -168,7 +172,11 @@ module Fluent
 hostname = Socket.gethostname
 worker_id = ENV['SERVERENGINE_WORKER_ID'] || ''
 EOM
-        @eval_context.instance_eval(code)
+        begin
+          @eval_context.instance_eval(code)
+        rescue SetNil => e
+          nil
+        end
       end
 
       def eval_escape_char(c)

--- a/lib/fluent/config/literal_parser.rb
+++ b/lib/fluent/config/literal_parser.rb
@@ -83,6 +83,8 @@ module Fluent
           if skip(/\"/)
             if string.include?(nil)
               return nil
+            elsif string.include?(:default)
+              return :default
             else
               return string.join
             end
@@ -176,6 +178,8 @@ EOM
           @eval_context.instance_eval(code)
         rescue SetNil => e
           nil
+        rescue SetDefault => e
+          :default
         end
       end
 

--- a/lib/fluent/config/section.rb
+++ b/lib/fluent/config/section.rb
@@ -106,7 +106,7 @@ module Fluent
     end
 
     module SectionGenerator
-      def self.generate(proxy, conf, logger, plugin_class, strict_config_value = false, stack = [])
+      def self.generate(proxy, conf, logger, plugin_class, stack = [], strict_config_value = false)
         return nil if conf.nil?
 
         section_stack = ""
@@ -192,13 +192,13 @@ module Fluent
             raise ConfigError, "'<#{subproxy.name}>' sections are required" + section_stack
           end
           if subproxy.multi?
-            section_params[varname] = elements.map{ |e| generate(subproxy, e, logger, plugin_class, strict_config_value, stack + [subproxy.name]) }
+            section_params[varname] = elements.map{ |e| generate(subproxy, e, logger, plugin_class, stack + [subproxy.name], strict_config_value) }
           else
             if elements.size > 1
               logger.error "config error in:\n#{conf}" if logger
               raise ConfigError, "'<#{subproxy.name}>' section cannot be written twice or more" + section_stack
             end
-            section_params[varname] = generate(subproxy, elements.first, logger, plugin_class, strict_config_value, stack + [subproxy.name])
+            section_params[varname] = generate(subproxy, elements.first, logger, plugin_class, stack + [subproxy.name], strict_config_value)
           end
         end
 

--- a/lib/fluent/config/types.rb
+++ b/lib/fluent/config/types.rb
@@ -135,34 +135,34 @@ module Fluent
     }
 
     INTEGER_TYPE = Proc.new { |val, opts = {}, name = nil|
-      begin
-        if val.nil?
-          nil
-        elsif val == :default
-          Config.default_value(opts)
-        elsif opts[:strict]
+      if val.nil?
+        nil
+      elsif val == :default
+        Config.default_value(opts)
+      elsif opts[:strict]
+        begin
           Integer(val)
-        else
-          val.to_i
+        rescue ArgumentError, TypeError => e
+          raise ConfigError, "#{name}: #{e.message}"
         end
-      rescue ArgumentError, TypeError => e
-        raise ConfigError, "#{name}: #{e.message}"
+      else
+        val.to_i
       end
     }
 
     FLOAT_TYPE = Proc.new { |val, opts = {}, name = nil|
-      begin
-        if val.nil?
-          nil
-        elsif val == :default
-          Config.default_value(opts)
-        elsif opts[:strict]
+      if val.nil?
+        nil
+      elsif val == :default
+        Config.default_value(opts)
+      elsif opts[:strict]
+        begin
           Float(val)
-        else
-          val.to_f
+        rescue ArgumentError, TypeError => e
+          raise ConfigError, "#{name}: #{e.message}"
         end
-      rescue ArgumentError, TypeError => e
-        raise ConfigError, "#{name}: #{e.message}"
+      else
+        val.to_f
       end
     }
 

--- a/lib/fluent/config/types.rb
+++ b/lib/fluent/config/types.rb
@@ -20,17 +20,17 @@ require 'fluent/config/error'
 
 module Fluent
   module Config
-    def self.default_value(opts = {})
+    def self.default_value(opts = {}, name)
       if opts.has_key?(:default)
         opts[:default]
       else
-        nil
+        raise Fluent::ConfigError, "\'#{name}\' doesn't have default value"
       end
     end
 
     def self.size_value(str, opts = {}, name = nil)
       return nil if str.nil?
-      return Config.default_value(opts) if str == :default
+      return Config.default_value(opts, name) if str == :default
 
       case str.to_s
       when /([0-9]+)k/i
@@ -48,7 +48,7 @@ module Fluent
 
     def self.time_value(str, opts = {}, name = nil)
       return nil if str.nil?
-      return Config.default_value(opts) if str == :default
+      return Config.default_value(opts, name) if str == :default
 
       case str.to_s
       when /([0-9]+)s/
@@ -66,7 +66,7 @@ module Fluent
 
     def self.bool_value(str, opts = {}, name = nil)
       return nil if str.nil?
-      return Config.default_value(opts) if str == :default
+      return Config.default_value(opts, name) if str == :default
 
       case str.to_s
       when 'true', 'yes'
@@ -90,7 +90,7 @@ module Fluent
 
     def self.regexp_value(str, opts = {}, name = nil)
       return nil unless str
-      return Config.default_value(opts) if str == :default
+      return Config.default_value(opts, name) if str == :default
 
       return Regexp.compile(str) unless str.start_with?("/")
       right_slash_position = str.rindex("/")
@@ -106,7 +106,7 @@ module Fluent
 
     def self.string_value(val, opts = {}, name = nil)
       return nil if val.nil?
-      return Config.default_value(opts) if val == :default
+      return Config.default_value(opts, name) if val == :default
 
       v = val.to_s
       v = v.frozen? ? v.dup : v # config_param can't assume incoming string is mutable
@@ -119,7 +119,7 @@ module Fluent
 
     def self.enum_value(val, opts = {}, name = nil)
       return nil if val.nil?
-      return Config.default_value(opts) if val == :default
+      return Config.default_value(opts, name) if val == :default
 
       s = val.to_sym
       list = opts[:list]
@@ -138,7 +138,7 @@ module Fluent
       if val.nil?
         nil
       elsif val == :default
-        Config.default_value(opts)
+        Config.default_value(opts, name)
       elsif opts[:strict]
         begin
           Integer(val)
@@ -154,7 +154,7 @@ module Fluent
       if val.nil?
         nil
       elsif val == :default
-        Config.default_value(opts)
+        Config.default_value(opts, name)
       elsif opts[:strict]
         begin
           Float(val)
@@ -202,7 +202,7 @@ module Fluent
 
     def self.hash_value(val, opts = {}, name = nil)
       return nil if val.nil?
-      return Config.default_value(opts) if val == :default
+      return Config.default_value(opts, name) if val == :default
 
       param = if val.is_a?(String)
                 val.start_with?('{') ? JSON.load(val) : Hash[val.strip.split(/\s*,\s*/).map{|v| v.split(':', 2)}]
@@ -230,7 +230,7 @@ module Fluent
 
     def self.array_value(val, opts = {}, name = nil)
       return nil if val.nil?
-      return Config.default_value(opts) if val == :default
+      return Config.default_value(opts, name) if val == :default
 
       param = if val.is_a?(String)
                 val.start_with?('[') ? JSON.load(val) : val.strip.split(/\s*,\s*/)

--- a/lib/fluent/config/types.rb
+++ b/lib/fluent/config/types.rb
@@ -20,8 +20,18 @@ require 'fluent/config/error'
 
 module Fluent
   module Config
+    def self.default_value(opts = {})
+      if opts.has_key?(:default)
+        opts[:default]
+      else
+        nil
+      end
+    end
+
     def self.size_value(str, opts = {}, name = nil)
       return nil if str.nil?
+      return Config.default_value(opts) if str == :default
+
       case str.to_s
       when /([0-9]+)k/i
         $~[1].to_i * 1024
@@ -38,6 +48,8 @@ module Fluent
 
     def self.time_value(str, opts = {}, name = nil)
       return nil if str.nil?
+      return Config.default_value(opts) if str == :default
+
       case str.to_s
       when /([0-9]+)s/
         $~[1].to_i
@@ -54,6 +66,8 @@ module Fluent
 
     def self.bool_value(str, opts = {}, name = nil)
       return nil if str.nil?
+      return Config.default_value(opts) if str == :default
+
       case str.to_s
       when 'true', 'yes'
         true
@@ -76,6 +90,8 @@ module Fluent
 
     def self.regexp_value(str, opts = {}, name = nil)
       return nil unless str
+      return Config.default_value(opts) if str == :default
+
       return Regexp.compile(str) unless str.start_with?("/")
       right_slash_position = str.rindex("/")
       if right_slash_position < str.size - 3
@@ -90,6 +106,8 @@ module Fluent
 
     def self.string_value(val, opts = {}, name = nil)
       return nil if val.nil?
+      return Config.default_value(opts) if val == :default
+
       v = val.to_s
       v = v.frozen? ? v.dup : v # config_param can't assume incoming string is mutable
       v.force_encoding(Encoding::UTF_8)
@@ -101,6 +119,8 @@ module Fluent
 
     def self.enum_value(val, opts = {}, name = nil)
       return nil if val.nil?
+      return Config.default_value(opts) if val == :default
+
       s = val.to_sym
       list = opts[:list]
       raise "Plugin BUG: config type 'enum' requires :list of symbols" unless list.is_a?(Array) && list.all?{|v| v.is_a? Symbol }
@@ -118,6 +138,8 @@ module Fluent
       begin
         if val.nil?
           nil
+        elsif val == :default
+          Config.default_value(opts)
         elsif opts[:strict]
           Integer(val)
         else
@@ -132,6 +154,8 @@ module Fluent
       begin
         if val.nil?
           nil
+        elsif val == :default
+          Config.default_value(opts)
         elsif opts[:strict]
           Float(val)
         else
@@ -178,6 +202,8 @@ module Fluent
 
     def self.hash_value(val, opts = {}, name = nil)
       return nil if val.nil?
+      return Config.default_value(opts) if val == :default
+
       param = if val.is_a?(String)
                 val.start_with?('{') ? JSON.load(val) : Hash[val.strip.split(/\s*,\s*/).map{|v| v.split(':', 2)}]
               else
@@ -204,6 +230,8 @@ module Fluent
 
     def self.array_value(val, opts = {}, name = nil)
       return nil if val.nil?
+      return Config.default_value(opts) if val == :default
+
       param = if val.is_a?(String)
                 val.start_with?('[') ? JSON.load(val) : val.strip.split(/\s*,\s*/)
               else

--- a/lib/fluent/config/types.rb
+++ b/lib/fluent/config/types.rb
@@ -64,6 +64,8 @@ module Fluent
         # parser should pass empty string in this case but changing behaviour may break existing environment so keep parser behaviour. Just ignore comment value in boolean handling for now.
         if str.respond_to?('start_with?') && str.start_with?('#')
           true
+        elsif opts[:strict]
+          raise Fluent::ConfigError, "#{name}: invalid bool value: #{str}"
         else
           nil
         end

--- a/lib/fluent/config/types.rb
+++ b/lib/fluent/config/types.rb
@@ -20,17 +20,8 @@ require 'fluent/config/error'
 
 module Fluent
   module Config
-    def self.default_value(opts = {}, name)
-      if opts.has_key?(:default)
-        opts[:default]
-      else
-        raise Fluent::ConfigError, "\'#{name}\' doesn't have default value"
-      end
-    end
-
     def self.size_value(str, opts = {}, name = nil)
       return nil if str.nil?
-      return Config.default_value(opts, name) if str == :default
 
       case str.to_s
       when /([0-9]+)k/i
@@ -48,7 +39,6 @@ module Fluent
 
     def self.time_value(str, opts = {}, name = nil)
       return nil if str.nil?
-      return Config.default_value(opts, name) if str == :default
 
       case str.to_s
       when /([0-9]+)s/
@@ -66,7 +56,6 @@ module Fluent
 
     def self.bool_value(str, opts = {}, name = nil)
       return nil if str.nil?
-      return Config.default_value(opts, name) if str == :default
 
       case str.to_s
       when 'true', 'yes'
@@ -90,7 +79,6 @@ module Fluent
 
     def self.regexp_value(str, opts = {}, name = nil)
       return nil unless str
-      return Config.default_value(opts, name) if str == :default
 
       return Regexp.compile(str) unless str.start_with?("/")
       right_slash_position = str.rindex("/")
@@ -106,7 +94,6 @@ module Fluent
 
     def self.string_value(val, opts = {}, name = nil)
       return nil if val.nil?
-      return Config.default_value(opts, name) if val == :default
 
       v = val.to_s
       v = v.frozen? ? v.dup : v # config_param can't assume incoming string is mutable
@@ -119,7 +106,6 @@ module Fluent
 
     def self.enum_value(val, opts = {}, name = nil)
       return nil if val.nil?
-      return Config.default_value(opts, name) if val == :default
 
       s = val.to_sym
       list = opts[:list]
@@ -137,8 +123,6 @@ module Fluent
     INTEGER_TYPE = Proc.new { |val, opts = {}, name = nil|
       if val.nil?
         nil
-      elsif val == :default
-        Config.default_value(opts, name)
       elsif opts[:strict]
         begin
           Integer(val)
@@ -153,8 +137,6 @@ module Fluent
     FLOAT_TYPE = Proc.new { |val, opts = {}, name = nil|
       if val.nil?
         nil
-      elsif val == :default
-        Config.default_value(opts, name)
       elsif opts[:strict]
         begin
           Float(val)
@@ -202,7 +184,6 @@ module Fluent
 
     def self.hash_value(val, opts = {}, name = nil)
       return nil if val.nil?
-      return Config.default_value(opts, name) if val == :default
 
       param = if val.is_a?(String)
                 val.start_with?('{') ? JSON.load(val) : Hash[val.strip.split(/\s*,\s*/).map{|v| v.split(':', 2)}]
@@ -230,7 +211,6 @@ module Fluent
 
     def self.array_value(val, opts = {}, name = nil)
       return nil if val.nil?
-      return Config.default_value(opts, name) if val == :default
 
       param = if val.is_a?(String)
                 val.start_with?('[') ? JSON.load(val) : val.strip.split(/\s*,\s*/)

--- a/lib/fluent/configurable.rb
+++ b/lib/fluent/configurable.rb
@@ -91,7 +91,7 @@ module Fluent
 
       # In the nested section, can't get plugin class through proxies so get plugin class here
       plugin_class = Fluent::Plugin.lookup_type_from_class(proxy.name.to_s)
-      root = Fluent::Config::SectionGenerator.generate(proxy, conf, logger, plugin_class, strict_config_value)
+      root = Fluent::Config::SectionGenerator.generate(proxy, conf, logger, plugin_class, [], strict_config_value)
       @config_root_section = root
 
       root.instance_eval{ @params.keys }.each do |param_name|

--- a/lib/fluent/configurable.rb
+++ b/lib/fluent/configurable.rb
@@ -74,7 +74,7 @@ module Fluent
       Fluent::Config::SectionGenerator.generate(proxy, conf, nil, nil)
     end
 
-    def configure(conf, strict_config_value: false)
+    def configure(conf, strict_config_value=false)
       @config = conf
 
       logger = if self.respond_to?(:log)

--- a/lib/fluent/configurable.rb
+++ b/lib/fluent/configurable.rb
@@ -74,7 +74,7 @@ module Fluent
       Fluent::Config::SectionGenerator.generate(proxy, conf, nil, nil)
     end
 
-    def configure(conf)
+    def configure(conf, strict_config_value: false)
       @config = conf
 
       logger = if self.respond_to?(:log)
@@ -91,7 +91,7 @@ module Fluent
 
       # In the nested section, can't get plugin class through proxies so get plugin class here
       plugin_class = Fluent::Plugin.lookup_type_from_class(proxy.name.to_s)
-      root = Fluent::Config::SectionGenerator.generate(proxy, conf, logger, plugin_class)
+      root = Fluent::Config::SectionGenerator.generate(proxy, conf, logger, plugin_class, strict_config_value)
       @config_root_section = root
 
       root.instance_eval{ @params.keys }.each do |param_name|

--- a/lib/fluent/plugin/base.rb
+++ b/lib/fluent/plugin/base.rb
@@ -60,7 +60,7 @@ module Fluent
                     end
           system_config_override(workers: workers)
         end
-        super
+        super(conf, strict_config_value: system_config.strict_config_value)
         @_state ||= State.new(false, false, false, false, false, false, false, false, false)
         @_state.configure = true
         self

--- a/lib/fluent/plugin/base.rb
+++ b/lib/fluent/plugin/base.rb
@@ -60,7 +60,7 @@ module Fluent
                     end
           system_config_override(workers: workers)
         end
-        super(conf, strict_config_value: system_config.strict_config_value)
+        super(conf, system_config.strict_config_value)
         @_state ||= State.new(false, false, false, false, false, false, false, false, false)
         @_state.configure = true
         self

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -776,7 +776,7 @@ module Fluent
     end
 
     def build_system_config(conf)
-      system_config = SystemConfig.create(conf)
+      system_config = SystemConfig.create(conf, strict_config_value: @cl_opt[:strict_config_value])
       opt = {}
       Fluent::SystemConfig::SYSTEM_CONFIG_PARAMETERS.each do |param|
         if @cl_opt.key?(param) && !@cl_opt[param].nil?

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -404,6 +404,7 @@ module Fluent
         suppress_repeated_stacktrace: true,
         without_source: nil,
         use_v1_config: true,
+        strict_config_value: nil,
         supervise: true,
         standalone_worker: false,
         signame: nil,

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -776,7 +776,7 @@ module Fluent
     end
 
     def build_system_config(conf)
-      system_config = SystemConfig.create(conf, strict_config_value: @cl_opt[:strict_config_value])
+      system_config = SystemConfig.create(conf, @cl_opt[:strict_config_value])
       opt = {}
       Fluent::SystemConfig::SYSTEM_CONFIG_PARAMETERS.each do |param|
         if @cl_opt.key?(param) && !@cl_opt[param].nil?

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -75,12 +75,12 @@ module Fluent
       config_param :timeout, :time, default: nil
     end
 
-    def self.create(conf)
+    def self.create(conf, strict_config_value: false)
       systems = conf.elements(name: 'system')
       return SystemConfig.new if systems.empty?
       raise Fluent::ConfigError, "<system> is duplicated. <system> should be only one" if systems.size > 1
 
-      SystemConfig.new(systems.first)
+      SystemConfig.new(systems.first, strict_config_value)
     end
 
     def self.blank_system_config
@@ -97,13 +97,13 @@ module Fluent
       end
     end
 
-    def initialize(conf=nil)
+    def initialize(conf=nil, strict_config_value=false)
       super()
       conf ||= SystemConfig.blank_system_config
-      configure(conf)
+      configure(conf, strict_config_value: strict_config_value)
     end
 
-    def configure(conf)
+    def configure(conf, strict_config_value: false)
       super
 
       @log_level = Log.str_to_level(@log_level.to_s) if @log_level

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -104,7 +104,19 @@ module Fluent
     end
 
     def configure(conf, strict_config_value: false)
-      super
+      strict = strict_config_value
+      if !strict && conf && conf.has_key?("strict_config_value")
+        strict = Fluent::Config.bool_value(conf["strict_config_value"])
+      end
+
+      begin
+        super(conf, strict_config_value: strict)
+      rescue ConfigError => e
+        $log.error "config error in:\n#{conf}"
+        $log.error 'config error', error: e
+        $log.debug_backtrace
+        exit!(1)
+      end
 
       @log_level = Log.str_to_level(@log_level.to_s) if @log_level
     end

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -27,6 +27,7 @@ module Fluent
       :log_event_verbose,
       :without_source, :rpc_endpoint, :enable_get_dump, :process_name,
       :file_permission, :dir_permission, :counter_server, :counter_client,
+      :strict_config_value
     ]
 
     config_param :workers,   :integer, default: 1
@@ -40,6 +41,7 @@ module Fluent
     config_param :rpc_endpoint,    :string, default: nil
     config_param :enable_get_dump, :bool, default: nil
     config_param :process_name,    :string, default: nil
+    config_param :strict_config_value, :bool, default: nil
     config_param :file_permission, default: nil do |v|
       v.to_i(8)
     end

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -75,7 +75,7 @@ module Fluent
       config_param :timeout, :time, default: nil
     end
 
-    def self.create(conf, strict_config_value: false)
+    def self.create(conf, strict_config_value=false)
       systems = conf.elements(name: 'system')
       return SystemConfig.new if systems.empty?
       raise Fluent::ConfigError, "<system> is duplicated. <system> should be only one" if systems.size > 1
@@ -100,17 +100,17 @@ module Fluent
     def initialize(conf=nil, strict_config_value=false)
       super()
       conf ||= SystemConfig.blank_system_config
-      configure(conf, strict_config_value: strict_config_value)
+      configure(conf, strict_config_value)
     end
 
-    def configure(conf, strict_config_value: false)
+    def configure(conf, strict_config_value=false)
       strict = strict_config_value
       if !strict && conf && conf.has_key?("strict_config_value")
         strict = Fluent::Config.bool_value(conf["strict_config_value"])
       end
 
       begin
-        super(conf, strict_config_value: strict)
+        super(conf, strict)
       rescue ConfigError => e
         $log.error "config error in:\n#{conf}"
         $log.error 'config error', error: e

--- a/test/config/test_configurable.rb
+++ b/test/config/test_configurable.rb
@@ -602,6 +602,20 @@ module Fluent::Config
             assert_equal([], x6a.obj2)
           end
         end
+
+        test 'strict value type' do
+          class InfFloatConfig
+            include Fluent::Configurable
+            config_param :int1, :integer
+            config_param :float1, :float
+          end
+
+          default = config_element("", "", {"int1" => "1", "float1" => ""})
+
+          c = InfFloatConfig.new
+          assert_nothing_raised { c.configure(default) }
+          assert_raise(ArgumentError) { c.configure(default, strict_config_value: true) }
+        end
       end
     end
 

--- a/test/config/test_configurable.rb
+++ b/test/config/test_configurable.rb
@@ -214,6 +214,12 @@ module ConfigurableSpec
     end
   end
 
+  class ExampleWithIntFloat
+    include Fluent::Configurable
+    config_param :int1, :integer
+    config_param :float1, :float
+  end
+
   module Overwrite
     class Base
       include Fluent::Configurable
@@ -604,17 +610,11 @@ module Fluent::Config
         end
 
         test 'strict value type' do
-          class InfFloatConfig
-            include Fluent::Configurable
-            config_param :int1, :integer
-            config_param :float1, :float
-          end
-
           default = config_element("", "", {"int1" => "1", "float1" => ""})
 
-          c = InfFloatConfig.new
+          c = ConfigurableSpec::ExampleWithIntFloat.new
           assert_nothing_raised { c.configure(default) }
-          assert_raise(ArgumentError) { c.configure(default, strict_config_value: true) }
+          assert_raise(Fluent::ConfigError) { c.configure(default, strict_config_value: true) }
         end
       end
     end

--- a/test/config/test_configurable.rb
+++ b/test/config/test_configurable.rb
@@ -621,7 +621,7 @@ module Fluent::Config
 
           c = ConfigurableSpec::ExampleWithIntFloat.new
           assert_nothing_raised { c.configure(default) }
-          assert_raise(Fluent::ConfigError) { c.configure(default, strict_config_value: true) }
+          assert_raise(Fluent::ConfigError) { c.configure(default, true) }
         end
       end
 
@@ -1714,7 +1714,7 @@ module Fluent::Config
         c = TestClass01.new
         subsection = config_element('subsection', "hoge", { })
         assert_raise(Fluent::ConfigError.new('param1: invalid value for Integer(): "hoge"')) do
-          c.configure(config_element('root', '', {}, [subsection]), strict_config_value: true)
+          c.configure(config_element('root', '', {}, [subsection]), true)
         end
       end
 

--- a/test/config/test_element.rb
+++ b/test/config/test_element.rb
@@ -254,6 +254,24 @@ CONF
       assert_not_equal(e.inspect, e.to_s)
       assert_equal(dump, e.to_s)
     end
+
+    test 'dump nil and default for v1' do
+      expected = <<-CONF
+<ROOT>
+  str1 
+  str2 defstring
+</ROOT>
+CONF
+      e = element('ROOT', '', {'str1' => nil, "str2" => :default}, [])
+      type_lookup = ->(type){ Fluent::Configurable.lookup_type(type) }
+      p = Fluent::Config::ConfigureProxy.new("test", type_lookup: type_lookup)
+      p.config_param :str1, :string
+      p.config_param :str2, :string, default: "defstring"
+      e.corresponding_proxies << p
+      e.v1_config = true
+      assert_not_equal(e.inspect, e.to_s)
+      assert_equal(expected, e.to_s)
+    end
   end
 
   sub_test_case '#inspect' do

--- a/test/config/test_literal_parser.rb
+++ b/test/config/test_literal_parser.rb
@@ -240,6 +240,7 @@ module Fluent::Config
         assert_text_parsed_as("foo1", '"foo#{worker_id}"')
         ENV.delete('SERVERENGINE_WORKER_ID')
       }
+      test('nil') { assert_text_parsed_as(nil, '"#{raise SetNil}"') }
     end
 
     sub_test_case 'array parsing' do

--- a/test/config/test_literal_parser.rb
+++ b/test/config/test_literal_parser.rb
@@ -242,6 +242,8 @@ module Fluent::Config
       }
       test('nil') { assert_text_parsed_as(nil, '"#{raise SetNil}"') }
       test('default') { assert_text_parsed_as(:default, '"#{raise SetDefault}"') }
+      test('nil helper') { assert_text_parsed_as(nil, '"#{use_nil}"') }
+      test('default helper') { assert_text_parsed_as(:default, '"#{use_default}"') }
     end
 
     sub_test_case 'array parsing' do

--- a/test/config/test_literal_parser.rb
+++ b/test/config/test_literal_parser.rb
@@ -241,6 +241,7 @@ module Fluent::Config
         ENV.delete('SERVERENGINE_WORKER_ID')
       }
       test('nil') { assert_text_parsed_as(nil, '"#{raise SetNil}"') }
+      test('default') { assert_text_parsed_as(:default, '"#{raise SetDefault}"') }
     end
 
     sub_test_case 'array parsing' do

--- a/test/config/test_system_config.rb
+++ b/test/config/test_system_config.rb
@@ -88,6 +88,7 @@ module Fluent::Config
       'log_event_verbose' => ['log_event_verbose', true],
       'suppress_config_dump' => ['suppress_config_dump', true],
       'without_source' => ['without_source', true],
+      'strict_config_value' => ['strict_config_value', true],
     )
     test "accepts parameters" do |(k, v)|
       conf = parse_text(<<-EOS)

--- a/test/config/test_types.rb
+++ b/test/config/test_types.rb
@@ -46,6 +46,14 @@ class TestConfigTypes < ::Test::Unit::TestCase
     test 'nil with strict' do
       assert_equal(nil, Config.size_value(nil, { strict: true }))
     end
+
+    test 'default' do
+      assert_equal(2, Config.size_value(:default, { default: 2 }))
+    end
+
+    test 'no default' do
+      assert_equal(nil, Config.size_value(:default))
+    end
   end
 
   sub_test_case 'Config.time_value' do
@@ -87,6 +95,14 @@ class TestConfigTypes < ::Test::Unit::TestCase
     test 'nil with strict' do
       assert_equal(nil, Config.time_value(nil, { strict: true }))
     end
+
+    test 'default' do
+      assert_equal(0.5, Config.time_value(:default, { default: 0.5 }))
+    end
+
+    test 'no default' do
+      assert_equal(nil, Config.time_value(:default))
+    end
   end
 
   sub_test_case 'Config.bool_value' do
@@ -111,7 +127,7 @@ class TestConfigTypes < ::Test::Unit::TestCase
     data("true" =>  [true,  true],
          "false" => [false, false],
          "hoge" => [Fluent::ConfigError.new("name1: invalid bool value: hoge"), "hoge"],
-         "nill" => [nil, nil],
+         "nil" => [nil, nil],
          "integer" => [Fluent::ConfigError.new("name1: invalid bool value: 10"), 10])
     test 'not assumed case with strict' do |(expected, val)|
       if expected.kind_of? Exception
@@ -121,6 +137,14 @@ class TestConfigTypes < ::Test::Unit::TestCase
       else
         assert_equal(expected, Config.bool_value(val, { strict: true }, "name1"))
       end
+    end
+
+    test 'default' do
+      assert_equal(true, Config.bool_value(:default, { default: true }))
+    end
+
+    test 'no default' do
+      assert_equal(nil, Config.time_value(:default))
     end
   end
 
@@ -154,6 +178,14 @@ class TestConfigTypes < ::Test::Unit::TestCase
     test 'nil' do
       assert_equal nil, Config.regexp_value(nil)
     end
+
+    test 'default' do
+      assert_equal /regexp/, Config.regexp_value(:default, {default: /regexp/})
+    end
+
+    test 'no default' do
+      assert_equal nil, Config.regexp_value(:default)
+    end
   end
 
   sub_test_case 'type converters for config_param definitions' do
@@ -167,6 +199,14 @@ class TestConfigTypes < ::Test::Unit::TestCase
 
     test 'string nil' do
       assert_equal nil, Config::STRING_TYPE.call(nil, {})
+    end
+
+    test 'string default' do
+      assert_equal "hoge", Config::STRING_TYPE.call(:default, {default: "hoge"})
+    end
+
+    test 'string no default' do
+      assert_equal nil, Config::STRING_TYPE.call(:default)
     end
 
     data('latin' => 'Märch',
@@ -205,6 +245,14 @@ class TestConfigTypes < ::Test::Unit::TestCase
       assert_equal nil, Config::ENUM_TYPE.call(nil)
     end
 
+    test 'enum: default' do
+      assert_equal :v, Config::ENUM_TYPE.call(:default, {list: [:val, :value, :v, :default], default: :v})
+    end
+
+    test 'enum: no default' do
+      assert_equal nil, Config::ENUM_TYPE.call(:default, {list: [:val, :value, :v, :default]})
+    end
+
     data("1" => [1, '1'],
          "1.0" => [1, '1.0'],
          "1_000" => [1000, '1_000'],
@@ -241,6 +289,14 @@ class TestConfigTypes < ::Test::Unit::TestCase
       assert_equal nil, Config::INTEGER_TYPE.call(nil, { strict: true })
     end
 
+    test 'integer: default' do
+      assert_equal 4, Config::INTEGER_TYPE.call(:default, {default: 4})
+    end
+
+    test 'integer: no default' do
+      assert_equal nil, Config::INTEGER_TYPE.call(:default)
+    end
+
     data("1" => [1.0, '1'],
          "1.0" => [1.0, '1.0'],
          "1.00" => [1.0, '1.00'],
@@ -275,6 +331,14 @@ class TestConfigTypes < ::Test::Unit::TestCase
 
     test 'float: nil with strict' do
       assert_equal nil, Config::FLOAT_TYPE.call(nil, { strict: true })
+    end
+
+    test 'float: default' do
+      assert_equal 4.0, Config::FLOAT_TYPE.call(:default, {default: 4.0})
+    end
+
+    test 'float: no default' do
+      assert_equal nil, Config::FLOAT_TYPE.call(:default)
     end
 
     data("1000" => [1000, '1000'],
@@ -358,6 +422,14 @@ class TestConfigTypes < ::Test::Unit::TestCase
       assert_equal(nil, Config::HASH_TYPE.call(nil))
     end
 
+    test 'hash w/ default' do
+      assert_equal({"a":"b", "c":"d"}, Config::HASH_TYPE.call(:default, {default: {"a":"b", "c":"d"}}))
+    end
+
+    test 'hash w/o default' do
+      assert_equal(nil, Config::HASH_TYPE.call(:default))
+    end
+
     data("strings and integer" => [["1","2",1],   '["1","2",1]', {}],
          "number strings" => [["1","2","1"], '1,2,1', {}],
          "alphabets" => [["a","b","c"], '["a","b","c"]', {}],
@@ -394,8 +466,16 @@ class TestConfigTypes < ::Test::Unit::TestCase
       end
     end
 
-    test 'aray w/ nil' do
+    test 'array w/ nil' do
       assert_equal(nil, Config::ARRAY_TYPE.call(nil))
+    end
+
+    test 'array w/ default' do
+      assert_equal([1, 2, 3], Config::ARRAY_TYPE.call(:default, {default: [1, 2, 3]}))
+    end
+
+    test 'array w/o default' do
+      assert_equal(nil, Config::ARRAY_TYPE.call(:default))
     end
   end
 end

--- a/test/config/test_types.rb
+++ b/test/config/test_types.rb
@@ -21,16 +21,18 @@ class TestConfigTypes < ::Test::Unit::TestCase
 
     data("integer" => [6, 6],
          "hoge" => [0, "hoge"],
-         "empty" => [0, ""],
-         "nil" => [0, nil])
+         "empty" => [0, ""])
     test 'not assumed case' do |(expected, val)|
       assert_equal(expected, Config.size_value(val))
     end
 
+    test 'nil' do
+      assert_equal(nil, Config.size_value(nil))
+    end
+
     data("integer" => [6, 6],
          "hoge" => [Fluent::ConfigError.new("name1: invalid value for Integer(): \"hoge\""), "hoge"],
-         "empty" => [Fluent::ConfigError.new("name1: invalid value for Integer(): \"\""), ""],
-         "nil" => [Fluent::ConfigError.new("name1: can't convert nil into Integer"), nil])
+         "empty" => [Fluent::ConfigError.new("name1: invalid value for Integer(): \"\""), ""])
     test 'not assumed case with strict' do |(expected, val)|
       if expected.kind_of? Exception
         assert_raise(expected) do
@@ -39,6 +41,10 @@ class TestConfigTypes < ::Test::Unit::TestCase
       else
         assert_equal(expected, Config.size_value(val, { strict: true }, "name1"))
       end
+    end
+
+    test 'nil with strict' do
+      assert_equal(nil, Config.size_value(nil, { strict: true }))
     end
   end
 
@@ -56,16 +62,18 @@ class TestConfigTypes < ::Test::Unit::TestCase
     data("integer" => [4.0, 4],
          "float" => [0.4, 0.4],
          "hoge" => [0.0, "hoge"],
-         "empty" => [0.0, ""],
-         "nil" => [0.0, nil])
+         "empty" => [0.0, ""])
     test 'not assumed case' do |(expected, val)|
       assert_equal(expected, Config.time_value(val))
     end
 
+    test 'nil' do
+      assert_equal(nil, Config.time_value(nil))
+    end
+
     data("integer" => [6, 6],
          "hoge" => [Fluent::ConfigError.new("name1: invalid value for Float(): \"hoge\""), "hoge"],
-         "empty" => [Fluent::ConfigError.new("name1: invalid value for Float(): \"\""), ""],
-         "nil" => [Fluent::ConfigError.new("name1: can't convert nil into Float"), nil])
+         "empty" => [Fluent::ConfigError.new("name1: invalid value for Float(): \"\""), ""])
     test 'not assumed case with strict' do |(expected, val)|
       if expected.kind_of? Exception
         assert_raise(expected) do
@@ -74,6 +82,10 @@ class TestConfigTypes < ::Test::Unit::TestCase
       else
         assert_equal(expected, Config.time_value(val, { strict: true }, "name1"))
       end
+    end
+
+    test 'nil with strict' do
+      assert_equal(nil, Config.time_value(nil, { strict: true }))
     end
   end
 
@@ -138,6 +150,10 @@ class TestConfigTypes < ::Test::Unit::TestCase
         Config.regexp_value(str)
       end
     end
+
+    test 'nil' do
+      assert_equal nil, Config.regexp_value(nil)
+    end
   end
 
   sub_test_case 'type converters for config_param definitions' do
@@ -147,6 +163,10 @@ class TestConfigTypes < ::Test::Unit::TestCase
     test 'string' do |(expected, val)|
       assert_equal expected, Config::STRING_TYPE.call(val, {})
       assert_equal Encoding::UTF_8, Config::STRING_TYPE.call(val, {}).encoding
+    end
+
+    test 'string nil' do
+      assert_equal nil, Config::STRING_TYPE.call(nil, {})
     end
 
     data('latin' => 'Märch',
@@ -181,6 +201,10 @@ class TestConfigTypes < ::Test::Unit::TestCase
       end
     end
 
+    test 'enum: nil' do
+      assert_equal nil, Config::ENUM_TYPE.call(nil)
+    end
+
     data("1" => [1, '1'],
          "1.0" => [1, '1.0'],
          "1_000" => [1000, '1_000'],
@@ -191,16 +215,18 @@ class TestConfigTypes < ::Test::Unit::TestCase
 
     data("integer" => [6, 6],
          "hoge" => [0, "hoge"],
-         "empty" => [0, ""],
-         "nil" => [0, nil])
+         "empty" => [0, ""])
     test 'integer: not assumed case' do |(expected, val)|
       assert_equal expected, Config::INTEGER_TYPE.call(val, {})
     end
 
+    test 'integer: nil' do
+      assert_equal nil, Config::INTEGER_TYPE.call(nil, {})
+    end
+
     data("integer" => [6, 6],
          "hoge" => [Fluent::ConfigError.new("name1: invalid value for Integer(): \"hoge\""), "hoge"],
-         "empty" => [Fluent::ConfigError.new("name1: invalid value for Integer(): \"\""), ""],
-         "nil" => [Fluent::ConfigError.new("name1: can't convert nil into Integer"), nil])
+         "empty" => [Fluent::ConfigError.new("name1: invalid value for Integer(): \"\""), ""])
     test 'integer: not assumed case with strict' do |(expected, val)|
       if expected.kind_of? Exception
         assert_raise(expected) do
@@ -209,6 +235,10 @@ class TestConfigTypes < ::Test::Unit::TestCase
       else
         assert_equal expected, Config::INTEGER_TYPE.call(val, { strict: true }, "name1")
       end
+    end
+
+    test 'integer: nil with strict' do
+      assert_equal nil, Config::INTEGER_TYPE.call(nil, { strict: true })
     end
 
     data("1" => [1.0, '1'],
@@ -221,16 +251,18 @@ class TestConfigTypes < ::Test::Unit::TestCase
 
     data("integer" => [6, 6],
          "hoge" => [0, "hoge"],
-         "empty" => [0, ""],
-         "nil" => [0, nil])
+         "empty" => [0, ""])
     test 'float: not assumed case' do |(expected, val)|
       assert_equal expected, Config::FLOAT_TYPE.call(val, {})
     end
 
+    test 'float: nil' do
+      assert_equal nil, Config::FLOAT_TYPE.call(nil, {})
+    end
+
     data("integer" => [6, 6],
          "hoge" => [Fluent::ConfigError.new("name1: invalid value for Float(): \"hoge\""), "hoge"],
-         "empty" => [Fluent::ConfigError.new("name1: invalid value for Float(): \"\""), ""],
-         "nil" => [Fluent::ConfigError.new("name1: can't convert nil into Float"), nil])
+         "empty" => [Fluent::ConfigError.new("name1: invalid value for Float(): \"\""), ""])
     test 'float: not assumed case with strict' do |(expected, val)|
       if expected.kind_of? Exception
         assert_raise(expected) do
@@ -239,6 +271,10 @@ class TestConfigTypes < ::Test::Unit::TestCase
       else
         assert_equal expected, Config::FLOAT_TYPE.call(val, { strict: true }, "name1")
       end
+    end
+
+    test 'float: nil with strict' do
+      assert_equal nil, Config::FLOAT_TYPE.call(nil, { strict: true })
     end
 
     data("1000" => [1000, '1000'],
@@ -318,6 +354,10 @@ class TestConfigTypes < ::Test::Unit::TestCase
       assert_equal(expected, Config::HASH_TYPE.call(target.b, { value_type: :string }))
     end
 
+    test 'hash w/ nil' do
+      assert_equal(nil, Config::HASH_TYPE.call(nil))
+    end
+
     data("strings and integer" => [["1","2",1],   '["1","2",1]', {}],
          "number strings" => [["1","2","1"], '1,2,1', {}],
          "alphabets" => [["a","b","c"], '["a","b","c"]', {}],
@@ -352,6 +392,10 @@ class TestConfigTypes < ::Test::Unit::TestCase
       assert_raise(Fluent::ConfigError.new(": invalid value for Integer(): \"hoge\"")) do
         Config::ARRAY_TYPE.call("1,hoge", {value_type: :integer, strict: true}, "name1")
       end
+    end
+
+    test 'aray w/ nil' do
+      assert_equal(nil, Config::ARRAY_TYPE.call(nil))
     end
   end
 end

--- a/test/config/test_types.rb
+++ b/test/config/test_types.rb
@@ -31,8 +31,8 @@ class TestConfigTypes < ::Test::Unit::TestCase
     end
 
     data("integer" => [6, 6],
-         "hoge" => [Fluent::ConfigError.new("name1: invalid value for Integer(): \"hoge\""), "hoge"],
-         "empty" => [Fluent::ConfigError.new("name1: invalid value for Integer(): \"\""), ""])
+         "hoge" => [Fluent::ConfigError.new('name1: invalid value for Integer(): "hoge"'), "hoge"],
+         "empty" => [Fluent::ConfigError.new('name1: invalid value for Integer(): ""'), ""])
     test 'not assumed case with strict' do |(expected, val)|
       if expected.kind_of? Exception
         assert_raise(expected) do
@@ -72,8 +72,8 @@ class TestConfigTypes < ::Test::Unit::TestCase
     end
 
     data("integer" => [6, 6],
-         "hoge" => [Fluent::ConfigError.new("name1: invalid value for Float(): \"hoge\""), "hoge"],
-         "empty" => [Fluent::ConfigError.new("name1: invalid value for Float(): \"\""), ""])
+         "hoge" => [Fluent::ConfigError.new('name1: invalid value for Float(): "hoge"'), "hoge"],
+         "empty" => [Fluent::ConfigError.new('name1: invalid value for Float(): ""'), ""])
     test 'not assumed case with strict' do |(expected, val)|
       if expected.kind_of? Exception
         assert_raise(expected) do
@@ -225,8 +225,8 @@ class TestConfigTypes < ::Test::Unit::TestCase
     end
 
     data("integer" => [6, 6],
-         "hoge" => [Fluent::ConfigError.new("name1: invalid value for Integer(): \"hoge\""), "hoge"],
-         "empty" => [Fluent::ConfigError.new("name1: invalid value for Integer(): \"\""), ""])
+         "hoge" => [Fluent::ConfigError.new('name1: invalid value for Integer(): "hoge"'), "hoge"],
+         "empty" => [Fluent::ConfigError.new('name1: invalid value for Integer(): ""'), ""])
     test 'integer: not assumed case with strict' do |(expected, val)|
       if expected.kind_of? Exception
         assert_raise(expected) do
@@ -261,8 +261,8 @@ class TestConfigTypes < ::Test::Unit::TestCase
     end
 
     data("integer" => [6, 6],
-         "hoge" => [Fluent::ConfigError.new("name1: invalid value for Float(): \"hoge\""), "hoge"],
-         "empty" => [Fluent::ConfigError.new("name1: invalid value for Float(): \"\""), ""])
+         "hoge" => [Fluent::ConfigError.new('name1: invalid value for Float(): "hoge"'), "hoge"],
+         "empty" => [Fluent::ConfigError.new('name1: invalid value for Float(): ""'), ""])
     test 'float: not assumed case with strict' do |(expected, val)|
       if expected.kind_of? Exception
         assert_raise(expected) do
@@ -341,7 +341,7 @@ class TestConfigTypes < ::Test::Unit::TestCase
     end
 
     test 'hash w/ strict option' do
-      assert_raise(Fluent::ConfigError.new("y: invalid value for Integer(): \"hoge\"")) do
+      assert_raise(Fluent::ConfigError.new('y: invalid value for Integer(): "hoge"')) do
         Config::HASH_TYPE.call("x:1,y:hoge", {value_type: :integer, strict: true})
       end
     end
@@ -389,7 +389,7 @@ class TestConfigTypes < ::Test::Unit::TestCase
     end
 
     test 'array w/ strict option' do
-      assert_raise(Fluent::ConfigError.new(": invalid value for Integer(): \"hoge\"")) do
+      assert_raise(Fluent::ConfigError.new(': invalid value for Integer(): "hoge"')) do
         Config::ARRAY_TYPE.call("1,hoge", {value_type: :integer, strict: true}, "name1")
       end
     end

--- a/test/config/test_types.rb
+++ b/test/config/test_types.rb
@@ -52,7 +52,9 @@ class TestConfigTypes < ::Test::Unit::TestCase
     end
 
     test 'no default' do
-      assert_equal(nil, Config.size_value(:default))
+      assert_raise(Fluent::ConfigError.new("'key' doesn't have default value")) do
+        Config.size_value(:default, {}, "key")
+      end
     end
   end
 
@@ -101,7 +103,9 @@ class TestConfigTypes < ::Test::Unit::TestCase
     end
 
     test 'no default' do
-      assert_equal(nil, Config.time_value(:default))
+      assert_raise(Fluent::ConfigError.new("'key' doesn't have default value")) do
+        Config.time_value(:default, {}, "key")
+      end
     end
   end
 
@@ -144,7 +148,9 @@ class TestConfigTypes < ::Test::Unit::TestCase
     end
 
     test 'no default' do
-      assert_equal(nil, Config.time_value(:default))
+      assert_raise(Fluent::ConfigError.new("'key' doesn't have default value")) do
+        Config.time_value(:default, {}, "key")
+      end
     end
   end
 
@@ -184,7 +190,9 @@ class TestConfigTypes < ::Test::Unit::TestCase
     end
 
     test 'no default' do
-      assert_equal nil, Config.regexp_value(:default)
+      assert_raise(Fluent::ConfigError.new("'key' doesn't have default value")) do
+        Config.regexp_value(:default, {}, "key")
+      end
     end
   end
 
@@ -206,7 +214,9 @@ class TestConfigTypes < ::Test::Unit::TestCase
     end
 
     test 'string no default' do
-      assert_equal nil, Config::STRING_TYPE.call(:default)
+      assert_raise(Fluent::ConfigError.new("'key' doesn't have default value")) do
+        Config::STRING_TYPE.call(:default, {}, "key")
+      end
     end
 
     data('latin' => 'Märch',
@@ -250,7 +260,9 @@ class TestConfigTypes < ::Test::Unit::TestCase
     end
 
     test 'enum: no default' do
-      assert_equal nil, Config::ENUM_TYPE.call(:default, {list: [:val, :value, :v, :default]})
+      assert_raise(Fluent::ConfigError.new("'key' doesn't have default value")) do
+        Config::ENUM_TYPE.call(:default, {list: [:val, :value, :v, :default]}, "key")
+      end
     end
 
     data("1" => [1, '1'],
@@ -294,7 +306,9 @@ class TestConfigTypes < ::Test::Unit::TestCase
     end
 
     test 'integer: no default' do
-      assert_equal nil, Config::INTEGER_TYPE.call(:default)
+      assert_raise(Fluent::ConfigError.new("'key' doesn't have default value")) do
+        Config::INTEGER_TYPE.call(:default, {}, "key")
+      end
     end
 
     data("1" => [1.0, '1'],
@@ -338,7 +352,9 @@ class TestConfigTypes < ::Test::Unit::TestCase
     end
 
     test 'float: no default' do
-      assert_equal nil, Config::FLOAT_TYPE.call(:default)
+      assert_raise(Fluent::ConfigError.new("'key' doesn't have default value")) do
+        Config::FLOAT_TYPE.call(:default, {}, "key")
+      end
     end
 
     data("1000" => [1000, '1000'],
@@ -427,7 +443,9 @@ class TestConfigTypes < ::Test::Unit::TestCase
     end
 
     test 'hash w/o default' do
-      assert_equal(nil, Config::HASH_TYPE.call(:default))
+      assert_raise(Fluent::ConfigError.new("'key' doesn't have default value")) do
+        Config::HASH_TYPE.call(:default, {}, "key")
+      end
     end
 
     data("strings and integer" => [["1","2",1],   '["1","2",1]', {}],
@@ -475,7 +493,9 @@ class TestConfigTypes < ::Test::Unit::TestCase
     end
 
     test 'array w/o default' do
-      assert_equal(nil, Config::ARRAY_TYPE.call(:default))
+      assert_raise(Fluent::ConfigError.new("'key' doesn't have default value")) do
+        Config::ARRAY_TYPE.call(:default, {}, "key")
+      end
     end
   end
 end

--- a/test/config/test_types.rb
+++ b/test/config/test_types.rb
@@ -95,6 +95,21 @@ class TestConfigTypes < ::Test::Unit::TestCase
     test 'not assumed case' do |(expected, val)|
       assert_equal(expected, Config.bool_value(val))
     end
+
+    data("true" =>  [true,  true],
+         "false" => [false, false],
+         "hoge" => [Fluent::ConfigError.new("name1: invalid bool value: hoge"), "hoge"],
+         "nill" => [nil, nil],
+         "integer" => [Fluent::ConfigError.new("name1: invalid bool value: 10"), 10])
+    test 'not assumed case with strict' do |(expected, val)|
+      if expected.kind_of? Exception
+        assert_raise(expected) do
+          Config.bool_value(val, { strict: true }, "name1")
+        end
+      else
+        assert_equal(expected, Config.bool_value(val, { strict: true }, "name1"))
+      end
+    end
   end
 
   sub_test_case 'Config.regexp_value' do

--- a/test/config/test_types.rb
+++ b/test/config/test_types.rb
@@ -28,16 +28,16 @@ class TestConfigTypes < ::Test::Unit::TestCase
     end
 
     data("integer" => [6, 6],
-         "hoge" => [ArgumentError.new("invalid value for Integer(): \"hoge\""), "hoge"],
-         "empty" => [ArgumentError.new("invalid value for Integer(): \"\""), ""],
-         "nil" => [TypeError.new("can't convert nil into Integer"), nil])
+         "hoge" => [Fluent::ConfigError.new("name1: invalid value for Integer(): \"hoge\""), "hoge"],
+         "empty" => [Fluent::ConfigError.new("name1: invalid value for Integer(): \"\""), ""],
+         "nil" => [Fluent::ConfigError.new("name1: can't convert nil into Integer"), nil])
     test 'not assumed case with strict' do |(expected, val)|
       if expected.kind_of? Exception
         assert_raise(expected) do
-          Config.size_value(val, { strict: true })
+          Config.size_value(val, { strict: true }, "name1")
         end
       else
-        assert_equal(expected, Config.size_value(val, { strict: true }))
+        assert_equal(expected, Config.size_value(val, { strict: true }, "name1"))
       end
     end
   end
@@ -63,16 +63,16 @@ class TestConfigTypes < ::Test::Unit::TestCase
     end
 
     data("integer" => [6, 6],
-         "hoge" => [ArgumentError.new("invalid value for Float(): \"hoge\""), "hoge"],
-         "empty" => [ArgumentError.new("invalid value for Float(): \"\""), ""],
-         "nil" => [TypeError.new("can't convert nil into Float"), nil])
+         "hoge" => [Fluent::ConfigError.new("name1: invalid value for Float(): \"hoge\""), "hoge"],
+         "empty" => [Fluent::ConfigError.new("name1: invalid value for Float(): \"\""), ""],
+         "nil" => [Fluent::ConfigError.new("name1: can't convert nil into Float"), nil])
     test 'not assumed case with strict' do |(expected, val)|
       if expected.kind_of? Exception
         assert_raise(expected) do
-          Config.time_value(val, { strict: true })
+          Config.time_value(val, { strict: true }, "name1")
         end
       else
-        assert_equal(expected, Config.time_value(val, { strict: true }))
+        assert_equal(expected, Config.time_value(val, { strict: true }, "name1"))
       end
     end
   end
@@ -183,16 +183,16 @@ class TestConfigTypes < ::Test::Unit::TestCase
     end
 
     data("integer" => [6, 6],
-         "hoge" => [ArgumentError.new("invalid value for Integer(): \"hoge\""), "hoge"],
-         "empty" => [ArgumentError.new("invalid value for Integer(): \"\""), ""],
-         "nil" => [TypeError.new("can't convert nil into Integer"), nil])
+         "hoge" => [Fluent::ConfigError.new("name1: invalid value for Integer(): \"hoge\""), "hoge"],
+         "empty" => [Fluent::ConfigError.new("name1: invalid value for Integer(): \"\""), ""],
+         "nil" => [Fluent::ConfigError.new("name1: can't convert nil into Integer"), nil])
     test 'integer: not assumed case with strict' do |(expected, val)|
       if expected.kind_of? Exception
         assert_raise(expected) do
-          Config::INTEGER_TYPE.call(val, { strict: true })
+          Config::INTEGER_TYPE.call(val, { strict: true }, "name1")
         end
       else
-        assert_equal expected, Config::INTEGER_TYPE.call(val, { strict: true })
+        assert_equal expected, Config::INTEGER_TYPE.call(val, { strict: true }, "name1")
       end
     end
 
@@ -213,16 +213,16 @@ class TestConfigTypes < ::Test::Unit::TestCase
     end
 
     data("integer" => [6, 6],
-         "hoge" => [ArgumentError.new("invalid value for Float(): \"hoge\""), "hoge"],
-         "empty" => [ArgumentError.new("invalid value for Float(): \"\""), ""],
-         "nil" => [TypeError.new("can't convert nil into Float"), nil])
+         "hoge" => [Fluent::ConfigError.new("name1: invalid value for Float(): \"hoge\""), "hoge"],
+         "empty" => [Fluent::ConfigError.new("name1: invalid value for Float(): \"\""), ""],
+         "nil" => [Fluent::ConfigError.new("name1: can't convert nil into Float"), nil])
     test 'float: not assumed case with strict' do |(expected, val)|
       if expected.kind_of? Exception
         assert_raise(expected) do
-          Config::FLOAT_TYPE.call(val, { strict: true })
+          Config::FLOAT_TYPE.call(val, { strict: true }, "name1")
         end
       else
-        assert_equal expected, Config::FLOAT_TYPE.call(val, { strict: true })
+        assert_equal expected, Config::FLOAT_TYPE.call(val, { strict: true }, "name1")
       end
     end
 
@@ -290,7 +290,7 @@ class TestConfigTypes < ::Test::Unit::TestCase
     end
 
     test 'hash w/ strict option' do
-      assert_raise(ArgumentError.new("invalid value for Integer(): \"hoge\"")) do
+      assert_raise(Fluent::ConfigError.new("y: invalid value for Integer(): \"hoge\"")) do
         Config::HASH_TYPE.call("x:1,y:hoge", {value_type: :integer, strict: true})
       end
     end
@@ -334,8 +334,8 @@ class TestConfigTypes < ::Test::Unit::TestCase
     end
 
     test 'array w/ strict option' do
-      assert_raise(ArgumentError.new("invalid value for Integer(): \"hoge\"")) do
-        Config::ARRAY_TYPE.call("1,hoge", {value_type: :integer, strict: true})
+      assert_raise(Fluent::ConfigError.new(": invalid value for Integer(): \"hoge\"")) do
+        Config::ARRAY_TYPE.call("1,hoge", {value_type: :integer, strict: true}, "name1")
       end
     end
   end

--- a/test/config/test_types.rb
+++ b/test/config/test_types.rb
@@ -46,16 +46,6 @@ class TestConfigTypes < ::Test::Unit::TestCase
     test 'nil with strict' do
       assert_equal(nil, Config.size_value(nil, { strict: true }))
     end
-
-    test 'default' do
-      assert_equal(2, Config.size_value(:default, { default: 2 }))
-    end
-
-    test 'no default' do
-      assert_raise(Fluent::ConfigError.new("'key' doesn't have default value")) do
-        Config.size_value(:default, {}, "key")
-      end
-    end
   end
 
   sub_test_case 'Config.time_value' do
@@ -97,16 +87,6 @@ class TestConfigTypes < ::Test::Unit::TestCase
     test 'nil with strict' do
       assert_equal(nil, Config.time_value(nil, { strict: true }))
     end
-
-    test 'default' do
-      assert_equal(0.5, Config.time_value(:default, { default: 0.5 }))
-    end
-
-    test 'no default' do
-      assert_raise(Fluent::ConfigError.new("'key' doesn't have default value")) do
-        Config.time_value(:default, {}, "key")
-      end
-    end
   end
 
   sub_test_case 'Config.bool_value' do
@@ -142,16 +122,6 @@ class TestConfigTypes < ::Test::Unit::TestCase
         assert_equal(expected, Config.bool_value(val, { strict: true }, "name1"))
       end
     end
-
-    test 'default' do
-      assert_equal(true, Config.bool_value(:default, { default: true }))
-    end
-
-    test 'no default' do
-      assert_raise(Fluent::ConfigError.new("'key' doesn't have default value")) do
-        Config.time_value(:default, {}, "key")
-      end
-    end
   end
 
   sub_test_case 'Config.regexp_value' do
@@ -184,16 +154,6 @@ class TestConfigTypes < ::Test::Unit::TestCase
     test 'nil' do
       assert_equal nil, Config.regexp_value(nil)
     end
-
-    test 'default' do
-      assert_equal /regexp/, Config.regexp_value(:default, {default: /regexp/})
-    end
-
-    test 'no default' do
-      assert_raise(Fluent::ConfigError.new("'key' doesn't have default value")) do
-        Config.regexp_value(:default, {}, "key")
-      end
-    end
   end
 
   sub_test_case 'type converters for config_param definitions' do
@@ -207,16 +167,6 @@ class TestConfigTypes < ::Test::Unit::TestCase
 
     test 'string nil' do
       assert_equal nil, Config::STRING_TYPE.call(nil, {})
-    end
-
-    test 'string default' do
-      assert_equal "hoge", Config::STRING_TYPE.call(:default, {default: "hoge"})
-    end
-
-    test 'string no default' do
-      assert_raise(Fluent::ConfigError.new("'key' doesn't have default value")) do
-        Config::STRING_TYPE.call(:default, {}, "key")
-      end
     end
 
     data('latin' => 'Märch',
@@ -255,16 +205,6 @@ class TestConfigTypes < ::Test::Unit::TestCase
       assert_equal nil, Config::ENUM_TYPE.call(nil)
     end
 
-    test 'enum: default' do
-      assert_equal :v, Config::ENUM_TYPE.call(:default, {list: [:val, :value, :v, :default], default: :v})
-    end
-
-    test 'enum: no default' do
-      assert_raise(Fluent::ConfigError.new("'key' doesn't have default value")) do
-        Config::ENUM_TYPE.call(:default, {list: [:val, :value, :v, :default]}, "key")
-      end
-    end
-
     data("1" => [1, '1'],
          "1.0" => [1, '1.0'],
          "1_000" => [1000, '1_000'],
@@ -301,16 +241,6 @@ class TestConfigTypes < ::Test::Unit::TestCase
       assert_equal nil, Config::INTEGER_TYPE.call(nil, { strict: true })
     end
 
-    test 'integer: default' do
-      assert_equal 4, Config::INTEGER_TYPE.call(:default, {default: 4})
-    end
-
-    test 'integer: no default' do
-      assert_raise(Fluent::ConfigError.new("'key' doesn't have default value")) do
-        Config::INTEGER_TYPE.call(:default, {}, "key")
-      end
-    end
-
     data("1" => [1.0, '1'],
          "1.0" => [1.0, '1.0'],
          "1.00" => [1.0, '1.00'],
@@ -345,16 +275,6 @@ class TestConfigTypes < ::Test::Unit::TestCase
 
     test 'float: nil with strict' do
       assert_equal nil, Config::FLOAT_TYPE.call(nil, { strict: true })
-    end
-
-    test 'float: default' do
-      assert_equal 4.0, Config::FLOAT_TYPE.call(:default, {default: 4.0})
-    end
-
-    test 'float: no default' do
-      assert_raise(Fluent::ConfigError.new("'key' doesn't have default value")) do
-        Config::FLOAT_TYPE.call(:default, {}, "key")
-      end
     end
 
     data("1000" => [1000, '1000'],
@@ -438,16 +358,6 @@ class TestConfigTypes < ::Test::Unit::TestCase
       assert_equal(nil, Config::HASH_TYPE.call(nil))
     end
 
-    test 'hash w/ default' do
-      assert_equal({"a":"b", "c":"d"}, Config::HASH_TYPE.call(:default, {default: {"a":"b", "c":"d"}}))
-    end
-
-    test 'hash w/o default' do
-      assert_raise(Fluent::ConfigError.new("'key' doesn't have default value")) do
-        Config::HASH_TYPE.call(:default, {}, "key")
-      end
-    end
-
     data("strings and integer" => [["1","2",1],   '["1","2",1]', {}],
          "number strings" => [["1","2","1"], '1,2,1', {}],
          "alphabets" => [["a","b","c"], '["a","b","c"]', {}],
@@ -486,16 +396,6 @@ class TestConfigTypes < ::Test::Unit::TestCase
 
     test 'array w/ nil' do
       assert_equal(nil, Config::ARRAY_TYPE.call(nil))
-    end
-
-    test 'array w/ default' do
-      assert_equal([1, 2, 3], Config::ARRAY_TYPE.call(:default, {default: [1, 2, 3]}))
-    end
-
-    test 'array w/o default' do
-      assert_raise(Fluent::ConfigError.new("'key' doesn't have default value")) do
-        Config::ARRAY_TYPE.call(:default, {}, "key")
-      end
     end
   end
 end

--- a/test/plugin/test_output.rb
+++ b/test/plugin/test_output.rb
@@ -870,7 +870,7 @@ class OutputTest < Test::Unit::TestCase
 
   test 'raises an error if timekey is less than equal 0' do
     i = create_output(:delayed)
-    assert_raise Fluent::ConfigError.new('timekey should be greater than 0. current timekey: 0.0') do
+    assert_raise Fluent::ConfigError.new("<buffer ...> argument includes 'time', but timekey is not configured") do
       i.configure(config_element('ROOT','',{},[config_element('buffer', 'time', { "timekey" => nil })]))
     end
 


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #2616

**What this PR does / why we need it**: 
Add a new command line option `--strict-config-value` to parse `integer`, `float` and `bool` values in a config file more strictly. A system config item `strict_config_value` is also added.
Since non-numerical (or unrecognized values for `bool`) values for them in config values are implicitly parsed as `0` , sometimes it makes troubleshooting hard. This option will raise an error for such values to clarify such issues in a config file.

In addition, this PR also adds helper methods to set `nil` or default value to parameters in config files, since many users expect `nil` for `"#{ENV['SOME_ENV_VAR']}"` with empty `SOME_ENV_VAR` environment variable (but it's converted to an empty string in actual).

```
some_param "#{ENV['SOME_ENV_VAR'] || use_nil}"
```

```
some_param "#{ENV['SOME_ENV_VAR'] || use_default}"
```


**Docs Changes**:
* Add `--strict-config-value` to `Command Line Options` in `Deployment - System Configuration`.
* Add `strict_config_value` to system config in `Configuration - Config File Syntax` and `Deployment - System Configuration`.
* Add note for `use_nil` and `use_default` to `Embedding Ruby Expressions` in `Config File Syntax`.

**Release Note**: 
Same with the title.
