### PR TITLE
in_forward: Set encoding us-ascii to source_host and source_address

### DIFF
--- a/lib/fluent/plugin/in_forward.rb
+++ b/lib/fluent/plugin/in_forward.rb
@@ -381,6 +381,12 @@ module Fluent::Plugin
       if @source_address_key && @source_hostname_key
         address = conn.remote_addr
         hostname = conn.remote_host
+        if address.ascii_only?
+          address.force_encoding(Encoding::US_ASCII)
+        end
+        if hostname.ascii_only?
+          hostname.force_encoding(Encoding::US_ASCII)
+        end
         es.each { |time, record|
           record[@source_address_key] = address
           record[@source_hostname_key] = hostname
@@ -388,12 +394,18 @@ module Fluent::Plugin
         }
       elsif @source_address_key
         address = conn.remote_addr
+        if address.ascii_only?
+          address.force_encoding(Encoding::US_ASCII)
+        end
         es.each { |time, record|
           record[@source_address_key] = address
           new_es.add(time, record)
         }
       elsif @source_hostname_key
         hostname = conn.remote_host
+        if hostname.ascii_only?
+          hostname.force_encoding(Encoding::US_ASCII)
+        end
         es.each { |time, record|
           record[@source_hostname_key] = hostname
           new_es.add(time, record)


### PR DESCRIPTION
source_host and source_address should not be binary.

Signed-off-by: okkez <okkez000@gmail.com>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes none

**What this PR does / why we need it**: 
In the previous version, the values added by `source_hostname_key` and `souce_address_key` are encoded as `bin 8`. I expected `str N` or `fixstr`.

If `source_hostname` and `source_address` is encoded as `bin 8` (binary), we cannot convert records to parquet using `string` type defined by Avro schema. If we use `bytes` in Avro schema, we can convert records to parquet format but we cannot get human-readable dumped records from `*.parquet` file using parquet-tools.

In this version, encode `source_hostname` and `source_address` as `fixstr` or `str N` in msgpack.
We can use `string` type in Avro schema and we can convert records to parquet format. We can get human-readable dumped records from `*.parquet` file using parquet-tools.

**Docs Changes**: none

**Release Note**: 
