### PR TITLE
Fix bug that log level in system config doesn't affect

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -780,7 +780,7 @@ module Fluent
       opt = {}
       Fluent::SystemConfig::SYSTEM_CONFIG_PARAMETERS.each do |param|
         if @cl_opt.key?(param) && !@cl_opt[param].nil?
-          if param == :log_level && opt[:log_level] == Fluent::Log::LEVEL_INFO
+          if param == :log_level && @cl_opt[:log_level] == Fluent::Log::LEVEL_INFO
             # info level can't be specified via command line option.
             # log_level is info here, it is default value and <system>'s log_level should be applied if exists.
             next

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -32,7 +32,7 @@ module Fluent
 
     config_param :workers,   :integer, default: 1
     config_param :root_dir,  :string, default: nil
-    config_param :log_level, :enum, list: [:trace, :debug, :info, :warn, :error, :fatal], default: nil
+    config_param :log_level, :enum, list: [:trace, :debug, :info, :warn, :error, :fatal], default: 'info'
     config_param :suppress_repeated_stacktrace, :bool, default: nil
     config_param :emit_error_log_interval,      :time, default: nil
     config_param :suppress_config_dump, :bool, default: nil

--- a/test/config/test_system_config.rb
+++ b/test/config/test_system_config.rb
@@ -71,7 +71,7 @@ module Fluent::Config
       sc.overwrite_variables(s.for_system_config)
       assert_equal(1, sc.workers)
       assert_nil(sc.root_dir)
-      assert_nil(sc.log_level)
+      assert_equal(Fluent::Log::LEVEL_INFO, sc.log_level)
       assert_nil(sc.suppress_repeated_stacktrace)
       assert_nil(sc.emit_error_log_interval)
       assert_nil(sc.suppress_config_dump)

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -423,6 +423,17 @@ class SupervisorTest < ::Test::Unit::TestCase
     assert_equal inline_config, sv.instance_variable_get(:@inline_config)
   end
 
+  def test_log_level_affects
+    opts = Fluent::Supervisor.default_options
+    sv = Fluent::Supervisor.new(opts)
+
+    c = Fluent::Config::Element.new('system', '', { 'log_level' => 'error' }, [])
+    stub(sv).read_config { config_element('ROOT', '', {}, [c]) }
+
+    sv.configure
+    assert_equal Fluent::Log::LEVEL_ERROR, $log.level
+  end
+
   def create_debug_dummy_logger
     dl_opts = {}
     dl_opts[:log_level] = ServerEngine::DaemonLogger::DEBUG


### PR DESCRIPTION
Signed-off-by: Yuta Iwama <ganmacs@gmail.com>

<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
follow up https://github.com/fluent/fluentd/pull/2674

**What this PR does / why we need it**: 

Fix bug that log level in system config doesn't affect

**Docs Changes**:

need to change [log_level](https://docs.fluentd.org/deployment/system-config#log_level) default value https://github.com/fluent/fluentd-docs-gitbook/pull/122


**Release Note**: 

same as the title