### PR TITLE
Don't use timekey.object_id for Metadata instance comparison on Windows. Fix #2713

### DIFF
--- a/lib/fluent/plugin/buffer.rb
+++ b/lib/fluent/plugin/buffer.rb
@@ -138,9 +138,12 @@ module Fluent
         # Actually this overhead is very small but this class is generated *per chunk* (and used in hash object).
         # This means that this class is one of the most called object in Fluentd.
         # See https://github.com/fluent/fluentd/pull/2560
+        # But, this optimization has a side effect on Windows due to differing object_id.
+        # This difference causes flood of buffer files.
+        # So, this optimization should be enabled on non-Windows platform.
         def hash
           timekey.object_id
-        end
+        end unless Fluent.windows?
       end
 
       # for tests


### PR DESCRIPTION
Because this data will be differed unexpectedly on Windows.
This unexpected differing caused flood of buffer files
due to wrong metadata comparision.
`hash` method inside Metadata struct should be used on non-Windows environment.

This object_id value's unstability is monitored as follows:

```
{:timekey_object_id=>36247560}
{:timekey_object_id=>36247560}
{:timekey_object_id=>38199640}
{:timekey_object_id=>38199640}
{:timekey_object_id=>38199640}
{:timekey_object_id=>38240520}
{:timekey_object_id=>38240520}
{:timekey_object_id=>38240520}
{:timekey_object_id=>38277560}
{:timekey_object_id=>38277560}
{:timekey_object_id=>38277560}
{:timekey_object_id=>38314220}
{:timekey_object_id=>38314220}
{:timekey_object_id=>38314220}
{:timekey_object_id=>40539060}
{:timekey_object_id=>40539060}
{:timekey_object_id=>40539060}
{:timekey_object_id=>40598620}
{:timekey_object_id=>40598620}
{:timekey_object_id=>40598620}
{:timekey_object_id=>40764680}
{:timekey_object_id=>40764680}
{:timekey_object_id=>40764680}
{:timekey_object_id=>40613600}
{:timekey_object_id=>40613600}
{:timekey_object_id=>40613600}
{:timekey_object_id=>40741660}
{:timekey_object_id=>40741660}
{:timekey_object_id=>40741660}
{:timekey_object_id=>40895360}
{:timekey_object_id=>40895360}
{:timekey_object_id=>40895360}
{:timekey_object_id=>40926520}
<snip>
```

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>

<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #2713 

**What this PR does / why we need it**: 
Prevent flood of buffer files which cause BufferOverflowError due to fd limit on Windows.

**Docs Changes**:
No need.

**Release Note**: 
Same as title.