### PR TITLE
Set TLS ciphers list correcty on older OpenSSL

### DIFF
--- a/lib/fluent/plugin_helper/cert_option.rb
+++ b/lib/fluent/plugin_helper/cert_option.rb
@@ -27,13 +27,9 @@ module Fluent
         cert, key, extra = cert_option_server_validate!(conf)
 
         ctx = OpenSSL::SSL::SSLContext.new
-        unless insecure
-          # inject OpenSSL::SSL::SSLContext::DEFAULT_PARAMS
-          # https://bugs.ruby-lang.org/issues/9424
-          ctx.set_params({})
-
-          ctx.ciphers = ciphers
-        end
+        # inject OpenSSL::SSL::SSLContext::DEFAULT_PARAMS
+        # https://bugs.ruby-lang.org/issues/9424
+        ctx.set_params({}) unless insecure
 
         if conf.client_cert_auth
           ctx.verify_mode = OpenSSL::SSL::VERIFY_PEER | OpenSSL::SSL::VERIFY_FAIL_IF_NO_PEER_CERT
@@ -56,6 +52,7 @@ module Fluent
         end
 
         Fluent::TLS.set_version_to_context(ctx, version, conf.min_version, conf.max_version)
+        ctx.ciphers = ciphers unless insecure
 
         ctx
       end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
None.

**What this PR does / why we need it**: 
Since `SSL_CTX_set_ssl_version()` of older OpenSSL reverts to the default
ciphers list, `SSL_CTX_set_cipher_list()` has to be called after that.
OpenSSL 1.1.1 doesn't have this issue.

See also:
https://github.com/openssl/openssl/blob/OpenSSL_1_0_2-stable/ssl/ssl_lib.c#L285
https://github.com/openssl/openssl/blob/OpenSSL_1_0_2-stable/ssl/ssl_ciph.c#L1473

**Docs Changes**:
None.

**Release Note**: 
Same as title.