### PR TITLE
Reduce time of test

### DIFF
--- a/test/plugin/test_in_exec.rb
+++ b/test/plugin/test_in_exec.rb
@@ -28,7 +28,7 @@ class ExecInputTest < Test::Unit::TestCase
 
   TSV_CONFIG = %[
     command ruby #{SCRIPT_PATH} "#{TEST_TIME}" 0
-    run_interval 1s
+    run_interval 0.3
     <parse>
       @type tsv
       keys time, tag, k1
@@ -43,7 +43,7 @@ class ExecInputTest < Test::Unit::TestCase
 
   JSON_CONFIG = %[
     command ruby #{SCRIPT_PATH} #{TEST_UNIX_TIME.to_i} 1
-    run_interval 1s
+    run_interval 0.3
     <parse>
       @type json
     </parse>
@@ -56,7 +56,7 @@ class ExecInputTest < Test::Unit::TestCase
 
   MSGPACK_CONFIG = %[
     command ruby #{SCRIPT_PATH} #{TEST_UNIX_TIME.to_i} 2
-    run_interval 1s
+    run_interval 0.3
     <parse>
       @type msgpack
     </parse>
@@ -70,7 +70,7 @@ class ExecInputTest < Test::Unit::TestCase
   # here document for not de-quoting backslashes
   REGEXP_CONFIG = %[
     command ruby #{SCRIPT_PATH} "#{TEST_TIME}" 3
-    run_interval 1s
+    run_interval 0.3
     tag regex_tag
 ] + <<'EOC'
     <parse>
@@ -143,7 +143,7 @@ EOC
       time_key time
       tag_key tag
       time_format %Y-%m-%d %H:%M:%S
-      run_interval 1s
+      run_interval 0.3
   ]
 
   JSON_CONFIG_COMPAT = %[
@@ -151,7 +151,7 @@ EOC
       format json
       tag_key tag
       time_key time
-      run_interval 1s
+      run_interval 0.3
   ]
 
   MSGPACK_CONFIG_COMPAT = %[
@@ -159,14 +159,14 @@ EOC
       format msgpack
       tag_key tagger
       time_key datetime
-      run_interval 1s
+      run_interval 0.3
   ]
 
   REGEXP_CONFIG_COMPAT = %[
       command ruby #{SCRIPT_PATH} "#{TEST_TIME}" 3
       format /(?<time>[^\\\]]*) (?<message>[^ ]*)/
       tag regex_tag
-      run_interval 1s
+      run_interval 0.3
   ]
 
   sub_test_case 'with traditional configuration' do
@@ -235,7 +235,7 @@ EOC
     d.run(expect_emits: 2, timeout: 10)
 
     assert{ d.events.length > 0 }
-    d.events.each_with_index {|event, i|
+    d.events.each {|event|
       assert_equal_event_time(time, event[1])
       assert_equal [tag, time, record], event
     }

--- a/test/plugin/test_in_forward.rb
+++ b/test/plugin/test_in_forward.rb
@@ -231,10 +231,9 @@ class ForwardInputTest < Test::Unit::TestCase
         ["tag2", time_i, {"a"=>2}],
       ]
 
-      d.run(expect_records: records.length, timeout: 20) do
+      d.run(expect_records: records.length, timeout: 20, shutdown: true) do
         records.each {|tag, _time, record|
           send_data [tag, _time, record].to_json + "\n"
-        sleep 1
         }
       end
 
@@ -727,7 +726,7 @@ class ForwardInputTest < Test::Unit::TestCase
         events.each {|tag, _time, record|
           op = { 'chunk' => Base64.encode64(record.object_id.to_s) }
           expected_acks << op['chunk']
-          send_data [tag, _time, record, op].to_msgpack, try_to_receive_response: true, **options
+          send_data([tag, _time, record, op].to_msgpack, try_to_receive_response: true, response_timeout: 1, **options)
         }
       end
 
@@ -769,7 +768,7 @@ class ForwardInputTest < Test::Unit::TestCase
         }
         op = { 'chunk' => Base64.encode64(entries.object_id.to_s) }
         expected_acks << op['chunk']
-        send_data ["tag1", entries, op].to_msgpack, try_to_receive_response: true, **options
+        send_data(["tag1", entries, op].to_msgpack, try_to_receive_response: true, response_timeout: 1, **options)
       end
 
       assert_equal events, d.events
