### PR TITLE
out_http: Don't use destructive method for json_array. fix #3139

### DIFF
--- a/lib/fluent/plugin/out_http.rb
+++ b/lib/fluent/plugin/out_http.rb
@@ -215,7 +215,7 @@ module Fluent::Plugin
         req.basic_auth(@auth.username, @auth.password)
       end
       set_headers(req)
-      req.body = @json_array ? "[#{chunk.read.chop!}]" : chunk.read
+      req.body = @json_array ? "[#{chunk.read.chop}]" : chunk.read
       req
     end
 


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

**Which issue(s) this PR fixes**: 
Fixes #3139 

**What this PR does / why we need it**: 
`buf_memory`'s `read` returns same object. Don't use destructive method to avoid broken data.

**Docs Changes**:
No need

**Release Note**: 
Same as title