### PR TITLE
Syslog parser works with any time format

### DIFF
--- a/lib/fluent/plugin/parser_syslog.rb
+++ b/lib/fluent/plugin/parser_syslog.rb
@@ -148,11 +148,11 @@ module Fluent
 
         i = idx - 1
         @space_count.times do
-          while text[i + 1] == ' '
+          while text[i + 1] == ' '.freeze
             i += 1
           end
 
-          i = text.index(' ', i + 1)
+          i = text.index(' '.freeze, i + 1)
         end
 
         time_str = text.slice(idx, i - idx)
@@ -180,11 +180,11 @@ module Fluent
 
         i = idx - 1
         @space_count_rfc5424.times {
-          while text[i + 1] == ' '
+          while text[i + 1] == ' '.freeze
             i += 1
           end
 
-          i = text.index(' ', i + 1)
+          i = text.index(' '.freeze, i + 1)
         }
 
         time_str = text.slice(idx, i - idx)

--- a/lib/fluent/plugin/parser_syslog.rb
+++ b/lib/fluent/plugin/parser_syslog.rb
@@ -41,11 +41,11 @@ module Fluent
       REGEXP_DETECT_RFC5424 = /^\<[0-9]{1,3}\>[1-9]\d{0,2}/
 
       RFC3164_WITHOUT_TIME_AND_PRI_REGEXP = /(?<host>[^ ]*) (?<ident>[^ :\[]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$/
-      RFC3164_CAPTURES = ['host', 'ident', 'pid', 'message'].freeze
+      RFC3164_CAPTURES = RFC3164_WITHOUT_TIME_AND_PRI_REGEXP.names.freeze
       RFC3164_PRI_REGEXP = /^<(?<pri>[0-9]{1,3})>/
 
       RFC5424_WITHOUT_TIME_AND_PRI_REGEXP = /(?<host>[!-~]{1,255}) (?<ident>[!-~]{1,48}) (?<pid>[!-~]{1,128}) (?<msgid>[!-~]{1,32}) (?<extradata>(?:\-|(?:\[.*?(?<!\\)\])+))(?: (?<message>.+))?\z/m
-      RFC5424_CAPTURES = ['host', 'ident', 'extradata', 'pid', 'msgid', 'message'].freeze
+      RFC5424_CAPTURES = RFC5424_WITHOUT_TIME_AND_PRI_REGEXP.names.freeze
       RFC5424_PRI_REGEXP = /^<(?<pri>\d{1,3})>(?<version>\d\d{0,2})\s/
 
       config_set_default :time_format, "%b %d %H:%M:%S"

--- a/lib/fluent/plugin/parser_syslog.rb
+++ b/lib/fluent/plugin/parser_syslog.rb
@@ -172,9 +172,8 @@ module Fluent
 
         if @with_priority
           if (m = RFC5424_PRI_REGEXP.match(text))
-            m.names.each do |name|
-              record[name] = m[name]
-            end
+            record['pri'] = m['pri']
+            record['version'] = m['version']
             idx = m.end(0)
           else
             yield(nil, nil)

--- a/lib/fluent/plugin/parser_syslog.rb
+++ b/lib/fluent/plugin/parser_syslog.rb
@@ -93,6 +93,7 @@ module Fluent
         @time_parser_rfc5424_without_subseconds = time_parser_create(format: "%Y-%m-%dT%H:%M:%S%z")
       end
 
+      # this method is for tests
       def patterns
         {'format' => @regexp, 'time_format' => @time_format}
       end

--- a/lib/fluent/plugin/parser_syslog.rb
+++ b/lib/fluent/plugin/parser_syslog.rb
@@ -162,7 +162,9 @@ module Fluent
 
         time_str = sq ? text.slice(idx, i - idx).squeeze(' ') : text.slice(idx, i - idx)
         time = @mutex.synchronize { @time_parser.parse(time_str) }
-        record['time'] = time_str
+        if @keep_time_key
+          record['time'] = time_str
+        end
 
         parse_plain(time, text, i + 1, record, RFC3164_CAPTURES, &block)
       end
@@ -207,7 +209,9 @@ module Fluent
           end
         end
 
-        record['time'] = time_str
+        if @keep_time_key
+          record['time'] = time_str
+        end
         parse_plain(time, text, i + 1, record, RFC5424_CAPTURES, &block)
       end
 
@@ -220,10 +224,6 @@ module Fluent
         if m.nil?
           yield nil, nil
           return
-        end
-
-        unless @keep_time_key
-          record.delete('time'.freeze)
         end
 
         capture_list.each { |name|

--- a/lib/fluent/plugin/parser_syslog.rb
+++ b/lib/fluent/plugin/parser_syslog.rb
@@ -46,7 +46,7 @@ module Fluent
 
       RFC5424_WITHOUT_TIME_AND_PRI_REGEXP = /(?<host>[!-~]{1,255}) (?<ident>[!-~]{1,48}) (?<pid>[!-~]{1,128}) (?<msgid>[!-~]{1,32}) (?<extradata>(?:\-|(?:\[.*?(?<!\\)\])+))(?: (?<message>.+))?\z/m
       RFC5424_CAPTURES = RFC5424_WITHOUT_TIME_AND_PRI_REGEXP.names.freeze
-      RFC5424_PRI_REGEXP = /^<(?<pri>\d{1,3})>(?<version>\d\d{0,2})\s/
+      RFC5424_PRI_REGEXP = /^<(?<pri>\d{1,3})>\d\d{0,2}\s/
 
       config_set_default :time_format, "%b %d %H:%M:%S"
       desc 'If the incoming logs have priority prefix, e.g. <9>, set true'
@@ -176,7 +176,6 @@ module Fluent
         if @with_priority
           if (m = RFC5424_PRI_REGEXP.match(text))
             record['pri'] = m['pri']
-            record['version'] = m['version']
             idx = m.end(0)
           else
             yield(nil, nil)

--- a/lib/fluent/plugin/parser_syslog.rb
+++ b/lib/fluent/plugin/parser_syslog.rb
@@ -62,6 +62,7 @@ module Fluent
         super
         @mutex = Mutex.new
         @space_count = nil
+        @space_count_rfc5424 = nil
       end
 
       def configure(conf)

--- a/lib/fluent/plugin/parser_syslog.rb
+++ b/lib/fluent/plugin/parser_syslog.rb
@@ -147,15 +147,17 @@ module Fluent
         end
 
         i = idx - 1
+        sq = false
         @space_count.times do
           while text[i + 1] == ' '.freeze
+            sq = true
             i += 1
           end
 
           i = text.index(' '.freeze, i + 1)
         end
 
-        time_str = text.slice(idx, i - idx)
+        time_str = sq ? text.slice(idx, i - idx).squeeze(' ') : text.slice(idx, i - idx)
         time = @mutex.synchronize { @time_parser.parse(time_str) }
         record['time'] = time_str
 
@@ -179,15 +181,17 @@ module Fluent
         end
 
         i = idx - 1
+        sq = false
         @space_count_rfc5424.times {
           while text[i + 1] == ' '.freeze
+            sq = true
             i += 1
           end
 
           i = text.index(' '.freeze, i + 1)
         }
 
-        time_str = text.slice(idx, i - idx)
+        time_str = sq ? text.slice(idx, i - idx).squeeze(' '.freeze) : text.slice(idx, i - idx)
         time = @mutex.synchronize do
           begin
             @time_parser.parse(time_str)
@@ -215,9 +219,7 @@ module Fluent
           return
         end
 
-        if @keep_time_key
-          record['time'].squeeze!(' ')
-        else
+        unless @keep_time_key
           record.delete('time'.freeze)
         end
 

--- a/lib/fluent/plugin/parser_syslog.rb
+++ b/lib/fluent/plugin/parser_syslog.rb
@@ -139,9 +139,10 @@ module Fluent
         record = {}
 
         if @with_priority
-          if (m = RFC3164_PRI_REGEXP.match(text))
-            record['pri'] = Integer(m['pri'])
-            idx = m.end(0)
+          if RFC3164_PRI_REGEXP.match?(text)
+            v = text.index('>')
+            record['pri'] = text[1..v].to_i # trim `<` and ``>
+            idx = v + 1
           else
             yield(nil, nil)
             return

--- a/test/plugin/test_parser_syslog.rb
+++ b/test/plugin/test_parser_syslog.rb
@@ -21,7 +21,7 @@ class SyslogParserTest < ::Test::Unit::TestCase
       assert_equal(event_time('Feb 28 12:00:00', format: '%b %d %H:%M:%S'), time)
       assert_equal(@expected, record)
     }
-    assert_equal(Fluent::Plugin::SyslogParser::REGEXP, @parser.instance.patterns['format'])
+    assert_equal(Fluent::Plugin::SyslogParser::RFC3164_WITHOUT_TIME_AND_PRI_REGEXP, @parser.instance.patterns['format'])
     assert_equal("%b %d %H:%M:%S", @parser.instance.patterns['time_format'])
   end
 
@@ -51,7 +51,7 @@ class SyslogParserTest < ::Test::Unit::TestCase
       assert_equal(event_time('Feb 28 12:00:00', format: '%b %d %H:%M:%S'), time)
       assert_equal(@expected.merge('pri' => 6), record)
     }
-    assert_equal(Fluent::Plugin::SyslogParser::REGEXP_WITH_PRI, @parser.instance.patterns['format'])
+    assert_equal(Fluent::Plugin::SyslogParser::RFC3164_WITHOUT_TIME_AND_PRI_REGEXP, @parser.instance.patterns['format'])
     assert_equal("%b %d %H:%M:%S", @parser.instance.patterns['time_format'])
   end
 
@@ -71,7 +71,7 @@ class SyslogParserTest < ::Test::Unit::TestCase
       assert_equal(event_time('Feb 28 12:00:00', format: '%b %d %H:%M:%S'), time)
       assert_equal(@expected, record)
     }
