### PR TITLE
Fix off-by one for octet-counting code in in_sysylog.rb

### DIFF
--- a/lib/fluent/plugin/in_syslog.rb
+++ b/lib/fluent/plugin/in_syslog.rb
@@ -181,12 +181,14 @@ module Fluent::Plugin
           if octet_count_frame
             while idx = buffer.index(delimiter, pos)
               num = Integer(buffer[pos..idx])
-              pos = idx + num
-              msg = buffer[idx + 1...pos]
-              if msg.size < num - 1
-                pos = pos - num - num.to_s.size
+              idx = idx + delimiter_size
+              msg = buffer[idx, num]
+              if msg.size != num
                 break
               end
+              pos = idx + msg.size
+              # syslog might append a \n as an extra frame delimiter
+              msg.chomp!
               message_handler(msg, conn)
             end
           else

--- a/test/plugin/test_in_syslog.rb
+++ b/test/plugin/test_in_syslog.rb
@@ -321,11 +321,11 @@ EOS
   end
 
   sub_test_case 'octet counting frame' do
-    def test_msg_size_with_tcp
+    def test_octet_counting_with_tcp
       d = create_driver([CONFIG, "<transport tcp> \n</transport>", 'frame_type octet_count'].join("\n"))
       tests = create_test_case
 
-      d.run(expect_emits: 2) do
+      d.run(expect_emits: 1) do
         tests.each {|test|
           TCPSocket.open('127.0.0.1', PORT) do |s|
             s.send(test['msg'], 0)
@@ -337,7 +337,7 @@ EOS
       compare_test_result(d.events, tests)
     end
 
-    def test_msg_size_with_same_tcp_connection
+    def test_octet_counting_with_same_tcp_connection
       d = create_driver([CONFIG, "<transport tcp> \n</transport>", 'frame_type octet_count'].join("\n"))
       tests = create_test_case
 
@@ -354,13 +354,14 @@ EOS
     end
 
     def create_test_case(large_message: false)
+      # actual syslog message may or may not have "\n"
       msgs = [
         {'msg' => '<6>Sep 10 00:00:00 localhost logger: ' + 'x' * 100, 'expected' => 'x' * 100},
-        {'msg' => '<6>Sep 10 00:00:00 localhost logger: ' + 'x' * 1024, 'expected' => 'x' * 1024},
+        {'msg' => '<6>Sep 10 00:00:00 localhost logger: ' + 'x' * 1024 + "\n", 'expected' => 'x' * 1024},
       ]
       msgs.each { |msg|
         m = msg['msg']
-        msg['msg'] = "#{m.size + 1} #{m}"
+        msg['msg'] = "#{m.size} #{m}"
       }
       msgs
     end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

There is an off-by-one counting issue in octet-transported syslog messages. In most case syslog transport clients will append a `\n` to the end of each line, hiding this bug. The bug gets triggered whenever a syslog client doesn't append a `\n`.

**Docs Changes**:

None

**Release Note**: 

Support octet-counted syslog transport when the last character in each message is not a \n.