### PR TITLE
Make time_format configurable in stdout format

### DIFF
--- a/lib/fluent/plugin/formatter_stdout.rb
+++ b/lib/fluent/plugin/formatter_stdout.rb
@@ -28,7 +28,7 @@ module Fluent
       def configure(conf)
         super
 
-        @time_formatter = Strftime.new(TIME_FORMAT)
+        @time_formatter = Strftime.new(@time_format || TIME_FORMAT)
         @sub_formatter = Plugin.new_formatter(@output_type, parent: self.owner)
         @sub_formatter.configure(conf)
       end

--- a/test/plugin/test_out_stdout.rb
+++ b/test/plugin/test_out_stdout.rb
@@ -37,6 +37,25 @@ class StdoutOutputTest < Test::Unit::TestCase
       end
     end
 
+    test 'configure with time_format' do
+      d = create_driver(CONFIG + <<-CONF)
+        <format>
+          @type stdout
+          time_format %Y-%m-%dT%H:%M:%S.%L%z
+        </format>
+      CONF
+
+      time = event_time
+      out = capture_log do
+        d.run(default_tag: 'test') do
+          d.feed(time, {'test' => 'test'})
+        end
+      end
+
+      t = Time.at(time).localtime.strftime("%Y-%m-%dT%H:%M:%S.%L%z")
+      assert_equal "#{t} test: {\"test\":\"test\"}\n", out
+    end
+
     test 'emit with default configuration' do
       d = create_driver
       time = event_time()


### PR DESCRIPTION
Signed-off-by: Yuta Iwama <ganmacs@gmail.com>

<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
ref https://github.com/fluent/fluentd/issues/2718#issuecomment-563372355

**What this PR does / why we need it**: 

stdout format does not see the time_format even if user can set the value. 

**Docs Changes**:

no need(already mentioned but it doesn't work)

**Release Note**: 

same as the title.
