### PR TITLE
Stop to output deprecated warning log about MessagePackFactory::Mixin multiple times for performance

### DIFF
--- a/lib/fluent/msgpack_factory.rb
+++ b/lib/fluent/msgpack_factory.rb
@@ -23,24 +23,31 @@ module Fluent
 
     module Mixin
       def msgpack_factory
-        if $log
-          $log.warn('Deprecated method: this method is going to be deleted. Use Fluent::MessagePackFactory.engine_factory')
+        unless @deprecated_log_done
+          deprecated_log('Deprecated method: this method is going to be deleted. Use Fluent::MessagePackFactory.engine_factory')
         end
         MessagePackFactory.engine_factory
       end
 
       def msgpack_packer(*args)
-        if $log
-          $log.warn('Deprecated method: this method is going to be deleted. Use Fluent::MessagePackFactory.msgpack_packer')
+        unless @deprecated_log_done
+          deprecated_log('Deprecated method: this method is going to be deleted. Use Fluent::MessagePackFactory.msgpack_packer')
         end
         MessagePackFactory.msgpack_packer(*args)
       end
 
       def msgpack_unpacker(*args)
-        if $log
-          $log.warn('Deprecated method: this method is going to be deleted. Use Fluent::MessagePackFactory.msgpack_unpacker')
+        unless @deprecated_log_done
+          deprecated_log('Deprecated method: this method is going to be deleted. Use Fluent::MessagePackFactory.msgpack_unpacker')
         end
         MessagePackFactory.msgpack_unpacker(*args)
+      end
+
+      def deprecated_log(str)
+        if $log
+          $log.warn(str)
+          @deprecated_log_done = true
+        end
       end
     end
 

--- a/test/test_msgpack_factory.rb
+++ b/test/test_msgpack_factory.rb
@@ -1,0 +1,18 @@
+require_relative 'helper'
+require 'fluent/msgpack_factory'
+
+class MessagePackFactoryTest < Test::Unit::TestCase
+  test 'call log.warn only once' do
+    klass = Class.new do
+      include Fluent::MessagePackFactory::Mixin
+    end
+
+    mp = klass.new
+
+    mock.proxy($log).warn(anything).once
+
+    assert mp.msgpack_factory
+    assert mp.msgpack_factory
+    assert mp.msgpack_factory
+  end
+end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes https://github.com/fluent/fluentd/issues/2871

**What this PR does / why we need it**: 

Stop to output a deprecated warning multiple times.
fluent-plugin-google-cloud uses  Fluent::Engine.msgpack_factory and the method changed  deprecated in [this commit](https://github.com/fluent/fluentd/commit/7b166f08f1f1c5d7aa8f49709843bc0b332ee33e).
https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/blob/65b9d0e1afdec26ea14e01d7a731f05d499d3477/lib/fluent/plugin/out_google_cloud.rb#L1912


The deprecated method print [warning log]( https://github.com/fluent/fluentd/commit/fcd467c722c491919c7044c772e9e49ead3ef787#diff-2127cc829c2d543c1d9564680b1d4050R33) and it causes the performance issue.

**Docs Changes**:

no need

**Release Note**: 

same as the title.

**bechmark**

```
Warming up --------------------------------------
            original   346.805k i/100ms
                 now   243.599k i/100ms
                 new   345.928k i/100ms
Calculating -------------------------------------
            original     11.621M (± 5.3%) i/s -     57.916M in   4.999822s
                 now      4.617M (± 4.7%) i/s -     23.142M in   5.023242s
                 new     11.359M (± 4.6%) i/s -     56.732M in   5.005022s
```

```rb
require 'benchmark/ips'
require 'logger'
require 'msgpack'

$log = Logger.new(nil)

module MessagePackFactory
  @@engine_factory = nil

  def self.engine_factory(enable_time_support: false)
    @@engine_factory || factory(enable_time_support: enable_time_support)
  end

  def self.factory(enable_time_support: false)
    @@engine_factory = MessagePack::Factory.new
  end
end

module Mixin
  def msgpack_factory_original
    MessagePackFactory.engine_factory
  end

  def msgpack_factory
    if $log
      $log.warn('Deprecated method: this method is going to be deleted. Use Fluent::MessagePackFactory.engine_factory')
    end

    MessagePackFactory.engine_factory
  end

  def msgpack_factory_cache
    unless @deprecated_log_done
      deprecated_log { 'Deprecated method: this method is going to be deleted. Use Fluent::MessagePackFactory.engine_factory' }
    end
    MessagePackFactory.engine_factory
  end

  def deprecated_log
    if $log
      $log.warn(yield)
      @deprecated_log_done = true
    end
  end
end

class A
  include Mixin
end

a = A.new
b = A.new
c = A.new

Benchmark.ips do |x|
  x.report "original" do
    a.msgpack_factory_original
  end

  x.report "now" do
    b.msgpack_factory
  end

  x.report "new" do
    c.msgpack_factory_cache
  end
end
```