### PR TITLE
Wait until `@tails` is set a new watcher

### DIFF
--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -1078,11 +1078,11 @@ class TailInputTest < Test::Unit::TestCase
                                 "refresh_interval" => 1,
                               })
       d = create_driver(config, false)
-      d.run(expect_emits: 1, shutdown: false) do
+      d.end_if { d.instance.instance_variable_get(:@tails).keys.size >= 1 }
+      d.run(expect_emits: 1, shutdown: false, timeout: 1) do
         File.open("#{TMP_DIR}/tail.txt", "ab") { |f| f.puts "test3\n" }
       end
 
-      assert_equal 1, d.instance.instance_variable_get(:@tails).keys.size
       cleanup_directory(TMP_DIR)
       waiting(20) { sleep 0.1 until Dir.glob("#{TMP_DIR}/*.txt").size == 0 } # Ensure file is deleted on Windows
       waiting(5) { sleep 0.1 until d.instance.instance_variable_get(:@tails).keys.size == 0 }


### PR DESCRIPTION
Signed-off-by: Yuta Iwama <ganmacs@gmail.com>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
fixes https://travis-ci.org/github/fluent/fluentd/jobs/663388229#L761

**What this PR does / why we need it**: 

`@tails` can be 0 after Driver::Base#run
when [this line](https://github.com/fluent/fluentd/blob/2b7ed60ddc7edbab0dcbb57d4a13c4dd5175512d/lib/fluent/test/driver/base.rb#L96
) is performed between [#setup_watcher](https://github.com/fluent/fluentd/blob/2b7ed60ddc7edbab0dcbb57d4a13c4dd5175512d/lib/fluent/plugin/in_tail.rb#L334) in [#start_watchers](https://github.com/fluent/fluentd/blob/2b7ed60ddc7edbab0dcbb57d4a13c4dd5175512d/lib/fluent/plugin/in_tail.rb#L368) and [setting the value to @tails](https://github.com/fluent/fluentd/blob/2b7ed60ddc7edbab0dcbb57d4a13c4dd5175512d/lib/fluent/plugin/in_tail.rb#L373)

**Docs Changes**:

no need

**Release Note**: 

no need
