### PR TITLE
output: Replace ${chunk_id} before logging warning.

### DIFF
--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -769,17 +769,19 @@ module Fluent
             end
           end
 
-          if rvalue =~ CHUNK_KEY_PLACEHOLDER_PATTERN
-            log.warn "chunk key placeholder '#{$1}' not replaced. template:#{str}"
-          end
-
-          rvalue.sub(CHUNK_ID_PLACEHOLDER_PATTERN) {
+          rvalue = rvalue.sub(CHUNK_ID_PLACEHOLDER_PATTERN) {
             if chunk_passed
               dump_unique_id_hex(chunk.unique_id)
             else
               log.warn "${chunk_id} is not allowed in this plugin. Pass Chunk instead of metadata in extract_placeholders's 2nd argument"
             end
           }
+
+          if rvalue =~ CHUNK_KEY_PLACEHOLDER_PATTERN
+            log.warn "chunk key placeholder '#{$1}' not replaced. template:#{str}"
+          end
+
+          rvalue
         end
       end
 

--- a/test/plugin/test_output.rb
+++ b/test/plugin/test_output.rb
@@ -378,6 +378,18 @@ class OutputTest < Test::Unit::TestCase
       assert { logs.any? { |log| log.include?("${chunk_id} is not allowed in this plugin") } }
     end
 
+    test '#extract_placeholders does not log for ${chunk_id} placeholder' do
+      @i.configure(config_element('ROOT', '', {}, [config_element('buffer', '')]))
+      tmpl = "/mypath/${chunk_id}/tail"
+      t = event_time('2016-04-11 20:30:00 +0900')
+      v = {key1: "value1", key2: "value2"}
+      c = create_chunk(timekey: t, tag: 'fluentd.test.output', variables: v)
+      @i.log.out.logs.clear
+      @i.extract_placeholders(tmpl, c)
+      logs = @i.log.out.logs
+      assert { logs.none? { |log| log.include?("${chunk_id}") } }
+    end
+
     test '#extract_placeholders logs warn message with not replaced key' do
       @i.configure(config_element('ROOT', '', {}, [config_element('buffer', '')]))
       tmpl = "/mypath/${key1}/test"


### PR DESCRIPTION
The updated implementation makes sure to replace instances of
${chunk_id} prior to looking for and warning on unreplaced keys in the
pattern. Prior to this, a warning line was printed for every chunk that
was flushed even though nothing was actually wrong (replacement happened
right after).

Signed-off-by: Brian Atkinson <brian@atkinson.mn>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
None filed.

**What this PR does / why we need it**: 
When using the s3 output plugin, with the `path` set to `"${tag}/%Y/%m/%d/%H/${chunk_id}_#{ENV['RUN_ID']}_#{worker_id}"` the fluentd process would print a log line like the following for every chunk flushed.
```
2020-09-25 00:32:49 +0000 [warn]: #1 [s3_output] chunk key placeholder 'chunk_id' not replaced. template:${tag}/%Y/%m/%d/%H/${chunk_id}_6ead9663854b0799849b47d91148d344f5fcb534329354a0dfad76ef6056_1.gz
```
This log line was being printed a little too early and is entirely misleading.

**Note to reviewer(s):** This is the first ruby I've worked with in about 10 years. Anything that doesn't feel normal about the code is likely due to this, and any improvements are appreciated.

**Docs Changes**:

**Release Note**: 
