### PR TITLE
inline_config is replaced with the input value when user specify `-`

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -251,9 +251,7 @@ module Fluent
       # Assume fluent.conf encoding is UTF-8
       config_data = File.open(path, "r:#{params['conf_encoding']}:utf-8") {|f| f.read }
       inline_config = params['inline_config']
-      if inline_config == '-'
-        config_data << "\n" << STDIN.read
-      elsif inline_config
+      if inline_config
         config_data << "\n" << inline_config.gsub("\\n","\n")
       end
       fluentd_conf = Fluent::Config.parse(config_data, config_fname, config_basedir, params['use_v1_config'])
@@ -572,6 +570,10 @@ module Fluent
         show_plugin_config
       end
 
+      if @inline_config == '-'
+        @inline_config = STDIN.read
+      end
+
       @conf = read_config
       @system_config = build_system_config(@conf)
 
@@ -783,10 +785,8 @@ module Fluent
       config_fname = File.basename(@config_path)
       config_basedir = File.dirname(@config_path)
       config_data = File.open(@config_path, "r:#{@conf_encoding}:utf-8") {|f| f.read }
-      if @inline_config == '-'
-        config_data << "\n" << STDIN.read
-      elsif @inline_config
-        config_data << "\n" << @inline_config.gsub("\\n","\n")
+      if @inline_config
+        config_data << "\n" << @inline_config.gsub("\\n", "\n")
       end
       Fluent::Config.parse(config_data, config_fname, config_basedir, @use_v1_config)
     end

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -448,6 +448,21 @@ class SupervisorTest < ::Test::Unit::TestCase
     assert_equal 10, $log.out.instance_variable_get(:@shift_size)
   end
 
+  def test_inline_config
+    opts = Fluent::Supervisor.default_options
+    opts[:inline_config] = '-'
+    sv = Fluent::Supervisor.new(opts)
+    assert_equal '-', sv.instance_variable_get(:@inline_config)
+
+    inline_config = '<match *>\n@type stdout\n</match>'
+    stub(STDIN).read { inline_config }
+    stub(sv).read_config        # to skip
+    stub(sv).build_system_config { Fluent::SystemConfig.new } # to skip
+
+    sv.configure
+    assert_equal inline_config, sv.instance_variable_get(:@inline_config)
+  end
+
   def create_debug_dummy_logger
     dl_opts = {}
     dl_opts[:log_level] = ServerEngine::DaemonLogger::DEBUG


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
no

**What this PR does / why we need it**: 

Current implementation calling `STDIN.read` in supervisors and workers.
it causes blocking in worker side.

**Docs Changes**:

no

**Release Note**: 

same as the title .
