### PR TITLE
Fix appveyor ci for round3

### DIFF
--- a/lib/fluent/plugin_helper/socket_option.rb
+++ b/lib/fluent/plugin_helper/socket_option.rb
@@ -58,6 +58,10 @@ module Fluent
           # This unintented behavior causes "Errno::ECONNRESET: An existing connection was forcibly
           # closed by the remote host." on Windows.
           if linger_timeout.to_i > 0
+            if linger_timeout >= 2**16
+              log.warn "maximum linger_timeout is 65535(2^16 - 1). Set to 65535 forcibly."
+              linger_timeout = 2**16 - 1
+            end
             optval = [1, linger_timeout.to_i].pack(FORMAT_STRUCT_LINGER_WINDOWS)
             socket_option_set_one(sock, :SO_LINGER, optval)
           end

--- a/test/plugin/test_buf_file.rb
+++ b/test/plugin/test_buf_file.rb
@@ -1062,7 +1062,9 @@ class FileBufferTest < Test::Unit::TestCase
       if @bufdir
         Dir.glob(File.join(@bufdir, '*')).each do |path|
           next if ['.', '..'].include?(File.basename(path))
-          File.delete(path)
+          # Windows does not permit to delete files which are used in another process.
+          # Just ignore for removing failure.
+          File.delete(path) rescue nil
         end
       end
     end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 

Related to #2854.

* Omit deleting ephemeral buffer file due to permission error.
  * Windows does not permit removing files which are used in another process even if administrator.
* Fix `linger_timeout` handling on Windows

**What this PR does / why we need it**: 
We should take care of AppVeyor CI result.

**Docs Changes**:
No needed.

**Release Note**: 

None.