### PR TITLE
Creating timer of purging obsolete sockets if keepalive_timeout is nil

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -324,7 +324,7 @@ module Fluent::Plugin
         end
       end
 
-      if @keepalive && @keepalive_timeout
+      if @keepalive
         timer_execute(:out_forward_keep_alived_socket_watcher, @keep_alive_watcher_interval, &method(:on_purge_obsolete_socks))
       end
     end

--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -1200,6 +1200,15 @@ EOL
       end
     end
 
+    test 'create timer of purging obsolete sockets' do
+      output_conf = CONFIG + %[keepalive true]
+      d = create_driver(output_conf)
+
+      mock(d.instance).timer_execute(:out_forward_heartbeat_request, 1).once
+      mock(d.instance).timer_execute(:out_forward_keep_alived_socket_watcher, 5).once
+      d.instance_start
+    end
+
     sub_test_case 'with require_ack_response' do
       test 'Create connection per send_data' do
         target_input_driver = create_target_input_driver(conf: TARGET_CONFIG)


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
ref https://github.com/fluent/fluentd/issues/2926

**What this PR does / why we need it**: 

If connection sockets raise some errors, the cached socket is revoked.
Revoked cached socket(`@inactive_sockets`) must be deleted by
purge_obsolete_socks method so that memory usage doesn't increase.

https://github.com/fluent/fluentd/blob/0e901e7974232dd05f098ad74ea5be956aaba0e3/lib/fluent/plugin/out_forward/connection_manager.rb#L99
https://github.com/fluent/fluentd/blob/0e901e7974232dd05f098ad74ea5be956aaba0e3/lib/fluent/plugin/out_forward/socket_cache.rb#L63

This memory leak happens when keepalive and user_auth are on.
The memory leaking is easier to detect in TLS connection than in TCP connection since a lot of error can happen in [here](https://github.com/fluent/fluentd/blob/0e901e7974232dd05f098ad74ea5be956aaba0e3/lib/fluent/plugin/out_forward/connection_manager.rb#L99).

sender
```
<source>
  @type dummy
  size 1000
  rate 450
  tag test
</source>

<match **>
  @type forward

  keepalive true

  <server>
    host 127.0.0.1
    port 24284

    password testpassword
    username testuser
  </server>

  <buffer>
    @type file
    chunk_limit_size 1m
    flush_at_shutdown true
    flush_interval 1s
    path "#{Dir.pwd}/example/certs/buf"
    total_limit_size 128m
  </buffer>

  <security>
    self_hostname client
    shared_key sharedkeypassword
  </security>

  transport tls
  tls_verify_hostname false
  tls_cert_path "#{Dir.pwd}/example/certs/server.pem"
  tls_insecure_mode false
</match>
```

receiver
```
<source>
  @type forward
  port 24284

  <security>
    self_hostname server
    shared_key sharedkeypassword

    <user>
      password testpassword
      username testuser
    </user>

    user_auth true
  </security>

  <transport tls>
    cert_path "#{Dir.pwd}/example/certs/server.pem"
    insecure false
    private_key_path "#{Dir.pwd}/example/certs/server-key.pem"
    private_key_passphrase hoge
  </transport>
</source>

<match test>
  @type null
</match>
```

**Docs Changes**:

no need

**Release Note**: 

same as title
