### PR TITLE
Use given encoding when RUBYOPT has -E

### DIFF
--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -797,7 +797,13 @@ CONF
       )
     end
 
-    test "-E option is set to RUBYOPT" do
+    data(
+      '-E' => '-Eutf-8',
+      '-encoding' => '--encoding=utf-8',
+      '-external-encoding' => '--external-encoding=utf-8',
+      '-internal-encoding' => '--internal-encoding=utf-8',
+    )
+    test "-E option is set to RUBYOPT3" do |opt|
       conf = <<CONF
 <source>
   @type dummy
@@ -810,9 +816,9 @@ CONF
       conf_path = create_conf_file('rubyopt_test.conf', conf)
       assert_log_matches(
         create_cmdline(conf_path),
-        '-Eutf-8',
+        *opt.split(' '),
         patterns_not_match: ['-Eascii-8bit:ascii-8bit'],
-        env: { 'RUBYOPT' => '-Eutf-8' },
+        env: { 'RUBYOPT' => opt },
       )
     end
 

--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -797,6 +797,39 @@ CONF
       )
     end
 
+    test "-E option is set to RUBYOPT" do
+      conf = <<CONF
+<source>
+  @type dummy
+  tag dummy
+</source>
+<match>
+  @type null
+</match>
+CONF
+      conf_path = create_conf_file('rubyopt_test.conf', conf)
+      assert_log_matches(
+        create_cmdline(conf_path),
+        '-Eutf-8',
+        patterns_not_match: ['-Eascii-8bit:ascii-8bit'],
+        env: { 'RUBYOPT' => '-Eutf-8' },
+      )
+    end
+
+        test "without RUBYOPT" do
+      conf = <<CONF
+<source>
+  @type dummy
+  tag dummy
+</source>
+<match>
+  @type null
+</match>
+CONF
+      conf_path = create_conf_file('rubyopt_test.conf', conf)
+      assert_log_matches(create_cmdline(conf_path), '-Eascii-8bit:ascii-8bit')
+    end
+
     test 'invalid values are set to RUBYOPT' do
       conf = <<CONF
 <source>


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
merge after https://github.com/fluent/fluentd/pull/2813
Fix https://github.com/fluent/fluentd/issues/2799

**What this PR does / why we need it**: 

note: 
~~I decided that fluentd uses the last option of `-E`, but I'm not sure it's the best way.
Any suggestions are welcome!~~
Use the encoding options(`-E`, `--encoding`,  `--external-encoding`, `--internal-encoding`) in RUBYOPT env var as it is if exists. if not fluentd `-Eascii-8bit:ascii-8bit`. https://github.com/fluent/fluentd/pull/2814/commits/f51154699ca30485473c4097208148e91d15e3ab#diff-dbe0e1ec4079138e48ca6a4d7c7248f9R884


**Docs Changes**:

no need

**Release Note**: 

same as the title
