### PR TITLE
Fix child process failure due to SIGPIPE if the command uses stdout

### DIFF
--- a/lib/fluent/plugin_helper/child_process.rb
+++ b/lib/fluent/plugin_helper/child_process.rb
@@ -259,6 +259,9 @@ module Fluent
 
         if !mode.include?(:stderr) && !mode.include?(:read_with_stderr)
           spawn_opts[:err] = IO::NULL if stderr == :discard
+          if !mode.include?(:read) && !mode.include?(:read_with_stderr)
+            spawn_opts[:out] = IO::NULL
+          end
           writeio, readio, wait_thread = *Open3.popen2(*spawn_args, spawn_opts)
         elsif mode.include?(:read_with_stderr)
           writeio, readio, wait_thread = *Open3.popen2e(*spawn_args, spawn_opts)
@@ -275,8 +278,6 @@ module Fluent
         if mode.include?(:read) || mode.include?(:read_with_stderr)
           readio.set_encoding(external_encoding, internal_encoding, **encoding_options)
           readio_in_use = true
-        else
-          readio.reopen(IO::NULL) if readio
         end
         if mode.include?(:stderr)
           stderrio.set_encoding(external_encoding, internal_encoding, **encoding_options)

--- a/test/plugin_helper/test_child_process.rb
+++ b/test/plugin_helper/test_child_process.rb
@@ -818,5 +818,20 @@ class ChildProcessTest < Test::Unit::TestCase
       end
       assert File.exist?(@temp_path)
     end
+
+    test 'execute child process writing data to stdout which is unread' do
+      callback_called = false
+      exit_status = nil
+      prog = "echo writing to stdout"
+      callback = ->(status){ exit_status = status; callback_called = true }
+      Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
+        @d.child_process_execute(:out_exec_process, prog, stderr: :connect, immediate: true, parallel: true, mode: [], wait_timeout: 1, on_exit_callback: callback)
+        sleep TEST_WAIT_INTERVAL_FOR_BLOCK_RUNNING until callback_called
+      end
+      assert callback_called
+      assert exit_status
+      assert exit_status.success?
+      assert_equal 0, exit_status.exitstatus
+    end
   end
 end


### PR DESCRIPTION
If I use exec output plugin with `command` which writes data to stdout (i.e. /bin/echo foo), the command fails due to SIGPIPE(13).

```
2020-06-18 20:00:08 +0900 [debug]: #0 Executing command title=:out_exec_process spawn=[{}, "/bin/echo foo.bar.baz foo /tmp/fluent-plugin-out-exec-20200618-8149-1hyzffl"] mode=[] stderr=:connect
...
2020-06-18 20:00:08 +0900 [warn]: #0 command exits with error code prog="/bin/echo foo.bar.baz foo /tmp/fluent-plugin-out-exec-20200618-8149-1hyzffl" status=nil signal=13
```

Setting the stdout to /dev/null via spawn_opts rather than after spawning process should fix this.