-    assert_equal(Fluent::Plugin::SyslogParser::REGEXP, @parser.instance.patterns['format'])
+    assert_equal(Fluent::Plugin::SyslogParser::RFC3164_WITHOUT_TIME_AND_PRI_REGEXP, @parser.instance.patterns['format'])
     assert_equal("%b %d %H:%M:%S", @parser.instance.patterns['time_format'])
   end
 
@@ -184,8 +184,7 @@ class SyslogParserTest < ::Test::Unit::TestCase
         assert_equal "-", record["extradata"]
         assert_equal "Hi, from Fluentd!", record["message"]
       end
-      assert_equal(Fluent::Plugin::SyslogParser::REGEXP_RFC5424_WITH_PRI,
-                   @parser.instance.patterns['format'])
+      assert_equal(Fluent::Plugin::SyslogParser::RFC5424_WITHOUT_TIME_AND_PRI_REGEXP, @parser.instance.patterns['format'])
     end
 
     def test_parse_with_rfc5424_message_trailing_eol
@@ -202,8 +201,7 @@ class SyslogParserTest < ::Test::Unit::TestCase
         assert_equal "-", record["extradata"]
         assert_equal "Hi, from Fluentd!", record["message"]
       end
-      assert_equal(Fluent::Plugin::SyslogParser::REGEXP_RFC5424_WITH_PRI,
-                   @parser.instance.patterns['format'])
+      assert_equal(Fluent::Plugin::SyslogParser::RFC5424_WITHOUT_TIME_AND_PRI_REGEXP, @parser.instance.patterns['format'])
     end
 
     def test_parse_with_rfc5424_multiline_message
