### PR TITLE
Allow to launch fluentd from `C:\Program Files\`

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -882,7 +882,11 @@ module Fluent
     RUBY_ENCODING_OPTIONS_REGEX = %r{\A(-E|--encoding=|--internal-encoding=|--external-encoding=)}.freeze
 
     def build_spawn_command
-      fluentd_spawn_cmd = [ServerEngine.ruby_bin_path]
+      if ENV['TEST_RUBY_PATH']
+        fluentd_spawn_cmd = [ENV['TEST_RUBY_PATH']]
+      else
+        fluentd_spawn_cmd = [ServerEngine.ruby_bin_path]
+      end
 
       rubyopt = ENV['RUBYOPT']
       if rubyopt

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -897,10 +897,9 @@ module Fluent
 
       # Adding `-h` so that it can avoid ruby's command blocking
       # e.g. `ruby -Eascii-8bit:ascii-8bit` will block. but `ruby -Eascii-8bit:ascii-8bit -h` won't.
-      cmd = fluentd_spawn_cmd.join(' ')
-      _, e, s = Open3.capture3("#{cmd} -h")
+      _, e, s = Open3.capture3(*fluentd_spawn_cmd, "-h")
       if s.exitstatus != 0
-        $log.error('Invalid option is passed to RUBYOPT', command: cmd, error: e)
+        $log.error('Invalid option is passed to RUBYOPT', command: fluentd_spawn_cmd, error: e)
         exit s.exitstatus
       end
 

--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -892,7 +892,7 @@ CONF
     end
 
     test 'invalid values are set to RUBYOPT' do
-      omit "hard to run correctly on Windows. Need to debug." if Fluent.windows?
+      omit "hard to run correctly because RUBYOPT=-r/path/to/bundler/setup is required on Windows while this test set invalid RUBYOPT" if Fluent.windows?
       conf = <<CONF
 <source>
   @type dummy

--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -858,7 +858,6 @@ CONF
       '-internal-encoding' => '--internal-encoding=utf-8',
     )
     test "-E option is set to RUBYOPT" do |opt|
-      omit "hard to run correctly on Windows. Need to debug." if Fluent.windows?
       conf = <<CONF
 <source>
   @type dummy
@@ -869,6 +868,7 @@ CONF
 </match>
 CONF
       conf_path = create_conf_file('rubyopt_test.conf', conf)
+      opt << " #{ENV['RUBYOPT']}" if ENV['RUBYOPT']
       assert_log_matches(
         create_cmdline(conf_path),
         *opt.split(' '),

--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -843,7 +843,7 @@ CONF
       '-external-encoding' => '--external-encoding=utf-8',
       '-internal-encoding' => '--internal-encoding=utf-8',
     )
-    test "-E option is set to RUBYOPT3" do |opt|
+    test "-E option is set to RUBYOPT" do |opt|
       omit "hard to run correctly on Windows. Need to debug." if Fluent.windows?
       conf = <<CONF
 <source>
@@ -863,7 +863,7 @@ CONF
       )
     end
 
-        test "without RUBYOPT" do
+    test "without RUBYOPT" do
       conf = <<CONF
 <source>
   @type dummy


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #2915

**What this PR does / why we need it**: 

On testing arguments in RUBYOPT, command line arguments aren't quoted so that it will fail if ruby command (which is passed as the first arugment) is placed under a directory which contains spaces.
Since `C:\Profram Files\` is the default application directory on Windows, it may be unfriendly for Windows users.

This patch uses `spawn(program, *args)` instead of `spawn(command, options={})` to fix it.

**Docs Changes**:

no need

**Release Note**: 

no need