### PR TITLE
Feature/fix wrong syslog format detection

### DIFF
--- a/lib/fluent/plugin/parser_syslog.rb
+++ b/lib/fluent/plugin/parser_syslog.rb
@@ -36,7 +36,7 @@ module Fluent
       REGEXP_RFC5424_WITH_PRI = Regexp.new(<<~'EOS'.chomp % REGEXP_RFC5424, Regexp::MULTILINE)
         \A<(?<pri>[0-9]{1,3})\>[1-9]\d{0,2} %s\z
       EOS
-      REGEXP_DETECT_RFC5424 = /^\<.*\>[1-9]\d{0,2}/
+      REGEXP_DETECT_RFC5424 = /^\<[0-9]{1,3}\>[1-9]\d{0,2}/
 
       config_set_default :time_format, "%b %d %H:%M:%S"
       desc 'If the incoming logs have priority prefix, e.g. <9>, set true'

--- a/test/plugin/test_parser_syslog.rb
+++ b/test/plugin/test_parser_syslog.rb
@@ -496,6 +496,13 @@ class SyslogParserTest < ::Test::Unit::TestCase
       assert_equal(Fluent::Plugin::SyslogParser::REGEXP_RFC5424_WITH_PRI,
                    @parser.instance.patterns['format'])
 
+      text = '<1>Feb 28 12:00:02 192.168.0.1 fluentd[11111]: [error] Syslog test 2>1'
+      @parser.instance.parse(text) do |time, record|
+         assert_equal(event_time("Feb 28 12:00:02", format: '%b %d %M:%S:%H'), time)
+         assert_equal(@expected.merge('pri' => 1, 'message'=> '[error] Syslog test 2>1'), record)
+       end
+       assert_equal(Fluent::Plugin::SyslogParser::REGEXP_WITH_PRI, @parser.instance.patterns['format'])
+
       text = '<1>Feb 28 12:00:02 192.168.0.1 fluentd[11111]: [error] Syslog test'
       @parser.instance.parse(text) do |time, record|
         assert_equal(event_time("Feb 28 12:00:02", format: '%b %d %M:%S:%H'), time)


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #2877 

**What this PR does / why we need it**: 
Regex to detect RFC5424 syslog format did not match  regex to parse it - leading to bugs

**Docs Changes**:
None

**Release Note**: 
Fix inappropriate parsing of some RFC3164 syslog messages with specific combination of characters (> followed by a number)