### PR TITLE
Suppress warning of verify_hostname

### DIFF
--- a/lib/fluent/plugin_helper/socket.rb
+++ b/lib/fluent/plugin_helper/socket.rb
@@ -145,7 +145,7 @@ module Fluent
           context.ciphers = ciphers
           context.verify_mode = OpenSSL::SSL::VERIFY_PEER
           context.cert_store = cert_store
-          context.verify_hostname = true if verify_fqdn && fqdn && context.respond_to?(:verify_hostname=)
+          context.verify_hostname = true if verify_fqdn && fqdn
           context.key = OpenSSL::PKey::read(File.read(private_key_path), private_key_passphrase) if private_key_path
 
           if cert_path

--- a/lib/fluent/plugin_helper/socket.rb
+++ b/lib/fluent/plugin_helper/socket.rb
@@ -145,7 +145,7 @@ module Fluent
           context.ciphers = ciphers
           context.verify_mode = OpenSSL::SSL::VERIFY_PEER
           context.cert_store = cert_store
-          context.verify_hostname = true if verify_fqdn && fqdn
+          context.verify_hostname = verify_fqdn && fqdn
           context.key = OpenSSL::PKey::read(File.read(private_key_path), private_key_passphrase) if private_key_path
 
           if cert_path

--- a/test/plugin_helper/test_http_server_helper.rb
+++ b/test/plugin_helper/test_http_server_helper.rb
@@ -110,7 +110,7 @@ class HttpHelperTest < Test::Unit::TestCase
       end
 
       context.cert_store = cert_store
-      if !hostname && context.respond_to?(:verify_hostname=)
+      if !hostname
         context.verify_hostname = false # In test code, using hostname to be connected is very difficult
       end
 

--- a/test/plugin_helper/test_server.rb
+++ b/test/plugin_helper/test_server.rb
@@ -860,7 +860,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
       end
       context.verify_mode = OpenSSL::SSL::VERIFY_PEER
       context.cert_store = cert_store
-      if !hostname && context.respond_to?(:verify_hostname=)
+      if !hostname
         context.verify_hostname = false # In test code, using hostname to be connected is very difficult
       end
     else


### PR DESCRIPTION

**Which issue(s) this PR fixes**: 
ref: https://github.com/fluent/fluentd/issues/2699

**What this PR does / why we need it**: 

Suppress warning of verify_hostname
https://travis-ci.org/github/fluent/fluentd/jobs/671447462#L758

**Docs Changes**:

no need

**Release Note**: 

no need
