### PR TITLE
syslog_parser: Add string parser for rfc5424

### DIFF
--- a/test/plugin/test_parser_syslog.rb
+++ b/test/plugin/test_parser_syslog.rb
@@ -199,11 +199,13 @@ class SyslogParserTest < ::Test::Unit::TestCase
   end
 
   class TestRFC5424Regexp < self
-    def test_parse_with_rfc5424_message
+    data('regexp' => 'regexp', 'string' => 'string')
+    def test_parse_with_rfc5424_message(param)
       @parser.configure(
                         'time_format' => '%Y-%m-%dT%H:%M:%S.%L%z',
                         'message_format' => 'rfc5424',
                         'with_priority' => true,
+                        'parser_type' => param
                         )
       text = '<16>1 2017-02-06T13:14:15.003Z 192.168.0.1 fluentd - - - Hi, from Fluentd!'
       @parser.instance.parse(text) do |time, record|
@@ -216,11 +218,13 @@ class SyslogParserTest < ::Test::Unit::TestCase
       assert_equal(Fluent::Plugin::SyslogParser::RFC5424_WITHOUT_TIME_AND_PRI_REGEXP, @parser.instance.patterns['format'])
     end
 
-    def test_parse_with_rfc5424_message_trailing_eol
+    data('regexp' => 'regexp', 'string' => 'string')
+    def test_parse_with_rfc5424_message_trailing_eol(param)
       @parser.configure(
                         'time_format' => '%Y-%m-%dT%H:%M:%S.%L%z',
                         'message_format' => 'rfc5424',
                         'with_priority' => true,
+                        'parser_type' => param
                         )
       text = "<16>1 2017-02-06T13:14:15.003Z 192.168.0.1 fluentd - - - Hi, from Fluentd!\n"
       @parser.instance.parse(text) do |time, record|
@@ -233,11 +237,13 @@ class SyslogParserTest < ::Test::Unit::TestCase
       assert_equal(Fluent::Plugin::SyslogParser::RFC5424_WITHOUT_TIME_AND_PRI_REGEXP, @parser.instance.patterns['format'])
     end
 
-    def test_parse_with_rfc5424_multiline_message
+    data('regexp' => 'regexp', 'string' => 'string')
+    def test_parse_with_rfc5424_multiline_message(param)
       @parser.configure(
                         'time_format' => '%Y-%m-%dT%H:%M:%S.%L%z',
                         'message_format' => 'rfc5424',
                         'with_priority' => true,
+                        'parser_type' => param
                         )
       text = "<16>1 2017-02-06T13:14:15.003Z 192.168.0.1 fluentd - - - Hi,\nfrom\nFluentd!"
       @parser.instance.parse(text) do |time, record|
@@ -250,10 +256,12 @@ class SyslogParserTest < ::Test::Unit::TestCase
       assert_equal(Fluent::Plugin::SyslogParser::RFC5424_WITHOUT_TIME_AND_PRI_REGEXP, @parser.instance.patterns['format'])
     end
 
-    def test_parse_with_rfc5424_message_and_without_priority
+    data('regexp' => 'regexp', 'string' => 'string')
+    def test_parse_with_rfc5424_message_and_without_priority(param)
       @parser.configure(
                         'time_format' => '%Y-%m-%dT%H:%M:%S.%L%z',
                         'message_format' => 'rfc5424',
+                        'parser_type' => param
                         )
       text = '2017-02-06T13:14:15.003Z 192.168.0.1 fluentd - - - Hi, from Fluentd!'
       @parser.instance.parse(text) do |time, record|
@@ -266,10 +274,12 @@ class SyslogParserTest < ::Test::Unit::TestCase
       assert_equal(Fluent::Plugin::SyslogParser::RFC5424_WITHOUT_TIME_AND_PRI_REGEXP, @parser.instance.patterns['format'])
     end
 
-    def test_parse_with_rfc5424_empty_message_and_without_priority
+    data('regexp' => 'regexp', 'string' => 'string')
+    def test_parse_with_rfc5424_empty_message_and_without_priority(param)
       @parser.configure(
                         'time_format' => '%Y-%m-%dT%H:%M:%S.%L%z',
                         'message_format' => 'rfc5424',
+                        'parser_type' => param
                         )
       text = '2017-02-06T13:14:15.003Z 192.168.0.1 fluentd - - -'
       @parser.instance.parse(text) do |time, record|
@@ -282,10 +292,12 @@ class SyslogParserTest < ::Test::Unit::TestCase
       assert_equal(Fluent::Plugin::SyslogParser::RFC5424_WITHOUT_TIME_AND_PRI_REGEXP, @parser.instance.patterns['format'])
     end
 
