### PR TITLE
windows: Disable specifying linger_timeout again

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -382,7 +382,12 @@ module Fluent::Plugin
           cert_logical_store_name: @tls_cert_logical_store_name,
           cert_use_enterprise_store: @tls_cert_use_enterprise_store,
 
-          linger_timeout: @send_timeout,
+          # Enabling SO_LINGER causes tcp port exhaustion on Windows.
+          # This is because dynamic ports are only 16384 (from 49152 to 65535) and
+          # expiring SO_LINGER enabled ports should wait 4 minutes
+          # where set by TcpTimeDelay. Its default value is 4 minutes.
+          # So, we should disable SO_LINGER on Windows to prevent flood of waiting ports.
+          linger_timeout: Fluent.windows? ? nil : @send_timeout,
           send_timeout: @send_timeout,
           recv_timeout: @ack_response_timeout,
           connect_timeout: @connect_timeout,


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 
Enabling SO_LINGER causes tcp port exhaustion on Windows.
This is because dynamic ports are only 16384 (from 49152 to 65535) and
expiring SO_LINGER enabled ports should wait 4 minutes where set by TcpTimeDelay.
Its default value is 4 minutes.
So, we should disable SO_LINGER on Windows to prevent flood of waiting ports.

**Docs Changes**:
No needed.

**Release Note**: 
Same as title