### PR TITLE
Add win32 events alternative to unix signals

### DIFF
--- a/bin/fluent-ctl
+++ b/bin/fluent-ctl
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+here = File.dirname(__FILE__)
+$LOAD_PATH << File.expand_path(File.join(here, '..', 'lib'))
+require 'fluent/command/ctl'
+
+Fluent::Ctl.new.call

--- a/lib/fluent/command/ctl.rb
+++ b/lib/fluent/command/ctl.rb
@@ -31,7 +31,7 @@ module Fluent
       include Windows::ServiceStructs
       include Windows::ServiceFunctions
 
-      WINDOWS_EVENT_MAP = {
+      COMMAND_MAP = {
         shutdown: "",
         restart: "HUP",
         flush: "USR1",
@@ -45,15 +45,13 @@ module Fluent
         flush: 129,
         reload: SERVICE_CONTROL_PARAMCHANGE,
       }
-      COMMAND_MAP = WINDOWS_EVENT_MAP
     else
-      UNIX_SIGNAL_MAP = {
+      COMMAND_MAP = {
         shutdown: :TERM,
         restart: :HUP,
         flush: :USR1,
         reload: :USR2,
       }
-      COMMAND_MAP = UNIX_SIGNAL_MAP
     end
 
     def initialize(argv = ARGV)

--- a/lib/fluent/command/ctl.rb
+++ b/lib/fluent/command/ctl.rb
@@ -1,0 +1,132 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'optparse'
+require 'fluent/env'
+require 'fluent/version'
+require 'win32/event' if Fluent.windows?
+
+module Fluent
+  class Ctl
+    DEFAULT_OPTIONS = {}
+    UNIX_SIGNAL_MAP = {
+      shutdown: :TERM,
+      restart: :HUP,
+      flush: :USR1,
+      reload: :USR2,
+    }
+    WINDOWS_EVENT_MAP = {
+      shutdown: "",
+      restart: "HUP",
+      flush: "USR1",
+      reload: "USR2",
+    }
+    if Fluent.windows?
+      COMMAND_MAP = WINDOWS_EVENT_MAP
+    else
+      COMMAND_MAP = UNIX_SIGNAL_MAP
+    end
+
+    def initialize(argv = ARGV)
+      @argv = argv
+      @options = {}
+      @opt_parser = OptionParser.new
+      configure_option_parser
+      @options.merge!(DEFAULT_OPTIONS)
+      parse_options!
+    end
+
+    def help_text
+      text = "\n"
+      if Fluent.windows?
+        text << "Usage: #{$PROGRAM_NAME} COMMAND PID_OR_SIGNAME\n"
+      else
+        text << "Usage: #{$PROGRAM_NAME} COMMAND PID\n"
+      end
+      text << "\n"
+      text << "Commands: \n"
+      COMMAND_MAP.each do |key, value|
+        text << "  #{key}\n"
+      end
+      text
+    end
+
+    def usage(msg = nil)
+      puts help_text
+      if msg
+        puts
+        puts "Error: #{msg}"
+      end
+      exit 1
+    end
+
+    def call
+      if Fluent.windows?
+        call_windows_event(@command, @pid_or_signame)
+      else
+        call_signal(@command, @pid_or_signame)
+      end
+    end
+
+    private
+
+    def call_signal(command, pid)
+      signal = COMMAND_MAP[command.to_sym]
+      Process.kill(signal, pid.to_i)
+    end
+
+    def call_windows_event(command, pid_or_signame)
+      if pid_or_signame =~ /^[0-9]+$/
+        prefix = "fluentd_#{pid_or_signame}"
+      else
+        prefix = pid_or_signame
+      end
+      event_name = COMMAND_MAP[command.to_sym]
+      suffix = event_name.empty? ? "" : "_#{event_name}"
+
+      begin
+        event = Win32::Event.open("#{prefix}#{suffix}")
+        event.set
+        event.close
+      rescue Errno::ENOENT => e
+        puts "Error: Cannot find the fluentd process with the event name: \"#{prefix}\""
+      end
+    end
+
+    def configure_option_parser
+      @opt_parser.banner = help_text
+      @opt_parser.version = Fluent::VERSION
+    end
+
+    def parse_options!
+      @opt_parser.parse!(@argv)
+
+      @command = @argv[0]
+      @pid_or_signame = @argv[1]
+
+      usage("Command isn't specified!") if @command.nil? || @command.empty?
+      usage("Unknown command: #{@command}") unless COMMAND_MAP.has_key?(@command.to_sym)
+
+      if Fluent.windows?
+        usage("PID or SIGNAME isn't specified!") if @pid_or_signame.nil? || @pid_or_signame.empty?
+      else
+        usage("PID isn't specified!") if @pid_or_signame.nil? || @pid_or_signame.empty?
+        usage("Invalid PID: #{pid}") unless @pid_or_signame =~ /^[0-9]+$/
+      end
+    end
+  end
+end
+

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -93,7 +93,8 @@ module Fluent
       @rpc_server.mount_proc('/api/processes.flushBuffersAndKillWorkers') { |req, res|
         $log.debug "fluentd RPC got /api/processes.flushBuffersAndKillWorkers request"
         if Fluent.windows?
-          $log.warn "operation 'flushBuffersAndKillWorkers' is not supported on Windows now."
+          supervisor_sigusr1_handler
+          stop(true)
         else
           Process.kill :USR1, $$
           Process.kill :TERM, $$
@@ -102,7 +103,9 @@ module Fluent
       }
       @rpc_server.mount_proc('/api/plugins.flushBuffers') { |req, res|
         $log.debug "fluentd RPC got /api/plugins.flushBuffers request"
-        unless Fluent.windows?
+        if Fluent.windows?
+          supervisor_sigusr1_handler
+        else
           Process.kill :USR1, $$
         end
         nil
@@ -126,7 +129,9 @@ module Fluent
 
       @rpc_server.mount_proc('/api/config.gracefulReload') { |req, res|
         $log.debug "fluentd RPC got /api/config.gracefulReload request"
-        unless Fluent.windows?
+        if Fluent.windows?
+          supervisor_sigusr2_handler
+        else
           Process.kill :USR2, $$
         end
 

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -70,6 +70,7 @@ module Fluent
     end
 
     def after_run
+      stop_windows_event_thread if Fluent.windows?
       stop_rpc_server if @rpc_endpoint
       stop_counter_server if @counter
       Fluent::Supervisor.cleanup_resources
@@ -177,6 +178,24 @@ module Fluent
       end
     end
 
+    if Fluent.windows?
+      # Override some methods of ServerEngine::MultiSpawnWorker
+      # Since Fluentd's Supervisor doesn't use ServerEngine's HUP, USR1 and USR2
+      # handlers (see install_supervisor_signal_handlers), they should be
+      # disabled also on Windows, just send commands to workers instead.
+      def restart(graceful)
+        @monitors.each do |m|
+          m.send_command(graceful ? "GRACEFUL_RESTART\n" : "IMMEDIATE_RESTART\n")
+        end
+      end
+
+      def reload
+        @monitors.each do |m|
+          m.send_command("RELOAD\n")
+        end
+      end
+    end
+
     def install_windows_event_handler
       return unless Fluent.windows?
       return unless config[:signame]
@@ -184,16 +203,46 @@ module Fluent
       @signame = config[:signame]
 
       Thread.new do
-        ev = Win32::Event.new(@signame)
+        ipc = Win32::Ipc.new(nil)
+        events = [
+          Win32::Event.new("#{@signame}"),
+          Win32::Event.new("#{@signame}_HUP"),
+          Win32::Event.new("#{@signame}_USR1"),
+          Win32::Event.new("#{@signame}_USR2"),
+          Win32::Event.new("#{@signame}_STOP_EVENT_THREAD"),
+        ]
         begin
-          ev.reset
-          until WaitForSingleObject(ev.handle, 0) == WAIT_OBJECT_0
-            sleep 1
+          loop do
+            idx = ipc.wait_any(events, Windows::Synchronize::INFINITE)
+            if idx > 0 && idx <= events.length
+              $log.debug("Got Win32 event \"#{events[idx - 1].name}\"")
+            else
+              $log.warn("Unexpected reutrn value of Win32::Ipc#wait_any: #{idx}")
+            end
+            case idx
+            when 1
+              stop(true)
+            when 2
+              supervisor_sighup_handler
+            when 3
+              supervisor_sigusr1_handler
+            when 4
+              supervisor_sigusr2_handler
+            when 5
+              break
+            end
           end
-          stop(true)
         ensure
-          ev.close
+          events.each { |event| event.close }
         end
+      end
+    end
+
+    def stop_windows_event_thread
+      if Fluent.windows? && @signame
+        ev = Win32::Event.open("#{@signame}_STOP_EVENT_THREAD")
+        ev.set
+        ev.close
       end
     end
 
@@ -271,9 +320,25 @@ module Fluent
     def send_signal_to_workers(signal)
       return unless config[:worker_pid]
 
-      config[:worker_pid].each_value do |pid|
-        # don't rescue Errno::ESRCH here (invalid status)
-        Process.kill(signal, pid)
+      if Fluent.windows?
+        send_command_to_workers(signal)
+      else
+        config[:worker_pid].each_value do |pid|
+          # don't rescue Errno::ESRCH here (invalid status)
+          Process.kill(signal, pid)
+        end
+      end
+    end
+
+    def send_command_to_workers(signal)
+      # Use SeverEngine's CommandSender on Windows
+      case signal
+      when :HUP
+        restart(false)
+      when :USR1
+        restart(true)
+      when :USR2
+        reload
       end
     end
   end
@@ -752,33 +817,45 @@ module Fluent
         end
       end
 
-      trap :USR1 do
-        flush_buffer
-      end unless Fluent.windows?
-
-      trap :USR2 do
-        reload_config
-      end unless Fluent.windows?
-
       if Fluent.windows?
-        command_pipe = STDIN.dup
-        STDIN.reopen(File::NULL, "rb")
-        command_pipe.binmode
-        command_pipe.sync = true
+        install_main_process_command_handlers
+      else
+        trap :USR1 do
+          flush_buffer
+        end
 
-        Thread.new do
-          loop do
-            cmd = command_pipe.gets.chomp
-            case cmd
-            when "GRACEFUL_STOP", "IMMEDIATE_STOP"
-              $log.debug "fluentd main process get #{cmd} command"
-              @finished = true
-              $log.debug "getting start to shutdown main process"
-              Fluent::Engine.stop
-              break
-            else
-              $log.warn "fluentd main process get unknown command [#{cmd}]"
-            end
+        trap :USR2 do
+          reload_config
+        end
+      end
+    end
+
+    def install_main_process_command_handlers
+      command_pipe = $stdin.dup
+      $stdin.reopen(File::NULL, "rb")
+      command_pipe.binmode
+      command_pipe.sync = true
+
+      Thread.new do
+        loop do
+          cmd = command_pipe.gets
+          break unless cmd
+
+          case cmd.chomp!
+          when "GRACEFUL_STOP", "IMMEDIATE_STOP"
+            $log.debug "fluentd main process get #{cmd} command"
+            @finished = true
+            $log.debug "getting start to shutdown main process"
+            Fluent::Engine.stop
+            break
+          when "GRACEFUL_RESTART"
+            $log.debug "fluentd main process get #{cmd} command"
+            flush_buffer
+          when "RELOAD"
+            $log.debug "fluentd main process get #{cmd} command"
+            reload_config
+          else
+            $log.warn "fluentd main process get unknown command [#{cmd}]"
           end
         end
       end

--- a/lib/fluent/winsvc.rb
+++ b/lib/fluent/winsvc.rb
@@ -61,7 +61,6 @@ begin
     end
     
     def service_main
-    
       @pid = service_main_start(@service_name)
       while running?
         sleep 10
@@ -69,12 +68,22 @@ begin
     end
 
     def service_stop
-      ev = Win32::Event.open(@service_name)
-      ev.set
-      ev.close
+      set_event(@service_name)
       if @pid > 0
         Process.waitpid(@pid)
       end
+    end
+
+    def service_paramchange
+      set_event("#{@service_name}_USR2")
+    end
+
+    private
+
+    def set_event(event_name)
+      ev = Win32::Event.open(event_name)
+      ev.set
+      ev.close
     end
   end
 

--- a/lib/fluent/winsvc.rb
+++ b/lib/fluent/winsvc.rb
@@ -78,6 +78,15 @@ begin
       set_event("#{@service_name}_USR2")
     end
 
+    def service_user_defined_control(code)
+      case code
+      when 128
+        set_event("#{@service_name}_HUP")
+      when 129
+        set_event("#{@service_name}_USR1")
+      end
+    end
+
     private
 
     def set_event(event_name)

--- a/test/command/test_ctl.rb
+++ b/test/command/test_ctl.rb
@@ -1,0 +1,57 @@
+require_relative '../helper'
+
+require 'test-unit'
+require 'win32/event' if Fluent.windows?
+
+require 'fluent/command/ctl'
+
+class TestFluentdCtl < ::Test::Unit::TestCase
+  def assert_win32_event(event_name, command, pid_or_svcname)
+    command, event_suffix = data
+    event = Win32::Event.new(event_name)
+    ipc = Win32::Ipc.new(event.handle)
+    ret = Win32::Ipc::TIMEOUT
+
+    wait_thread = Thread.new do
+      ret = ipc.wait(1)
+    end
+    Fluent::Ctl.new([command, pid_or_svcname]).call
+    wait_thread.join
+    assert_equal(Win32::Ipc::SIGNALED, ret)
+  end
+
+  data("shutdown" => ["shutdown", "TERM", ""],
+       "restart" => ["restart", "HUP", "HUP"],
+       "flush" => ["flush", "USR1", "USR1"],
+       "reload" => ["reload", "USR2", "USR2"])
+  def test_commands(data)
+    command, signal, event_suffix = data
+
+    if Fluent.windows?
+      event_name = "fluentd_54321"
+      event_name << "_#{event_suffix}" unless event_suffix.empty?
+      assert_win32_event(event_name, command, "54321")
+    else
+      got_signal = false
+      Signal.trap(signal) do
+        got_signal = true
+      end
+      Fluent::Ctl.new([command, "#{$$}"]).call
+      assert_true(got_signal)
+    end
+  end
+
+  data("shutdown" => ["shutdown", ""],
+       "restart" => ["restart", "HUP"],
+       "flush" => ["flush", "USR1"],
+       "reload" => ["reload", "USR2"])
+  def test_commands_with_winsvcname(data)
+    omit "Only for Windows" unless Fluent.windows?
+
+    command, event_suffix = data
+    event_name = "testfluentdwinsvc"
+    event_name << "_#{event_suffix}" unless event_suffix.empty?
+
+    assert_win32_event(event_name, command, "testfluentdwinsvc")
+  end
+end

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -234,7 +234,7 @@ class SupervisorTest < ::Test::Unit::TestCase
     server.run_rpc_server
 
     sv.send(:install_main_process_signal_handlers)
-    Net::HTTP.get URI.parse('http://127.0.0.1:24447/api/plugins.flushBuffers')
+    response = Net::HTTP.get(URI.parse('http://127.0.0.1:24447/api/plugins.flushBuffers'))
     info_msg = '[info]: force flushing buffered events' + "\n"
 
     server.stop_rpc_server
@@ -243,6 +243,7 @@ class SupervisorTest < ::Test::Unit::TestCase
     # This test will be passed in such environment.
     pend unless $log.out.logs.first
 
+    assert_equal('{"ok":true}', response)
     assert{ $log.out.logs.first.end_with?(info_msg) }
   ensure
     $log.out.reset if $log.out.is_a?(Fluent::Test::DummyLogDevice)
@@ -275,9 +276,10 @@ class SupervisorTest < ::Test::Unit::TestCase
     server.run_rpc_server
 
     mock(server).restart(true) { nil }
-    Net::HTTP.get URI.parse('http://127.0.0.1:24447/api/plugins.flushBuffers')
+    response = Net::HTTP.get(URI.parse('http://127.0.0.1:24447/api/plugins.flushBuffers'))
 
     server.stop_rpc_server
+    assert_equal('{"ok":true}', response)
   end
 
   def test_load_config

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -111,6 +111,32 @@ class SupervisorTest < ::Test::Unit::TestCase
     $log.out.reset if $log && $log.out && $log.out.respond_to?(:reset)
   end
 
+  def test_main_process_command_handlers
+    omit "Only for Windows, alternative to UNIX signals" unless Fluent.windows?
+
+    create_info_dummy_logger
+
+    opts = Fluent::Supervisor.default_options
+    sv = Fluent::Supervisor.new(opts)
+    r, w = IO.pipe
+    $stdin = r
+    sv.send(:install_main_process_signal_handlers)
+
+    begin
+      w.write("GRACEFUL_RESTART\n")
+      w.flush
+    ensure
+      $stdin = STDIN
+    end
+
+    sleep 1
+
+    info_msg = '[info]: force flushing buffered events' + "\n"
+    assert{ $log.out.logs.first.end_with?(info_msg) }
+  ensure
+    $log.out.reset if $log && $log.out && $log.out.respond_to?(:reset)
+  end
+
   def test_supervisor_signal_handler
     omit "Windows cannot handle signals" if Fluent.windows?
 
@@ -137,21 +163,53 @@ class SupervisorTest < ::Test::Unit::TestCase
 
     server = DummyServer.new
     def server.config
-      {:signame => "TestFluentdEvent", :worker_pid => {0 => 1234}}
+      {:signame => "TestFluentdEvent"}
     end
 
     mock(server).stop(true)
     stub(Process).kill.times(0)
 
-    server.before_run
     server.install_windows_event_handler
-    sleep 0.1 # Wait for starting windows event thread
-    event = Win32::Event.open("TestFluentdEvent")
-    event.set
-    event.close
-    # Wait for stopping windows event thread. Should larger than 1 sec
-    # because the thread is awaked every 1 sec.
-    sleep 1.1
+    begin
+      sleep 0.1 # Wait for starting windows event thread
+      event = Win32::Event.open("TestFluentdEvent")
+      event.set
+      event.close
+    ensure
+      server.stop_windows_event_thread
+    end
+
+    debug_msg = '[debug]: Got Win32 event "TestFluentdEvent"'
+    logs = $log.out.logs
+    assert{ logs.any?{|log| log.include?(debug_msg) } }
+  ensure
+    $log.out.reset if $log && $log.out && $log.out.respond_to?(:reset)
+  end
+
+  def test_supervisor_event_handler
+    omit "Only for Windows, alternative to UNIX signals" unless Fluent.windows?
+
+    create_debug_dummy_logger
+
+    server = DummyServer.new
+    def server.config
+      {:signame => "TestFluentdEvent"}
+    end
+    server.install_windows_event_handler
+    begin
+      sleep 0.1 # Wait for starting windows event thread
+      event = Win32::Event.open("TestFluentdEvent_USR1")
+      event.set
+      event.close
+    ensure
+      server.stop_windows_event_thread
+    end
+
+    debug_msg = '[debug]: Got Win32 event "TestFluentdEvent_USR1"'
+    logs = $log.out.logs
+    assert{ logs.any?{|log| log.include?(debug_msg) } }
+  ensure
+    $log.out.reset if $log && $log.out && $log.out.respond_to?(:reset)
   end
 
   def test_rpc_server


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 
Since Windows doesn't have UNIX signals, features realized by them such as flushing buffers aren't implemented on Windows.
This PR adds triggers for them by using win32 events. Currently only supervisor process supports them.

In addition, this PR adds a new command `fluent-ctl`. It sends a simple command to a fluentd process.
The main purpose of this command is that providing a kill command alternative on Windows.
On UNIX, it just only send a UNIX signal to a specified process.

```
Usage: fluent-ctl COMMAND PID_OR_SIGNAME
    
Commands:
  shutdown
  restart
  flush
  reload
```

SIGNAME can be specified by fluentd's "-x" or "--signame" option.
Note that this command doesn't support sending events to windows service.
Probably we need to trigger these events via `sc` command for windows service.

This PR also fixes a bug that the graceful shutdown feature doesn't work correctly when Fluentd is launched as Windows service. On this case, worker processes were killed forcedly before receiving `GRACEFUL_STOP` command.

**Docs Changes**:
Add `fluent-ctl` to https://docs.fluentd.org/deployment/command-line-option

**Release Note**: 
Same as title.