### PR TITLE
Prevent garbage from coming out of the LTSV parser

### DIFF
--- a/lib/fluent/plugin/parser_ltsv.rb
+++ b/lib/fluent/plugin/parser_ltsv.rb
@@ -38,8 +38,10 @@ module Fluent
       def parse(text)
         r = {}
         text.split(@delimiter).each do |pair|
-          key, value = pair.split(@label_delimiter, 2)
-          r[key] = value
+          if pair.include? @label_delimiter
+            key, value = pair.split(@label_delimiter, 2)
+            r[key] = value
+          end
         end
         time, record = convert_values(parse_time(r), r)
         yield time, record

--- a/test/plugin/test_parser_labeled_tsv.rb
+++ b/test/plugin/test_parser_labeled_tsv.rb
@@ -100,6 +100,21 @@ class LabeledTSVParserTest < ::Test::Unit::TestCase
     end
   end
 
+  def test_parse_and_reject_invalid_kv_pairs
+    parser = Fluent::Test::Driver::Parser.new(Fluent::Plugin::LabeledTSVParser)
+    parser.configure(
+                     'delimiter'       => ' ',
+                     'label_delimiter' => '=',
+                     )
+    text = 'A leading portion that is not LTSV    :  foo=bar baz=derp and a trailing portion'
+
+    expected = {'foo' => 'bar', 'baz' => 'derp'}
+    parser.instance.parse(text) do |time, record|
+      assert_equal expected, record
+    end
+
+  end
+
   def test_parse_with_null_value_pattern
     parser = Fluent::Test::Driver::Parser.new(Fluent::Plugin::LabeledTSVParser)
     parser.configure(


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
I have not opened one yet.

**What this PR does / why we need it**: 
The LTSV parser does not check whether the delimiter is in the pair before it tries to parse it. With `delimiter_pattern /\s+/` and `label_delimiter =`,If I give it the value:
```
"Sylvanus_007               : ok=45   changed=6"
```
it parses it like this:
```
{ "Sylvanus_007":null,":":null,"ok":"45","changed":"6" }
```
Both `Sylvanus_007: null` and `":": null` were never specified by key=value. This PR prevents this drastically wrong behavior and parses it like this:
```
{ "ok":"45","changed":"6" }
```

**Docs Changes**:
None

**Release Note**: 
None