### PR TITLE
This class is no more used

### DIFF
--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -163,7 +163,6 @@ module Fluent
     def setup_error_label(e)
       error_label = add_label(ERROR_LABEL)
       error_label.configure(e)
-      error_label.root_agent = RootAgentProxyWithoutErrorCollector.new(self)
       @error_collector = error_label.event_router
     end
 
@@ -361,35 +360,6 @@ module Fluent
           @next_emit_error_log_time = now + @suppress_emit_error_log_interval
         end
         raise error
-      end
-    end
-
-    # <label @ERROR> element use RootAgent wrapped by # this RootAgentProxyWithoutErrorCollector.
-    # So that those elements don't send cause infinite loop.
-    class RootAgentProxyWithoutErrorCollector < SimpleDelegator
-      def initialize(root_agent)
-        super
-
-        @suppress_emit_error_log_interval = 0
-        @next_emit_error_log_time = nil
-
-        interval_time = root_agent.instance_variable_get(:@suppress_emit_error_log_interval)
-        suppress_interval(interval_time) unless interval_time.zero?
-      end
-
-      def emit_error_event(tag, time, record, error)
-        error_info = {error: error, location: (error.backtrace ? error.backtrace.first : nil), tag: tag, time: time, record: record}
-        log.warn "dump an error event in @ERROR:", error_info
-      end
-
-      def handle_emits_error(tag, es, e)
-        now = EventTime.now.to_i
-        if @suppress_emit_error_log_interval.zero? || now > @next_emit_error_log_time
-          log.warn "emit transaction failed in @ERROR:", error: e, tag: tag
-          log.warn_backtrace
-          @next_emit_error_log_time = now + @suppress_emit_error_log_interval
-        end
-        raise e
       end
     end
   end

--- a/test/test_root_agent.rb
+++ b/test/test_root_agent.rb
@@ -170,7 +170,6 @@ EOC
 
       error_label = ra.labels['@ERROR']
       assert_kind_of Fluent::Plugin::NullOutput, error_label.outputs.first
-      assert_kind_of RootAgent::RootAgentProxyWithoutErrorCollector, error_label.root_agent
     end
   end
 
@@ -853,7 +852,6 @@ EOC
 
       error_label = ra.labels['@ERROR']
       assert_kind_of Fluent::Plugin::NullOutput, error_label.outputs.first
-      assert_kind_of RootAgent::RootAgentProxyWithoutErrorCollector, error_label.root_agent
     end
 
     test 'with plugins but for another worker' do


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
ref https://github.com/fluent/fluentd/issues/2624

**What this PR does / why we need it**: 

introduce at
https://github.com/fluent/fluentd/commit/ed93293a0360d839bb7da0183e0d4a06e19cbc1d

Label class's error_collector can not be not nil.
because error_collector is assigned a value by root_agent. and Lable
inherits Agent not RootAgent.
https://github.com/fluent/fluentd/blob/fcef949ce40472547fde295ddd2cfe297e1eddd6/lib/fluent/label.rb

**Docs Changes**:

no

**Release Note**: 

no
