### PR TITLE
chunk: Use Tempfile for decompressing as binmode

### DIFF
--- a/lib/fluent/plugin/buffer/chunk.rb
+++ b/lib/fluent/plugin/buffer/chunk.rb
@@ -206,7 +206,7 @@ module Fluent
                 output_io = if chunk_io.is_a?(StringIO)
                               StringIO.new
                             else
-                              Tempfile.new('decompressed-data')
+                              Tempfile.new('decompressed-data').binmode
                             end
                 decompress(input_io: chunk_io, output_io: output_io)
                 output_io.seek(0, IO::SEEK_SET)


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 

Because it may fail to decompress such as \u0000 (invalid chraracter for plain text mode) on Windows.
When we use tempfile as binmode, it can handle such as \u0000 within
the contents where cause problem plain text mode(default mode).

Otherwise, the following error occurs:

```log
2020-02-27 16:39:55.455308000 +0900 test.winsec: {"ProviderName":"Microsoft-Windows-Security-Auditing","ProviderGUID":"","EventID":"5379","Level":"0","Task":"13824","Opcode":"0","Keywords":"0x8020000000000000","TimeCreated":"2020/02/27 07:39:52.588903600","EventRecordID":"542997","ActivityID":"{F3774C06-E87C-0002-954C-77F37CE8D501}","RelatedActivityID":"","ProcessID":"820","ThreadID":"1076","Channel":"Security","Computer":"DESKTOP-G457RDR","UserID":"","Version":"0","Description":"資格情報マネージャーの資格情報が読み取られました。\r\r\n\r\r\nサブジェクト:\r\r\n\tセキュリティ ID:\t\tS-1-5-21-581519880-1353037380-2415444059-1001\r\r\n\tアカウント名:\t\tcosmo\r\r\n\tアカウント ドメイン:\t\tDESKTOP-G457RDR\r\r\n\tログオン ID:\t\t0xE9015\r\r\n\t読み取り操作: \t\t資格情報の列挙\r\r\n\r\r\nこのイベントは、ユーザーが資格情報マネージャー 内に格納されている資格情報の読み取り操作を実行したときに発生し","-29":{"す。�EventData��-S-1-5-21-58":49}}
1970-01-01 09:00:53.000000000 +0900 test.winsec: null
1970-01-01 09:00:49.000000000 +0900 test.winsec: null
1970-01-01 09:00:57.000000000 +0900 test.winsec: null
1970-01-01 09:00:56.000000000 +0900 test.winsec: null
1970-01-01 09:00:56.000000000 +0900 test.winsec: null
1970-01-01 09:00:48.000000000 +0900 test.winsec: null
1970-01-01 09:00:45.000000000 +0900 test.winsec: null
1970-01-01 09:00:49.000000000 +0900 test.winsec: null
1970-01-01 09:00:51.000000000 +0900 test.winsec: null
1970-01-01 09:00:53.000000000 +0900 test.winsec: null
1970-01-01 09:00:51.000000000 +0900 test.winsec: null
1970-01-01 09:00:48.000000000 +0900 test.winsec: null
1970-01-01 09:00:51.000000000 +0900 test.winsec: null
1970-01-01 09:00:55.000000000 +0900 test.winsec: null
1970-01-01 09:00:51.000000000 +0900 test.winsec: null
1970-01-01 09:00:56.000000000 +0900 test.winsec: null
1970-01-01 09:00:48.000000000 +0900 test.winsec: null
1970-01-01 09:00:45.000000000 +0900 test.winsec: null
1970-01-01 09:00:50.000000000 +0900 test.winsec: null
1970-01-01 09:00:52.000000000 +0900 test.winsec: null
1970-01-01 09:00:49.000000000 +0900 test.winsec: null
1970-01-01 09:00:53.000000000 +0900 test.winsec: null
1970-01-01 09:00:52.000000000 +0900 test.winsec: null
1970-01-01 09:00:52.000000000 +0900 test.winsec: null
```

With this patch, in_tail/in_windows_eventlog2 and out_forward with compress chunk can work correctly.

**Docs Changes**:

No needed.

**Release Note**: 

Same as title.