@@ -220,8 +218,7 @@ class SyslogParserTest < ::Test::Unit::TestCase
         assert_equal "-", record["extradata"]
         assert_equal "Hi,\nfrom\nFluentd!", record["message"]
       end
-      assert_equal(Fluent::Plugin::SyslogParser::REGEXP_RFC5424_WITH_PRI,
-                   @parser.instance.patterns['format'])
+      assert_equal(Fluent::Plugin::SyslogParser::RFC5424_WITHOUT_TIME_AND_PRI_REGEXP, @parser.instance.patterns['format'])
     end
 
     def test_parse_with_rfc5424_message_and_without_priority
@@ -237,8 +234,7 @@ class SyslogParserTest < ::Test::Unit::TestCase
         assert_equal "-", record["extradata"]
         assert_equal "Hi, from Fluentd!", record["message"]
       end
-      assert_equal(Fluent::Plugin::SyslogParser::REGEXP_RFC5424_NO_PRI,
-                   @parser.instance.patterns['format'])
+      assert_equal(Fluent::Plugin::SyslogParser::RFC5424_WITHOUT_TIME_AND_PRI_REGEXP, @parser.instance.patterns['format'])
     end
 
     def test_parse_with_rfc5424_empty_message_and_without_priority
@@ -254,8 +250,7 @@ class SyslogParserTest < ::Test::Unit::TestCase
         assert_equal "-", record["extradata"]
         assert_nil record["message"]
       end
