### PR TITLE
Add warning about retryable_response_codes

### DIFF
--- a/lib/fluent/plugin/out_http.rb
+++ b/lib/fluent/plugin/out_http.rb
@@ -64,7 +64,7 @@ module Fluent::Plugin
     desc 'Raise UnrecoverableError when the response is non success, 4xx/5xx'
     config_param :error_response_as_unrecoverable, :bool, default: true
     desc 'The list of retryable response code'
-    config_param :retryable_response_codes, :array, value_type: :integer, default: [503]
+    config_param :retryable_response_codes, :array, value_type: :integer, default: nil
 
     config_section :format do
       config_set_default :@type, 'json'
@@ -89,6 +89,11 @@ module Fluent::Plugin
 
     def configure(conf)
       super
+
+      if @retryable_response_codes.nil?
+        log.warn('Status code 503 is going to be removed from default `retryable_response_codes` from fluentd v2. Please add it by yourself if you wish')
+        @retryable_response_codes = [503]
+      end
 
       @http_opt = setup_http_option
       @proxy_uri = URI.parse(@proxy) if @proxy
@@ -172,7 +177,7 @@ module Fluent::Plugin
     end
 
     def parse_endpoint(chunk)
-      endpoint = extract_placeholders(@endpoint, chunk)    
+      endpoint = extract_placeholders(@endpoint, chunk)
       URI.parse(endpoint)
     end
 

--- a/test/plugin/test_out_http.rb
+++ b/test/plugin/test_out_http.rb
@@ -168,6 +168,19 @@ class HTTPOutputTest < Test::Unit::TestCase
     assert_nil d.instance.headers
   end
 
+  def test_configure_with_warn
+    d = create_driver(config)
+    assert_match(/Status code 503 is going to be removed/, d.instance.log.out.logs.join)
+  end
+
+  def test_configure_without_warn
+    d = create_driver(<<~CONFIG)
+      endpoint #{base_endpoint}/test
+      retryable_response_codes [503]
+    CONFIG
+    assert_not_match(/Status code 503 is going to be removed/, d.instance.log.out.logs.join)
+  end
+
   data('json' => ['json', 'application/x-ndjson'],
        'ltsv' => ['ltsv', 'text/tab-separated-values'],
        'msgpack' => ['msgpack', 'application/x-msgpack'],
@@ -257,7 +270,7 @@ class HTTPOutputTest < Test::Unit::TestCase
         d.feed(event)
       }
     end
-    assert_match(/got error response from.*404 Not Found Not Found/, d.instance.log.out.logs.first)
+    assert_match(/got error response from.*404 Not Found Not Found/, d.instance.log.out.logs.join)
     d.instance_shutdown
   end
 
@@ -313,7 +326,7 @@ class HTTPOutputTest < Test::Unit::TestCase
           d.feed(event)
         }
       end
-      assert_match(/got unrecoverable error/, d.instance.log.out.logs.first)
+      assert_match(/got unrecoverable error/, d.instance.log.out.logs.join)
 
       d.instance_shutdown
     end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
ref https://github.com/fluent/fluentd/pull/2779#discussion_r368345580

**What this PR does / why we need it**: 

Added warning message when a user uses a default `retryable_response_codes`  to remove 503 from `retryable_response_codes` next release(fluentd 2.0?).

**Docs Changes**:

no need

**Release Note**: 

same as the title.
