### PR TITLE
Use Ruby's builtin time parser.

### DIFF
--- a/lib/fluent/time.rb
+++ b/lib/fluent/time.rb
@@ -16,6 +16,7 @@
 
 require 'time'
 require 'msgpack'
+require 'strptime'
 require 'fluent/timezone'
 require 'fluent/configurable'
 require 'fluent/config/error'

--- a/lib/fluent/time.rb
+++ b/lib/fluent/time.rb
@@ -16,7 +16,6 @@
 
 require 'time'
 require 'msgpack'
-require 'strptime'
 require 'fluent/timezone'
 require 'fluent/configurable'
 require 'fluent/config/error'
@@ -231,18 +230,9 @@ module Fluent
                     else Time.now.localtime.utc_offset # utc
                     end
 
-      strptime = format && (Strptime.new(format) rescue nil)
-
       @parse = case
-               when format_with_timezone && strptime then ->(v){ Fluent::EventTime.from_time(strptime.exec(v)) }
                when format_with_timezone             then ->(v){ Fluent::EventTime.from_time(Time.strptime(v, format)) }
                when format == '%iso8601'             then ->(v){ Fluent::EventTime.from_time(Time.iso8601(v)) }
-               when strptime then
-                 if offset_diff.respond_to?(:call)
-                   ->(v) { t = strptime.exec(v); Fluent::EventTime.new(t.to_i + offset_diff.call(t), t.nsec) }
-                 else
-                   ->(v) { t = strptime.exec(v); Fluent::EventTime.new(t.to_i + offset_diff, t.nsec) }
-                 end
                when format   then
                  if offset_diff.respond_to?(:call)
                    ->(v){ t = Time.strptime(v, format); Fluent::EventTime.new(t.to_i + offset_diff.call(t), t.nsec) }


### PR DESCRIPTION
This reduces CPU usage in micro and macro benchmarks of our GKE setup by 20-30%. I ran the macro benchmark with Ruby 2.6.3, and the micro benchmark with Ruby 2.5.7 and 2.6.3.

This replaces nurse/strptime, which is purported to be more efficient, but that no longer seems true on Ruby 2.5 and higher. I couldn't find any existing benchmarks, so I made my own micro and macro benchmarks: https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/pull/363

I see nurse/strptime hasn't gotten much love recently. E.g. https://github.com/nurse/strptime/issues/10

I could remove the dependency on strptime by replacing the usage of FORMATTER inside `inspect` with a Time.strftime call, but I don't know much about that impact.