### PR TITLE
record_accessor: Add set method for nested record

### DIFF
--- a/lib/fluent/plugin_helper/record_accessor.rb
+++ b/lib/fluent/plugin_helper/record_accessor.rb
@@ -41,9 +41,11 @@ module Fluent
             else
               mcall = method(:call_dig)
               mdelete = method(:delete_nest)
+              mset = method(:set_nest)
               singleton_class.module_eval do
                 define_method(:call, mcall)
                 define_method(:delete, mdelete)
+                define_method(:set, mset)
               end
             end
           end
@@ -71,6 +73,18 @@ module Fluent
               target.delete(@last_key)
             end
           end
+        rescue
+          nil
+        end
+
+        def set(r, v)
+          r[@keys] = v
+        end
+
+        # set_nest doesn't create intermediate object. If key doesn't exist, no effect.
+        # See also: https://bugs.ruby-lang.org/issues/11747
+        def set_nest(r, v)
+          r.dig(*@dig_keys)&.[]=(@last_key, v)
         rescue
           nil
         end

--- a/test/plugin_helper/test_record_accessor.rb
+++ b/test/plugin_helper/test_record_accessor.rb
@@ -232,6 +232,7 @@ class RecordAccessorHelperTest < Test::Unit::TestCase
       assert_nothing_raised do
         accessor.set(r, "unknown field")
       end
+      assert_equal({'key1' => [{'key3' => "value"}]}, r)
     end
   end
 end

--- a/test/plugin_helper/test_record_accessor.rb
+++ b/test/plugin_helper/test_record_accessor.rb
@@ -194,4 +194,44 @@ class RecordAccessorHelperTest < Test::Unit::TestCase
       end
     end
   end
+
+  sub_test_case 'Fluent::PluginHelper::RecordAccessor::Accessor#set' do
+    setup do
+      @d = Dummy.new
+    end
+
+    data('normal' => 'key1',
+         'space' => 'ke y2',
+         'dot key' => 'this.is.key3')
+    test 'set top key' do |param|
+      r = {'key1' => 'v1', 'ke y2' => 'v2', 'this.is.key3' => 'v3'}
+      accessor = @d.record_accessor_create(param)
+      accessor.set(r, "test")
+      assert_equal "test", r[param]
+    end
+
+    test "set top key using bracket style" do
+      r = {'key1' => 'v1', 'ke y2' => 'v2', 'this.is.key3' => 'v3'}
+      accessor = @d.record_accessor_create('$["this.is.key3"]')
+      accessor.set(r, "test")
+      assert_equal "test", r["this.is.key3"]
+    end
+
+    data('bracket' => "$['key1'][0]['ke y2']",
+         'bracket w/ double quotes' => '$["key1"][0]["ke y2"]')
+    test "set nested keys ['key1', 0, 'ke y2']" do |param|
+      r = {'key1' => [{'ke y2' => "value"}]}
+      accessor = @d.record_accessor_create(param)
+      accessor.set(r, "nested_message")
+      assert_equal "nested_message", r['key1'][0]['ke y2']
+    end
+
+    test "don't raise an error when unexpected record is coming" do
+      r = {'key1' => [{'key3' => "value"}]}
+      accessor = @d.record_accessor_create("$['key1']['key2']['key3']")
+      assert_nothing_raised do
+        accessor.set(r, "unknown field")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

**Which issue(s) this PR fixes**: 
No issue

**What this PR does / why we need it**: 
Add `set` method to record_accessor.

This method will be used in `<record>`'s nested update.

**Docs Changes**:
Add `set` section to record_accessor article.

**Release Note**: 
Same as title.