### PR TITLE
Fix regex and output warning log correctly

### DIFF
--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -40,7 +40,7 @@ module Fluent
       helpers_internal :thread, :retry_state
 
       CHUNK_KEY_PATTERN = /^[-_.@a-zA-Z0-9]+$/
-      CHUNK_KEY_PLACEHOLDER_PATTERN = /\$\{[-_.@$a-zA-Z0-9]+\}/
+      CHUNK_KEY_PLACEHOLDER_PATTERN = /\$\{([-_.@$a-zA-Z0-9]+)\}/
       CHUNK_TAG_PLACEHOLDER_PATTERN = /\$\{(tag(?:\[-?\d+\])?)\}/
       CHUNK_ID_PLACEHOLDER_PATTERN = /\$\{chunk_id\}/
 
@@ -707,7 +707,7 @@ module Fluent
       end
 
       def get_placeholders_keys(str)
-        str.scan(CHUNK_KEY_PLACEHOLDER_PATTERN).map{|ph| ph[2..-2]}.reject{|s| (s == "tag") || (s == 'chunk_id') }.sort
+        str.scan(CHUNK_KEY_PLACEHOLDER_PATTERN).map(&:first).reject{|s| (s == "tag") || (s == 'chunk_id') }.sort
       end
 
       # TODO: optimize this code
@@ -761,9 +761,11 @@ module Fluent
             end
             rvalue = rvalue.gsub(CHUNK_KEY_PLACEHOLDER_PATTERN, hash)
           end
+
           if rvalue =~ CHUNK_KEY_PLACEHOLDER_PATTERN
-            log.warn "chunk key placeholder '#{$&}' not replaced. template:#{str}"
+            log.warn "chunk key placeholder '#{$1}' not replaced. template:#{str}"
           end
+
           rvalue.sub(CHUNK_ID_PLACEHOLDER_PATTERN) {
             if chunk_passed
               dump_unique_id_hex(chunk.unique_id)

--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -759,7 +759,13 @@ module Fluent
             @chunk_keys.each do |key|
               hash["${#{key}}"] = metadata.variables[key.to_sym]
             end
-            rvalue = rvalue.gsub(CHUNK_KEY_PLACEHOLDER_PATTERN, hash)
+
+            rvalue = rvalue.gsub(CHUNK_KEY_PLACEHOLDER_PATTERN) do |matched|
+              hash.fetch(matched) do
+                log.warn "chunk key placeholder '#{matched[2..-2]}' not replaced. template:#{str}"
+                ''
+              end
+            end
           end
 
           if rvalue =~ CHUNK_KEY_PLACEHOLDER_PATTERN

--- a/test/plugin/test_output.rb
+++ b/test/plugin/test_output.rb
@@ -378,6 +378,18 @@ class OutputTest < Test::Unit::TestCase
       assert { logs.any? { |log| log.include?("${chunk_id} is not allowed in this plugin") } }
     end
 
+    test '#extract_placeholders logs warn message with not replaced key' do
+      @i.configure(config_element('ROOT', '', {}, [config_element('buffer', '')]))
+      tmpl = "/mypath/${key1}/test"
+      t = event_time('2016-04-11 20:30:00 +0900')
+      v = { key1: "value1" }
+      m = create_metadata(timekey: t, tag: 'fluentd.test.output', variables: v)
+      @i.extract_placeholders(tmpl, m)
+      logs = @i.log.out.logs
+
+      assert { logs.any? { |log| log.include?("chunk key placeholder 'key1' not replaced. template:#{tmpl}") } }
+    end
+
     sub_test_case '#placeholder_validators' do
       test 'returns validators for time, tag and keys when a template has placeholders even if plugin is not configured with these keys' do
         @i.configure(config_element('ROOT', '', {}, [config_element('buffer', '')]))

--- a/test/plugin/test_output.rb
+++ b/test/plugin/test_output.rb
@@ -390,6 +390,18 @@ class OutputTest < Test::Unit::TestCase
       assert { logs.any? { |log| log.include?("chunk key placeholder 'key1' not replaced. template:#{tmpl}") } }
     end
 
+    test '#extract_placeholders logs warn message with not replaced key if variables exist and chunk_key is not empty' do
+      @i.configure(config_element('ROOT', '', {}, [config_element('buffer', 'key1')]))
+      tmpl = "/mypath/${key1}/${key2}/test"
+      t = event_time('2016-04-11 20:30:00 +0900')
+      v = { key1: "value1" }
+      m = create_metadata(timekey: t, tag: 'fluentd.test.output', variables: v)
+      @i.extract_placeholders(tmpl, m)
+      logs = @i.log.out.logs
+
+      assert { logs.any? { |log| log.include?("chunk key placeholder 'key2' not replaced. template:#{tmpl}") } }
+    end
+
     sub_test_case '#placeholder_validators' do
       test 'returns validators for time, tag and keys when a template has placeholders even if plugin is not configured with these keys' do
         @i.configure(config_element('ROOT', '', {}, [config_element('buffer', '')]))


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
ref: https://github.com/fluent/fluentd/pull/2523

**What this PR does / why we need it**: 
Fixed regext to match with https://github.com/fluent/fluentd/blob/7482802d75ba7b61a2997b15a02c45ff6a376e61/lib/fluent/plugin/output.rb#L753.
Be able to output a warning log even if  chunk_key is passed.

**Docs Changes**:

none

**Release Note**: 

same as the title