### PR TITLE
server: Fix IPv6 dual stack mode issue for udp socket. fix #2768

### DIFF
--- a/lib/fluent/plugin_helper/server.rb
+++ b/lib/fluent/plugin_helper/server.rb
@@ -370,6 +370,7 @@ module Fluent
         sock = if shared
                  server_socket_manager_client.listen_udp(bind, port)
                else
+                 # UDPSocket.new doesn't set IPV6_V6ONLY flag, so use Addrinfo class instead.
                  usock = Addrinfo.udp(bind, port).bind
                  usock.autoclose = false
                  UDPSocket.for_fd(usock.fileno)

--- a/lib/fluent/plugin_helper/server.rb
+++ b/lib/fluent/plugin_helper/server.rb
@@ -370,10 +370,9 @@ module Fluent
         sock = if shared
                  server_socket_manager_client.listen_udp(bind, port)
                else
-                 family = IPAddr.new(IPSocket.getaddress(bind)).ipv4? ? ::Socket::AF_INET : ::Socket::AF_INET6
-                 usock = UDPSocket.new(family)
-                 usock.bind(bind, port)
-                 usock
+                 usock = Addrinfo.udp(bind, port).bind
+                 usock.autoclose = false
+                 UDPSocket.for_fd(usock.fileno)
                end
         # close-on-exec is set by default in Ruby 2.0 or later (, and it's unavailable on Windows)
         sock.fcntl(Fcntl::F_SETFL, Fcntl::O_NONBLOCK) # nonblock

--- a/test/plugin_helper/test_server.rb
+++ b/test/plugin_helper/test_server.rb
@@ -751,6 +751,19 @@ class ServerPluginHelperTest < Test::Unit::TestCase
       assert_equal 1, errors.size
       assert_equal "BUG: this event is disabled for udp: close", errors.first.message
     end
+
+    test 'can bind IPv4 / IPv6 together' do
+      omit "IPv6 unavailable here" unless ipv6_enabled?
+
+      assert_nothing_raised do
+        @d.server_create_udp(:s_ipv4_udp, PORT, bind: '0.0.0.0', shared: false, max_bytes: 128) do |data, sock|
+          # ...
+        end
+        @d.server_create_udp(:s_ipv6_udp, PORT, bind: '::', shared: false, max_bytes: 128) do |data, sock|
+          # ...
+        end
+      end
+    end
   end
 
   module CertUtil


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

<!--
Thank you for contributing to Fluentd!
Please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #2768 

**What this PR does / why we need it**: 
Set `IPV6_V6ONLY` to udp socket.

**Docs Changes**:
No need

**Release Note**: 
Same at title.