-      assert_equal(Fluent::Plugin::SyslogParser::REGEXP_RFC5424_NO_PRI,
-                   @parser.instance.patterns['format'])
+      assert_equal(Fluent::Plugin::SyslogParser::RFC5424_WITHOUT_TIME_AND_PRI_REGEXP, @parser.instance.patterns['format'])
     end
 
     def test_parse_with_rfc5424_message_without_time_format
@@ -408,7 +403,7 @@ class SyslogParserTest < ::Test::Unit::TestCase
         assert_equal(event_time("Feb 28 00:00:12", format: '%b %d %M:%S:%H'), time)
         assert_equal(@expected, record)
       end
-      assert_equal(Fluent::Plugin::SyslogParser::REGEXP, @parser.instance.patterns['format'])
+      assert_equal(Fluent::Plugin::SyslogParser::RFC3164_WITHOUT_TIME_AND_PRI_REGEXP, @parser.instance.patterns['format'])
     end
 
     data('regexp' => 'regexp', 'string' => 'string')
@@ -424,7 +419,7 @@ class SyslogParserTest < ::Test::Unit::TestCase
         assert_equal(event_time("Feb 28 12:00:00", format: '%b %d %M:%S:%H'), time)
         assert_equal(@expected.merge('pri' => 6), record)
       end
-      assert_equal(Fluent::Plugin::SyslogParser::REGEXP_WITH_PRI, @parser.instance.patterns['format'])
+      assert_equal(Fluent::Plugin::SyslogParser::RFC3164_WITHOUT_TIME_AND_PRI_REGEXP, @parser.instance.patterns['format'])
     end
 
     data('regexp' => 'regexp', 'string' => 'string')
@@ -443,8 +438,7 @@ class SyslogParserTest < ::Test::Unit::TestCase
         assert_equal "-", record["extradata"]
         assert_equal "Hi, from Fluentd!", record["message"]
       end
-      assert_equal(Fluent::Plugin::SyslogParser::REGEXP_RFC5424_WITH_PRI,
-                   @parser.instance.patterns['format'])
+      assert_equal(Fluent::Plugin::SyslogParser::RFC5424_WITHOUT_TIME_AND_PRI_REGEXP, @parser.instance.patterns['format'])
     end
 
     data('regexp' => 'regexp', 'string' => 'string')
@@ -464,9 +458,7 @@ class SyslogParserTest < ::Test::Unit::TestCase
                      record["extradata"]
         assert_equal "Hi, from Fluentd!", record["message"]
       end
-      assert_equal(Fluent::Plugin::SyslogParser::REGEXP_RFC5424_WITH_PRI,
-                   @parser.instance.patterns['format'])
-    end
+      assert_equal(Fluent::Plugin::SyslogParser::RFC5424_WITHOUT_TIME_AND_PRI_REGEXP, @parser.instance.patterns['format'])end
 
     data('regexp' => 'regexp', 'string' => 'string')
     def test_parse_with_both_message_type(param)
@@ -482,7 +474,7 @@ class SyslogParserTest < ::Test::Unit::TestCase
         assert_equal(event_time("Feb 28 12:00:00", format: '%b %d %M:%S:%H'), time)
         assert_equal(@expected.merge('pri' => 1), record)
       end
-      assert_equal(Fluent::Plugin::SyslogParser::REGEXP_WITH_PRI, @parser.instance.patterns['format'])
+      assert_equal(Fluent::Plugin::SyslogParser::RFC3164_WITHOUT_TIME_AND_PRI_REGEXP, @parser.instance.patterns['format'])
 
       text = '<16>1 2017-02-06T13:14:15.003Z 192.168.0.1 fluentd 11111 ID24224 [exampleSDID@20224 iut="3" eventSource="Application" eventID="11211"] Hi, from Fluentd!'
       @parser.instance.parse(text) do |time, record|
@@ -493,22 +485,21 @@ class SyslogParserTest < ::Test::Unit::TestCase
                      record["extradata"]
         assert_equal "Hi, from Fluentd!", record["message"]
       end
