### PR TITLE
Specify the dir mode explicitly

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -49,6 +49,7 @@ module Fluent::Plugin
     end
 
     FILE_PERMISSION = 0644
+    DIR_PERMISSION = 0755
 
     def initialize
       super
@@ -168,6 +169,7 @@ module Fluent::Plugin
                            method(:parse_singleline)
                          end
       @file_perm = system_config.file_permission || FILE_PERMISSION
+      @dir_perm = system_config.dir_permission || DIR_PERMISSION
       # parser is already created by parser helper
       @parser = parser_create(usage: parser_config['usage'] || @parser_configs.first.usage)
     end
@@ -210,7 +212,7 @@ module Fluent::Plugin
 
       if @pos_file
         pos_file_dir = File.dirname(@pos_file)
-        FileUtils.mkdir_p(pos_file_dir) unless Dir.exist?(pos_file_dir)
+        FileUtils.mkdir_p(pos_file_dir, mode: @dir_perm) unless Dir.exist?(pos_file_dir)
         @pf_file = File.open(@pos_file, File::RDWR|File::CREAT|File::BINARY, @file_perm)
         @pf_file.sync = true
         @pf = PositionFile.load(@pf_file, logger: log)

--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -1203,7 +1203,7 @@ module Fluent
           backup_dir = File.dirname(backup_file)
 
           log.warn "bad chunk is moved to #{backup_file}"
-          FileUtils.mkdir_p(backup_dir) unless Dir.exist?(backup_dir)
+          FileUtils.mkdir_p(backup_dir, mode: system_config.dir_permission || 0755) unless Dir.exist?(backup_dir)
           File.open(backup_file, 'ab', system_config.file_permission || 0644) { |f|
             chunk.write_to(f)
           }

--- a/lib/fluent/plugin_id.rb
+++ b/lib/fluent/plugin_id.rb
@@ -76,7 +76,7 @@ module Fluent
 
       # Fluent::Plugin::Base#fluentd_worker_id
       dir = File.join(system_config.root_dir, "worker#{fluentd_worker_id}", plugin_id)
-      FileUtils.mkdir_p(dir) unless Dir.exist?(dir)
+      FileUtils.mkdir_p(dir, mode: system_config.dir_permission || 0755) unless Dir.exist?(dir)
       @_plugin_root_dir = dir.freeze
       dir
     end

--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -694,6 +694,23 @@ CONF
       )
     end
 
+    test 'success to start a worker2 with worker specific configuration' do
+      conf = <<CONF
+<system>
+  root_dir #{@root_path}
+  dir_permission 0744
+</system>
+CONF
+      conf_path = create_conf_file('worker_section0.conf', conf)
+
+      FileUtils.rm_rf(@root_path) rescue nil
+
+      assert_path_not_exist(@root_path)
+      assert_log_matches(create_cmdline(conf_path), 'spawn command to main') # any message is ok
+      assert_path_exist(@root_path)
+      assert_equal '744', File.stat(@root_path).mode.to_s(8)[-3, 3]
+    end
+
     test 'success to start a worker with worker specific configuration' do
       conf = <<CONF
 <system>

--- a/test/test_logger_initializer.rb
+++ b/test/test_logger_initializer.rb
@@ -17,10 +17,28 @@ class LoggerInitializerTest < ::Test::Unit::TestCase
 
     assert_false File.exist?(TMP_DIR)
     logger = Fluent::Supervisor::LoggerInitializer.new(path, Fluent::Log::LEVEL_DEBUG, nil, nil, {})
+    mock.proxy(File).chmod(0o777, TMP_DIR).never
 
     assert_nothing_raised do
       logger.init(:supervisor, 0)
     end
+
     assert_true File.exist?(TMP_DIR)
+  end
+
+  test 'apply_options with log_dir_perm' do
+    path = File.join(TMP_DIR, 'fluent_with_path.log')
+
+    assert_false File.exist?(TMP_DIR)
+    logger = Fluent::Supervisor::LoggerInitializer.new(path, Fluent::Log::LEVEL_DEBUG, nil, nil, {})
+    mock.proxy(File).chmod(0o777, TMP_DIR).once
+
+    assert_nothing_raised do
+      logger.init(:supervisor, 0)
+    end
+
+    logger.apply_options(log_dir_perm: 0o777)
+    assert_true File.exist?(TMP_DIR)
+    assert_equal 0o777, (File.stat(TMP_DIR).mode & 0xFFF)
   end
 end

--- a/test/test_plugin_id.rb
+++ b/test/test_plugin_id.rb
@@ -97,5 +97,21 @@ class PluginIdTest < Test::Unit::TestCase
         ENV['SERVERENGINE_WORKER_ID'] = prev_env_val
       end
     end
+
+    test '#plugin_root_dir create dirctory with specify mode if not exists ' do
+      root_dir = Fluent::SystemConfig.overwrite_system_config({ 'root_dir' => File.join(TMP_DIR, "myroot"), 'dir_permission' => '0777' }) do
+        @p.plugin_root_dir
+      end
+
+      assert_equal '777', File.stat(root_dir).mode.to_s(8)[-3, 3]
+    end
+
+    test '#plugin_root_dir create dirctory with default permission if not exists ' do
+      root_dir = Fluent::SystemConfig.overwrite_system_config({ 'root_dir' => File.join(TMP_DIR, "myroot") }) do
+        @p.plugin_root_dir
+      end
+
+      assert_equal '755', File.stat(root_dir).mode.to_s(8)[-3, 3]
+    end
   end
 end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes https://github.com/fluent/fluentd/issues/2821

**What this PR does / why we need it**: 

Specify the dir permission mode explicitly to avoid creating world writable dir in some env.

**Docs Changes**:

no need

**Release Note**: 

Specify the dir permission mode explicitly