### PR TITLE
60 * 0.8 + 2 * i should be less than retry_state

### DIFF
--- a/test/plugin/test_output_as_buffered_secondary.rb
+++ b/test/plugin/test_output_as_buffered_secondary.rb
@@ -617,7 +617,7 @@ class BufferedOutputSecondaryTest < Test::Unit::TestCase
       assert{ !chunks[1].empty? }
 
       30.times do |i| # large enough
-        now = first_failure + 60 * 0.8 + 2 + [i, 10].min # must be less than retry_timeout
+        now = first_failure + 60 * 0.8 + 2 + [i, 9].min # must be less than retry_timeout
         Timecop.freeze( now )
         @i.flush_thread_wakeup
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Follow up https://github.com/fluent/fluentd/pull/2901

**What this PR does / why we need it**: 

in this test retry_state = 60. So `i` should be less than 9

https://github.com/fluent/fluentd/blob/b18f995335b5d573cfbb56bc3e2759c2d287da67/lib/fluent/plugin_helper/retry_state.rb#L134

**Docs Changes**:

no need

**Release Note**: 

no need
