### PR TITLE
in_exec: Add connect_mode parameter to read stderr. fix #3091

### DIFF
--- a/lib/fluent/plugin/in_exec.rb
+++ b/lib/fluent/plugin/in_exec.rb
@@ -25,6 +25,8 @@ module Fluent::Plugin
 
     desc 'The command (program) to execute.'
     config_param :command, :string
+    desc 'Specify connect mode to executed process'
+    config_param :connect_mode, :enum, list: [:read, :read_with_stderr], default: :read
 
     config_section :parse do
       config_set_default :@type, 'tsv'
@@ -72,9 +74,9 @@ module Fluent::Plugin
       super
 
       if @run_interval
-        child_process_execute(:exec_input, @command, interval: @run_interval, mode: [:read], &method(:run))
+        child_process_execute(:exec_input, @command, interval: @run_interval, mode: [@connect_mode], &method(:run))
       else
-        child_process_execute(:exec_input, @command, immediate: true, mode: [:read], &method(:run))
+        child_process_execute(:exec_input, @command, immediate: true, mode: [@connect_mode], &method(:run))
       end
     end
 

--- a/test/plugin/test_in_exec.rb
+++ b/test/plugin/test_in_exec.rb
@@ -240,4 +240,22 @@ EOC
       assert_equal [tag, time, record], event
     }
   end
+
+  test 'emit error message with read_with_stderr' do
+    d = create_driver %[
+      tag test
+      command ruby #{File.join(File.dirname(SCRIPT_PATH), 'foo_bar_baz_no_existence.rb')}
+      connect_mode read_with_stderr
+      <parse>
+        @type none
+      </parse>
+    ]
+    d.run(expect_records: 1, timeout: 10)
+
+    assert{ d.events.length > 0 }
+    d.events.each do |event|
+      assert_equal 'test', event[0]
+      assert_match /LoadError/, event[2]['message']
+    end
+  end
 end


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

**Which issue(s) this PR fixes**: 
Fixes #3091

**What this PR does / why we need it**: 
Add `connect_mode` parameter to read stderr message.
This is useful for debugging.

**Docs Changes**:
Need to add `connect_mode` parameter to in_exec article.

**Release Note**: 
Same as title.