### PR TITLE
server: Add cert_verifier parameter for TLS transport

### DIFF
--- a/lib/fluent/plugin_helper/cert_option.rb
+++ b/lib/fluent/plugin_helper/cert_option.rb
@@ -46,8 +46,13 @@ module Fluent
           ctx.extra_chain_cert = extra
         end
         if conf.cert_verifier
-          verifier = File.exist?(conf.cert_verifier) ? File.read(conf.cert_verifier) : conf.cert_verifier
-          ctx.verify_callback = self.instance_eval(verifier, File.basename(conf.cert_verifier))
+          sandbox = Class.new
+          ctx.verify_callback = if File.exist?(conf.cert_verifier)
+                                  verifier = File.read(conf.cert_verifier)
+                                  sandbox.instance_eval(verifier, File.basename(conf.cert_verifier))
+                                else
+                                  sandbox.instance_eval(conf.cert_verifier)
+                                end
         end
 
         Fluent::TLS.set_version_to_context(ctx, version, conf.min_version, conf.max_version)

--- a/lib/fluent/plugin_helper/cert_option.rb
+++ b/lib/fluent/plugin_helper/cert_option.rb
@@ -36,7 +36,7 @@ module Fluent
         end
 
         if conf.client_cert_auth
-            ctx.verify_mode = OpenSSL::SSL::VERIFY_PEER | OpenSSL::SSL::VERIFY_FAIL_IF_NO_PEER_CERT
+          ctx.verify_mode = OpenSSL::SSL::VERIFY_PEER | OpenSSL::SSL::VERIFY_FAIL_IF_NO_PEER_CERT
         end
 
         ctx.ca_file = conf.ca_path
@@ -45,6 +45,11 @@ module Fluent
         if extra && !extra.empty?
           ctx.extra_chain_cert = extra
         end
+        if conf.cert_verifier
+          verifier = File.exist?(conf.cert_verifier) ? File.read(conf.cert_verifier) : conf.cert_verifier
+          ctx.verify_callback = self.instance_eval(verifier)
+        end
+
         Fluent::TLS.set_version_to_context(ctx, version, conf.min_version, conf.max_version)
 
         ctx

--- a/lib/fluent/plugin_helper/cert_option.rb
+++ b/lib/fluent/plugin_helper/cert_option.rb
@@ -47,7 +47,7 @@ module Fluent
         end
         if conf.cert_verifier
           verifier = File.exist?(conf.cert_verifier) ? File.read(conf.cert_verifier) : conf.cert_verifier
-          ctx.verify_callback = self.instance_eval(verifier)
+          ctx.verify_callback = self.instance_eval(verifier, File.basename(conf.cert_verifier))
         end
 
         Fluent::TLS.set_version_to_context(ctx, version, conf.min_version, conf.max_version)

--- a/lib/fluent/plugin_helper/server.rb
+++ b/lib/fluent/plugin_helper/server.rb
@@ -243,7 +243,7 @@ module Fluent
         :protocol, :version, :min_version, :max_version, :ciphers, :insecure,
         :ca_path, :cert_path, :private_key_path, :private_key_passphrase, :client_cert_auth,
         :ca_cert_path, :ca_private_key_path, :ca_private_key_passphrase,
-        :generate_private_key_length,
+        :cert_verifier, :generate_private_key_length,
         :generate_cert_country, :generate_cert_state, :generate_cert_state,
         :generate_cert_locality, :generate_cert_common_name,
         :generate_cert_expiration, :generate_cert_digest,
@@ -280,6 +280,8 @@ module Fluent
           config_param :ca_cert_path, :string, default: nil
           config_param :ca_private_key_path, :string, default: nil
           config_param :ca_private_key_passphrase, :string, default: nil, secret: true
+
+          config_param :cert_verifier, :string, default: nil
 
           # Options for generating certs by private CA certs or self-signed
           config_param :generate_private_key_length, :integer, default: 2048


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
No issue.

**What this PR does / why we need it**: 
Support user defined verifier for certificate via `cert_verifier` parameter.
This parameter uses `SSLContext#verify_callback` internally.

- conf

```
<transport tls>
 # other parameters...
  client_cert_auth true
  cert_verifier /path/to/cert_checker.rb
</transport>
```

### cert_checker.rb example

Code must be return callbale object. It means returned object must have `#call` method with 2 arguments.

- Proc or lambda for simple case

```
Proc.new { |ok, ctx|
  # check code
}
```

- Use class for complicated case

```
class HooBarChecker
  def initialize
    # Setup data
  end

  def call(ok, ctx)
    # check code
  end
end

HooBarChecker.new
```

Here is actual command and conf: https://gist.github.com/repeatedly/6df9881d7ce62bcf321e2a07799d8909

**Docs Changes**:
Add `cert_verifier` to TLS parameters

**Release Note**: 
Same as title.