-    def test_parse_with_rfc5424_message_without_time_format
+    data('regexp' => 'regexp', 'string' => 'string')
+    def test_parse_with_rfc5424_message_without_time_format(param)
       @parser.configure(
                         'message_format' => 'rfc5424',
                         'with_priority' => true,
+                        'parser_type' => param
                         )
       text = '<16>1 2017-02-06T13:14:15.003Z 192.168.0.1 fluentd - - - Hi, from Fluentd!'
       @parser.instance.parse(text) do |time, record|
@@ -297,10 +309,12 @@ class SyslogParserTest < ::Test::Unit::TestCase
       end
     end
 
-    def test_parse_with_rfc5424_message_with_priority_and_pid
+    data('regexp' => 'regexp', 'string' => 'string')
+    def test_parse_with_rfc5424_message_with_priority_and_pid(param)
       @parser.configure(
                         'message_format' => 'rfc5424',
                         'with_priority' => true,
+                        'parser_type' => param
                         )
       text = '<28>1 2018-09-26T15:54:26.620412+09:00 machine minissdpd 1298 - -  peer 192.168.0.5:50123 is not from a LAN'
       @parser.instance.parse(text) do |time, record|
@@ -312,11 +326,13 @@ class SyslogParserTest < ::Test::Unit::TestCase
       end
     end
 
-    def test_parse_with_rfc5424_structured_message
+    data('regexp' => 'regexp', 'string' => 'string')
+    def test_parse_with_rfc5424_structured_message(param)
       @parser.configure(
                         'time_format' => '%Y-%m-%dT%H:%M:%S.%L%z',
                         'message_format' => 'rfc5424',
                         'with_priority' => true,
+                        'parser_type' => param
                         )
       text = '<16>1 2017-02-06T13:14:15.003Z 192.168.0.1 fluentd 11111 ID24224 [exampleSDID@20224 iut="3" eventSource="Application" eventID="11211"] [Hi] from Fluentd!'
       @parser.instance.parse(text) do |time, record|
@@ -329,11 +345,13 @@ class SyslogParserTest < ::Test::Unit::TestCase
       end
     end
 
-    def test_parse_with_rfc5424_multiple_structured_message
+    data('regexp' => 'regexp', 'string' => 'string')
+    def test_parse_with_rfc5424_multiple_structured_message(param)
       @parser.configure(
                         'time_format' => '%Y-%m-%dT%H:%M:%S.%L%z',
                         'message_format' => 'rfc5424',
                         'with_priority' => true,
+                        'parser_type' => param
                         )
       text = '<16>1 2017-02-06T13:14:15.003Z 192.168.0.1 fluentd 11111 ID24224 [exampleSDID@20224 iut="3" eventSource="Application" eventID="11211"][exampleSDID@20224 class="high"] Hi, from Fluentd!'
       @parser.instance.parse(text) do |time, record|
@@ -346,11 +364,13 @@ class SyslogParserTest < ::Test::Unit::TestCase
       end
     end
 
-    def test_parse_with_rfc5424_message_includes_right_bracket
+    data('regexp' => 'regexp', 'string' => 'string')
+    def test_parse_with_rfc5424_message_includes_right_bracket(param)
       @parser.configure(
                         'time_format' => '%Y-%m-%dT%H:%M:%S.%L%z',
                         'message_format' => 'rfc5424',
                         'with_priority' => true,
+                        'parser_type' => param
                         )
       text = '<16>1 2017-02-06T13:14:15.003Z 192.168.0.1 fluentd 11111 ID24224 [exampleSDID@20224 iut="3" eventSource="Application" eventID="11211"] [Hi] from Fluentd]!'
       @parser.instance.parse(text) do |time, record|
@@ -363,11 +383,13 @@ class SyslogParserTest < ::Test::Unit::TestCase
       end
     end
 
-    def test_parse_with_rfc5424_empty_message
+    data('regexp' => 'regexp', 'string' => 'string')
+    def test_parse_with_rfc5424_empty_message(param)
       @parser.configure(
                         'time_format' => '%Y-%m-%dT%H:%M:%S.%L%z',
                         'message_format' => 'rfc5424',
                         'with_priority' => true,
+                        'parser_type' => param
                         )
       text = '<16>1 2017-02-06T13:14:15.003Z 192.168.0.1 fluentd 11111 ID24224 [exampleSDID@20224 iut="3" eventSource="Application" eventID="11211"]'
       @parser.instance.parse(text) do |time, record|
