### PR TITLE
server: Ignore Errno::EHOSTUNREACH in TLS accept to avoid fluentd restart. #2772

### DIFF
--- a/lib/fluent/plugin_helper/server.rb
+++ b/lib/fluent/plugin_helper/server.rb
@@ -711,7 +711,7 @@ module Fluent
 
                 return true
               end
-            rescue Errno::EPIPE, Errno::ECONNRESET, Errno::ETIMEDOUT, Errno::ECONNREFUSED, OpenSSL::SSL::SSLError => e
+            rescue Errno::EPIPE, Errno::ECONNRESET, Errno::ETIMEDOUT, Errno::ECONNREFUSED, Errno::EHOSTUNREACH, OpenSSL::SSL::SSLError => e
               @log.trace "unexpected error before accepting TLS connection", error: e
               close rescue nil
             end


### PR DESCRIPTION
Which issue(s) this PR fixes:
Fixes #2772

What this PR does / why we need it:
Ignore unrecoverable error in SSL_accept

Docs Changes:
No need.

Release Note:
Same as title.