### PR TITLE
supervisor: Call File.umask for standalone worker. fix #2984

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -593,7 +593,10 @@ module Fluent
 
       main_process do
         create_socket_manager if @standalone_worker
-        ServerEngine::Privilege.change(@chuser, @chgroup) if @standalone_worker
+        if @standalone_worker
+          ServerEngine::Privilege.change(@chuser, @chgroup)
+          File.umask(0)
+        end
         MessagePackFactory.init(enable_time_support: @system_config.enable_msgpack_time_support)
         Fluent::Engine.init(@system_config)
         Fluent::Engine.run_configure(@conf)


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

**Which issue(s) this PR fixes**: 
Fixes #2984 

**What this PR does / why we need it**: 
Add missing `File.umask(0)` for standalone worker mode.
With supervisor, serverengine handles chuser, chgroup and chumask here.

https://github.com/treasure-data/serverengine/blob/master/lib/serverengine/multi_process_server.rb#L79-L80

**Docs Changes**:
No need

**Release Note**: 
Same as title