@@ -809,7 +808,7 @@ class ForwardInputTest < Test::Unit::TestCase
         }
         op = { 'chunk' => Base64.encode64(entries.object_id.to_s) }
         expected_acks << op['chunk']
-        send_data ["tag1", entries, op].to_msgpack, try_to_receive_response: true, **options
+        send_data(["tag1", entries, op].to_msgpack, try_to_receive_response: true, response_timeout: 1, **options)
       end
 
       assert_equal events, d.events
@@ -849,7 +848,7 @@ class ForwardInputTest < Test::Unit::TestCase
         events.each {|tag, _time, record|
           op = { 'chunk' => Base64.encode64(record.object_id.to_s) }
           expected_acks << op['chunk']
-          send_data [tag, _time, record, op].to_json, try_to_receive_response: true, **options
+          send_data([tag, _time, record, op].to_json, try_to_receive_response: true, response_timeout: 1, **options)
         }
       end
 
@@ -885,7 +884,7 @@ class ForwardInputTest < Test::Unit::TestCase
 
       d.run(expect_records: events.size, timeout: 20) do
         events.each {|tag, _time, record|
-          send_data [tag, _time, record].to_msgpack, try_to_receive_response: true, **options
+          send_data([tag, _time, record].to_msgpack, try_to_receive_response: true, response_timeout: 1, **options)
         }
       end
 
@@ -922,7 +921,7 @@ class ForwardInputTest < Test::Unit::TestCase
         events.each {|tag, _time, record|
           entries << [_time, record]
         }
-        send_data ["tag1", entries].to_msgpack, try_to_receive_response: true, **options
+        send_data(["tag1", entries].to_msgpack, try_to_receive_response: true, response_timeout: 1, **options)
       end
 
       assert_equal events, d.events
@@ -958,7 +957,7 @@ class ForwardInputTest < Test::Unit::TestCase
         events.each {|tag, _time, record|
           [_time, record].to_msgpack(entries)
         }
-        send_data ["tag1", entries].to_msgpack, try_to_receive_response: true, **options
+        send_data(["tag1", entries].to_msgpack, try_to_receive_response: true, response_timeout: 1, **options)
       end
 
       assert_equal events, d.events
@@ -994,7 +993,7 @@ class ForwardInputTest < Test::Unit::TestCase
 
       d.run(expect_records: events.size, timeout: 20) do
         events.each {|tag, _time, record|
-          send_data [tag, _time, record].to_json, try_to_receive_response: true, **options
+          send_data([tag, _time, record].to_json, try_to_receive_response: true, response_timeout: 1, **options)
         }
       end
 
@@ -1016,7 +1015,7 @@ class ForwardInputTest < Test::Unit::TestCase
   # nil: socket read timeout
   def read_data(io, timeout, &block)
     res = ''
-    select_timeout = 2
+    select_timeout = 0.5
     clock_id = Process::CLOCK_MONOTONIC_RAW rescue Process::CLOCK_MONOTONIC
     timeout_at = Process.clock_gettime(clock_id) + timeout
     begin

--- a/test/plugin/test_in_object_space.rb
+++ b/test/plugin/test_in_object_space.rb
@@ -27,7 +27,7 @@ class ObjectSpaceInputTest < Test::Unit::TestCase
   end
 
   TESTCONFIG = %[
-    emit_interval 1
+    emit_interval 0.2
     tag t1
     top 2
   ]
@@ -38,7 +38,7 @@ class ObjectSpaceInputTest < Test::Unit::TestCase
 
   def test_configure
     d = create_driver
-    assert_equal 1, d.instance.emit_interval
+    assert_equal 0.2, d.instance.emit_interval
     assert_equal "t1", d.instance.tag
     assert_equal 2, d.instance.top
   end
@@ -46,11 +46,7 @@ class ObjectSpaceInputTest < Test::Unit::TestCase
   def test_emit
     d = create_driver
 
-    d.run do
-      waiting(10, d.instance) do
-        sleep 0.5 until d.events.size > 3
-      end
-    end
+    d.run(expect_emits: 3)
 
     emits = d.events
     assert{ emits.length > 0 }

