### PR TITLE
Fix bug when RUBYOPT is invalid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,9 @@ branches:
   only:
     - master
 
+before_install:
+  - gem update --system=3.1.2
+
 sudo: false
 dist: trusty # for TLSv1.2 support
 

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -15,6 +15,7 @@
 #
 
 require 'fileutils'
+require 'open3'
 
 require 'fluent/config'
 require 'fluent/counter'
@@ -664,6 +665,16 @@ module Fluent
       if rubyopt
         fluentd_spawn_cmd.concat(rubyopt.split(' '))
       end
+
+      # Adding `-h` so that it can avoid ruby's command blocking
+      # e.g. `ruby -Eascii-8bit:ascii-8bit` will block. but `ruby -Eascii-8bit:ascii-8bit -h` won't.
+      cmd = fluentd_spawn_cmd.join(' ')
+      _, e, s = Open3.capture3("#{cmd} -h")
+      if s.exitstatus != 0
+        $log.error('Invalid option is passed to RUBYOPT', command: cmd, error: e)
+        exit s.exitstatus
+      end
+
       fluentd_spawn_cmd << $0
       fluentd_spawn_cmd += $fluentdargv
       fluentd_spawn_cmd << "--under-supervisor"

--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -797,6 +797,24 @@ CONF
       )
     end
 
+    test 'invalid values are set to RUBYOPT' do
+      conf = <<CONF
+<source>
+  @type dummy
+  tag dummy
+</source>
+<match>
+  @type null
+</match>
+CONF
+      conf_path = create_conf_file('rubyopt_invalid_test.conf', conf)
+      assert_log_matches(
+        create_cmdline(conf_path),
+        'Invalid option is passed to RUBYOPT',
+        env: { 'RUBYOPT' => 'a' },
+      )
+    end
+
     test 'success to start workers when file buffer is configured in non-workers way only for specific worker' do
       conf = <<CONF
 <system>

--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -47,7 +47,7 @@ class TestFluentdCommand < ::Test::Unit::TestCase
 
   def create_cmdline(conf_path, *fluentd_options)
     cmd_path = File.expand_path(File.dirname(__FILE__) + "../../../bin/fluentd")
-    ["bundle", "exec", "ruby", cmd_path, "-c", conf_path, *fluentd_options]
+    ["bundle", "exec", cmd_path, "-c", conf_path, *fluentd_options]
   end
 
   def execute_command(cmdline, chdir=TMP_DIR, env = {})
@@ -283,7 +283,7 @@ CONF
 
       assert_fluentd_fails_to_start(
         create_cmdline(conf_path),
-        "non directory entry exists:#{@root_path} (Fluent::InvalidRootDirectory)",
+        "non directory entry exists:#{@root_path}",
       )
     end
   end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
ref: https://github.com/fluent/fluentd/issues/2799

**What this PR does / why we need it**: 

When `RUBYOPT=a`(other invalid options do the same) is added,  fluentd gets into an infinite loop.

```
$ RUBYOPT=a be fluentd -c example/debug/dummy.conf                                                                                              
2020-02-03 16:27:32 +0900 [info]: parsing config file is succeeded path="example/debug/dummy.conf"
2020-02-03 16:27:32 +0900 [info]: gem 'fluentd' version '1.9.1'
2020-02-03 16:27:32 +0900 [warn]: both of Plugin @id and path for <storage> are not specified. Using on-memory store.
2020-02-03 16:27:32 +0900 [warn]: both of Plugin @id and path for <storage> are not specified. Using on-memory store.
2020-02-03 16:27:32 +0900 [info]: using configuration file: <ROOT>
  <source>
    @type dummy
    tag "dummy.ts3"
  </source>
  <match dummy.*>
    @type stdout
  </match>
</ROOT>
2020-02-03 16:27:32 +0900 [info]: starting fluentd-1.9.1 pid=22329 ruby="2.5.7"
2020-02-03 16:27:32 +0900 [info]: spawn command to main:  cmdline=["/Users/yuta.iwama/.rbenv/versions/2.5.7/bin/ruby", "-Eascii-8bit:ascii-8bit", "-r/Users/yuta.iwama/.rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/gems/bundler-2.1.4/lib/bundler/setup", "a", "/Users/yuta.iwama/.rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/bin/fluentd", "-c", "example/debug/dummy.conf", "--under-supervisor"]
Traceback (most recent call last):
/Users/yuta.iwama/.rbenv/versions/2.5.7/bin/ruby: invalid switch in RUBYOPT: -a (RuntimeError)
2020-02-03 16:27:32 +0900 [info]: Worker 0 finished unexpectedly with status 1
Traceback (most recent call last):
/Users/yuta.iwama/.rbenv/versions/2.5.7/bin/ruby: invalid switch in RUBYOPT: -a (RuntimeError)
2020-02-03 16:27:32 +0900 [info]: Worker 0 finished unexpectedly with status 1
Traceback (most recent call last):
/Users/yuta.iwama/.rbenv/versions/2.5.7/bin/ruby: invalid switch in RUBYOPT: -a (RuntimeError)
2020-02-03 16:27:32 +0900 [info]: Worker 0 finished unexpectedly with status 1
Traceback (most recent call last):
/Users/yuta.iwama/.rbenv/versions/2.5.7/bin/ruby: invalid switch in RUBYOPT: -a (RuntimeError)
2020-02-03 16:27:32 +0900 [info]: Worker 0 finished unexpectedly with status 1
Traceback (most recent call last):
....
```


**Docs Changes**:

no need

**Release Note**: 

same as the title
