### PR TITLE
Parser's error is more informative

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -113,9 +113,6 @@ module Fluent::Plugin
       unless parser_config
         raise Fluent::ConfigError, "<parse> section is required."
       end
-      unless parser_config["@type"]
-        raise Fluent::ConfigError, "parse/@type is required."
-      end
 
       (1..Fluent::Plugin::MultilineParser::FORMAT_MAX_NUM).each do |n|
         parser_config["format#{n}"] = conf["format#{n}"] if conf["format#{n}"]


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
none

**What this PR does / why we need it**: 

config

```
<source>
  @type tail
  path ...
  pos_file ...
  tag ...

  <parse>
  </parse>
</source>
```

before

```
2020-01-24 15:03:15 +0900 [info]: parsing config file is succeeded path="example/debug/in_tail.conf"
2020-01-24 15:03:15 +0900 [info]: gem 'fluentd' version '1.9.0'
2020-01-24 15:03:15 +0900 [error]: config error file="example/debug/in_tail.conf" error_class=Fluent::ConfigError error="parse/@type is required."
```

after

```
2020-01-24 15:03:24 +0900 [info]: parsing config file is succeeded path="example/debug/in_tail.conf"
2020-01-24 15:03:24 +0900 [info]: gem 'fluentd' version '1.9.0'
2020-01-24 15:03:24 +0900 [error]: config error in:
<parse>
</parse>

2020-01-24 15:03:24 +0900 [error]: config error file="example/debug/in_tail.conf" error_class=Fluent::ConfigError error="'@type' parameter is required, in section parse"
```

**Docs Changes**:

no need

**Release Note**: 

no need