-      assert_equal(Fluent::Plugin::SyslogParser::REGEXP_RFC5424_WITH_PRI,
-                   @parser.instance.patterns['format'])
+      assert_equal(Fluent::Plugin::SyslogParser::RFC5424_WITHOUT_TIME_AND_PRI_REGEXP, @parser.instance.patterns['format'])
 
       text = '<1>Feb 28 12:00:02 192.168.0.1 fluentd[11111]: [error] Syslog test 2>1'
       @parser.instance.parse(text) do |time, record|
-         assert_equal(event_time("Feb 28 12:00:02", format: '%b %d %M:%S:%H'), time)
-         assert_equal(@expected.merge('pri' => 1, 'message'=> '[error] Syslog test 2>1'), record)
-       end
-       assert_equal(Fluent::Plugin::SyslogParser::REGEXP_WITH_PRI, @parser.instance.patterns['format'])
+        assert_equal(event_time("Feb 28 12:00:02", format: '%b %d %M:%S:%H'), time)
+        assert_equal(@expected.merge('pri' => 1, 'message'=> '[error] Syslog test 2>1'), record)
+      end
+      assert_equal(Fluent::Plugin::SyslogParser::RFC3164_WITHOUT_TIME_AND_PRI_REGEXP, @parser.instance.patterns['format'])
 
       text = '<1>Feb 28 12:00:02 192.168.0.1 fluentd[11111]: [error] Syslog test'
       @parser.instance.parse(text) do |time, record|
         assert_equal(event_time("Feb 28 12:00:02", format: '%b %d %M:%S:%H'), time)
         assert_equal(@expected.merge('pri' => 1), record)
       end
-      assert_equal(Fluent::Plugin::SyslogParser::REGEXP_WITH_PRI, @parser.instance.patterns['format'])
+      assert_equal(Fluent::Plugin::SyslogParser::RFC3164_WITHOUT_TIME_AND_PRI_REGEXP, @parser.instance.patterns['format'])
 
       text = '<16>1 2017-02-06T13:14:15.003Z 192.168.0.1 fluentd - - - Hi, from Fluentd!'
       @parser.instance.parse(text) do |time, record|
@@ -518,8 +509,7 @@ class SyslogParserTest < ::Test::Unit::TestCase
         assert_equal "-", record["extradata"]
         assert_equal "Hi, from Fluentd!", record["message"]
       end
-      assert_equal(Fluent::Plugin::SyslogParser::REGEXP_RFC5424_WITH_PRI,
-                   @parser.instance.patterns['format'])
+      assert_equal(Fluent::Plugin::SyslogParser::RFC5424_WITHOUT_TIME_AND_PRI_REGEXP, @parser.instance.patterns['format'])
     end
 
     data('regexp' => 'regexp', 'string' => 'string')
@@ -536,7 +526,7 @@ class SyslogParserTest < ::Test::Unit::TestCase
         assert_equal(event_time("Feb 28 12:00:00", format: '%b %d %M:%S:%H'), time)
         assert_equal(@expected.merge('pri' => 6), record)
       end
-      assert_equal(Fluent::Plugin::SyslogParser::REGEXP_WITH_PRI, @parser.instance.patterns['format'])
+      assert_equal(Fluent::Plugin::SyslogParser::RFC3164_WITHOUT_TIME_AND_PRI_REGEXP, @parser.instance.patterns['format'])
 
       text = '<16>1 2017-02-06T13:14:15.003Z 192.168.0.1 fluentd 11111 ID24224 [exampleSDID@20224 iut="3" eventSource="Application" eventID="11211"] Hi, from Fluentd!'
       @parser.instance.parse(text) do |time, record|
@@ -547,15 +537,14 @@ class SyslogParserTest < ::Test::Unit::TestCase
                      record["extradata"]
         assert_equal "Hi, from Fluentd!", record["message"]
       end
-      assert_equal(Fluent::Plugin::SyslogParser::REGEXP_RFC5424_WITH_PRI,
-                   @parser.instance.patterns['format'])
+      assert_equal(Fluent::Plugin::SyslogParser::RFC5424_WITHOUT_TIME_AND_PRI_REGEXP, @parser.instance.patterns['format'])
 
       text = '<16>Feb 28 12:00:02 192.168.0.1 fluentd[11111]: [error] Syslog test'
       @parser.instance.parse(text) do |time, record|
         assert_equal(event_time("Feb 28 12:00:02", format: '%b %d %M:%S:%H'), time)
         assert_equal(@expected.merge('pri' => 16), record)
       end
