### PR TITLE
Cast `pri` to integer so it can be properly "bitwised"

### DIFF
--- a/lib/fluent/plugin/in_syslog.rb
+++ b/lib/fluent/plugin/in_syslog.rb
@@ -235,7 +235,7 @@ module Fluent::Plugin
           return
         end
 
-        pri ||= record.delete('pri')
+        pri ||= record.delete('pri').to_i
         facility = FACILITY_MAP[pri >> 3]
         severity = SEVERITY_MAP[pri & 0b111]
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
While parsing a valid RFC 5424 log message with following configuration:

```
<source>
  @type syslog
  port 5141
  bind 0.0.0.0
  <transport tcp>
  </transport>
  <parse>
    message_format rfc5424
    with_priority true
  </parse>
```
Following error is returned:

```
2020-04-15 07:58:05 +0000 [error]: #0 invalid input data="<16>1 2013-02-28T12:00:00.003Z 192.168.0.1 fluentd 11111 ID24224 [exampleSDID@20224 iut=\"3\" eventSource=\"Application\" eventID=\"11211\"] Hi, from Fluentd!" error_class=Fluent::TimeParser::TimeParseError error="invalid time format: value = 2013-02-28T12:00:00.003Z, error_class = ArgumentError, error = string doesn't match"
```

**Docs Changes**:

**Release Note**: 
