### PR TITLE
Make ruby dsl config deprecated

### DIFF
--- a/lib/fluent/config.rb
+++ b/lib/fluent/config.rb
@@ -62,6 +62,7 @@ module Fluent
         Parser.parse(str, fname, basepath)
       when :ruby
         require 'fluent/config/dsl'
+        $log.warn("Ruby DSL configuration format is deprecated. Please use original configuration format. https://docs.fluentd.org/configuration/config-file")
         Config::DSL::Parser.parse(str, File.join(basepath, fname))
       else
         raise "[BUG] unknown configuration parser specification:'#{parser}'"


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Ref https://github.com/fluent/fluentd/issues

**What this PR does / why we need it**: 

Added a warning log

**Docs Changes**:

no need

**Release Note**: 

same as title
