### PR TITLE
server helper: Change SSLError log level to warn in accept

### DIFF
--- a/lib/fluent/plugin_helper/server.rb
+++ b/lib/fluent/plugin_helper/server.rb
@@ -706,8 +706,12 @@ module Fluent
 
                 return true
               end
-            rescue Errno::EPIPE, Errno::ECONNRESET, Errno::ETIMEDOUT, Errno::ECONNREFUSED, Errno::EHOSTUNREACH, OpenSSL::SSL::SSLError => e
+            rescue Errno::EPIPE, Errno::ECONNRESET, Errno::ETIMEDOUT, Errno::ECONNREFUSED, Errno::EHOSTUNREACH => e
               @log.trace "unexpected error before accepting TLS connection", error: e
+              close rescue nil
+            rescue OpenSSL::SSL::SSLError => e
+              # Use same log level as on_readable
+              @log.warn "unexpected error before accepting TLS connection by OpenSSL", error: e
               close rescue nil
             end
 


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
No issue

**What this PR does / why we need it**: 
Follow `on_readable` and identify what is the cause.
With trace level, users hard to find ssl setting mistake.

**Docs Changes**:
No need.

**Release Note**: 
Same as title.