### PR TITLE
Allow cert chains

### DIFF
--- a/lib/fluent/plugin_helper/socket.rb
+++ b/lib/fluent/plugin_helper/socket.rb
@@ -150,7 +150,11 @@ module Fluent
           context.ciphers = ciphers
           context.verify_mode = OpenSSL::SSL::VERIFY_PEER
           context.cert_store = cert_store
-          context.verify_hostname = true if verify_fqdn && fqdn && context.respond_to?(:verify_hostname=)
+          if verify_fqdn && fqdn && context.respond_to?(:verify_hostname=)
+            context.verify_hostname = true
+          else
+            context.verify_hostname = false
+          end
           context.cert = OpenSSL::X509::Certificate.new(File.read(cert_path)) if cert_path
           context.key = OpenSSL::PKey::read(File.read(private_key_path), private_key_passphrase) if private_key_path
         end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #2699 

**What this PR does / why we need it**:

Adds support for certificate chains to Fluentd sockets. Needed for good practice around issuing certificates.

The added test fails if the new line:
```
context.extra_chain_cert = client_certs[1..-1]
```
is remove (effectively reverting to the old behavior of only loading the leaf certificate).

**Docs Changes**: 

Unsure if needed.

**Release Note**: 
