### PR TITLE
chunk: fix binmode usage for prevent gc

### DIFF
--- a/lib/fluent/plugin/buffer/chunk.rb
+++ b/lib/fluent/plugin/buffer/chunk.rb
@@ -206,8 +206,9 @@ module Fluent
                 output_io = if chunk_io.is_a?(StringIO)
                               StringIO.new
                             else
-                              Tempfile.new('decompressed-data').binmode
+                              Tempfile.new('decompressed-data')
                             end
+                output_io.binmode if output_io.is_a?(Tempfile)
                 decompress(input_io: chunk_io, output_io: output_io)
                 output_io.seek(0, IO::SEEK_SET)
                 yield output_io


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #3110 

**What this PR does / why we need it**: 

I had a same problems as the issue.

Just set binmode, not use return value.
It is because IO#binmode returns File not Tempfile, so It would be collected by GC in if block.

```
irb(main):001:0>  require 'tempfile'
=> true
irb(main):002:0>  a = Tempfile.new("example")
=> #<Tempfile:/var/folders/bm/69m8bqqd343fx6vddc3lkqyc0000gp/T/example20200929-59624-zqnwq>
irb(main):003:0>
irb(main):004:0> a.binmode
=> #<File:/var/folders/bm/69m8bqqd343fx6vddc3lkqyc0000gp/T/example20200929-59624-zqnwq>
irb(main):005:0> a.binmode?
=> true
irb(main):006:0> a
=> #<Tempfile:/var/folders/bm/69m8bqqd343fx6vddc3lkqyc0000gp/T/example20200929-59624-zqnwq>
irb(main):007:0> a.class
=> Tempfile
irb(main):008:0> b = a.binmode
=> #<File:/var/folders/bm/69m8bqqd343fx6vddc3lkqyc0000gp/T/example20200929-59624-zqnwq>
```
**Docs Changes**:

**Release Note**: 
