### PR TITLE
Remove a entry from PositionFile when it is unwatched

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -22,6 +22,7 @@ require 'fluent/event'
 require 'fluent/plugin/buffer'
 require 'fluent/plugin/parser_multiline'
 require 'fluent/variable_store'
+require 'fluent/plugin/in_tail/position_file'
 
 if Fluent.windows?
   require_relative 'file_wrapper'
@@ -908,140 +909,6 @@ module Fluent::Plugin
         def reset_timer
           @start = Time.now
         end
-      end
-    end
-
-    class PositionFile
-      UNWATCHED_POSITION = 0xffffffffffffffff
-
-      def initialize(file, file_mutex, map, last_pos)
-        @file = file
-        @file_mutex = file_mutex
-        @map = map
-        @last_pos = last_pos
-      end
-
-      def [](path)
-        if m = @map[path]
-          return m
-        end
-
-        @file_mutex.synchronize {
-          @file.pos = @last_pos
-          @file.write "#{path}\t0000000000000000\t0000000000000000\n"
-          seek = @last_pos + path.bytesize + 1
-          @last_pos = @file.pos
-          @map[path] = FilePositionEntry.new(@file, @file_mutex, seek, 0, 0)
-        }
-      end
-
-      def self.parse(file)
-        compact(file)
-
-        file_mutex = Mutex.new
-        map = {}
-        file.pos = 0
-        file.each_line {|line|
-          m = /^([^\t]+)\t([0-9a-fA-F]+)\t([0-9a-fA-F]+)/.match(line)
-          unless m
-            $log.warn "Unparsable line in pos_file: #{line}"
-            next
-          end
-          path = m[1]
-          pos = m[2].to_i(16)
-          ino = m[3].to_i(16)
-          seek = file.pos - line.bytesize + path.bytesize + 1
-          map[path] = FilePositionEntry.new(file, file_mutex, seek, pos, ino)
-        }
-        new(file, file_mutex, map, file.pos)
-      end
-
-      # Clean up unwatched file entries
-      def self.compact(file)
-        file.pos = 0
-        existent_entries = file.each_line.map { |line|
-          m = /^([^\t]+)\t([0-9a-fA-F]+)\t([0-9a-fA-F]+)/.match(line)
-          unless m
-            $log.warn "Unparsable line in pos_file: #{line}"
-            next
-          end
-          path = m[1]
-          pos = m[2].to_i(16)
-          ino = m[3].to_i(16)
-          # 32bit inode converted to 64bit at this phase
-          pos == UNWATCHED_POSITION ? nil : ("%s\t%016x\t%016x\n" % [path, pos, ino])
-        }.compact
-
-        file.pos = 0
-        file.truncate(0)
-        file.write(existent_entries.join)
-      end
-    end
-
-    # pos               inode
-    # ffffffffffffffff\tffffffffffffffff\n
-    class FilePositionEntry
-      POS_SIZE = 16
-      INO_OFFSET = 17
-      INO_SIZE = 16
-      LN_OFFSET = 33
-      SIZE = 34
-
-      def initialize(file, file_mutex, seek, pos, inode)
-        @file = file
-        @file_mutex = file_mutex
-        @seek = seek
-        @pos = pos
-        @inode = inode
-      end
-
-      def update(ino, pos)
-        @file_mutex.synchronize {
-          @file.pos = @seek
-          @file.write "%016x\t%016x" % [pos, ino]
-        }
-        @pos = pos
-        @inode = ino
-      end
-
-      def update_pos(pos)
-        @file_mutex.synchronize {
-          @file.pos = @seek
-          @file.write "%016x" % pos
-        }
-        @pos = pos
-      end
-
-      def read_inode
-        @inode
-      end
-
-      def read_pos
-        @pos
-      end
-    end
-
-    class MemoryPositionEntry
-      def initialize
-        @pos = 0
-        @inode = 0
-      end
-
-      def update(ino, pos)
-        @inode = ino
-        @pos = pos
-      end
-
-      def update_pos(pos)
-        @pos = pos
-      end
-
-      def read_pos
-        @pos
-      end
-
-      def read_inode
-        @inode
       end
     end
   end

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -389,7 +389,7 @@ module Fluent::Plugin
       tw.close if close_io
       flush_buffer(tw)
       if tw.unwatched && @pf
-        @pf[tw.path].update_pos(PositionFile::UNWATCHED_POSITION)
+        @pf.unwatch(tw.path)
       end
     end
 

