### PR TITLE
emit_count can be bigger than num_events

### DIFF
--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -237,7 +237,7 @@ class TailInputTest < Test::Unit::TestCase
       assert_equal(true, events.length > 0)
       assert_equal({"message" => msg}, events[0][2])
       assert_equal({"message" => msg}, events[1][2])
-      assert_equal(num_events, d.emit_count)
+      assert num_events <= d.emit_count
     end
 
     data(flat: CONFIG_READ_FROM_HEAD + SINGLE_LINE_CONFIG,


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes https://travis-ci.org/github/fluent/fluentd/jobs/663376812#L619

**What this PR does / why we need it**: 

Fluent::Test::Driver#run assumes that it emits the mount of message bigger than `expect_emits`.

https://github.com/fluent/fluentd/blob/4d7cb814064c244841c3c94c977ed8dd2e530de0/lib/fluent/test/driver/base_owner.rb#L124


**Docs Changes**:

no need

**Release Note**: 

no need
