### PR TITLE
Add unixtime_millis to inject plugin helper

### DIFF
--- a/lib/fluent/plugin_helper/inject.rb
+++ b/lib/fluent/plugin_helper/inject.rb
@@ -76,7 +76,7 @@ module Fluent
           config_param :time_key, :string, default: nil
 
           # To avoid defining :time_type twice
-          config_param :time_type, :enum, list: [:float, :unixtime, :string], default: :float
+          config_param :time_type, :enum, list: [:float, :unixtime, :unixtime_millis, :string], default: :float
 
           Fluent::TimeMixin::TIME_PARAMETERS.each do |name, type, opts|
             config_param(name, type, **opts)
@@ -132,6 +132,7 @@ module Fluent
           if @_inject_time_key
             @_inject_time_formatter = case @inject_config.time_type
                                       when :float then ->(time){ time.to_r.truncate(+6).to_f } # microsecond floating point value
+                                      when :unixtime_millis then ->(time) { time.to_f.floor(3) * 1000 }
                                       when :unixtime then ->(time){ time.to_i }
                                       else
                                         localtime = @inject_config.localtime && !@inject_config.utc

--- a/test/plugin_helper/test_inject.rb
+++ b/test/plugin_helper/test_inject.rb
@@ -176,6 +176,19 @@ class InjectHelperTest < Test::Unit::TestCase
       assert_equal record.merge({"timedata" => float_time}), @d.inject_values_to_record('tag', time, record)
     end
 
+    test 'injects time as unix time millis into specified key' do
+      time_in_unix = Time.parse("2016-06-21 08:10:11 +0900").to_i
+      time_subsecond = 320_101_224
+      time = Fluent::EventTime.new(time_in_unix, time_subsecond)
+      unixtime_millis = 1466464211320
+
+      @d.configure(config_inject_section("time_key" => "timedata", "time_type" => "unixtime_millis"))
+      @d.start
+
+      record = {"key1" => "value1", "key2" => 2}
+      assert_equal record.merge({"timedata" => unixtime_millis}), @d.inject_values_to_record('tag', time, record)
+    end
+
     test 'injects time as unix time into specified key' do
       time_in_unix = Time.parse("2016-06-21 08:10:11 +0900").to_i
       time_subsecond = 320_101_224


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**What this PR does / why we need it**: 

It is useful to add timestamp as milliseconds since Unix epoch.
This is the short hand to add the filed using filter
record_transformer like followings:

```
<filter>
  @type record_transformer
  enable_ruby
  <record>
    time ${time.to_f.floor(3) * 1000}
  </record>
</filter>
```

This is useful to reduce data size with presto like system such as AWS Athena with S3.

**Docs Changes**: Need

**Release Note**: 

Add unixtime_millis to inject plugin helper