--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -671,7 +671,7 @@ EOL
 
     @d = d = create_driver(CONFIG + %[
       require_ack_response true
-      ack_response_timeout 5s
+      ack_response_timeout 1s
       <buffer tag>
         flush_mode immediate
         retry_type periodic
@@ -699,7 +699,7 @@ EOL
       end
     end
 
-    assert_equal (5 + 2), delayed_commit_timeout_value
+    assert_equal (1 + 2), delayed_commit_timeout_value
 
     events = target_input_driver.events
     assert_equal ['test', time, records[0]], events[0]

--- a/test/plugin/test_output_as_buffered.rb
+++ b/test/plugin/test_output_as_buffered.rb
@@ -699,7 +699,7 @@ class BufferedOutputTest < Test::Unit::TestCase
         r["key#{i}"] = "value #{i}"
       end
 
-      3.times do |i|
+      2.times do |i|
         rand_records = rand(1..4)
         es = Fluent::ArrayEventStream.new([ [t, r] ] * rand_records)
         assert_equal rand_records, es.size

--- a/test/plugin/test_output_as_buffered_overflow.rb
+++ b/test/plugin/test_output_as_buffered_overflow.rb
@@ -141,7 +141,7 @@ class BufferedOutputOverflowTest < Test::Unit::TestCase
       assert !@i.buffer.storable?
 
       Thread.new do
-        sleep 3
+        sleep 1
         failing = false
       end
 

--- a/test/plugin_helper/test_child_process.rb
+++ b/test/plugin_helper/test_child_process.rb
@@ -232,13 +232,11 @@ class ChildProcessTest < Test::Unit::TestCase
   end
 
   test 'can execute external command at just once, which runs forever' do
-    m = Mutex.new
     ary = []
     Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
       ran = false
-      args = ["-e", "while sleep #{TEST_WAIT_INTERVAL_FOR_LOOP}; puts 1; STDOUT.flush; end"]
+      args = ["-e", "while sleep 0.2; puts 1; STDOUT.flush; end"]
       @d.child_process_execute(:t3, "ruby", arguments: args, mode: [:read]) do |io|
-        m.lock
         ran = true
         begin
           while @d.child_process_running? && line = io.readline
@@ -246,16 +244,14 @@ class ChildProcessTest < Test::Unit::TestCase
           end
         rescue
           # ignore
-        ensure
-          m.unlock
         end
       end
-      sleep TEST_WAIT_INTERVAL_FOR_BLOCK_RUNNING until m.locked? || ran
-      sleep TEST_WAIT_INTERVAL_FOR_LOOP * 10
+      sleep TEST_WAIT_INTERVAL_FOR_BLOCK_RUNNING until ran
+      sleep 1
+
       @d.stop # nothing occurs
       @d.shutdown
-
-      assert{ ary.size > 5 }
+      assert { ary.size >= 4 }
 
       @d.close
 
@@ -272,7 +268,7 @@ class ChildProcessTest < Test::Unit::TestCase
     ary = []
     Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
       ran = false
-      @d.child_process_execute(:t4, "ruby -e 'Signal.trap(:TERM, nil); while sleep #{TEST_WAIT_INTERVAL_FOR_LOOP}; puts 1; STDOUT.flush rescue nil; end'", mode: [:read]) do |io|
+      @d.child_process_execute(:t4, "ruby -e 'Signal.trap(:TERM, nil); while sleep 0.1; puts 1; STDOUT.flush rescue nil; end'", mode: [:read]) do |io|
         m.lock
         ran = true
         begin
@@ -290,17 +286,17 @@ class ChildProcessTest < Test::Unit::TestCase
       assert_equal [], @d.log.out.logs
 
       @d.stop # nothing occurs
-      sleep TEST_WAIT_INTERVAL_FOR_LOOP * 5
+      sleep TEST_WAIT_INTERVAL_FOR_LOOP
       lines1 = ary.size
       assert{ lines1 > 1 }
 
       pid = @d._child_process_processes.keys.first
-
+      # default value 10 is too long for test
+      @d.instance_eval { @_child_process_exit_timeout = 1 }
       @d.shutdown
-      sleep TEST_WAIT_INTERVAL_FOR_LOOP * 5
+      sleep TEST_WAIT_INTERVAL_FOR_LOOP
       lines2 = ary.size
-      assert{ lines2 > lines1 }
-
+      assert { lines2 > lines1 }
       @d.close
 
       assert_nil((Process.waitpid(pid, Process::WNOHANG) rescue nil))
@@ -318,12 +314,12 @@ class ChildProcessTest < Test::Unit::TestCase
 
   test 'can execute external command many times, which finishes immediately' do
     ary = []
-    arguments = ["-e", "3.times{ puts 'okay'; STDOUT.flush rescue nil; sleep #{TEST_WAIT_INTERVAL_FOR_LOOP} }"] # 0.5 * 3
+    arguments = ["-e", "puts 'okay'; STDOUT.flush rescue nil"]
     Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
-      @d.child_process_execute(:t5, "ruby", arguments: arguments, interval: 5, mode: [:read]) do |io|
+      @d.child_process_execute(:t5, "ruby", arguments: arguments, interval: 1, mode: [:read]) do |io|
         ary << io.read.split("\n").map(&:chomp).join
       end
-      sleep 13 # 5sec * 2 + 3sec
+      sleep 2.5 # 2sec(second invocation) + 0.5sec
       assert_equal [], @d.log.out.logs
       @d.stop
       assert_equal [], @d.log.out.logs
@@ -334,13 +330,12 @@ class ChildProcessTest < Test::Unit::TestCase
 
   test 'can execute external command many times, with leading once executed immediately' do
     ary = []
-    arguments = ["-e", "3.times{ puts 'okay'; STDOUT.flush rescue nil; sleep #{TEST_WAIT_INTERVAL_FOR_LOOP} }"]
+    arguments = ["-e", "puts 'okay'; STDOUT.flush rescue nil"]
     Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
-      @d.child_process_execute(:t6, "ruby", arguments: arguments, interval: 5, immediate: true, mode: [:read]) do |io|
+      @d.child_process_execute(:t6, "ruby", arguments: arguments, interval: 1, immediate: true, mode: [:read]) do |io|
         ary << io.read.split("\n").map(&:chomp).join
       end
-      sleep 8 # 5sec * 1 + 3sec
-              # but expected lines are same with test above
+      sleep 1.5 # 2sec(second invocation) + 0.5sec
       @d.stop; @d.shutdown; @d.close; @d.terminate
       assert_equal 2, ary.size
       assert_equal [], @d.log.out.logs
@@ -349,7 +344,7 @@ class ChildProcessTest < Test::Unit::TestCase
 
   test 'does not execute long running external command in parallel in default' do
     ary = []
-    arguments = ["-e", "10.times{ puts 'okay'; STDOUT.flush rescue nil; sleep #{TEST_WAIT_INTERVAL_FOR_LOOP} }"] # 0.5 * 10
+    arguments = ["-e", "10.times{ sleep #{TEST_WAIT_INTERVAL_FOR_LOOP} }"] # 5 sec
     Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
       assert_equal [], @d.log.out.logs
       @d.log.out.singleton_class.module_eval do
@@ -359,13 +354,13 @@ class ChildProcessTest < Test::Unit::TestCase
         }
       end
 
-      @d.child_process_execute(:t7, "ruby", arguments: arguments, interval: 2, immediate: true, mode: [:read]) do |io|
+      @d.child_process_execute(:t7, "ruby", arguments: arguments, interval: 1, immediate: true, mode: [:read]) do |io|
         ary << io.read.split("\n").map(&:chomp).join
       end
-      sleep 4
+      sleep 2
       assert_equal 1, @d._child_process_processes.size
       @d.stop
-      warn_msg = '[warn]: previous child process is still running. skipped. title=:t7 command="ruby" arguments=["-e", "10.times{ puts \'okay\'; STDOUT.flush rescue nil; sleep 0.5 }"] interval=2 parallel=false' + "\n"
+      warn_msg = '[warn]: previous child process is still running. skipped. title=:t7 command="ruby" arguments=["-e", "10.times{ sleep 0.5 }"] interval=1 parallel=false' + "\n"
       logs = @d.log.out.logs
       assert{ logs.first.end_with?(warn_msg) }
       assert{ logs.all?{|line| line.end_with?(warn_msg) } }
@@ -376,14 +371,14 @@ class ChildProcessTest < Test::Unit::TestCase
 
   test 'can execute long running external command in parallel if specified' do
     ary = []
-    arguments = ["-e", "10.times{ puts 'okay'; STDOUT.flush rescue nil; sleep #{TEST_WAIT_INTERVAL_FOR_LOOP} }"] # 0.5 * 10 sec
+    arguments = ["-e", "10.times{  puts 'okay'; STDOUT.flush rescue nil; sleep #{TEST_WAIT_INTERVAL_FOR_LOOP} }"] # 5 sec
     Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
       @d.child_process_execute(:t8, "ruby", arguments: arguments, interval: 1, immediate: true, parallel: true, mode: [:read]) do |io|
         ary << io.read.split("\n").map(&:chomp).join
       end
-      sleep 4
+      sleep 2
       processes = @d._child_process_processes.size
-      assert{ processes >= 3 && processes <= 5 }
+      assert { processes >= 2 && processes <= 4 }
       @d.stop; @d.shutdown; @d.close; @d.terminate
       assert_equal [], @d.log.out.logs
     end
@@ -662,14 +657,14 @@ class ChildProcessTest < Test::Unit::TestCase
       block_exits = false
       callback_called = false
       exit_status = nil
-      args = ['-e', 'sleep ARGV[0].to_i; puts "yay"; File.unlink ARGV[1]', '1', @temp_path]
+      args = ['-e', 'puts "yay"; File.unlink ARGV[0]', @temp_path]
       cb = ->(status){ exit_status = status; callback_called = true }
 
       str = nil
-
       pid = nil
       @d.child_process_execute(:st1, "ruby", arguments: args, mode: [:read], on_exit_callback: cb) do |readio|
-        pid = @d.instance_eval{ child_process_id }
+        assert !callback_called # ensure yet to be called
+        pid = @d.instance_eval { child_process_id }
         str = readio.read.chomp
         block_exits = true
       end
@@ -697,16 +692,11 @@ class ChildProcessTest < Test::Unit::TestCase
       cb = ->(status){ exit_status = status; callback_called = true }
 
       str = nil
-
       pid = nil
       @d.child_process_execute(:st1, "ruby", arguments: args, mode: [:read], on_exit_callback: cb) do |readio|
-        pid = @d.instance_eval{ child_process_id }
-        sleep 10 # to run child process correctly
+        pid = @d.instance_eval { child_process_id }
+        sleep 1
         Process.kill(:QUIT, pid)
-        sleep 1
-        Process.kill(:QUIT, pid) rescue nil # once more to send kill
-        sleep 1
-        Process.kill(:QUIT, pid) rescue nil # just like sync
         str = readio.read.chomp rescue nil # empty string before EOF
         block_exits = true
       end
@@ -717,29 +707,28 @@ class ChildProcessTest < Test::Unit::TestCase
       assert callback_called
       assert exit_status
 
-      # This test sometimes fails on TravisCI
-      #    with [nil, 11] # SIGSEGV
-      # or with [1, nil]  # ???
-      assert_equal [nil, 3, true, ""], [exit_status.exitstatus, exit_status.termsig, File.exist?(@temp_path), str] # SIGQUIT
-      # SIGSEGV looks a kind of BUG of ruby...
+      assert_equal nil, exit_status.exitstatus
+      assert_equal 3, exit_status.termsig
+      assert File.exist?(@temp_path)
+      assert_equal '', str
     end
 
     test 'calls on_exit_callback for each process exits for interval call using on_exit_callback' do
       read_data_list = []
       exit_status_list = []
 
-      args = ['-e', 'puts "yay"', '1']
+      args = ['-e', 'puts "yay"']
       cb = ->(status){ exit_status_list << status }
 
       Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
-        @d.child_process_execute(:st1, "ruby", arguments: args, immediate: true, interval: 2, mode: [:read], on_exit_callback: cb) do |readio|
+        @d.child_process_execute(:st1, "ruby", arguments: args, immediate: true, interval: 1, mode: [:read], on_exit_callback: cb) do |readio|
           read_data_list << readio.read.chomp
         end
-        sleep 10
+        sleep 2
       end
 
-      assert{ read_data_list.size >= 3 }
-      assert{ exit_status_list.size >= 3 }
+      assert { read_data_list.size >= 2 }
+      assert { exit_status_list.size >= 2 }
     end
 
     test 'waits lasting child process until wait_timeout if block is not specified' do
@@ -747,11 +736,11 @@ class ChildProcessTest < Test::Unit::TestCase
 
       callback_called = false
       exit_status = nil
-      args = ['-e', 'sleep ARGV[0].to_i; File.unlink ARGV[1]', '1', @temp_path]
+      args = ['-e', 'File.unlink ARGV[0]', @temp_path]
       cb = ->(status){ exit_status = status; callback_called = true }
 
       Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
-        @d.child_process_execute(:t17, "ruby", arguments: args, on_exit_callback: cb, wait_timeout: 5)
+        @d.child_process_execute(:t17, "ruby", arguments: args, on_exit_callback: cb, wait_timeout: 2)
         sleep TEST_WAIT_INTERVAL_FOR_BLOCK_RUNNING until callback_called
       end
 
@@ -766,7 +755,7 @@ class ChildProcessTest < Test::Unit::TestCase
 
       callback_called = false
       exit_status = nil
-      args = ['-e', 'sleep ARGV[0].to_i; File.unlink ARGV[1]', '3', @temp_path]
+      args = ['-e', 'File.unlink ARGV[0]', @temp_path]
       cb = ->(status){ exit_status = status; callback_called = true }
 
       Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
@@ -791,7 +780,7 @@ class ChildProcessTest < Test::Unit::TestCase
       cb = ->(status){ exit_status = status; callback_called = true }
 
       Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
-        @d.child_process_execute(:t17, "ruby", arguments: args, on_exit_callback: cb, wait_timeout: 3)
+        @d.child_process_execute(:t17, "ruby", arguments: args, on_exit_callback: cb, wait_timeout: 1)
         sleep TEST_WAIT_INTERVAL_FOR_BLOCK_RUNNING until callback_called
       end
 
@@ -813,8 +802,8 @@ class ChildProcessTest < Test::Unit::TestCase
       cb = ->(status){ exit_status = status; callback_called = true }
 
       Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
-        @d.child_process_execute(:t17, "ruby", arguments: args, mode: nil, on_exit_callback: cb, wait_timeout: 3) do
-          sleep 3
+        @d.child_process_execute(:t17, "ruby", arguments: args, mode: nil, on_exit_callback: cb, wait_timeout: 1) do
+          sleep 1
         end
         sleep TEST_WAIT_INTERVAL_FOR_BLOCK_RUNNING until callback_called
       end

--- a/test/plugin_helper/test_child_process.rb
+++ b/test/plugin_helper/test_child_process.rb
@@ -235,11 +235,11 @@ class ChildProcessTest < Test::Unit::TestCase
     ary = []
     Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
       ran = false
-      args = ["-e", "while sleep 0.2; puts 1; STDOUT.flush; end"]
+      args = ["-e", "while sleep 0.1; puts 1; STDOUT.flush; end"]
       @d.child_process_execute(:t3, "ruby", arguments: args, mode: [:read]) do |io|
-        ran = true
         begin
           while @d.child_process_running? && line = io.readline
+            ran ||= true
             ary << line
           end
         rescue

--- a/test/plugin_helper/test_timer.rb
+++ b/test/plugin_helper/test_timer.rb
@@ -34,12 +34,12 @@ class TimerTest < Test::Unit::TestCase
       counter += 1
     end
 
-    sleep 5
+    sleep 2
 
     d1.stop
     assert !d1.timer_running?
 
-    assert{ counter >= 3 && counter <= 6 }
+    assert{ counter >= 1 && counter <= 2 }
 
     d1.shutdown; d1.close; d1.terminate
   end
@@ -52,19 +52,18 @@ class TimerTest < Test::Unit::TestCase
     counter1 = 0
     counter2 = 0
 
-    d1.timer_execute(:t1, 1) do
+    d1.timer_execute(:t1, 0.2) do
       counter1 += 1
     end
-    d1.timer_execute(:t2, 2) do
+    d1.timer_execute(:t2, 0.2) do
       counter2 += 1
     end
 
-    sleep 6
-
+    sleep 1
     d1.stop
 
-    assert{ counter1 >= 4 && counter1 <= 7 }
-    assert{ counter2 >= 2 && counter2 <= 4 }
+    assert{ counter1 >= 4 && counter1 <= 5 }
+    assert{ counter2 >= 4 && counter2 <= 5 }
 
     d1.shutdown; d1.close; d1.terminate
   end
@@ -77,19 +76,18 @@ class TimerTest < Test::Unit::TestCase
     counter1 = 0
     counter2 = 0
 
-    d1.timer_execute(:t1, 1) do
+    d1.timer_execute(:t1, 0.2) do
       counter1 += 1
     end
-    d1.timer_execute(:t2, 1) do
+    d1.timer_execute(:t2, 0.2) do
       raise "abort!!!!!!" if counter2 > 1
       counter2 += 1
     end
 
-    sleep 5
-
+    sleep 1
     d1.stop
 
-    assert{ counter1 >= 3 && counter1 <= 6 }
+    assert{ counter1 >= 4 && counter1 <= 5 }
     assert{ counter2 == 2 }
     msg = "Unexpected error raised. Stopping the timer. title=:t2"
     assert{ d1.log.out.logs.any?{|line| line.include?("[error]:") && line.include?(msg) && line.include?("abort!!!!!!") } }

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -176,6 +176,9 @@ class SupervisorTest < ::Test::Unit::TestCase
   log_level debug
 </system>
 ]
