### PR TITLE
parser_json: Improve performance by reducing function call

### DIFF
--- a/lib/fluent/plugin/parser_json.rb
+++ b/lib/fluent/plugin/parser_json.rb
@@ -71,8 +71,11 @@ module Fluent
       end
 
       def parse(text)
-        r = @load_proc.call(text)
-        time, record = convert_values(parse_time(r), r)
+        record = @load_proc.call(text)
+        time = parse_time(record)
+        if @execute_convert_values
+          time, record = convert_values(time, record)
+        end
         yield time, record
       rescue @error_class, EncodingError # EncodingError is for oj 3.x or later
         yield nil, nil


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

**Which issue(s) this PR fixes**: 
No issue

**What this PR does / why we need it**: 
Avoid function call and array object creation to improve the performance.
`convert_values` in json parser is rare case because json is typed format.

Here is benchmark code:

```
require 'benchmark/ips'
require 'fluent/env'
require 'fluent/engine'
require_relative 'lib/fluent/plugin/parser_syslog'

class A
  def initialize
    @execute1 = false
    @execute2 = true
  end

  def f1(t, r)
    if @execute1
      t, r = convert(t, r)
    end
    yield t, r
  end

  def f2(t, r)
    if @execute2
      t, r = convert(t, r)
    end
    yield t, r
  end

  def f3(t, r)
    t, r = convert(t, r)
    yield t, r
  end

  def convert(t, r)
    return t, r unless @execute1
    return t, r
  end
end

a = A.new
t = 1
r = 2

Benchmark.ips do |x|
  x.report "new wo call" do
    a.f1(t, r) { |t, r| }
  end
  x.report "new w call" do
    a.f2(t, r) { |t, r| }
  end
  x.report "base" do
    a.f3(t, r) { |t, r| }
  end
  x.compare!
end


# result
Warming up --------------------------------------
         new wo call   322.780k i/100ms
          new w call   267.376k i/100ms
                base   275.333k i/100ms
Calculating -------------------------------------
         new wo call     12.118M (± 1.8%) i/s -     60.683M in   5.009375s
          new w call      7.053M (± 2.7%) i/s -     35.294M in   5.008071s
                base      7.165M (± 3.6%) i/s -     35.793M in   5.002995s

Comparison:
         new wo call: 12117945.6 i/s
                base:  7164638.6 i/s - 1.69x  slower
          new w call:  7052991.0 i/s - 1.72x  slower
```

json parser is frequently used in docker and other usecase.
So This change is worth.

**Docs Changes**:

**Release Note**: 
Same as title