### PR TITLE
PoC: json_array switch to use json array data format for HTTP request body

### DIFF
--- a/lib/fluent/plugin/out_http.rb
+++ b/lib/fluent/plugin/out_http.rb
@@ -215,7 +215,7 @@ module Fluent::Plugin
         req.basic_auth(@auth.username, @auth.password)
       end
       set_headers(req)
-      req.body = @json_array ? "[#{chunk.read[0...-1]}]" : chunk.read
+      req.body = @json_array ? "[#{chunk.read.chop!}]" : chunk.read
       req
     end
 

--- a/lib/fluent/plugin/out_http.rb
+++ b/lib/fluent/plugin/out_http.rb
@@ -105,7 +105,7 @@ module Fluent::Plugin
 
       if @json_array
         if @formatter_configs.first[:@type] != "json"
-            raise Fluent::ConfigError, "json_array option could be used with json formatter only"
+          raise Fluent::ConfigError, "json_array option could be used with json formatter only"
         end
         define_singleton_method(:format, method(:format_json_array))
       end

--- a/lib/fluent/plugin/out_http.rb
+++ b/lib/fluent/plugin/out_http.rb
@@ -124,7 +124,7 @@ module Fluent::Plugin
     end
 
     def format_json_array(tag, time, record)
-      @formatter.format(tag, time, record).strip() << ","
+      @formatter.format(tag, time, record) << ","
     end
 
     def write(chunk)


### PR DESCRIPTION
Signed-off-by: Roman Geraskin <roman.n.geraskin@gmail.com>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #2909 

**What this PR does / why we need it**: 
This PR implements the `json_array` option (bool, default false) for the out_http plugin. With this option, we can use the JSON array data format for the HTTP request body.

**Docs Changes**:
Docs update required.

**Release Note**: 
This is quick and easy feature implementation, sort of proof of concept. I will be grateful for any feedback.