+    now = Time.now
+    Timecop.freeze(now)
+
     write_config tmp_dir, conf_info_str
 
     params = {}
@@ -208,7 +211,7 @@ class SupervisorTest < ::Test::Unit::TestCase
     assert_nil pre_config_mtime
     assert_nil pre_loadtime
 
-    sleep 5
+    Timecop.freeze(now + 5)
 
     # third call after 5 seconds(don't reuse config)
     se_config = load_config_proc.call
@@ -228,6 +231,8 @@ class SupervisorTest < ::Test::Unit::TestCase
     # fifth call after changed conf file(don't reuse config)
     se_config = load_config_proc.call
     assert_equal Fluent::Log::LEVEL_INFO, se_config[:log_level]
+  ensure
+    Timecop.return
   end
 
   def test_load_config_for_daemonize
@@ -242,6 +247,10 @@ class SupervisorTest < ::Test::Unit::TestCase
   log_level debug
 </system>
 ]
+
+    now = Time.now
+    Timecop.freeze(now)
+
     write_config tmp_dir, conf_info_str
 
     params = {}
@@ -275,9 +284,9 @@ class SupervisorTest < ::Test::Unit::TestCase
     assert_nil pre_config_mtime
     assert_nil pre_loadtime
 
-    sleep 5
+    Timecop.freeze(now + 5)
 
