### PR TITLE
output: Show better message for different secondary type

### DIFF
--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -387,7 +387,7 @@ module Fluent
           @secondary.acts_as_secondary(self)
           @secondary.configure(secondary_conf)
           if (self.class != @secondary.class) && (@custom_format || @secondary.implement?(:custom_format))
-            log.warn "secondary type should be same with primary one", primary: self.class.to_s, secondary: @secondary.class.to_s
+            log.warn "Use different plugin for secondary. Check the plugin works with primary like secondary_file", primary: self.class.to_s, secondary: @secondary.class.to_s
           end
         else
           @secondary = nil

--- a/test/plugin/test_output.rb
+++ b/test/plugin/test_output.rb
@@ -855,7 +855,7 @@ class OutputTest < Test::Unit::TestCase
     sub_test_case 'configure secondary' do
       test "Warn if primary type is different from secondary type and either primary or secondary has custom_format" do
         o = create_output(:buffered)
-        mock(o.log).warn("secondary type should be same with primary one",
+        mock(o.log).warn("Use different plugin for secondary. Check the plugin works with primary like secondary_file",
                          { primary: o.class.to_s, secondary: "Fluent::Plugin::TestOutput" })
 
         o.configure(config_element('ROOT','',{},[config_element('secondary','',{'@type'=>'test', 'name' => "cool"})]))
@@ -864,7 +864,7 @@ class OutputTest < Test::Unit::TestCase
 
       test "don't warn if primary type is the same as secondary type" do
         o = Fluent::Plugin::TestOutput.new
-        mock(o.log).warn("secondary type should be same with primary one",
+        mock(o.log).warn("Use different plugin for secondary. Check the plugin works with primary like secondary_file",
                          { primary: o.class.to_s, secondary: "Fluent::Plugin::TestOutput" }).never
 
         o.configure(config_element('ROOT','',{'name' => "cool2"},
@@ -876,7 +876,7 @@ class OutputTest < Test::Unit::TestCase
 
       test "don't warn if primary type is different from secondary type and both don't have custom_format" do
         o = create_output(:standard)
-        mock(o.log).warn("secondary type should be same with primary one",
+        mock(o.log).warn("Use different plugin for secondary. Check the plugin works with primary like secondary_file",
                          { primary: o.class.to_s, secondary: "Fluent::Plugin::TestOutput" }).never
 
         o.configure(config_element('ROOT','',{},[config_element('secondary','',{'@type'=>'test', 'name' => "cool"})]))

--- a/test/plugin/test_output_as_buffered_secondary.rb
+++ b/test/plugin/test_output_as_buffered_secondary.rb
@@ -153,7 +153,7 @@ class BufferedOutputSecondaryTest < Test::Unit::TestCase
       i = create_output()
       i.configure(config_element('ROOT','',{},[priconf,secconf]))
       logs = i.log.out.logs
-      assert{ logs.any?{|l| l.include?("secondary type should be same with primary one") } }
+      assert{ logs.any?{|l| l.include?("Use different plugin for secondary. Check the plugin works with primary like secondary_file") } }
     end
 
     test 'secondary plugin lifecycle is kicked by primary' do
@@ -162,7 +162,7 @@ class BufferedOutputSecondaryTest < Test::Unit::TestCase
       i = create_output()
       i.configure(config_element('ROOT','',{},[priconf,secconf]))
       logs = i.log.out.logs
-      assert{ logs.any?{|l| l.include?("secondary type should be same with primary one") } }
+      assert{ logs.any?{|l| l.include?("Use different plugin for secondary. Check the plugin works with primary like secondary_file") } }
 
       assert i.secondary.configured?
 

--- a/test/test_output.rb
+++ b/test/test_output.rb
@@ -116,7 +116,7 @@ module FluentOutputTest
         end
       end
 
-      mock(d.instance.log).warn("secondary type should be same with primary one",
+      mock(d.instance.log).warn("Use different plugin for secondary. Check the plugin works with primary like secondary_file",
                                 { primary: d.instance.class.to_s, secondary: "Fluent::Plugin::Test2Output" })
       d.configure(CONFIG + %[
         <secondary>
@@ -132,7 +132,7 @@ module FluentOutputTest
       # ObjectBufferedOutput doesn't implement `custom_filter`
       d = Fluent::Test::BufferedOutputTestDriver.new(Fluent::ObjectBufferedOutput)
 
-      mock(d.instance.log).warn("secondary type should be same with primary one",
+      mock(d.instance.log).warn("Use different plugin for secondary. Check the plugin works with primary like secondary_file",
                                 { primary: d.instance.class.to_s, secondary: "Fluent::Plugin::Test2Output" }).never
       d.configure(CONFIG + %[
         <secondary>


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
No issue in this repository.

**What this PR does / why we need it**: 
Current message is bit misleading for users. Some output plugins work with primary.

**Docs Changes**:
No need for now.

**Release Note**: 
Same as title.