### PR TITLE
Accept localtime xor utc

### DIFF
--- a/lib/fluent/plugin_helper/compat_parameters.rb
+++ b/lib/fluent/plugin_helper/compat_parameters.rb
@@ -194,7 +194,9 @@ module Fluent
           hash['time_type'] = 'unixtime'
         end
         if conf.has_key?('localtime') || conf.has_key?('utc')
-          if conf.has_key?('localtime') && conf.has_key?('utc')
+          utc = to_bool(conf['utc'])
+          localtime = to_bool(conf['localtime'])
+          if conf.has_key?('localtime') && conf.has_key?('utc') && !(localtime ^ utc)
             raise Fluent::ConfigError, "both of utc and localtime are specified, use only one of them"
           elsif conf.has_key?('localtime')
             hash['localtime'] = Fluent::Config.bool_value(conf['localtime'])
@@ -215,6 +217,14 @@ module Fluent
         conf.elements << e
 
         conf
+      end
+
+      def to_bool(v)
+        if  v.is_a?(FalseClass) || v == 'false' || v.nil?
+          false
+        else
+          true
+        end
       end
 
       def compat_parameters_extract(conf)

--- a/lib/fluent/time.rb
+++ b/lib/fluent/time.rb
@@ -152,9 +152,7 @@ module Fluent
 
       def configure(conf)
         if conf.has_key?('localtime') || conf.has_key?('utc')
-          if conf.has_key?('localtime') && conf.has_key?('utc')
-            raise Fluent::ConfigError, "both of utc and localtime are specified, use only one of them"
-          elsif conf.has_key?('localtime')
+          if conf.has_key?('localtime')
             conf['localtime'] = Fluent::Config.bool_value(conf['localtime'])
           elsif conf.has_key?('utc')
             conf['localtime'] = !(Fluent::Config.bool_value(conf['utc']))
@@ -166,6 +164,10 @@ module Fluent
         end
 
         super
+
+        if conf.has_key?('localtime') && conf.has_key?('utc') && !(@localtime ^ @utc)
+          raise Fluent::ConfigError, "both of utc and localtime are specified, use only one of them"
+        end
 
         Fluent::Timezone.validate!(@timezone) if @timezone
       end

--- a/test/plugin/test_out_stdout.rb
+++ b/test/plugin/test_out_stdout.rb
@@ -157,6 +157,23 @@ class StdoutOutputTest < Test::Unit::TestCase
     end
   end
 
+  data(
+    'utc and !localtime' => "utc true\nlocaltime false",
+    '!utc and localtime' => "utc false\nlocaltime true")
+  test  'configure with localtime and utc' do |c|
+    assert_nothing_raised do
+      create_driver(CONFIG + c)
+    end
+  end
+
+  data('utc and localtime' => "utc true\nlocaltime true",
+       '!utc and !localtime' => "utc false\nlocaltime false")
+  test  'configure with localtime and utc' do |c|
+    assert_raise(Fluent::ConfigError.new('both of utc and localtime are specified, use only one of them')) do
+      create_driver(CONFIG + c)
+    end
+  end
+
   # Capture the log output of the block given
   def capture_log(&block)
     tmp = $log
@@ -167,4 +184,3 @@ class StdoutOutputTest < Test::Unit::TestCase
     $log = tmp
   end
 end
-


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 

I think `localtime = true && utc =false` and `locatime= false && utc = true` should be valid. 

In the current implementation, stdout format plugin raises the error like below with `utc true` in format section.

```
2019-12-10 15:06:02 +0900 [error]: config error file="example/debug/nginx.conf" error_class=Fluent::ConfigError error="both of utc and localtime are specified, use only one of them"
```

example conf
```
<match *>
  @type stdout

  <format>
    @type stdout
    utc true
  </format>
</match>
```

This is because of calling [TimeParameters#configure](https://github.com/fluent/fluentd/blob/master/lib/fluent/time.rb#L153) twice.
but it seems to be inevitable since the stdout format plugin has sub_formater object internally.

**Docs Changes**:

No need

**Release Note**: 

same as the title