-      assert_equal(Fluent::Plugin::SyslogParser::REGEXP_WITH_PRI, @parser.instance.patterns['format'])
+      assert_equal(Fluent::Plugin::SyslogParser::RFC3164_WITHOUT_TIME_AND_PRI_REGEXP, @parser.instance.patterns['format'])
 
       text = '<16>1 2017-02-06T13:14:15.003Z 192.168.0.1 fluentd - - - Hi, from Fluentd!'
       @parser.instance.parse(text) do |time, record|
@@ -565,8 +554,7 @@ class SyslogParserTest < ::Test::Unit::TestCase
         assert_equal "-", record["extradata"]
         assert_equal "Hi, from Fluentd!", record["message"]
       end
-      assert_equal(Fluent::Plugin::SyslogParser::REGEXP_RFC5424_WITH_PRI,
-                   @parser.instance.patterns['format'])
+      assert_equal(Fluent::Plugin::SyslogParser::RFC5424_WITHOUT_TIME_AND_PRI_REGEXP, @parser.instance.patterns['format'])
 
       text = '<16>1 2017-02-06T13:14:15Z 192.168.0.1 fluentd - - - Hi, from Fluentd without subseconds!'
       @parser.instance.parse(text) do |time, record|
@@ -576,8 +564,7 @@ class SyslogParserTest < ::Test::Unit::TestCase
         assert_equal "-", record["extradata"]
         assert_equal "Hi, from Fluentd without subseconds!", record["message"]
       end
-      assert_equal(Fluent::Plugin::SyslogParser::REGEXP_RFC5424_WITH_PRI,
-                   @parser.instance.patterns['format'])
+      assert_equal(Fluent::Plugin::SyslogParser::RFC5424_WITHOUT_TIME_AND_PRI_REGEXP, @parser.instance.patterns['format'])
     end
   end
 end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes https://github.com/fluent/fluentd/issues/2856

**What this PR does / why we need it**: 

Setting `time_format`  in syslog hasn't worked well in some situations.
I made a change to work with all formats.  There is no performance degradation.

```rb
require 'benchmark/ips'
require 'fluent/env'
require 'fluent/engine'
require_relative '../lib/fluent/plugin/parser_syslog'

parser = Fluent::Plugin::SyslogParser.new
parser.configure(Fluent::Config::Element.new('ROOT', '', {'keep_time_key' => true}, []))
log = 'Feb 28 12:00:00 192.168.0.1 fluentd[11111]: [error] Syslog test'
parser2 = Fluent::Plugin::SyslogParser.new
parser2.configure(Fluent::Config::Element.new('ROOT', '', {'with_priority' => true, 'keep_time_key' => true}, []))
log2 = '<1>Feb 28 12:00:00 192.168.0.1 fluentd[11111]: [error] Syslog test'

Benchmark.ips do |x|
  x.report "regexp" do
    parser.parse(log) { |t, r| }
  end
  x.report "string" do
    parser.parse_rfc3164(log) { |t, r| }
  end
  x.report "regexp with pri" do
    parser2.parse(log2) { |t, r| }
  end
  x.report "string with pri" do
    parser2.parse_rfc3164(log2) { |t, r| }
  end
end
```

master branch

```
Warming up --------------------------------------
              regexp    22.312k i/100ms
              string    58.311k i/100ms
     regexp with pri    20.555k i/100ms
     string with pri    48.698k i/100ms
Calculating -------------------------------------
              regexp    248.764k (± 4.0%) i/s -      1.249M in   5.031343s
              string    669.950k (± 3.7%) i/s -      3.382M in   5.055510s
     regexp with pri    225.592k (± 3.5%) i/s -      1.131M in   5.017706s
     string with pri    554.281k (± 3.0%) i/s -      2.776M in   5.012618s
```

this branch
```
Warming up --------------------------------------
              regexp    24.435k i/100ms
              string    59.052k i/100ms
     regexp with pri    21.334k i/100ms
     string with pri    48.109k i/100ms
Calculating -------------------------------------
              regexp    262.246k (± 3.3%) i/s -      1.319M in   5.037310s
              string    644.082k (± 2.8%) i/s -      3.248M in   5.046689s
     regexp with pri    225.242k (± 3.5%) i/s -      1.131M in   5.026692s
     string with pri    510.475k (± 7.3%) i/s -      2.550M in   5.026552s
```

**Docs Changes**:

no need

**Release Note**: 

same as the title

