### PR TITLE
fix for RFC5424 parsing

### DIFF
--- a/lib/fluent/plugin/parser_syslog.rb
+++ b/lib/fluent/plugin/parser_syslog.rb
@@ -27,7 +27,7 @@ module Fluent
       REGEXP = /^(?<time>[^ ]*\s*[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[^ :\[]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$/
       # From in_syslog default pattern
       REGEXP_WITH_PRI = /^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[^ :\[]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$/
-      REGEXP_RFC5424 = "(?<time>[^ ]+) (?<host>[!-~]{1,255}) (?<ident>[!-~]{1,48}) (?<pid>[!-~]{1,128}) (?<msgid>[!-~]{1,32}) (?<extradata>(?:\\-|(?:\\[.*?(?<!\\\\)\\])+))(?: (?:\xef\xbb\xbf)?(?<message>.+))?"
+      REGEXP_RFC5424 = "(?<time>[^ ]+) (?<host>[!-~]{1,255}) (?<ident>[!-~]{1,48}) (?<pid>[!-~]{1,128}) (?<msgid>[!-~]{1,32}) (?<extradata>(?:\\-|(?:\\[.*?(?<!\\\\)\\])+))(?: (?<message>.+))?"
       REGEXP_RFC5424_NO_PRI = Regexp.new('\\A' + REGEXP_RFC5424 + '\\z', Regexp::MULTILINE)
       REGEXP_RFC5424_WITH_PRI = Regexp.new('\\A<(?<pri>[0-9]{1,3})\\>[1-9]\\d{0,2} ' + REGEXP_RFC5424 + '\\z', Regexp::MULTILINE)
       REGEXP_DETECT_RFC5424 = /^\<.*\>[1-9]\d{0,2}/

--- a/lib/fluent/plugin/parser_syslog.rb
+++ b/lib/fluent/plugin/parser_syslog.rb
@@ -30,8 +30,12 @@ module Fluent
       REGEXP_RFC5424 = <<~'EOS'.chomp
         (?<time>[^ ]+) (?<host>[!-~]{1,255}) (?<ident>[!-~]{1,48}) (?<pid>[!-~]{1,128}) (?<msgid>[!-~]{1,32}) (?<extradata>(?:\-|(?:\[.*?(?<!\\)\])+))(?: (?<message>.+))?
       EOS
-      REGEXP_RFC5424_NO_PRI = Regexp.new('\\A' + REGEXP_RFC5424 + '\\z', Regexp::MULTILINE)
-      REGEXP_RFC5424_WITH_PRI = Regexp.new('\\A<(?<pri>[0-9]{1,3})\\>[1-9]\\d{0,2} ' + REGEXP_RFC5424 + '\\z', Regexp::MULTILINE)
+      REGEXP_RFC5424_NO_PRI = Regexp.new(<<~'EOS'.chomp % REGEXP_RFC5424, Regexp::MULTILINE)
+        \A%s\z
+      EOS
+      REGEXP_RFC5424_WITH_PRI = Regexp.new(<<~'EOS'.chomp % REGEXP_RFC5424, Regexp::MULTILINE)
+        \A<(?<pri>[0-9]{1,3})\>[1-9]\d{0,2} %s\z
+      EOS
       REGEXP_DETECT_RFC5424 = /^\<.*\>[1-9]\d{0,2}/
 
       config_set_default :time_format, "%b %d %H:%M:%S"

--- a/lib/fluent/plugin/parser_syslog.rb
+++ b/lib/fluent/plugin/parser_syslog.rb
@@ -27,8 +27,9 @@ module Fluent
       REGEXP = /^(?<time>[^ ]*\s*[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[^ :\[]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$/
       # From in_syslog default pattern
       REGEXP_WITH_PRI = /^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[^ :\[]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$/
-      REGEXP_RFC5424 = /\A(?<time>[^ ]+) (?<host>[!-~]{1,255}) (?<ident>[!-~]{1,48}) (?<pid>[!-~]{1,128}) (?<msgid>[!-~]{1,32}) (?<extradata>(?:\-|\[(.*)\]))(?: (?<message>.+))?\z/m
-      REGEXP_RFC5424_WITH_PRI = /\A\<(?<pri>[0-9]{1,3})\>[1-9]\d{0,2} (?<time>[^ ]+) (?<host>[!-~]{1,255}) (?<ident>[!-~]{1,48}) (?<pid>[!-~]{1,128}) (?<msgid>[!-~]{1,32}) (?<extradata>(?:\-|\[(.*)\]))(?: (?<message>.+))?\z/m
+      REGEXP_RFC5424 = "(?<time>[^ ]+) (?<host>[!-~]{1,255}) (?<ident>[!-~]{1,48}) (?<pid>[!-~]{1,128}) (?<msgid>[!-~]{1,32}) (?<extradata>(?:\\-|(?:\\[.*?(?<!\\\\)\\])+))(?: (?:\xef\xbb\xbf)?(?<message>.+))?"
+      REGEXP_RFC5424_NO_PRI = Regexp.new('\\A' + REGEXP_RFC5424 + '\\z', Regexp::MULTILINE)
+      REGEXP_RFC5424_WITH_PRI = Regexp.new('\\A<(?<pri>[0-9]{1,3})\\>[1-9]\\d{0,2} ' + REGEXP_RFC5424 + '\\z', Regexp::MULTILINE)
       REGEXP_DETECT_RFC5424 = /^\<.*\>[1-9]\d{0,2}/
 
       config_set_default :time_format, "%b %d %H:%M:%S"
@@ -73,7 +74,7 @@ module Fluent
                     end
                     @time_format = @rfc5424_time_format unless conf.has_key?('time_format')
                     @support_rfc5424_without_subseconds = true
-                    @with_priority ? REGEXP_RFC5424_WITH_PRI : REGEXP_RFC5424
+                    @with_priority ? REGEXP_RFC5424_WITH_PRI : REGEXP_RFC5424_NO_PRI
                   when :auto
                     class << self
                       alias_method :parse, :parse_auto
@@ -96,7 +97,7 @@ module Fluent
 
       def parse_auto(text, &block)
         if REGEXP_DETECT_RFC5424.match(text)
-          @regexp = @with_priority ? REGEXP_RFC5424_WITH_PRI : REGEXP_RFC5424
+          @regexp = @with_priority ? REGEXP_RFC5424_WITH_PRI : REGEXP_RFC5424_NO_PRI
           @time_parser = @time_parser_rfc5424
           @support_rfc5424_without_subseconds = true
           parse_plain(text, &block)

--- a/lib/fluent/plugin/parser_syslog.rb
+++ b/lib/fluent/plugin/parser_syslog.rb
@@ -27,7 +27,9 @@ module Fluent
       REGEXP = /^(?<time>[^ ]*\s*[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[^ :\[]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$/
       # From in_syslog default pattern
       REGEXP_WITH_PRI = /^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[^ :\[]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$/
-      REGEXP_RFC5424 = "(?<time>[^ ]+) (?<host>[!-~]{1,255}) (?<ident>[!-~]{1,48}) (?<pid>[!-~]{1,128}) (?<msgid>[!-~]{1,32}) (?<extradata>(?:\\-|(?:\\[.*?(?<!\\\\)\\])+))(?: (?<message>.+))?"
+      REGEXP_RFC5424 = <<~'EOS'.chomp
+        (?<time>[^ ]+) (?<host>[!-~]{1,255}) (?<ident>[!-~]{1,48}) (?<pid>[!-~]{1,128}) (?<msgid>[!-~]{1,32}) (?<extradata>(?:\-|(?:\[.*?(?<!\\)\])+))(?: (?<message>.+))?
+      EOS
       REGEXP_RFC5424_NO_PRI = Regexp.new('\\A' + REGEXP_RFC5424 + '\\z', Regexp::MULTILINE)
       REGEXP_RFC5424_WITH_PRI = Regexp.new('\\A<(?<pri>[0-9]{1,3})\\>[1-9]\\d{0,2} ' + REGEXP_RFC5424 + '\\z', Regexp::MULTILINE)
       REGEXP_DETECT_RFC5424 = /^\<.*\>[1-9]\d{0,2}/

--- a/test/plugin/test_parser_syslog.rb
+++ b/test/plugin/test_parser_syslog.rb
@@ -356,23 +356,6 @@ class SyslogParserTest < ::Test::Unit::TestCase
       end
     end
 
-    def test_parse_with_rfc5424_message_prefixed_unicode_bom
-      @parser.configure(
-                        'time_format' => '%Y-%m-%dT%H:%M:%S.%L%z',
-                        'message_format' => 'rfc5424',
-                        'with_priority' => true,
-                        )
-      text = "<16>1 2017-02-06T13:14:15.003Z 192.168.0.1 fluentd 11111 ID24224 [exampleSDID@20224 iut=\"3\" eventSource=\"Application\" eventID=\"11211\"] \xef\xbb\xbf[message]\n"
-      @parser.instance.parse(text) do |time, record|
-        assert_equal(event_time("2017-02-06T13:14:15.003Z", format: '%Y-%m-%dT%H:%M:%S.%L%z'), time)
-        assert_equal "11111", record["pid"]
-        assert_equal "ID24224", record["msgid"]
-        assert_equal "[exampleSDID@20224 iut=\"3\" eventSource=\"Application\" eventID=\"11211\"]",
-                     record["extradata"]
-        assert_equal "[message]", record["message"]
-      end
-    end
-
     def test_parse_with_rfc5424_message_without_subseconds
       @parser.configure(
                         'message_format' => 'rfc5424',


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes https://github.com/fluent/fluentd/issues/2815

**What this PR does / why we need it**: 
as described in the issue, updated the regex expression to cover the listed cases.

**Docs Changes**:
It's a bug fix, nothing doced should change

**Release Note**: 
Improved for parsing RFC5424 structured data in `parser_syslog`