### PR TITLE
Follow AppVeyor CI task definitions for Fluentd v1.9.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,11 +5,9 @@ version: '{build}'
 
 install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
-  - IF %ridk%==0 "%devkit%\\devkitvars.bat"
   - ruby --version
   - gem --version
-  - IF %ridk%==1 ridk.cmd exec bundle install
-  - IF %ridk%==0 bundle install
+  - ridk.cmd exec bundle install
 build: off
 test_script:
   - bundle exec rake test
@@ -23,10 +21,6 @@ branches:
 environment:
   matrix:
     - ruby_version: "25-x64"
-      ridk: 1
     - ruby_version: "25"
-      ridk: 1
     - ruby_version: "24-x64"
-      ridk: 1
     - ruby_version: "24"
-      ridk: 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,12 +22,6 @@ branches:
 # https://www.appveyor.com/docs/installed-software/#ruby
 environment:
   matrix:
-    - ruby_version: "23-x64"
-      devkit: C:\Ruby23-x64\DevKit
-      ridk: 0
-    - ruby_version: "23"
-      devkit: C:\Ruby23\DevKit
-      ridk: 0
     - ruby_version: "24-x64"
       ridk: 1
     - ruby_version: "24"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,8 @@ branches:
 # https://www.appveyor.com/docs/installed-software/#ruby
 environment:
   matrix:
+    - ruby_version: "26-x64"
+    - ruby_version: "26"
     - ruby_version: "25-x64"
     - ruby_version: "25"
     - ruby_version: "24-x64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,10 +22,11 @@ branches:
 # https://www.appveyor.com/docs/installed-software/#ruby
 environment:
   matrix:
+    - ruby_version: "25-x64"
+      ridk: 1
+    - ruby_version: "25"
+      ridk: 1
     - ruby_version: "24-x64"
       ridk: 1
     - ruby_version: "24"
       ridk: 1
-matrix:
-  allow_failures:
-    - ruby_version: "21"


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
None
**What this PR does / why we need it**: 
Fluentd v1.9.0 will support Ruby 2.4 or later. 
Current AppVeyor CI settings cause trouble on Ruby 2.3 due to Fluentd v1.9.0 bumping Ruby version requirements.
We should tidy up AppVeyor CI tasks for it.
**Docs Changes**:
None.
**Release Note**: 
Same as title.