### PR TITLE
serverengine's log should be formatted with the same format of fluentd.

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -315,6 +315,7 @@ module Fluent
       )
       # this #init sets initialized logger to $log
       logger_initializer.init(:supervisor, 0)
+      logger_initializer.apply_options(format: params['log_format'], time_format: params['log_time_format'])
       logger = $log
 
       command_sender = Fluent.windows? ? "pipe" : "signal"
@@ -691,6 +692,8 @@ module Fluent
         'rpc_endpoint' => @system_config.rpc_endpoint,
         'enable_get_dump' => @system_config.enable_get_dump,
         'counter_server' => @system_config.counter_server,
+        'log_format' => @system_config.log.format,
+        'log_time_format' => @system_config.log.time_format,
       }
 
       se = ServerEngine.create(ServerModule, WorkerModule){

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -235,6 +235,33 @@ class SupervisorTest < ::Test::Unit::TestCase
     Timecop.return
   end
 
+  def test_load_config_for_logger
+    tmp_dir = "#{TMP_DIR}/dir/test_load_config_log.conf"
+    conf_info_str = %[
+<system>
+  <log>
+    format json
+    time_format %FT%T.%L%z
+  </log>
+</system>
+]
+    write_config tmp_dir, conf_info_str
+    params = {
+      'use_v1_config' => true,
+      'conf_encoding' => 'utf8',
+      'log_level' => Fluent::Log::LEVEL_INFO,
+      'log_path' => 'test/tmp/supervisor/log',
+
+      'workers' => 1,
+      'log_format' => :json,
+      'log_time_format' => '%FT%T.%L%z',
+    }
+
+    r = Fluent::Supervisor.load_config(tmp_dir, params)
+    assert_equal :json, r[:logger].format
+    assert_equal '%FT%T.%L%z', r[:logger].time_format
+  end
+
   def test_load_config_for_daemonize
     tmp_dir = "#{TMP_DIR}/dir/test_load_config.conf"
     conf_info_str = %[


### PR DESCRIPTION
Signed-off-by: Yuta Iwama <ganmacs@gmail.com>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes https://github.com/fluent/fluentd/issues/2811

**What this PR does / why we need it**: 

Logger applied with `format` and `format_time` is passed to serverengine so that serverengines' log is formatted with the fluentd's one.

**Docs Changes**:

no need.

**Release Note**: 


same as the title.

```
{"time":"2020-02-03T15:20:07.423+0900","level":"info","message":"parsing config file is succeeded path=\"example/debug/log_time_format.conf\""}
{"time":"2020-02-03T15:20:07.423+0900","level":"info","message":"gem 'fluentd' version '1.9.1'"}
{"time":"2020-02-03T15:20:07.450+0900","level":"warn","message":"both of Plugin @id and path for <storage> are not specified. Using on-memory store."}
{"time":"2020-02-03T15:20:07.451+0900","level":"warn","message":"both of Plugin @id and path for <storage> are not specified. Using on-memory store."}
{"time":"2020-02-03T15:20:07.451+0900","level":"warn","message":"define <match fluent.**> to capture fluentd logs in top level is deprecated. Use <label @FLUENT_LOG> instead"}
{"time":"2020-02-03T15:20:07.451+0900","level":"info","message":"using configuration file: <ROOT>\n  <system>\n    <log>\n      format json\n      time_format \"%FT%T.%L%z\"\n    </log>\n  </system>\n  <source>\n    @type dummy\n    tag \"test\"\n  </source>\n  <match>\n    @type stdout\n  </match>\n</ROOT>"}
{"time":"2020-02-03T15:20:07.451+0900","level":"info","message":"starting fluentd-1.9.1 pid=11555 ruby=\"2.5.7\""}
{"time":"2020-02-03T15:20:07.452+0900","level":"info","message":"spawn command to main:  cmdline=[\"/Users/yuta.iwama/.rbenv/versions/2.5.7/bin/ruby\", \"-Eascii-8bit:ascii-8bit\", \"-r/Users/yuta.iwama/.rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/gems/bundler-2.1.4/lib/bundler/setup\", \"/Users/yuta.iwama/.rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/bin/fluentd\", \"-c\", \"example/debug/log_time_format.conf\", \"--under-supervisor\"]"}
{"time":"2020-02-03T15:20:08.079+0900","level":"info","message":"adding match pattern=\"**\" type=\"stdout\""}
{"time":"2020-02-03T15:20:08.096+0900","level":"info","message":"adding source type=\"dummy\""}
{"time":"2020-02-03T15:20:08.099+0900","level":"warn","message":"both of Plugin @id and path for <storage> are not specified. Using on-memory store.","worker_id":0}
{"time":"2020-02-03T15:20:08.099+0900","level":"warn","message":"both of Plugin @id and path for <storage> are not specified. Using on-memory store.","worker_id":0}
{"time":"2020-02-03T15:20:08.099+0900","level":"warn","message":"define <match fluent.**> to capture fluentd logs in top level is deprecated. Use <label @FLUENT_LOG> instead","worker_id":0}
{"time":"2020-02-03T15:20:08.100+0900","level":"info","message":"starting fluentd worker pid=11572 ppid=11555 worker=0","worker_id":0}
{"time":"2020-02-03T15:20:08.100+0900","level":"info","message":"fluentd worker is now running worker=0","worker_id":0}
2020-02-03 15:20:08.100020000 +0900 fluent.info: {"pid":11572,"ppid":11555,"worker":0,"message":"starting fluentd worker pid=11572 ppid=11555 worker=0"}
2020-02-03 15:20:08.100419000 +0900 fluent.info: {"worker":0,"message":"fluentd worker is now running worker=0"}
^C{"time":"2020-02-03T15:20:08.504+0900","level":"info","message":"Received graceful stop"}
2020-02-03 15:20:09.031506000 +0900 test: {"message":"dummy"}
{"time":"2020-02-03T15:20:09.613+0900","level":"info","message":"fluentd worker is now stopping worker=0","worker_id":0}
2020-02-03 15:20:09.613987000 +0900 fluent.info: {"worker":0,"message":"fluentd worker is now stopping worker=0"}
{"time":"2020-02-03T15:20:09.614+0900","level":"info","message":"shutting down fluentd worker worker=0","worker_id":0}
{"time":"2020-02-03T15:20:09.615+0900","level":"info","message":"shutting down input plugin type=:dummy plugin_id=\"object:3fd6aaa749a8\"","worker_id":0}
{"time":"2020-02-03T15:20:09.615+0900","level":"info","message":"shutting down output plugin type=:stdout plugin_id=\"object:3fd6ab4b71a4\"","worker_id":0}
{"time":"2020-02-03T15:20:10.147+0900","level":"info","message":"Worker 0 finished with status 0"}
```