### PR TITLE
Remove unnecessary timeout to fix unstable test

### DIFF
--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -1073,7 +1073,7 @@ class TailInputTest < Test::Unit::TestCase
                               })
       d = create_driver(config, false)
       d.end_if { d.instance.instance_variable_get(:@tails).keys.size >= 1 }
-      d.run(expect_emits: 1, shutdown: false, timeout: 1) do
+      d.run(expect_emits: 1, shutdown: false) do
         File.open("#{TMP_DIR}/tail.txt", "ab") { |f| f.puts "test3\n" }
       end
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fix https://travis-ci.org/github/fluent/fluentd/jobs/674236542#L752

**What this PR does / why we need it**: 

if timeout is given, the breaking condition is set. 
https://github.com/fluent/fluentd/blob/a8b6d6ff4aa83bb0f7c8aa54f3367018383236d6/lib/fluent/test/driver/base.rb#L81

if breaking condition is true, it passed without errors. So timeout must be removed.
https://github.com/fluent/fluentd/blob/a8b6d6ff4aa83bb0f7c8aa54f3367018383236d6/lib/fluent/test/driver/base.rb#L215

**Docs Changes**:

no need

**Release Note**: 

same as title
