### PR TITLE
When chunks are queued, their `metadata.seq` should be 0

### DIFF
--- a/lib/fluent/plugin/buf_file.rb
+++ b/lib/fluent/plugin/buf_file.rb
@@ -170,6 +170,7 @@ module Fluent
             # these chunks(unstaged chunks) has shared the same metadata
             # So perform enqueue step again https://github.com/fluent/fluentd/blob/9d113029d4550ce576d8825bfa9612aa3e55bff0/lib/fluent/plugin/buffer.rb#L364
             if chunk_size_full?(chunk) || stage.key?(chunk.metadata)
+              chunk.metadata.seq = 0 # metadata.seq should be 0 for counting @queued_num
               queue << chunk.enqueued!
             else
               stage[chunk.metadata] = chunk

--- a/lib/fluent/plugin/buffer.rb
+++ b/lib/fluent/plugin/buffer.rb
@@ -363,6 +363,8 @@ module Fluent
                 u = unstaged_chunks[m].pop
                 u.synchronize do
                   if u.unstaged? && !chunk_size_full?(u)
+                    # `u.metadata.seq` and `m.seq` can be different but Buffer#enqueue_chunk expect them to be the same value
+                    u.metadata.seq = 0
                     synchronize {
                       @stage[m] = u.staged!
                       @stage_size += u.bytesize

--- a/lib/fluent/plugin/buffer.rb
+++ b/lib/fluent/plugin/buffer.rb
@@ -428,6 +428,7 @@ module Fluent
             if chunk.empty?
               chunk.close
             else
+              chunk.metadata.seq = 0 # metadata.seq should be 0 for counting @queued_num
               @queue << chunk
               @queued_num[metadata] = @queued_num.fetch(metadata, 0) + 1
               chunk.enqueued!
@@ -446,6 +447,7 @@ module Fluent
         synchronize do
           chunk.synchronize do
             metadata = chunk.metadata
+            metadata.seq = 0 # metadata.seq should be 0 for counting @queued_num
             @queue << chunk
             @queued_num[metadata] = @queued_num.fetch(metadata, 0) + 1
             chunk.enqueued!

--- a/test/plugin/test_buf_file.rb
+++ b/test/plugin/test_buf_file.rb
@@ -1072,7 +1072,7 @@ class FileBufferTest < Test::Unit::TestCase
       assert_equal 3, s.size
       assert_equal [0, 1, 2], s.keys.map(&:seq).sort
       assert_equal 1, e.size
-      assert_equal [2], e.map { |e| e.metadata.seq }
+      assert_equal [0], e.map { |e| e.metadata.seq }
     end
   end
 

--- a/test/plugin/test_buffer.rb
+++ b/test/plugin/test_buffer.rb
@@ -903,9 +903,7 @@ class BufferTest < Test::Unit::TestCase
       # metadata whose seq is 4 is created, but overwrite with original metadata(seq=0) for next use of this chunk https://github.com/fluent/fluentd/blob/9d113029d4550ce576d8825bfa9612aa3e55bff0/lib/fluent/plugin/buffer.rb#L357
       assert_equal [@dm0], @p.stage.keys
       assert_equal 5400, @p.stage[@dm0].size
-      r = [@dm0]
-      3.times { |i| r << r[i].dup_next }
-      assert_equal [@dm0, *r], @p.queue.map(&:metadata)
+      assert_equal [@dm0, @dm0, @dm0, @dm0, @dm0], @p.queue.map(&:metadata)
       assert_equal [5000, 9900, 9900, 9900, 9900], @p.queue.map(&:size) # splits: 45000 / 100 => 450 * ...
       # 9900 * 4 + 5400 == 45000
     end
@@ -922,9 +920,7 @@ class BufferTest < Test::Unit::TestCase
 
       dequeued_chunks = 6.times.map { |e| @p.dequeue_chunk } # splits: 45000 / 100 => 450 * ...
       assert_equal [5000, 9900, 9900, 9900, 9900, 5400], dequeued_chunks.map(&:size)
-      r = [@dm0]
-      3.times { |i| r << r[i].dup_next }
-      assert_equal [@dm0, *r, @dm0], dequeued_chunks.map(&:metadata) # last last one's metadata.seq is 0
+      assert_equal [@dm0, @dm0, @dm0, @dm0, @dm0, @dm0], dequeued_chunks.map(&:metadata)
     end
 
     test '#write raises BufferChunkOverflowError if a record is biggar than chunk limit size' do
@@ -1010,9 +1006,7 @@ class BufferTest < Test::Unit::TestCase
 
       assert_equal [@dm0], @p.stage.keys
       assert_equal 900, @p.stage[@dm0].size
-      r = [@dm0]
-      4.times { |i| r << r[i].dup_next }
-      assert_equal r, @p.queue.map(&:metadata)
+      assert_equal [@dm0, @dm0, @dm0, @dm0, @dm0], @p.queue.map(&:metadata)
       assert_equal [9500, 9900, 9900, 9900, 9900], @p.queue.map(&:size) # splits: 45000 / 100 => 450 * ...
       ##### 900 + 9500 + 9900 * 4 == 5000 + 45000
     end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Follow up https://github.com/fluent/fluentd/pull/2824

**What this PR does / why we need it**: 

In #2824, I added `seq` to Metadata class so that it can identify the chunks which are created in Buffer#write_step_by_step for Buffer#resume.
When chunks are queued, their `metadata.seq` should be 0 for `@queued_num`. so I change seq to 0 when the chunks are queue. 

**Docs Changes**:

no

**Release Note**: 
same as the title