--- a/lib/fluent/plugin/in_tail/position_file.rb
+++ b/lib/fluent/plugin/in_tail/position_file.rb
@@ -1,0 +1,155 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'fluent/plugin/in_tail'
+
+module Fluent::Plugin
+  class TailInput < Fluent::Plugin::Input
+    class PositionFile
+      UNWATCHED_POSITION = 0xffffffffffffffff
+
+      def initialize(file, file_mutex, map, last_pos)
+        @file = file
+        @file_mutex = file_mutex
+        @map = map
+        @last_pos = last_pos
+      end
+
+      def [](path)
+        if m = @map[path]
+          return m
+        end
+
+        @file_mutex.synchronize {
+          @file.pos = @last_pos
+          @file.write "#{path}\t0000000000000000\t0000000000000000\n"
+          seek = @last_pos + path.bytesize + 1
+          @last_pos = @file.pos
+          @map[path] = FilePositionEntry.new(@file, @file_mutex, seek, 0, 0)
+        }
+      end
+
+      def self.parse(file)
+        compact(file)
+
+        file_mutex = Mutex.new
+        map = {}
+        file.pos = 0
+        file.each_line {|line|
+          m = /^([^\t]+)\t([0-9a-fA-F]+)\t([0-9a-fA-F]+)/.match(line)
+          unless m
+            $log.warn "Unparsable line in pos_file: #{line}"
+            next
+          end
+          path = m[1]
+          pos = m[2].to_i(16)
+          ino = m[3].to_i(16)
+          seek = file.pos - line.bytesize + path.bytesize + 1
+          map[path] = FilePositionEntry.new(file, file_mutex, seek, pos, ino)
+        }
+        new(file, file_mutex, map, file.pos)
+      end
+
+      # Clean up unwatched file entries
+      def self.compact(file)
+        file.pos = 0
+        existent_entries = file.each_line.map { |line|
+          m = /^([^\t]+)\t([0-9a-fA-F]+)\t([0-9a-fA-F]+)/.match(line)
+          unless m
+            $log.warn "Unparsable line in pos_file: #{line}"
+            next
+          end
+          path = m[1]
+          pos = m[2].to_i(16)
+          ino = m[3].to_i(16)
+          # 32bit inode converted to 64bit at this phase
+          pos == UNWATCHED_POSITION ? nil : ("%s\t%016x\t%016x\n" % [path, pos, ino])
+        }.compact
+
+        file.pos = 0
+        file.truncate(0)
+        file.write(existent_entries.join)
+      end
+    end
+
+    # pos               inode
+    # ffffffffffffffff\tffffffffffffffff\n
+    class FilePositionEntry
+      POS_SIZE = 16
+      INO_OFFSET = 17
+      INO_SIZE = 16
+      LN_OFFSET = 33
+      SIZE = 34
+
+      def initialize(file, file_mutex, seek, pos, inode)
+        @file = file
+        @file_mutex = file_mutex
+        @seek = seek
+        @pos = pos
+        @inode = inode
+      end
+
+      def update(ino, pos)
+        @file_mutex.synchronize {
+          @file.pos = @seek
+          @file.write "%016x\t%016x" % [pos, ino]
+        }
+        @pos = pos
+        @inode = ino
+      end
+
+      def update_pos(pos)
+        @file_mutex.synchronize {
+          @file.pos = @seek
+          @file.write "%016x" % pos
+        }
+        @pos = pos
+      end
+
+      def read_inode
+        @inode
+      end
+
+      def read_pos
+        @pos
+      end
+    end
+
+    class MemoryPositionEntry
+      def initialize
+        @pos = 0
+        @inode = 0
+      end
+
+      def update(ino, pos)
+        @inode = ino
+        @pos = pos
+      end
+
+      def update_pos(pos)
+        @pos = pos
+      end
+
+      def read_pos
+        @pos
+      end
+
+      def read_inode
+        @inode
+      end
+    end
+  end
+end

--- a/lib/fluent/plugin/in_tail/position_file.rb
+++ b/lib/fluent/plugin/in_tail/position_file.rb
@@ -42,6 +42,12 @@ module Fluent::Plugin
         }
       end
 
+      def unwatch(path)
+        if (entry = @map.delete(path))
+          entry.update_pos(UNWATCHED_POSITION)
+        end
+      end
+
       def self.parse(file)
         compact(file)
 

--- a/test/plugin/in_tail/test_position_file.rb
+++ b/test/plugin/in_tail/test_position_file.rb
@@ -86,6 +86,23 @@ class IntailPositionFileTest < Test::Unit::TestCase
     end
   end
 
