### PR TITLE
buffer: Fix calculation of timekey stats

### DIFF
--- a/lib/fluent/plugin/buffer.rb
+++ b/lib/fluent/plugin/buffer.rb
@@ -197,18 +197,13 @@ module Fluent
         @stage, @queue = resume
         @stage.each_pair do |metadata, chunk|
           @stage_size += chunk.bytesize
-          if chunk.metadata && chunk.metadata.timekey
-            add_timekey(metadata.timekey)
-          end
         end
         @queue.each do |chunk|
           @queued_num[chunk.metadata] ||= 0
           @queued_num[chunk.metadata] += 1
           @queue_size += chunk.bytesize
-          if chunk.metadata && chunk.metadata.timekey
-            add_timekey(chunk.metadata.timekey)
-          end
         end
+        update_timekeys
         log.debug "buffer started", instance: self.object_id, stage_size: @stage_size, queue_size: @queue_size
       end
 
@@ -259,10 +254,6 @@ module Fluent
 
       def metadata(timekey: nil, tag: nil, variables: nil)
         meta = Metadata.new(timekey, tag, variables)
-        if (t = meta.timekey)
-          add_timekey(t)
-        end
-        meta
       end
 
       def timekeys
@@ -456,9 +447,21 @@ module Fluent
         end
       end
 
+      def update_timekeys
+        synchronize do
+          @timekeys = (@stage.values + @queue).each_with_object({}) do |chunk, keys|
+            if chunk && chunk.metadata && chunk.metadata.timekey
+              t = chunk.metadata.timekey
+              keys[t] = keys.fetch(t, 0) + 1
+            end
+          end
+        end
+      end
+
       # At flush_at_shutdown, all staged chunks should be enqueued for buffer flush. Set true to force_enqueue for it.
       def enqueue_all(force_enqueue = false)
         log.on_trace { log.trace "enqueueing all chunks in buffer", instance: self.object_id }
+        update_timekeys
 
         if block_given?
           synchronize{ @stage.keys }.each do |metadata|
@@ -535,10 +538,6 @@ module Fluent
             @dequeued_num.delete(metadata)
           end
           log.trace "chunk purged", instance: self.object_id, chunk_id: dump_unique_id_hex(chunk_id), metadata: metadata
-        end
-
-        if metadata && metadata.timekey
-          del_timekey(metadata.timekey)
         end
 
         nil
@@ -788,24 +787,6 @@ module Fluent
         else
           !@queue.empty?
         end
-      end
-
-      def add_timekey(t)
-        @mutex.synchronize do
-          @timekeys[t] += 1
-        end
-        nil
-      end
-
-      def del_timekey(t)
-        @mutex.synchronize do
-          if @timekeys[t] <= 1
-            @timekeys.delete(t)
-          else
-            @timekeys[t] -= 1
-          end
-        end
-        nil
       end
     end
   end

--- a/test/plugin/test_buffer.rb
+++ b/test/plugin/test_buffer.rb
@@ -543,6 +543,8 @@ class BufferTest < Test::Unit::TestCase
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3,m], @p.stage.keys
 
+      @p.update_timekeys
+
       assert @p.timekeys.include?(timekey)
     end
 
@@ -674,6 +676,8 @@ class BufferTest < Test::Unit::TestCase
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
       assert_equal [@dm2,@dm3,m], @p.stage.keys
       assert_equal 1, @p.stage[m].append_count
+
+      @p.update_timekeys
 
       assert @p.timekeys.include?(timekey)
     end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

The `oldest_timekey` stat in buffer is broken.

The current approach of using `add_timekey` and `del_timekey` to track the count of chunks in each timekey doesn't work as intended - the count is never decreased to zero because of complications in chunk creation, as a result the `oldest_timekey` stat is almost never updated after initial flush(es).

**What this PR does / why we need it**: 

A simple and not-so-timely alternative, to perform recalculation in every flush cycle.

Signed-off-by: Ji-Ping Shen <ji-ping.shen@relexsolutions.com>