### PR TITLE
command: Avoid daemonize for supervisor's worker

### DIFF
--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -336,7 +336,7 @@ else
   worker = Fluent::Supervisor.new(opts)
   worker.configure
 
-  if opts[:daemonize]
+  if opts[:daemonize] && opts[:standalone_worker]
     require 'fluent/daemonizer'
     args = ARGV.dup
     i = args.index('--daemon')


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Follow up of #2912 

**What this PR does / why we need it**: 
Don't daemonize supervisor's worker. It is handled by serverengine.

**Docs Changes**:

**Release Note**: 