+  sub_test_case '#unwatch' do
+    test 'deletes entry by path' do
+      write_data(@file, TEST_CONTENT)
+      pf = Fluent::Plugin::TailInput::PositionFile.parse(@file)
+      p1 = pf['valid_path']
+      assert_equal Fluent::Plugin::TailInput::FilePositionEntry, p1.class
+
+      pf.unwatch('valid_path')
+      assert_equal p1.read_pos, Fluent::Plugin::TailInput::PositionFile::UNWATCHED_POSITION
+
+      p2 = pf['valid_path']
+      assert_equal Fluent::Plugin::TailInput::FilePositionEntry, p2.class
+
+      assert_not_equal p1, p2
+    end
+  end
+
   sub_test_case 'FilePositionEntry' do
     FILE_POS_CONTENT = <<~EOF
       valid_path\t0000000000000002\t0000000000000001

--- a/test/plugin/in_tail/test_position_file.rb
+++ b/test/plugin/in_tail/test_position_file.rb
@@ -19,15 +19,29 @@ class IntailPositionFileTest < Test::Unit::TestCase
     f.seek(0)
   end
 
-  test '.compact' do
-    write_data(@file, TEST_CONTENT)
-    Fluent::Plugin::TailInput::PositionFile.compact(@file)
+  sub_test_case '.compact' do
+    test 'compact invalid and convert 32 bit inode value' do
+      write_data(@file, TEST_CONTENT)
+      Fluent::Plugin::TailInput::PositionFile.compact(@file)
 
-    @file.seek(0)
-    lines = @file.readlines
-    assert_equal 2, lines.size
-    assert_equal "valid_path\t0000000000000002\t0000000000000001\n", lines[0]
-    assert_equal "inode23bit\t0000000000000000\t0000000000000000\n", lines[1]
+      @file.seek(0)
+      lines = @file.readlines
+      assert_equal 2, lines.size
+      assert_equal "valid_path\t0000000000000002\t0000000000000001\n", lines[0]
+      assert_equal "inode23bit\t0000000000000000\t0000000000000000\n", lines[1]
+    end
+
+    test 'compact data if duplicated line' do
+      write_data(@file, <<~EOF)
+        valid_path\t0000000000000002\t0000000000000001
+        valid_path\t0000000000000003\t0000000000000004
+      EOF
+      Fluent::Plugin::TailInput::PositionFile.compact(@file)
+
+      @file.seek(0)
+      lines = @file.readlines
+      assert_equal "valid_path\t0000000000000003\t0000000000000004\n", lines[0]
+    end
   end
 
   test '.parse' do

