### PR TITLE
Fix appveyor ci round1

### DIFF
--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -1102,7 +1102,11 @@ class TailInputTest < Test::Unit::TestCase
     end
 
     assert_path_exist("#{TMP_DIR}/pos")
-    assert_equal '744', File.stat("#{TMP_DIR}/pos").mode.to_s(8)[-3, 3]
+    if Fluent.windows?
+      assert_equal '755', File.stat("#{TMP_DIR}/pos").mode.to_s(8)[-3, 3]
+    else
+      assert_equal '744', File.stat("#{TMP_DIR}/pos").mode.to_s(8)[-3, 3]
+    end
   ensure
     cleanup_directory(TMP_DIR)
   end

--- a/test/plugin/test_output_as_buffered_backup.rb
+++ b/test/plugin/test_output_as_buffered_backup.rb
@@ -256,6 +256,8 @@ class BufferedOutputBackupTest < Test::Unit::TestCase
     end
 
     test 'create directory with specific mode' do
+      omit "NTFS doesn't support UNIX like permissions" if Fluent.windows?
+
       Fluent::SystemConfig.overwrite_system_config('root_dir' => TMP_DIR, 'dir_permission' => '744') do
         id = 'backup_test_with_same_secondary'
         hash = { 'flush_interval' => 1, 'flush_thread_burst_interval' => 0.1 }

--- a/test/test_logger_initializer.rb
+++ b/test/test_logger_initializer.rb
@@ -27,6 +27,8 @@ class LoggerInitializerTest < ::Test::Unit::TestCase
   end
 
   test 'apply_options with log_dir_perm' do
+    omit "NTFS doesn't support UNIX like permissions" if Fluent.windows?
+
     path = File.join(TMP_DIR, 'fluent_with_path.log')
 
     assert_false File.exist?(TMP_DIR)

--- a/test/test_plugin_id.rb
+++ b/test/test_plugin_id.rb
@@ -99,6 +99,8 @@ class PluginIdTest < Test::Unit::TestCase
     end
 
     test '#plugin_root_dir create dirctory with specify mode if not exists ' do
+      omit "NTFS doesn't support UNIX like permissions" if Fluent.windows?
+
       root_dir = Fluent::SystemConfig.overwrite_system_config({ 'root_dir' => File.join(TMP_DIR, "myroot"), 'dir_permission' => '0777' }) do
         @p.plugin_root_dir
       end

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -161,7 +161,7 @@ class SupervisorTest < ::Test::Unit::TestCase
 
     assert{ $log.out.logs.first.end_with?(info_msg) }
   ensure
-    $log.out.reset
+    $log.out.reset unless $log.out.is_a?(Fluent::LogDeviceIO)
   end
 
   def test_load_config

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -161,7 +161,7 @@ class SupervisorTest < ::Test::Unit::TestCase
 
     assert{ $log.out.logs.first.end_with?(info_msg) }
   ensure
-    $log.out.reset unless $log.out.is_a?(Fluent::LogDeviceIO)
+    $log.out.reset if $log.out.is_a?(Fluent::Test::DummyLogDevice)
   end
 
   def test_load_config


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 

Related to #2854.

* Omit/Fix permission related testcases.
* Prevent raising error on `$log.out.reset` for non `Fluent::Test::DummyLogDevice` instance case.

**What this PR does / why we need it**: 
We should take care of AppVeyor CI result.

**Docs Changes**:
No needed.

**Release Note**: 

None.