### PR TITLE
out_forward: windows: Permit to specify linger_timeout

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -382,9 +382,7 @@ module Fluent::Plugin
           cert_logical_store_name: @tls_cert_logical_store_name,
           cert_use_enterprise_store: @tls_cert_use_enterprise_store,
 
-          # Enabling SO_LINGER causes data loss on Windows
-          # https://github.com/fluent/fluentd/issues/1968
-          linger_timeout: Fluent.windows? ? nil : @send_timeout,
+          linger_timeout: @send_timeout,
           send_timeout: @send_timeout,
           recv_timeout: @ack_response_timeout,
           connect_timeout: @connect_timeout,


### PR DESCRIPTION
[The previous commit](https://github.com/fluent/fluentd/pull/2862/commits/7d16531c0fdf05763f25efb4b1cdb4314b1b1f70) solved linger_timeout member types glitch.
In the previous linger_timeout behavior is always occurring dropping data.
But the fixing member type glitches, Fluentd can handle linger_timeout on Windows.
This type glitch causes overflow and then linger_timeout should be 0.
So, this is why specifying linger_timeout causes data loss on Windows.

LIBC: { int l_onoff; int l_linger; } # I!I!
Winsock: { u_short l_onoff; u_short l_linger; } #S!S!

Really fixes for https://github.com/fluent/fluentd/issues/1968.
Reverted https://github.com/fluent/fluentd/pull/2398

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
No Fixes.

**What this PR does / why we need it**: 

To support SO_LINGER on Windows.

**Docs Changes**:

No needed.

**Release Note**: 

Same as title.