### PR TITLE
Add deprecated log for inline_config

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -555,6 +555,7 @@ module Fluent
       end
 
       if @inline_config == '-'
+        $log.warn('the value "-" for `inline_config` is deprecated. See https://github.com/fluent/fluentd/issues/2711')
         @inline_config = STDIN.read
       end
 


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
ref: https://github.com/fluent/fluentd/issues/2711

**What this PR does / why we need it**: 

add log when inline_config is `-`. it's good to remove this feature in v1.20.0.

**Docs Changes**:

no need

**Release Note**: 

no need
