### PR TITLE
Drop ruby 2.1/2.2/2.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,6 @@ cache: bundler
 # See here for osx_image -> OSX versions: https://docs.travis-ci.com/user/languages/objective-c
 matrix:
   include:
-    - rvm: 2.1.10
-      os: linux
-    - rvm: 2.2.10
-      os: linux
-    - rvm: 2.2.10
-      os: linux-ppc64le
     - rvm: 2.4.9
       os: linux
     - rvm: 2.4.9
@@ -29,9 +23,6 @@ matrix:
       os: linux
     - rvm: ruby-head
       os: linux-ppc64le
-    - rvm: 2.1.10
-      os: osx
-      osx_image: xcode8.3 # OSX 10.12
     - rvm: 2.4.6
       os: osx
       osx_image: xcode8.3 # OSX 10.12
@@ -39,9 +30,6 @@ matrix:
       os: osx
       osx_image: xcode8.3 # OSX 10.12
   allow_failures:
-    - rvm: 2.1.10
-      os: osx
-      osx_image: xcode8.3
     - rvm: 2.4.6
       os: osx
       osx_image: xcode8.3
@@ -54,8 +42,6 @@ matrix:
 branches:
   only:
     - master
-    - v0.12
-    - v0.14
 
 before_install:
   - gem update --system=2.7.8

--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,7 @@ source 'https://rubygems.org/'
 
 gemspec
 
-# https://github.com/socketry/async-io/blob/v1.23.1/async-io.gemspec#L21
-if Gem::Version.create(RUBY_VERSION) >= Gem::Version.create('2.3.0')
-  gem 'async-http', '~> 0.42'
-end
+gem 'async-http', '~> 0.42'
 
 local_gemfile = File.join(File.dirname(__FILE__), "Gemfile.local")
 if File.exist?(local_gemfile)

--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.license = "Apache-2.0"
 
-  gem.required_ruby_version = '>= 2.1'
+  gem.required_ruby_version = '>= 2.4'
 
   gem.add_runtime_dependency("msgpack", [">= 1.2.0", "< 2.0.0"])
   gem.add_runtime_dependency("yajl-ruby", ["~> 1.0"])
@@ -27,7 +27,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("tzinfo", [">= 1.0", "< 3.0"])
   gem.add_runtime_dependency("tzinfo-data", ["~> 1.0"])
   gem.add_runtime_dependency("strptime", [">= 0.2.2", "< 1.0.0"])
-  gem.add_runtime_dependency("dig_rb", ["~> 1.0.0"])
 
   # build gem for a certain platform. see also Rakefile
   fake_platform = ENV['GEM_BUILD_FAKE_PLATFORM'].to_s

--- a/lib/fluent/plugin_helper/http_server.rb
+++ b/lib/fluent/plugin_helper/http_server.rb
@@ -15,7 +15,6 @@
 #
 
 begin
-  # raise if RUBY_VERSION < 2.3.x. see Gemfile
   require 'async'
   require 'fluent/plugin_helper/http_server/server'
 rescue LoadError => _

--- a/lib/fluent/plugin_helper/record_accessor.rb
+++ b/lib/fluent/plugin_helper/record_accessor.rb
@@ -15,14 +15,6 @@
 #
 
 require 'fluent/config/error'
-unless {}.respond_to?(:dig)
-  begin
-    # backport_dig is faster than dig_rb so prefer backport_dig.
-    require 'backport_dig'
-  rescue LoadError
-    require 'dig_rb'
-  end
-end
 
 module Fluent
   module PluginHelper

--- a/lib/fluent/plugin_helper/server.rb
+++ b/lib/fluent/plugin_helper/server.rb
@@ -693,26 +693,11 @@ module Fluent
             end
           end
 
-          if RUBY_VERSION.to_f >= 2.3
-            NONBLOCK_ARG = { exception: false }
-            def try_handshake
-              @_handler_socket.accept_nonblock(**NONBLOCK_ARG)
-            end
-          else
-            def try_handshake
-              @_handler_socket.accept_nonblock
-            rescue IO::WaitReadable
-              :wait_readable
-            rescue IO::WaitWritable
-              :wait_writable
-            end
-          end
-
           def try_tls_accept
             return true if @_handler_accepted
 
             begin
-              result = try_handshake # this method call actually try to do handshake via TLS
+              result = @_handler_socket.accept_nonblock(exception: false) # this method call actually try to do handshake via TLS
               if result == :wait_readable || result == :wait_writable
                 # retry accept_nonblock: there aren't enough data in underlying socket buffer
               else


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #2380 
See also: https://www.fluentd.org/blog/drop-schedule-announcement-in-2019

This is for fluentd v1.9.0 which will be released in 2020

**What this PR does / why we need it**: 
Drop older rubies and related gems.

**Docs Changes**:
Need to update supported version

**Release Note**: 
Same as title.