### PR TITLE
Make compress test stable

### DIFF
--- a/test/plugin/test_compressable.rb
+++ b/test/plugin/test_compressable.rb
@@ -4,6 +4,12 @@ require 'fluent/plugin/compressable'
 class CompressableTest < Test::Unit::TestCase
   include Fluent::Plugin::Compressable
 
+  def compress_assert_equal(expected, actual)
+    e = Zlib::GzipReader.new(StringIO.new(expected)).read
+    a = Zlib::GzipReader.new(StringIO.new(actual)).read
+    assert_equal(e, a)
+  end
+
   sub_test_case '#compress' do
     setup do
       @src = 'text data for compressing' * 5
@@ -18,8 +24,7 @@ class CompressableTest < Test::Unit::TestCase
     test 'write compressed data to IO with output_io option' do
       io = StringIO.new
       compress(@src, output_io: io)
-      waiting(10){ sleep 0.1 until @gzipped_src == io.string }
-      assert_equal @gzipped_src, io.string
+      compress_assert_equal @gzipped_src, io.string
     end
   end
 

--- a/test/plugin/test_compressable.rb
+++ b/test/plugin/test_compressable.rb
@@ -36,7 +36,6 @@ class CompressableTest < Test::Unit::TestCase
     test 'write decompressed data to IO with output_io option' do
       io = StringIO.new
       decompress(@gzipped_src, output_io: io)
-      waiting(10){ sleep 0.1 until @src == io.string }
       assert_equal @src, io.string
     end
 
@@ -58,7 +57,6 @@ class CompressableTest < Test::Unit::TestCase
       output_io = StringIO.new
 
       decompress(input_io: input_io, output_io: output_io)
-      waiting(10){ sleep 0.1 until @src == output_io.string }
       assert_equal @src, output_io.string
     end
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes https://travis-ci.org/github/fluent/fluentd/jobs/662952965#L617

**What this PR does / why we need it**: 

Making gzip's header uses time so it doesn't return the same value.
https://github.com/ruby/ruby/blob/afd23ed0491b9df0b6a1753a2f66cd3f80428930/ext/zlib/zlib.c#L2520

```rb
require 'zlib'
require 'stringio'

def compress(data, **kwargs)
  output_io = kwargs[:output_io]
  io = output_io || StringIO.new
  Zlib::GzipWriter.wrap(io, Zlib::DEFAULT_COMPRESSION, Zlib::FILTERED) do |gz|
    gz.write data
  end
  output_io || io.string
end

@src = 'text data for compressing' * 5
v = compress(@src)

sleep 2                         # needed

io = StringIO.new
a = compress(@src, output_io: io)
v1 = a.string
if v != v1
  p v
  p v1
end
```

**Docs Changes**:
no need

**Release Note**: 
no need