### PR TITLE
out_file: Revert #1995 changes

### DIFF
--- a/lib/fluent/plugin/out_file.rb
+++ b/lib/fluent/plugin/out_file.rb
@@ -17,7 +17,6 @@
 require 'fileutils'
 require 'zlib'
 require 'time'
-require 'tempfile'
 
 require 'fluent/plugin/output'
 require 'fluent/config/error'
@@ -232,28 +231,10 @@ module Fluent::Plugin
     end
 
     def write_gzip_with_compression(path, chunk)
-      if @append
-        # This code will be removed after zlib/multithread bug is fixed.
-        # Use Tempfile to avoid broken gzip files: https://github.com/fluent/fluentd/issues/1903
-        Tempfile.create('out_file-gzip-append') { |temp|
-          begin
-            writer = Zlib::GzipWriter.new(temp)
-            chunk.write_to(writer, compressed: :text)
-          ensure
-            writer.finish # avoid zlib finalizer warning
-          end
-          temp.rewind
-
-          File.open(path, "ab", @file_perm) do |f|
-            IO.copy_stream(temp, f)
-          end
-        }
-      else
-        File.open(path, "ab", @file_perm) do |f|
-          gz = Zlib::GzipWriter.new(f)
-          chunk.write_to(gz, compressed: :text)
-          gz.close
-        end
+      File.open(path, "ab", @file_perm) do |f|
+        gz = Zlib::GzipWriter.new(f)
+        chunk.write_to(gz, compressed: :text)
+        gz.close
       end
     end
 


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
No issues

**What this PR does / why we need it**: 
This reverts #1995 changes. Recent fluentd doesn't have thread interruption issue for zlib.

**Docs Changes**:
No need

**Release Note**: 
Same as title or put it in `clean up code` list.