### PR TITLE
out_copy: Add copy_mode parameter. fix #2744

### DIFF
--- a/lib/fluent/plugin/out_copy.rb
+++ b/lib/fluent/plugin/out_copy.rb
@@ -23,7 +23,9 @@ module Fluent::Plugin
     Fluent::Plugin.register_output('copy', self)
 
     desc 'If true, pass different record to each `store` plugin.'
-    config_param :deep_copy, :bool, default: false
+    config_param :deep_copy, :bool, default: false, deprecated: "use 'copy_mode' parameter instead"
+    desc 'Pass different record to each `store` plugin by specified method'
+    config_param :copy_mode, :enum, list: [:no_copy, :shallow, :deep, :marshal], default: :no_copy
 
     attr_reader :ignore_errors
 
@@ -35,6 +37,7 @@ module Fluent::Plugin
     def configure(conf)
       super
 
+      @copy_proc = gen_copy_proc
       @stores.each { |store|
         @ignore_errors << (store.arg == 'ignore_error')
       }
@@ -55,7 +58,7 @@ module Fluent::Plugin
 
       outputs.each_with_index do |output, i|
         begin
-          output.emit_events(tag, @deep_copy ? es.dup : es)
+          output.emit_events(tag, @copy_proc ? @copy_proc.call(es) : es)
         rescue => e
           if @ignore_errors[i]
             log.error "ignore emit error", error: e
@@ -63,6 +66,41 @@ module Fluent::Plugin
             raise e
           end
         end
+      end
+    end
+
+    private
+
+    def gen_copy_proc
+      @copy_mode = :shallow if @deep_copy
+
+      case @copy_mode
+      when :no_copy
+         nil
+      when :shallow
+        Proc.new { |es| es.dup }
+      when :deep
+        Proc.new { |es|
+          packer = Fluent::MessagePackFactory.msgpack_packer
+          times = []
+          records = []
+          es.each { |time, record|
+            times << time
+            packer.pack(record)
+          }
+          Fluent::MessagePackFactory.msgpack_unpacker.feed_each(packer.full_pack) { |record|
+            records << record
+          }
+          Fluent::MultiEventStream.new(times, records)
+        }
+      when :marshal
+        Proc.new { |es|
+          new_es = Fluent::MultiEventStream.new
+          es.each { |time, record|
+            new_es.add(time, Marshal.load(Marshal.dump(record)))
+          }
+          new_es
+        }
       end
     end
   end

--- a/test/plugin/test_out_copy.rb
+++ b/test/plugin/test_out_copy.rb
@@ -50,6 +50,22 @@ class CopyOutputTest < Test::Unit::TestCase
     assert_equal "c0", outputs[0].name
     assert_equal "c1", outputs[1].name
     assert_equal "c2", outputs[2].name
+    assert_false d.instance.deep_copy
+    assert_equal :no_copy, d.instance.copy_mode
+  end
+
+  def test_configure_with_deep_copy_and_use_shallow_copy_mode
+    d = create_driver(%[
+      deep_copy true
+      <store>
+        @type test
+        name c0
+      </store>
+    ])
+
+    outputs = d.instance.outputs
+    assert_true d.instance.deep_copy
+    assert_equal :shallow, d.instance.copy_mode
   end
 
   def test_feed_events
@@ -86,9 +102,9 @@ class CopyOutputTest < Test::Unit::TestCase
     }
   end
 