--- a/test/plugin/in_tail/test_position_file.rb
+++ b/test/plugin/in_tail/test_position_file.rb
@@ -1,0 +1,161 @@
+require_relative '../../helper'
+require 'fluent/plugin/in_tail'
+
+class IntailPositionFileTest < Test::Unit::TestCase
+  setup do
+    @file = StringIO.new(+'')
+  end
+
+  UNWATCHED_STR = '%016x' % Fluent::Plugin::TailInput::PositionFile::UNWATCHED_POSITION
+  TEST_CONTENT = <<~EOF
+    valid_path\t0000000000000002\t0000000000000001
+    inode23bit\t0000000000000000\t00000000
+    invalidpath100000000000000000000000000000000
+    unwatched\t#{UNWATCHED_STR}\t0000000000000000
+  EOF
+
+  def write_data(f, content)
+    f.write(content)
+    f.seek(0)
+  end
+
+  test '.compact' do
+    write_data(@file, TEST_CONTENT)
+    Fluent::Plugin::TailInput::PositionFile.compact(@file)
+
+    @file.seek(0)
+    lines = @file.readlines
+    assert_equal 2, lines.size
+    assert_equal "valid_path\t0000000000000002\t0000000000000001\n", lines[0]
+    assert_equal "inode23bit\t0000000000000000\t0000000000000000\n", lines[1]
+  end
+
+  test '.parse' do
+    write_data(@file, TEST_CONTENT)
+    Fluent::Plugin::TailInput::PositionFile.parse(@file)
+
+    @file.seek(0)
+    lines = @file.readlines
+    assert_equal 2, lines.size
+    assert_equal "valid_path\t0000000000000002\t0000000000000001\n", lines[0]
+    assert_equal "inode23bit\t0000000000000000\t0000000000000000\n", lines[1]
+  end
+
+  sub_test_case '#[]' do
+    test 'return entry' do
+      write_data(@file, TEST_CONTENT)
+      pf = Fluent::Plugin::TailInput::PositionFile.parse(@file)
+
+      f = pf['valid_path']
+      assert_equal Fluent::Plugin::TailInput::FilePositionEntry, f.class
+      assert_equal 2, f.read_pos
+      assert_equal 1, f.read_inode
+
+      @file.seek(0)
+      lines = @file.readlines
+      assert_equal 2, lines.size
+
+      f = pf['nonexist_path']
+      assert_equal Fluent::Plugin::TailInput::FilePositionEntry, f.class
+      assert_equal 0, f.read_pos
+      assert_equal 0, f.read_inode
+
+      @file.seek(0)
+      lines = @file.readlines
+      assert_equal 3, lines.size
+      assert_equal "nonexist_path\t0000000000000000\t0000000000000000\n", lines[2]
+    end
+
+    test 'does not change other value position if other entry try to write' do
+      write_data(@file, TEST_CONTENT)
+      pf = Fluent::Plugin::TailInput::PositionFile.parse(@file)
+
+      f = pf['nonexist_path']
+      assert_equal 0, f.read_inode
+      assert_equal 0, f.read_pos
+
+      pf['valid_path'].update(1, 2)
+
+      f = pf['nonexist_path']
+      assert_equal 0, f.read_inode
+      assert_equal 0, f.read_pos
+
+      pf['nonexist_path'].update(1, 2)
+      assert_equal 1, f.read_inode
+      assert_equal 2, f.read_pos
+    end
+  end
+
+  sub_test_case 'FilePositionEntry' do
+    FILE_POS_CONTENT = <<~EOF
+      valid_path\t0000000000000002\t0000000000000001
+      valid_path2\t0000000000000003\t0000000000000002
+    EOF
+
+    def build_files(file)
+      r = {}
+
+      file.each_line do |line|
+        m = /^([^\t]+)\t([0-9a-fA-F]+)\t([0-9a-fA-F]+)/.match(line)
+        path = m[1]
+        pos = m[2].to_i(16)
+        ino = m[3].to_i(16)
+        seek = file.pos - line.bytesize + path.bytesize + 1
+        r[path] = Fluent::Plugin::TailInput::FilePositionEntry.new(@file, Mutex.new, seek, pos, ino)
+      end
+
+      r
+    end
+
+    test '#update' do
+      write_data(@file, FILE_POS_CONTENT)
+      fs = build_files(@file)
+      f = fs['valid_path']
+      f.update(11, 10)
+
+      @file.seek(0)
+      lines = @file.readlines
+      assert_equal 2, lines.size
+      assert_equal "valid_path\t000000000000000a\t000000000000000b\n", lines[0]
+      assert_equal "valid_path2\t0000000000000003\t0000000000000002\n", lines[1]
+    end
+
+    test '#update_pos' do
+      write_data(@file, FILE_POS_CONTENT)
+      fs = build_files(@file)
+      f = fs['valid_path']
+      f.update_pos(10)
+
+      @file.seek(0)
+      lines = @file.readlines
+      assert_equal 2, lines.size
+      assert_equal "valid_path\t000000000000000a\t0000000000000001\n", lines[0]
+      assert_equal "valid_path2\t0000000000000003\t0000000000000002\n", lines[1]
+    end
+
+    test '#read_pos' do
+      write_data(@file, FILE_POS_CONTENT)
+      fs = build_files(@file)
+      f = fs['valid_path']
+      assert_equal 2, f.read_pos
+
+      f.update_pos(10)
+      assert_equal 10, f.read_pos
+
+      f.update(2, 11)
+      assert_equal 11, f.read_pos
+    end
+
+    test '#read_inode' do
+      write_data(@file, FILE_POS_CONTENT)
+      fs = build_files(@file)
+      f = fs['valid_path']
+      assert_equal 1, f.read_inode
+      f.update_pos(10)
+      assert_equal 1, f.read_inode
+
+      f.update(2, 11)
+      assert_equal 2, f.read_inode
+    end
+  end
+end

--- a/test/plugin/in_tail/test_position_file.rb
+++ b/test/plugin/in_tail/test_position_file.rb
@@ -1,5 +1,5 @@
 require_relative '../../helper'
-require 'fluent/plugin/in_tail'
+require 'fluent/plugin/in_tail/position_file'
 
 class IntailPositionFileTest < Test::Unit::TestCase
   setup do


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
none

**What this PR does / why we need it**: 

* Remove a entry from PositionFile when it is unwatched to release memory
* Change not to allow duplicated path lines (It does not happen unless a user change pos file manually)

**Docs Changes**:

no need

**Release Note**: 

same as the title
