### PR TITLE
Fix pitfall which is the order of filter and match

### DIFF
--- a/lib/fluent/agent.rb
+++ b/lib/fluent/agent.rb
@@ -61,19 +61,26 @@ module Fluent
       super
 
       # initialize <match> and <filter> elements
-      conf.elements('filter', 'match').each { |e|
+      conf.elements('filter').each do |e|
         if !Fluent::Engine.supervisor_mode && e.for_another_worker?
           next
         end
         pattern = e.arg.empty? ? '**' : e.arg
         type = e['@type']
         raise ConfigError, "Missing '@type' parameter on <#{e.name}> directive" unless type
-        if e.name == 'filter'
-          add_filter(type, pattern, e)
-        else
-          add_match(type, pattern, e)
+        add_filter(type, pattern, e)
+      end
+
+      conf.elements('match').each do |e|
+        if !Fluent::Engine.supervisor_mode && e.for_another_worker?
+          next
         end
-      }
+        pattern = e.arg.empty? ? '**' : e.arg
+        type = e['@type']
+        raise ConfigError, "Missing '@type' parameter on <#{e.name}> directive" unless type
+
+        add_match(type, pattern, e)
+      end
     end
 
     def lifecycle_control_list


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
no

**What this PR does / why we need it**: 

https://docs.fluentd.org/configuration/config-file#note-on-match-order says as follows.

> The common pitfall is when you put a <filter> block after <match>. It will never work as supposed, since events never go through the filter for the reason explained above.

I think the behavior is a bit confusing. And I couldn't find any reasonable reasons for this behavior.
if there are reasons/pros to adopt this behavior, Could you tell me why it is? (@repeatedly ) or just a historical reason?

**Docs Changes**:

Delete the sentence about filter-match order in https://docs.fluentd.org/configuration/config-file#note-on-match-order

**Release Note**: 

same as the title

**TODO**

* [ ] add test 


before
```

2019-11-07 16:30:21 +0900 [info]: gem 'fluentd' version '1.8.0.rc2'
2019-11-07 16:30:22 +0900 [warn]: both of Plugin @id and path for <storage> are not specified. Using on-memory store.
2019-11-07 16:30:22 +0900 [warn]: both of Plugin @id and path for <storage> are not specified. Using on-memory store.
2019-11-07 16:30:22 +0900 [info]: using configuration file: <ROOT>
  <source>
    @type dummy
    tag "test.test.test.test"
  </source>
  <match test.test.test.test>
    @type stdout
  </match>
  <filter test.**>
    @type record_transformer
    <record>
      test_rec test
    </record>
  </filter>
</ROOT>
2019-11-07 16:30:22 +0900 [info]: starting fluentd-1.8.0.rc2 pid=69911 ruby="2.6.5"
2019-11-07 16:30:22 +0900 [info]: spawn command to main:  cmdline=["ruby", "-Eascii-8bit:ascii-8bit", "-rbundler/setup", "bin/fluentd", "-c", "example/debug/r.conf", "--under-supervisor"]
2019-11-07 16:30:22 +0900 [info]: adding match pattern="test.test.test.test" type="stdout"
2019-11-07 16:30:22 +0900 [info]: adding filter pattern="test.**" type="record_transformer"
2019-11-07 16:30:22 +0900 [info]: adding source type="dummy"
2019-11-07 16:30:22 +0900 [warn]: #0 both of Plugin @id and path for <storage> are not specified. Using on-memory store.
2019-11-07 16:30:22 +0900 [warn]: #0 both of Plugin @id and path for <storage> are not specified. Using on-memory store.
2019-11-07 16:30:22 +0900 [info]: #0 starting fluentd worker pid=69925 ppid=69911 worker=0
2019-11-07 16:30:22 +0900 [info]: #0 fluentd worker is now running worker=0
2019-11-07 16:30:23.054363000 +0900 test.test.test.test: {"message":"dummy"}
2019-11-07 16:30:24.075024000 +0900 test.test.test.test: {"message":"dummy"}
2019-11-07 16:30:25.001102000 +0900 test.test.test.test: {"message":"dummy"}
```

after

```
2019-11-07 16:29:34 +0900 [info]: gem 'fluentd' version '1.8.0.rc2'
2019-11-07 16:29:34 +0900 [warn]: both of Plugin @id and path for <storage> are not specified. Using on-memory store.
2019-11-07 16:29:34 +0900 [warn]: both of Plugin @id and path for <storage> are not specified. Using on-memory store.
2019-11-07 16:29:34 +0900 [info]: using configuration file: <ROOT>
  <source>
    @type dummy
    tag "test.test.test.test"
  </source>
  <match test.test.test.test>
    @type stdout
  </match>
  <filter test.**>
    @type record_transformer
    <record>
      test_rec test
    </record>
  </filter>
</ROOT>
2019-11-07 16:29:34 +0900 [info]: starting fluentd-1.8.0.rc2 pid=69824 ruby="2.6.5"
2019-11-07 16:29:34 +0900 [info]: spawn command to main:  cmdline=["ruby", "-Eascii-8bit:ascii-8bit", "-rbundler/setup", "bin/fluentd", "-c", "example/debug/r.conf", "--under-supervisor"]
2019-11-07 16:29:34 +0900 [info]: adding filter pattern="test.**" type="record_transformer"
2019-11-07 16:29:34 +0900 [info]: adding match pattern="test.test.test.test" type="stdout"
2019-11-07 16:29:34 +0900 [info]: adding source type="dummy"
2019-11-07 16:29:34 +0900 [warn]: #0 both of Plugin @id and path for <storage> are not specified. Using on-memory store.
2019-11-07 16:29:34 +0900 [warn]: #0 both of Plugin @id and path for <storage> are not specified. Using on-memory store.
2019-11-07 16:29:34 +0900 [info]: #0 starting fluentd worker pid=69838 ppid=69824 worker=0
2019-11-07 16:29:34 +0900 [info]: #0 fluentd worker is now running worker=0
2019-11-07 16:29:35.015223000 +0900 test.test.test.test: {"message":"dummy","test_rec":"test"}
2019-11-07 16:29:36.039565000 +0900 test.test.test.test: {"message":"dummy","test_rec":"test"}
2019-11-07 16:29:37.066552000 +0900 test.test.test.test: {"message":"dummy","test_rec":"test"}

```