### PR TITLE
test: Turn off aborted testcases on windows

### DIFF
--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -1403,6 +1403,9 @@ class TailInputTest < Test::Unit::TestCase
     end
 
     def test_tail_path_with_multiline_with_multiple_paths
+      if ENV["APPVEYOR"] && Fluent.windows?
+        omit "This testcase is unstable on AppVeyor."
+      end
       files = ["#{TMP_DIR}/tail1.txt", "#{TMP_DIR}/tail2.txt"]
       files.each { |file| File.open(file, "wb") { |f| } }
 

--- a/test/plugin_helper/test_http_server_helper.rb
+++ b/test/plugin_helper/test_http_server_helper.rb
@@ -278,6 +278,7 @@ class HttpHelperTest < Test::Unit::TestCase
             driver.http_server_create_https_server(:http_server_helper_test_tls, addr: '127.0.0.1', port: PORT, logger: NULL_LOGGER) do |s|
               s.get('/example/hello') { [200, { 'Content-Type' => 'text/plain' }, 'hello get'] }
             end
+            omit "TLS connection should be aborted due to `Errno::ECONNABORTED`. Need to debug." if Fluent.windows?
 
             resp = secure_get("https://127.0.0.1:#{PORT}/example/hello", verify: false)
             assert_equal('200', resp.code)
@@ -293,6 +294,8 @@ class HttpHelperTest < Test::Unit::TestCase
           'with passphrase' => ['apple', 'cert-pass.pem', 'cert-key-pass.pem'],
           'without passphrase' => [nil, 'cert.pem', 'cert-key.pem'])
         test 'load self-signed cert/key pair, verified from clients using cert files' do |(passphrase, cert, private_key)|
+          omit "Self signed certificate blocks TLS connection. Need to debug." if Fluent.windows?
+
           cert_path = File.join(CERT_DIR, cert)
           private_key_path = File.join(CERT_DIR, private_key)
           opt = { 'insecure' => 'false', 'private_key_path' => private_key_path, 'cert_path' => cert_path }
@@ -315,6 +318,8 @@ class HttpHelperTest < Test::Unit::TestCase
           'with passphrase' => ['apple', 'cert-pass.pem', 'cert-key-pass.pem', 'ca-cert-pass.pem'],
           'without passphrase' => [nil, 'cert.pem', 'cert-key.pem', 'ca-cert.pem'])
         test 'load cert by private CA cert file, verified from clients using CA cert file' do |(passphrase, cert, cert_key, ca_cert)|
+          omit "Self signed certificate blocks TLS connection. Need to debug." if Fluent.windows?
+
           cert_path = File.join(CERT_CA_DIR, cert)
           private_key_path = File.join(CERT_CA_DIR, cert_key)
 


### PR DESCRIPTION
In Windows, aborted testcases seems to be aborted with self certficates and
`Errno::ECONNABORTED`. These will be disabled for now. But they needed to debug.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
none

**What this PR does / why we need it**: 
For Windows CIs, we hadn't seen green for a bit of long time.
This is inconvenient to confirm whether PR patches will break backward compatibility or not. 

**Docs Changes**:

No needed.
**Release Note**: 

No needed.