-  def create_event_test_driver(does_deep_copy = false)
+  def create_event_test_driver(copy_mode = 'no_copy')
     config = %[
-      deep_copy #{does_deep_copy}
+      copy_mode #{copy_mode}
       <store>
         @type test
         name output1
@@ -110,49 +126,60 @@ class CopyOutputTest < Test::Unit::TestCase
   end
 
   time = event_time("2013-05-26 06:37:22 UTC")
-  mes0 = Fluent::MultiEventStream.new
-  mes0.add(time, {"a" => 1})
-  mes0.add(time, {"b" => 1})
-  mes1 = Fluent::MultiEventStream.new
-  mes1.add(time, {"a" => 1})
-  mes1.add(time, {"b" => 1})
+  gen_multi_es = Proc.new {
+    es = Fluent::MultiEventStream.new
+    es.add(time, {"a" => 1, "nest" => {'k' => 'v'}})
+    es.add(time, {"b" => 1, "nest" => {'k' => 'v'}})
+    es
+  }
 
   data(
-    "OneEventStream without deep_copy"   => [false, Fluent::OneEventStream.new(time, {"a" => 1})],
-    "OneEventStream with deep_copy"      => [true,  Fluent::OneEventStream.new(time, {"a" => 1})],
-    "ArrayEventStream without deep_copy" => [false, Fluent::ArrayEventStream.new([ [time, {"a" => 1}], [time, {"b" => 2}] ])],
-    "ArrayEventStream with deep_copy"    => [true,  Fluent::ArrayEventStream.new([ [time, {"a" => 1}], [time, {"b" => 2}] ])],
-    "MultiEventStream without deep_copy" => [false, mes0],
-    "MultiEventStream with deep_copy"    => [true,  mes1],
+    "OneEventStream without copy" => ['no_copy', Fluent::OneEventStream.new(time, {"a" => 1, "nest" => {'k' => 'v'}})],
+    "OneEventStream with shallow" => ['shallow', Fluent::OneEventStream.new(time, {"a" => 1, "nest" => {'k' => 'v'}})],
+    "OneEventStream with marshal" => ['marshal', Fluent::OneEventStream.new(time, {"a" => 1, "nest" => {'k' => 'v'}})],
+    "OneEventStream with deep"    => ['deep',    Fluent::OneEventStream.new(time, {"a" => 1, "nest" => {'k' => 'v'}})],
+    "ArrayEventStream without copy" => ['no_copy', Fluent::ArrayEventStream.new([[time, {"a" => 1, "nest" => {'k' => 'v'}}], [time, {"b" => 2, "nest" => {'k' => 'v'}}]])],
+    "ArrayEventStream with shallow" => ['shallow', Fluent::ArrayEventStream.new([[time, {"a" => 1, "nest" => {'k' => 'v'}}], [time, {"b" => 2, "nest" => {'k' => 'v'}}]])],
+    "ArrayEventStream with marshal" => ['marshal', Fluent::ArrayEventStream.new([[time, {"a" => 1, "nest" => {'k' => 'v'}}], [time, {"b" => 2, "nest" => {'k' => 'v'}}]])],
+    "ArrayEventStream with deep"    => ['deep',    Fluent::ArrayEventStream.new([[time, {"a" => 1, "nest" => {'k' => 'v'}}], [time, {"b" => 2, "nest" => {'k' => 'v'}}]])],
+    "MultiEventStream without copy" => ['no_copy', gen_multi_es.call],
+    "MultiEventStream with shallow" => ['shallow', gen_multi_es.call],
+    "MultiEventStream with marshal" => ['marshal', gen_multi_es.call],
+    "MultiEventStream with deep"    => ['deep',    gen_multi_es.call],
   )
-  def test_deep_copy_controls_shallow_or_deep_copied(data)
-    does_deep_copy, es = data
+  def test_copy_mode_with_event_streams(data)
+    copy_mode, es = data
 
-    d = create_event_test_driver(does_deep_copy)
-
+    d = create_event_test_driver(copy_mode)
     d.run(default_tag: 'test') do
       d.feed(es)
     end
 
     events = d.instance.outputs.map(&:events)
 
-    if does_deep_copy
+    if copy_mode != 'no_copy'
       events[0].each_with_index do |entry0, i|
         record0 = entry0.last
         record1 = events[1][i].last
 
-        assert{ record0.object_id != record1.object_id }
+        assert_not_equal record0.object_id, record1.object_id
         assert_equal "bar", record0["foo"]
         assert !record1.has_key?("foo")
+        if copy_mode == 'shallow'
+          assert_equal record0['nest'].object_id, record1['nest'].object_id
+        else
+          assert_not_equal record0['nest'].object_id, record1['nest'].object_id
+        end
       end
     else
       events[0].each_with_index do |entry0, i|
         record0 = entry0.last
         record1 = events[1][i].last
 
-        assert{ record0.object_id == record1.object_id }
+        assert_equal record0.object_id, record1.object_id
         assert_equal "bar", record0["foo"]
         assert_equal "bar", record1["foo"]
+        assert_equal record0['nest'].object_id, record1['nest'].object_id
       end
     end
   end


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #2744 

**What this PR does / why we need it**: 
Add `copy_mode` parameter to control no / shallow / deep copy.

Here is benchmark code:

```rb
require 'benchmark/ips'
require 'active_support/core_ext/object/deep_dup'
require 'fluent/event'
require 'fluent/time'
require 'msgpack'

test1 = Fluent::MultiEventStream.new
100.times { |i|
  record = {"time" => 1362020400,"host" => "192.168.0.1","size" => 777,"method" => "PUT", "kubernetes" => {"pod" => "test", "labels" => {"app" => "foo"}}}
  test1.add(Fluent::EventTime.now, record)
}

def f_n(es)
  es
end

def f_d(es)
  es.dup
end

def f_dd(es)
  new_es = Fluent::MultiEventStream.new
  es.each { |time, record|
    new_es.add(time, record.deep_dup)
  }
  new_es
end

def f_mp(es)
  new_es = Fluent::MultiEventStream.new
  es.each { |time, record|
    new_es.add(time, MessagePack.unpack(MessagePack.pack(record)))
  }
  new_es
end

def f_mp2(es)
  packer = Fluent::MessagePackFactory.msgpack_packer
  times = []
  records = []
  es.each { |time, record|
    times << time
    packer.pack(record)
  }
  Fluent::MessagePackFactory.msgpack_unpacker.feed_each(packer.full_pack) { |record|
    records << record
  }
  Fluent::MultiEventStream.new(times, records)
end

def f_m(es)
  new_es = Fluent::MultiEventStream.new
  es.each { |time, record|
    new_es.add(time, Marshal.load(Marshal.dump(record)))
  }
  new_es
end

Benchmark.ips do |x|
  x.report "none" do
    f_n(test1)
  end

  x.report "dup" do
    f_d(test1)
  end

  x.report "deep_dup" do
    f_dd(test1)
  end

  x.report "msgpack" do
    f_mp(test1)
  end

  x.report "msgpack2" do
    f_mp2(test1)
  end

  x.report "marshal" do
    f_m(test1)
  end
end
```

result:

```
Warming up --------------------------------------
                none   375.217k i/100ms
                 dup     2.231k i/100ms
            deep_dup   241.000  i/100ms
             msgpack   215.000  i/100ms
            msgpack2   525.000  i/100ms
             marshal    78.000  i/100ms
Calculating -------------------------------------
                none     18.437M (± 5.8%) i/s -     91.928M in   5.007073s
                 dup     22.413k (± 5.7%) i/s -    113.781k in   5.095399s
            deep_dup      2.436k (± 5.9%) i/s -     12.291k in   5.065170s
             msgpack      2.163k (± 6.8%) i/s -     10.750k in   5.000194s
            msgpack2      5.314k (± 6.4%) i/s -     26.775k in   5.063501s
             marshal    784.487  (± 5.1%) i/s -      3.978k in   5.086555s
```

**Docs Changes**:
Add `copy_mode` parameter.

**Release Note**: 
Same as title.