### PR TITLE
Fix appveyor ci for round4

### DIFF
--- a/test/plugin/in_tail/test_position_file.rb
+++ b/test/plugin/in_tail/test_position_file.rb
@@ -6,7 +6,7 @@ require 'tempfile'
 
 class IntailPositionFileTest < Test::Unit::TestCase
   setup do
-    @file = Tempfile.new('intail_position_file_test')
+    @file = Tempfile.new('intail_position_file_test').binmode
   end
 
   teardown do
@@ -196,11 +196,7 @@ class IntailPositionFileTest < Test::Unit::TestCase
       @file.seek(0)
       lines = @file.readlines
       assert_equal 2, lines.size
-      if Fluent.windows?
-        assert_equal "valid_path\t0000000000000000a\t000000000000000b\n", lines[0]
-      else
-        assert_equal "valid_path\t000000000000000a\t000000000000000b\n", lines[0]
-      end
+      assert_equal "valid_path\t000000000000000a\t000000000000000b\n", lines[0]
       assert_equal "valid_path2\t0000000000000003\t0000000000000002\n", lines[1]
     end
 
@@ -213,11 +209,7 @@ class IntailPositionFileTest < Test::Unit::TestCase
       @file.seek(0)
       lines = @file.readlines
       assert_equal 2, lines.size
-      if Fluent.windows?
-        assert_equal "valid_path\t0000000000000000a0000000000000001\n", lines[0]
-      else
-        assert_equal "valid_path\t000000000000000a\t0000000000000001\n", lines[0]
-      end
+      assert_equal "valid_path\t000000000000000a\t0000000000000001\n", lines[0]
       assert_equal "valid_path2\t0000000000000003\t0000000000000002\n", lines[1]
     end
 

--- a/test/plugin/in_tail/test_position_file.rb
+++ b/test/plugin/in_tail/test_position_file.rb
@@ -196,7 +196,11 @@ class IntailPositionFileTest < Test::Unit::TestCase
       @file.seek(0)
       lines = @file.readlines
       assert_equal 2, lines.size
-      assert_equal "valid_path\t000000000000000a\t000000000000000b\n", lines[0]
+      if Fluent.windows?
+        assert_equal "valid_path\t0000000000000000a\t000000000000000b\n", lines[0]
+      else
+        assert_equal "valid_path\t000000000000000a\t000000000000000b\n", lines[0]
+      end
       assert_equal "valid_path2\t0000000000000003\t0000000000000002\n", lines[1]
     end
 
@@ -209,7 +213,11 @@ class IntailPositionFileTest < Test::Unit::TestCase
       @file.seek(0)
       lines = @file.readlines
       assert_equal 2, lines.size
-      assert_equal "valid_path\t000000000000000a\t0000000000000001\n", lines[0]
+      if Fluent.windows?
+        assert_equal "valid_path\t0000000000000000a0000000000000001\n", lines[0]
+      else
+        assert_equal "valid_path\t000000000000000a\t0000000000000001\n", lines[0]
+      end
       assert_equal "valid_path2\t0000000000000003\t0000000000000002\n", lines[1]
     end
 

--- a/test/plugin/test_in_forward.rb
+++ b/test/plugin/test_in_forward.rb
@@ -218,7 +218,7 @@ class ForwardInputTest < Test::Unit::TestCase
         }
       end
 
-      assert_equal(records, d.events.sort_by {|a| a[1] })
+      assert_equal(records, d.events.sort_by {|a| a[0] })
     end
 
     test 'json_with_newline' do
@@ -237,7 +237,7 @@ class ForwardInputTest < Test::Unit::TestCase
         }
       end
 
-      assert_equal(records, d.events.sort_by {|a| a[1] })
+      assert_equal(records, d.events.sort_by {|a| a[0] })
     end
   end
 

--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -997,7 +997,11 @@ EOL
       e = assert_raise Fluent::UnrecoverableError do
         d.instance_start
       end
-      assert_match(/Connection refused/, e.message)
+      if Fluent.windows?
+        assert_match(/No connection could be made because the target machine actively refused it/, e.message)
+      else
+        assert_match(/Connection refused/, e.message)
+      end
 
       d.instance_shutdown
     end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 

Related to #2854.

* Fix expected position in posfile
* Use correct error message on connecting error
* Sort by tag name instead of timestamps which are same integer value (this causes unstable result)

**What this PR does / why we need it**: 
We should take care of AppVeyor CI result.

**Docs Changes**:
No needed.

**Release Note**: 

None.