### PR TITLE
socket and yajl are already required in L18 and L21

### DIFF
--- a/lib/fluent/plugin/in_unix.rb
+++ b/lib/fluent/plugin/in_unix.rb
@@ -28,12 +28,6 @@ module Fluent
   class StreamInput < Input
     config_param :blocking_timeout, :time, default: 0.5
 
-    def initialize
-      require 'socket'
-      require 'yajl'
-      super
-    end
-
     def start
       super
 


### PR DESCRIPTION

**Which issue(s) this PR fixes**: 
nope

**What this PR does / why we need it**: 

socket and yaml are already required in L18 and L21

https://github.com/fluent/fluentd/blob/9d113029d4550ce576d8825bfa9612aa3e55bff0/lib/fluent/plugin/in_unix.rb#L18-L21

**Docs Changes**:

nope

**Release Note**: 

nope