-    # third call after 5 seconds(don't reuse config)
+    # third call after 6 seconds(don't reuse config)
     se_config = load_config_proc.call
     pre_config_mtime = se_config[:windows_daemon_cmdline][5]['pre_config_mtime']
     pre_loadtime = se_config[:windows_daemon_cmdline][5]['pre_loadtime']
@@ -295,6 +304,8 @@ class SupervisorTest < ::Test::Unit::TestCase
     # fifth call after changed conf file(don't reuse config)
     se_config = load_config_proc.call
     assert_equal Fluent::Log::LEVEL_INFO, se_config[:log_level]
+  ensure
+    Timecop.return
   end
 
   def test_logger

--- a/test/test_test_drivers.rb
+++ b/test/test_test_drivers.rb
@@ -47,8 +47,8 @@ class TestDriverTest < ::Test::Unit::TestCase
       driver_class, plugin_class = args
       d = driver_class.new(Class.new(plugin_class))
       assert_raise Fluent::Test::Driver::TestTimedOut do
-        d.run(timeout: 1) do
-          sleep 5
+        d.run(timeout: 0.5) do
+          sleep 2
         end
       end
     end
@@ -67,7 +67,7 @@ class TestDriverTest < ::Test::Unit::TestCase
         assert_nothing_raised do
           before = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           d.end_if{ false }
-          d.run(timeout: 5) do
+          d.run(timeout: 1) do
             sleep 0.1 until d.stop?
           end
           after = Process.clock_gettime(Process::CLOCK_MONOTONIC)
@@ -89,6 +89,7 @@ class TestDriverTest < ::Test::Unit::TestCase
           end
         end
       end
+
       assert_raise RuntimeError.new("yaaaaaaaaaay!") do
         d.end_if{ false }
         d.run(timeout: 3) do


### PR DESCRIPTION
Signed-off-by: Yuta Iwama <ganmacs@gmail.com>

<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 

none


**What this PR does / why we need it**: 

Tests of fluentd became more stable than old versions. I tried to reduce the duration time of them for the next step.
As a result, reduced about 4 mins in ruby (17 min 43 sec ->  13 min 37 sec)
Before https://travis-ci.org/fluent/fluentd/jobs/637322326?utm_medium=notification&utm_source=github_status
After: https://travis-ci.org/fluent/fluentd/jobs/637798871?utm_medium=notification&utm_source=github_status
**Docs Changes**:

none

**Release Note**: 

none
