### PR TITLE
Avoid timeout of retry state

### DIFF
--- a/test/plugin/test_output_as_buffered_secondary.rb
+++ b/test/plugin/test_output_as_buffered_secondary.rb
@@ -617,7 +617,7 @@ class BufferedOutputSecondaryTest < Test::Unit::TestCase
       assert{ !chunks[1].empty? }
 
       30.times do |i| # large enough
-        now = first_failure + 60 * 0.8 + 2 + i
+        now = first_failure + 60 * 0.8 + 2 + [i, 10].min # must be less than retry_timeout
         Timecop.freeze( now )
         @i.flush_thread_wakeup
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes https://travis-ci.org/github/fluent/fluentd/jobs/664260115#L1720

**What this PR does / why we need it**: 

If it exceeds the retry limit,  https://travis-ci.org/github/fluent/fluentd/jobs/664260115#L1720 can happen (setting nil to `@retry`).
https://github.com/fluent/fluentd/blob/b18f995335b5d573cfbb56bc3e2759c2d287da67/lib/fluent/plugin/output.rb#L1241


if `i` become over 10, `@i.retry` can be `nil`.
https://github.com/fluent/fluentd/blob/b18f995335b5d573cfbb56bc3e2759c2d287da67/test/plugin/test_output_as_buffered_secondary.rb#L619-L625

**Docs Changes**:

no need

**Release Note**: 

no need