@@ -380,10 +402,35 @@ class SyslogParserTest < ::Test::Unit::TestCase
       end
     end
 
-    def test_parse_with_rfc5424_message_without_subseconds
+    data('regexp' => 'regexp', 'string' => 'string')
+    def test_parse_with_rfc5424_space_empty_message(param)
       @parser.configure(
                         'message_format' => 'rfc5424',
                         'with_priority' => true,
+                        'parser_type' => param
+                        )
+      text = '<16>1 2017-02-06T13:14:15.003Z 192.168.0.1 fluentd 11111 ID24224 [exampleSDID@20224 iut="3" eventSource="Application" eventID="11211"] '
+      @parser.instance.parse(text) do |time, record|
+        if param == 'string'
+          assert_equal(event_time("2017-02-06T13:14:15.003Z", format: '%Y-%m-%dT%H:%M:%S.%L%z'), time)
+          assert_equal "11111", record["pid"]
+          assert_equal "ID24224", record["msgid"]
+          assert_equal "[exampleSDID@20224 iut=\"3\" eventSource=\"Application\" eventID=\"11211\"]",
+                       record["extradata"]
+          assert_equal '', record["message"]
+        else
+          assert_nil time
+          assert_nil record
+        end
+      end
+    end
+
+    data('regexp' => 'regexp', 'string' => 'string')
+    def test_parse_with_rfc5424_message_without_subseconds(param)
+      @parser.configure(
+                        'message_format' => 'rfc5424',
+                        'with_priority' => true,
+                        'parser_type' => param
                         )
       text = '<16>1 2017-02-06T13:14:15Z 192.168.0.1 fluentd - - - Hi, from Fluentd!'
       @parser.instance.parse(text) do |time, record|
@@ -395,10 +442,12 @@ class SyslogParserTest < ::Test::Unit::TestCase
       end
     end
 
-    def test_parse_with_rfc5424_message_both_timestamp
+    data('regexp' => 'regexp', 'string' => 'string')
+    def test_parse_with_rfc5424_message_both_timestamp(param)
       @parser.configure(
                         'message_format' => 'rfc5424',
                         'with_priority' => true,
+                        'parser_type' => param
                         )
       text = '<16>1 2017-02-06T13:14:15Z 192.168.0.1 fluentd - - - Hi, from Fluentd!'
       @parser.instance.parse(text) do |time, record|


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #2997
Follow up of https://github.com/fluent/fluentd/pull/2599

**What this PR does / why we need it**: 
Add non-regexp parser to fix issues and improve the performance
New parser is 2x faster than current regexp based parser.

```
# code
require 'benchmark/ips'
require 'fluent/env'
require 'fluent/engine'
require_relative 'lib/fluent/plugin/parser_syslog'


log1 = '<16>1 2017-02-06T13:14:15.003Z 192.168.0.1 fluentd - - - Hi, from Fluentd!'
log2 = '<16>1 2017-02-06T13:14:15.003Z 192.168.0.1 fluentd 11111 ID24224 [exampleSDID@20224 iut="3" eventSource="Application" eventID="11211"] [Hi] from Fluentd!'

parser = Fluent::Plugin::SyslogParser.new
parser.configure(Fluent::Config::Element.new('ROOT', '', {'with_priority' => true, 'message_format' => 'rfc5424', 'keep_time_key' => true}, []))

Benchmark.ips do |x|
  x.report "regexp" do
    parser.parse_rfc5424_regex(log1) { |t, r| }
  end
  x.report "string" do
    parser.parse_rfc5424(log1) { |t, r| }
  end
  x.report "regexp with extra" do
    parser.parse_rfc5424_regex(log2) { |t, r| }
  end
  x.report "string with extra" do
    parser.parse_rfc5424(log2) { |t, r| }
  end
end

# result
Warming up --------------------------------------
              regexp    15.374k i/100ms
              string    35.795k i/100ms
   regexp with extra    11.660k i/100ms
   string with extra    27.389k i/100ms
Calculating -------------------------------------
              regexp    154.042k (± 9.1%) i/s -    768.700k in   5.051709s
              string    377.800k (± 8.6%) i/s -      1.897M in   5.078498s
   regexp with extra    127.052k (± 4.5%) i/s -    641.300k in   5.057835s
   string with extra    300.726k (± 3.9%) i/s -      1.506M in   5.017230s
```

**Docs Changes**:
Mention it in `parser_type` parameter.

**Release Note**: 
Same as title.