### PR TITLE
Need authentication when sending tcp heartbeat and keepalive in out_forward

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -578,12 +578,7 @@ module Fluent::Plugin
 
       def verify_connection
         connect do |sock, ri|
-          if ri.state != :established
-            establish_connection(sock, ri)
-            if ri.state != :established
-              raise "Failed to establish connection to #{@host}:#{@port}"
-            end
-          end
+          ensure_established_connection(sock, ri)
         end
       end
 
@@ -652,14 +647,7 @@ module Fluent::Plugin
       def send_data(tag, chunk)
         ack = @ack_handler && @ack_handler.create_ack(chunk.unique_id, self)
         connect(nil, ack: ack) do |sock, ri|
-          if ri.state != :established
-            establish_connection(sock, ri)
-
-            if ri.state != :established
-              raise ConnectionClosedError, "failed to establish connection with node #{@name}"
-            end
-          end
-
+          ensure_established_connection(sock, ri)
           send_data_actual(sock, tag, chunk)
         end
 
@@ -685,13 +673,7 @@ module Fluent::Plugin
         case @sender.heartbeat_type
         when :transport
           connect(dest_addr) do |sock, ri|
-            if ri.state != :established
-              establish_connection(sock, ri)
-
-              if ri.state != :established
-                raise ConnectionClosedError, "failed to establish connection with node #{@name}"
-              end
-            end
+            ensure_established_connection(sock, ri)
 
             ## don't send any data to not cause a compatibility problem
             # sock.write FORWARD_TCP_HEARTBEAT_DATA
@@ -783,6 +765,16 @@ module Fluent::Plugin
       end
 
       private
+
+      def ensure_established_connection(sock, request_info)
+        if request_info.state != :established
+          establish_connection(sock, request_info)
+
+          if request_info.state != :established
+            raise ConnectionClosedError, "failed to establish connection with node #{@name}"
+          end
+        end
+      end
 
       def connect(host = nil, ack: false, &block)
         @connection_manager.connect(host: host || resolved_host, port: port, hostname: @hostname, ack: ack, &block)

--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -684,7 +684,15 @@ module Fluent::Plugin
 
         case @sender.heartbeat_type
         when :transport
-          connect(dest_addr) do |_ri, _sock|
+          connect(dest_addr) do |sock, ri|
+            if ri.state != :established
+              establish_connection(sock, ri)
+
+              if ri.state != :established
+                raise ConnectionClosedError, "failed to establish connection with node #{@name}"
+              end
+            end
+
             ## don't send any data to not cause a compatibility problem
             # sock.write FORWARD_TCP_HEARTBEAT_DATA
 

--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -1056,7 +1056,7 @@ EOL
         e = assert_raise Fluent::UnrecoverableError do
           d.instance_start
         end
-        assert_match(/Failed to establish connection/, e.message)
+        assert_match(/failed to establish connection/, e.message)
       end
     end
 
@@ -1092,7 +1092,7 @@ EOL
           d.instance_start
         end
 
-        assert_match(/Failed to establish connection/, e.message)
+        assert_match(/failed to establish connection/, e.message)
       end
     end
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Ref https://github.com/fluent/fluentd/issues/2926

**What this PR does / why we need it**: 

When you turn keepalive config on and sending heartbeat and sending data happens at the same time, sending heartbeat creates new connection. The new heartbeat connection doesn't try to do user auth. So if the connection is used for sending data,  the error will happen.

**Docs Changes**:

no need

**Release Note**: 

same as the title
