### PR TITLE
'#match?' is better than '#match'

### DIFF
--- a/lib/fluent/match.rb
+++ b/lib/fluent/match.rb
@@ -125,7 +125,7 @@ module Fluent
     end
 
     def match(str)
-      @regex.match(str) != nil
+      @regex.match?(str)
     end
   end
 

--- a/lib/fluent/plugin/parser_multiline.rb
+++ b/lib/fluent/plugin/parser_multiline.rb
@@ -104,7 +104,7 @@ module Fluent
       end
 
       def firstline?(text)
-        @firstline_regex.match(text)
+        @firstline_regex.match?(text)
       end
 
       private


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
No issue.

**What this PR does / why we need it**: 
fluentd dropped ruby 2.3 or earlier, so we can use `match?` for faster matching.

**Docs Changes**:
No need

**Release Note**: 
Improve regexp match with `match?` method.