### PR TITLE
Split RUBYOPT with space

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -661,7 +661,9 @@ module Fluent
 
       rubyopt = ENV["RUBYOPT"]
       fluentd_spawn_cmd = [ServerEngine.ruby_bin_path, "-Eascii-8bit:ascii-8bit"]
-      fluentd_spawn_cmd << rubyopt if rubyopt
+      if rubyopt
+        fluentd_spawn_cmd.concat(rubyopt.split(' '))
+      end
       fluentd_spawn_cmd << $0
       fluentd_spawn_cmd += $fluentdargv
       fluentd_spawn_cmd << "--under-supervisor"


### PR DESCRIPTION
ruby does not have the option whose key and value are separated with space

https://github.com/ruby/ruby/blob/3893a8dd42fb3bbd71750648c3c0de118955a6ea/ruby.c#L1028

**Which issue(s) this PR fixes**: 
Fixes https://github.com/fluent/fluentd/issues/2801

**What this PR does / why we need it**: 

**Docs Changes**:

no need

**Release Note**: 

Accept RUBYOPT with two or more options
