### PR TITLE
output: Add EncodingError to unrecoverable errors. fix #2741

### DIFF
--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -1091,7 +1091,7 @@ module Fluent
         end
       end
 
-      UNRECOVERABLE_ERRORS = [Fluent::UnrecoverableError, TypeError, ArgumentError, NoMethodError, MessagePack::UnpackError]
+      UNRECOVERABLE_ERRORS = [Fluent::UnrecoverableError, TypeError, ArgumentError, NoMethodError, MessagePack::UnpackError, EncodingError]
 
       def try_flush
         chunk = @buffer.dequeue_chunk

--- a/test/plugin/test_output_as_buffered_backup.rb
+++ b/test/plugin/test_output_as_buffered_backup.rb
@@ -181,7 +181,8 @@ class BufferedOutputBackupTest < Test::Unit::TestCase
          'type error' => TypeError,
          'argument error' => ArgumentError,
          'no method error' => NoMethodError,
-         'msgpack unpack error' => MessagePack::UnpackError)
+         'msgpack unpack error' => MessagePack::UnpackError,
+         'encoding error' => EncodingError)
     test 'backup chunk without secondary' do |error_class|
       Fluent::SystemConfig.overwrite_system_config('root_dir' => TMP_DIR) do
         id = 'backup_test'


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #2741 

**What this PR does / why we need it**: 
Add `EncodingError` to unrecoverable errors to avoid infinite retry.
EncodingError can't be recovered.

**Docs Changes**:
Add `EncodingError` to output article.

**Release Note**: 
Same as title.