### PR TITLE
parser_syslog: Support configured time_format for rfc3164 string parser

### DIFF
--- a/test/plugin/test_parser_syslog.rb
+++ b/test/plugin/test_parser_syslog.rb
@@ -35,8 +35,9 @@ class SyslogParserTest < ::Test::Unit::TestCase
     assert_equal('%b %d %M:%S:%H', @parser.instance.patterns['time_format'])
   end
 
-  def test_parse_with_time_format2
-    @parser.configure('time_format' => '%Y-%m-%dT%H:%M:%SZ')
+  data('regexp' => 'regexp', 'string' => 'string')
+  def test_parse_with_time_format2(param)
+    @parser.configure('time_format' => '%Y-%m-%dT%H:%M:%SZ', 'parser_type' => param)
     @parser.instance.parse('2020-03-03T10:14:29Z 192.168.0.1 fluentd[11111]: [error] Syslog test') { |time, record|
       assert_equal(event_time('Mar 03 10:14:29', format: '%b %d %H:%M:%S'), time)
       assert_equal(@expected, record)


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Follow up of #2886 

**What this PR does / why we need it**: 
Support non-standard `time_format` in rfc3164 string parser.

Keep original implementation for the performance.

```
# Without space count
Warming up --------------------------------------
              regexp    22.144k i/100ms
              string    50.456k i/100ms
Calculating -------------------------------------
              regexp    241.978k (± 4.8%) i/s -      1.218M in   5.047216s
              string    589.696k (± 4.0%) i/s -      2.977M in   5.057291s

# With space count
Warming up --------------------------------------
              regexp    22.600k i/100ms
              string    37.845k i/100ms
Calculating -------------------------------------
              regexp    249.855k (± 2.7%) i/s -      1.266M in   5.069147s
              string    435.649k (± 4.3%) i/s -      2.195M in   5.048678s
```

**Docs Changes**:
No need.

**Release Note**: 
Same as title.