### PR TITLE
server helper: Fix IPv6 dual stack mode issue for tcp socket.

### DIFF
--- a/lib/fluent/plugin_helper/server.rb
+++ b/lib/fluent/plugin_helper/server.rb
@@ -356,7 +356,7 @@ module Fluent
                  server_socket_manager_client.listen_tcp(bind, port)
                else
                  # TCPServer.new doesn't set IPV6_V6ONLY flag, so use tcp_server_sockets instead.
-                 tsock = ::Socket.tcp_server_sockets(bind, port).first
+                 tsock = Addrinfo.tcp(bind, port).listen(::Socket::SOMAXCONN)
                  tsock.autoclose = false
                  TCPServer.for_fd(tsock.fileno)
                end

--- a/lib/fluent/plugin_helper/server.rb
+++ b/lib/fluent/plugin_helper/server.rb
@@ -355,7 +355,10 @@ module Fluent
         sock = if shared
                  server_socket_manager_client.listen_tcp(bind, port)
                else
-                 TCPServer.new(bind, port) # this method call can create sockets for AF_INET6
+                 # TCPServer.new doesn't set IPV6_V6ONLY flag, so use tcp_server_sockets instead.
+                 tsock = ::Socket.tcp_server_sockets(bind, port).first
+                 tsock.autoclose = false
+                 TCPServer.for_fd(tsock.fileno)
                end
         # close-on-exec is set by default in Ruby 2.0 or later (, and it's unavailable on Windows)
         sock.fcntl(Fcntl::F_SETFL, Fcntl::O_NONBLOCK) # nonblock

--- a/lib/fluent/plugin_helper/server.rb
+++ b/lib/fluent/plugin_helper/server.rb
@@ -355,8 +355,9 @@ module Fluent
         sock = if shared
                  server_socket_manager_client.listen_tcp(bind, port)
                else
-                 # TCPServer.new doesn't set IPV6_V6ONLY flag, so use tcp_server_sockets instead.
-                 tsock = Addrinfo.tcp(bind, port).listen(::Socket::SOMAXCONN)
+                 # TCPServer.new doesn't set IPV6_V6ONLY flag, so use Addrinfo class instead.
+                 # backlog will be set by the caller, we don't need to set backlog here
+                 tsock = Addrinfo.tcp(bind, port).listen
                  tsock.autoclose = false
                  TCPServer.for_fd(tsock.fileno)
                end

--- a/test/plugin_helper/test_server.rb
+++ b/test/plugin_helper/test_server.rb
@@ -538,6 +538,19 @@ class ServerPluginHelperTest < Test::Unit::TestCase
       assert_equal ["yayfoo\n", "yayfoo\n", "yayfoo\n"], lines
       assert_equal ["closed", "closed", "closed"], callback_results
     end
+
+    test 'can listen IPv4 / IPv6 together' do
+      omit "IPv6 unavailable here" unless ipv6_enabled?
+
+      assert_nothing_raised do
+        @d.server_create_tcp(:s_ipv4, PORT, bind: '0.0.0.0', shared: false) do |data, conn|
+          # ...
+        end
+        @d.server_create_tcp(:s_ipv6, PORT, bind: '::', shared: false) do |data, conn|
+          # ...
+        end
+      end
+    end
   end
 
   sub_test_case '#server_create_udp' do


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #2682 

**What this PR does / why we need it**: 
Use other socket method to set `IPV6_V6ONLY`.
See also https://github.com/treasure-data/serverengine/pull/101

**Docs Changes**:
No need

**Release Note**: 
Same as title