### PR TITLE
MatchPattern: allow regex patterns

### DIFF
--- a/lib/fluent/match.rb
+++ b/lib/fluent/match.rb
@@ -33,9 +33,9 @@ module Fluent
 
   class GlobMatchPattern < MatchPattern
     def initialize(pat)
-      if pat[0,1] == "/"
-        if pat[pat.length - 1,1] == "/"
-          @regex = Regexp.new("\\A"+pat[1, pat.length-2]+"\\Z")
+      if pat.start_with?('/')
+        if pat.end_with?('/')
+          @regex = Regexp.new("\\A"+pat[1..-2]+"\\Z")
           return
         else
           raise Fluent::ConfigError,  "invalid match - regex"

--- a/lib/fluent/match.rb
+++ b/lib/fluent/match.rb
@@ -33,6 +33,15 @@ module Fluent
 
   class GlobMatchPattern < MatchPattern
     def initialize(pat)
+      if pat[0,1] == "/"
+        if pat[pat.length - 1,1] == "/"
+          @regex = Regexp.new("\\A"+pat[1, pat.length-2]+"\\Z")
+          return
+        else
+          raise Fluent::ConfigError,  "invalid match - regex"
+        end
+      end
+
       stack = []
       regex = ['']
       escape = false

--- a/test/test_match.rb
+++ b/test/test_match.rb
@@ -107,9 +107,9 @@ class MatchTest < Test::Unit::TestCase
     assert_glob_match('/a.*/', 'abc')
     assert_glob_not_match('/b.*/', 'abc')
     assert_glob_match('/a\..*/', 'a.b.c')
-    assert_glob_not_match('/(?!a)\..*/', 'a.b.c')
+    assert_glob_not_match('/(?!a\.).*/', 'a.b.c')
     assert_glob_not_match('/a\..*/', 'b.b.c')
-    assert_glob_match('/(?!a)\..*/', 'b.b.c')
+    assert_glob_match('/(?!a\.).*/', 'b.b.c')
   end
 
   #def test_character_class

--- a/test/test_match.rb
+++ b/test/test_match.rb
@@ -105,7 +105,7 @@ class MatchTest < Test::Unit::TestCase
     assert_glob_match('/a/', 'a')
     assert_glob_not_match('/a/', 'abc')
     assert_glob_match('/a.*/', 'abc')
-    assert_glob_not_match('/a.*/', 'abc')
+    assert_glob_not_match('/b.*/', 'abc')
     assert_glob_match('/a\..*/', 'a.b.c')
     assert_glob_not_match('/(?!a)\..*/', 'a.b.c')
     assert_glob_not_match('/a\..*/', 'b.b.c')

--- a/test/test_match.rb
+++ b/test/test_match.rb
@@ -101,6 +101,17 @@ class MatchTest < Test::Unit::TestCase
     assert_or_not_match('a.b.** a.c', 'a.c.d')
   end
 
+  def test_regex_pattern
+    assert_glob_match('/a/', 'a')
+    assert_glob_not_match('/a/', 'abc')
+    assert_glob_match('/a.*/', 'abc')
+    assert_glob_not_match('/a.*/', 'abc')
+    assert_glob_match('/a\..*/', 'a.b.c')
+    assert_glob_not_match('/(?!a)\..*/', 'a.b.c')
+    assert_glob_not_match('/a\..*/', 'b.b.c')
+    assert_glob_match('/(?!a)\..*/', 'b.b.c')
+  end
+
   #def test_character_class
   #  assert_match('[a]', 'a')
   #  assert_match('[ab]', 'a')


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #3057

**What this PR does / why we need it**: 
Allow a (plain) regex as MatchPattern in <filter .... >
With a regex - assertion it allows a pattern that matches a tag not starting with a string. I think the regex MatchPattern can also replace the commented-out carachter classes.

**Docs Changes**:
Following lines should be added to https://docs.fluentd.org/configuration/config-file#how-match-patterns-work:
Starting with fluentd <version> a match pattern may be a regex by enclosing the regex with slashes.

### Regex match patterns
A regex match pattern looks like <filter /regex/>
This allows character classes or match patterns _not_ starting with a string.
```
# match tags starting with a
<filter a.** >
   ....
</filter
# match all tags not starting with a.
<filter /(?!a\.).*/ >
   ....
</filter>
```
For a complete list of supported regex expressions see: https://ruby-doc.org/core-2.7.1/Regexp.html

**Release Note**: 
Add regex match patterns

**Things I've considered**:
* The tag is checked with @regex.match(tag-name). I don't think that there's a way to break something with a bad regex.
* This patch wraps the regex with \A and \Z. I think this would be a more convenient behavior than without it
