### PR TITLE
Fix when origin is nil in http input plugin

### DIFF
--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -526,6 +526,10 @@ module Fluent::Plugin
       end
 
       def include_cors_allow_origin
+        if @origin.nil?
+          return false
+        end
+
         if @cors_allow_origins.include?(@origin)
           return true
         end

--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -530,10 +530,12 @@ module Fluent::Plugin
           return true
         end
         filtered_cors_allow_origins = @cors_allow_origins.select {|origin| origin != ""}
-        return filtered_cors_allow_origins.find do |origin|
-          (start_str,end_str) = origin.split("*",2)
-          @origin.start_with?(start_str) and @origin.end_with?(end_str)
-        end != nil
+        r = filtered_cors_allow_origins.find do |origin|
+          (start_str, end_str) = origin.split("*", 2)
+          @origin.start_with?(start_str) && @origin.end_with?(end_str)
+        end
+
+        !r.nil?
       end
     end
   end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes https://github.com/fluent/fluentd/issues/2820

**What this PR does / why we need it**: 

nil check about `@origin`

**Docs Changes**:

no 
**Release Note**: 
same as the title 
