### PR TITLE
log should be in else cond

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -446,8 +446,9 @@ module Fluent::Plugin
                 end
           record[@path_key] ||= tw.path unless @path_key.nil?
           router.emit(tag, time, record)
+        else
+          log.warn "got incomplete line at shutdown from #{tw.path}: #{buf.inspect}"
         end
-        log.warn "got incomplete line at shutdown from #{tw.path}: #{buf.inspect}"
       }
     end
 


### PR DESCRIPTION
https://github.com/fluent/fluentd/pull/2843/files

**Which issue(s) this PR fixes**: 
follows up https://github.com/fluent/fluentd/pull/2843

**What this PR does / why we need it**: 

I've noticed that I moved log.warn out of the else cond in https://github.com/fluent/fluentd/pull/2843/files#diff-1da710c9dcc8d0fc57996df7a9d39695L450-L451. so I reverted the change. 

**Docs Changes**:

no

**Release Note**: 

no
