### PR TITLE
Suppress redefined test suits

### DIFF
--- a/test/plugin/test_out_stdout.rb
+++ b/test/plugin/test_out_stdout.rb
@@ -179,7 +179,7 @@ class StdoutOutputTest < Test::Unit::TestCase
   data(
     'utc and !localtime' => "utc true\nlocaltime false",
     '!utc and localtime' => "utc false\nlocaltime true")
-  test  'configure with localtime and utc' do |c|
+  test 'success when configure with localtime and utc' do |c|
     assert_nothing_raised do
       create_driver(CONFIG + c)
     end
@@ -187,7 +187,7 @@ class StdoutOutputTest < Test::Unit::TestCase
 
   data('utc and localtime' => "utc true\nlocaltime true",
        '!utc and !localtime' => "utc false\nlocaltime false")
-  test  'configure with localtime and utc' do |c|
+  test 'raise an error when configure with localtime and utc' do |c|
     assert_raise(Fluent::ConfigError.new('both of utc and localtime are specified, use only one of them')) do
       create_driver(CONFIG + c)
     end


### PR DESCRIPTION
Signed-off-by: Yuta Iwama <ganmacs@gmail.com>

<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
follow up https://github.com/fluent/fluentd/pull/2720

**What this PR does / why we need it**: 

delete `Notification: <StdoutOutputTest#test: configure with localtime and utc> was redefined [test: configure with localtime and utc[utc and localtime](StdoutOutputTest)]`
https://travis-ci.org/fluent/fluentd/jobs/623812636?utm_medium=notification&utm_source=github_status

**Docs Changes**:

no need

**Release Note**: 

no need
