### PR TITLE
Provide CRLF newline style choice on formatter plugins. Fix #3151

### DIFF
--- a/lib/fluent/plugin/formatter.rb
+++ b/lib/fluent/plugin/formatter.rb
@@ -46,5 +46,29 @@ module Fluent
         @proc.call(tag, time, record)
       end
     end
+
+    module Newline
+      module Mixin
+        include Fluent::Configurable
+
+        DEFAULT_NEWLINE = if Fluent.windows?
+                            :crlf
+                          else
+                            :lf
+                          end
+
+        config_param :newline, :enum, list: [:lf, :crlf], default: DEFAULT_NEWLINE
+
+        def configure(conf)
+          super
+          @newline = case newline
+                     when :lf
+                       "\n"
+                     when :crlf
+                       "\r\n"
+                     end
+        end
+      end
+    end
   end
 end

--- a/lib/fluent/plugin/formatter_hash.rb
+++ b/lib/fluent/plugin/formatter_hash.rb
@@ -22,10 +22,21 @@ module Fluent
       Plugin.register_formatter('hash', self)
 
       config_param :add_newline, :bool, default: true
+      config_param :newline, :enum, list: [:lf, :crlf], default: :lf
+
+      def configure(conf)
+        super
+        @newline = case newline
+                   when :lf
+                     "\n"
+                   when :crlf
+                     "\r\n"
+                   end
+      end
 
       def format(tag, time, record)
         line = record.to_s
-        line << "\n".freeze if @add_newline
+        line << @newline.freeze if @add_newline
         line
       end
     end

--- a/lib/fluent/plugin/formatter_hash.rb
+++ b/lib/fluent/plugin/formatter_hash.rb
@@ -19,20 +19,11 @@ require 'fluent/plugin/formatter'
 module Fluent
   module Plugin
     class HashFormatter < Formatter
+      include Fluent::Plugin::Newline::Mixin
+
       Plugin.register_formatter('hash', self)
 
       config_param :add_newline, :bool, default: true
-      config_param :newline, :enum, list: [:lf, :crlf], default: :lf
-
-      def configure(conf)
-        super
-        @newline = case newline
-                   when :lf
-                     "\n"
-                   when :crlf
-                     "\r\n"
-                   end
-      end
 
       def format(tag, time, record)
         line = record.to_s

--- a/lib/fluent/plugin/formatter_json.rb
+++ b/lib/fluent/plugin/formatter_json.rb
@@ -20,11 +20,12 @@ require 'fluent/env'
 module Fluent
   module Plugin
     class JSONFormatter < Formatter
+      include Fluent::Plugin::Newline::Mixin
+
       Plugin.register_formatter('json', self)
 
       config_param :json_parser, :string, default: 'oj'
       config_param :add_newline, :bool, default: true
-      config_param :newline, :enum, list: [:lf, :crlf], default: :lf
 
       def configure(conf)
         super
@@ -42,13 +43,6 @@ module Fluent
         unless @add_newline
           define_singleton_method(:format, method(:format_without_nl))
         end
-
-        @newline = case newline
-                   when :lf
-                     "\n"
-                   when :crlf
-                     "\r\n"
-                   end
       end
 
       def format(tag, time, record)

--- a/lib/fluent/plugin/formatter_json.rb
+++ b/lib/fluent/plugin/formatter_json.rb
@@ -24,6 +24,7 @@ module Fluent
 
       config_param :json_parser, :string, default: 'oj'
       config_param :add_newline, :bool, default: true
+      config_param :newline, :enum, list: [:lf, :crlf], default: :lf
 
       def configure(conf)
         super
@@ -41,10 +42,17 @@ module Fluent
         unless @add_newline
           define_singleton_method(:format, method(:format_without_nl))
         end
+
+        @newline = case newline
+                   when :lf
+                     "\n"
+                   when :crlf
+                     "\r\n"
+                   end
       end
 
       def format(tag, time, record)
-        "#{@dump_proc.call(record)}\n"
+        "#{@dump_proc.call(record)}#{@newline}"
       end
 
       def format_without_nl(tag, time, record)

--- a/lib/fluent/plugin/formatter_ltsv.rb
+++ b/lib/fluent/plugin/formatter_ltsv.rb
@@ -19,6 +19,8 @@ require 'fluent/plugin/formatter'
 module Fluent
   module Plugin
     class LabeledTSVFormatter < Formatter
+      include Fluent::Plugin::Newline::Mixin
+
       Plugin.register_formatter('ltsv', self)
 
       # http://ltsv.org/
@@ -26,18 +28,6 @@ module Fluent
       config_param :delimiter, :string, default: "\t"
       config_param :label_delimiter, :string, default: ":"
       config_param :add_newline, :bool, default: true
-      config_param :newline, :enum, list: [:lf, :crlf], default: :lf
-
-      def configure(conf)
-        super
-
-        @newline = case newline
-                   when :lf
-                     "\n"
-                   when :crlf
-                     "\r\n"
-                   end
-      end
 
       # TODO: escaping for \t in values
       def format(tag, time, record)

--- a/lib/fluent/plugin/formatter_ltsv.rb
+++ b/lib/fluent/plugin/formatter_ltsv.rb
@@ -26,6 +26,18 @@ module Fluent
       config_param :delimiter, :string, default: "\t"
       config_param :label_delimiter, :string, default: ":"
       config_param :add_newline, :bool, default: true
+      config_param :newline, :enum, list: [:lf, :crlf], default: :lf
+
+      def configure(conf)
+        super
+
+        @newline = case newline
+                   when :lf
+                     "\n"
+                   when :crlf
+                     "\r\n"
+                   end
+      end
 
       # TODO: escaping for \t in values
       def format(tag, time, record)
@@ -34,7 +46,7 @@ module Fluent
           formatted << @delimiter if formatted.length.nonzero?
           formatted << "#{label}#{@label_delimiter}#{value}"
         end
-        formatted << "\n".freeze if @add_newline
+        formatted << @newline.freeze if @add_newline
         formatted
       end
     end

--- a/lib/fluent/plugin/formatter_out_file.rb
+++ b/lib/fluent/plugin/formatter_out_file.rb
@@ -32,19 +32,27 @@ module Fluent
         else "\t"
         end
       end
+      config_param :newline, :enum, list: [:lf, :crlf], default: :lf
       config_set_default :time_type, :string
       config_set_default :time_format, nil # time_format nil => iso8601
 
       def configure(conf)
         super
         @timef = time_formatter_create
+
+        @newline = case newline
+                   when :lf
+                     "\n"
+                   when :crlf
+                     "\r\n"
+                   end
       end
 
       def format(tag, time, record)
         header = ''
         header << "#{@timef.format(time)}#{@delimiter}" if @output_time
         header << "#{tag}#{@delimiter}" if @output_tag
-        "#{header}#{Yajl.dump(record)}\n"
+        "#{header}#{Yajl.dump(record)}#{@newline}"
       end
     end
   end

--- a/lib/fluent/plugin/formatter_out_file.rb
+++ b/lib/fluent/plugin/formatter_out_file.rb
@@ -21,6 +21,8 @@ require 'yajl'
 module Fluent
   module Plugin
     class OutFileFormatter < Formatter
+      include Fluent::Plugin::Newline::Mixin
+
       Plugin.register_formatter('out_file', self)
 
       config_param :output_time, :bool, default: true
@@ -32,20 +34,12 @@ module Fluent
         else "\t"
         end
       end
-      config_param :newline, :enum, list: [:lf, :crlf], default: :lf
       config_set_default :time_type, :string
       config_set_default :time_format, nil # time_format nil => iso8601
 
       def configure(conf)
         super
         @timef = time_formatter_create
-
-        @newline = case newline
-                   when :lf
-                     "\n"
-                   when :crlf
-                     "\r\n"
-                   end
       end
 
       def format(tag, time, record)

--- a/lib/fluent/plugin/formatter_single_value.rb
+++ b/lib/fluent/plugin/formatter_single_value.rb
@@ -23,10 +23,22 @@ module Fluent
 
       config_param :message_key, :string, default: 'message'
       config_param :add_newline, :bool, default: true
+      config_param :newline, :enum, list: [:lf, :crlf], default: :lf
+
+      def configure(conf)
+        super
+
+        @newline = case newline
+                   when :lf
+                     "\n"
+                   when :crlf
+                     "\r\n"
+                   end
+      end
 
       def format(tag, time, record)
         text = record[@message_key].to_s.dup
-        text << "\n" if @add_newline
+        text << @newline.freeze if @add_newline
         text
       end
     end

--- a/lib/fluent/plugin/formatter_single_value.rb
+++ b/lib/fluent/plugin/formatter_single_value.rb
@@ -19,22 +19,12 @@ require 'fluent/plugin/formatter'
 module Fluent
   module Plugin
     class SingleValueFormatter < Formatter
+      include Fluent::Plugin::Newline::Mixin
+
       Plugin.register_formatter('single_value', self)
 
       config_param :message_key, :string, default: 'message'
       config_param :add_newline, :bool, default: true
-      config_param :newline, :enum, list: [:lf, :crlf], default: :lf
-
-      def configure(conf)
-        super
-
-        @newline = case newline
-                   when :lf
-                     "\n"
-                   when :crlf
-                     "\r\n"
-                   end
-      end
 
       def format(tag, time, record)
         text = record[@message_key].to_s.dup

--- a/lib/fluent/plugin/formatter_tsv.rb
+++ b/lib/fluent/plugin/formatter_tsv.rb
@@ -19,6 +19,8 @@ require 'fluent/plugin/formatter'
 module Fluent
   module Plugin
     class TSVFormatter < Formatter
+      include Fluent::Plugin::Newline::Mixin
+
       Plugin.register_formatter('tsv', self)
 
       desc 'Field names included in each lines'
@@ -27,19 +29,6 @@ module Fluent
       config_param :delimiter, :string, default: "\t"
       desc 'The parameter to enable writing to new lines'
       config_param :add_newline, :bool, default: true
-      desc 'The newline code'
-      config_param :newline, :enum, list: [:lf, :crlf], default: :lf
-
-      def configure(conf)
-        super
-
-        @newline = case newline
-                   when :lf
-                     "\n"
-                   when :crlf
-                     "\r\n"
-                   end
-      end
 
       def format(tag, time, record)
         formatted = @keys.map{|k| record[k].to_s }.join(@delimiter)

--- a/lib/fluent/plugin/formatter_tsv.rb
+++ b/lib/fluent/plugin/formatter_tsv.rb
@@ -27,10 +27,23 @@ module Fluent
       config_param :delimiter, :string, default: "\t"
       desc 'The parameter to enable writing to new lines'
       config_param :add_newline, :bool, default: true
+      desc 'The newline code'
+      config_param :newline, :enum, list: [:lf, :crlf], default: :lf
+
+      def configure(conf)
+        super
+
+        @newline = case newline
+                   when :lf
+                     "\n"
+                   when :crlf
+                     "\r\n"
+                   end
+      end
 
       def format(tag, time, record)
         formatted = @keys.map{|k| record[k].to_s }.join(@delimiter)
-        formatted << "\n".freeze if @add_newline
+        formatted << @newline.freeze if @add_newline
         formatted
       end
     end

--- a/test/command/test_binlog_reader.rb
+++ b/test/command/test_binlog_reader.rb
@@ -82,6 +82,14 @@ class TestBaseCommand < ::Test::Unit::TestCase
 end
 
 class TestHead < TestBaseCommand
+  setup do
+    @default_newline = if Fluent.windows?
+                         "\r\n"
+                       else
+                         "\n"
+                       end
+  end
+
   sub_test_case 'initialize' do
     data(
       'file is not passed' => %w(),
@@ -138,7 +146,7 @@ class TestHead < TestBaseCommand
         create_message_packed_file(@file_name, [event_time(@t).to_i] * 6, [@record] * 6)
         head = BinlogReaderCommand::Head.new(argv)
         out = capture_stdout { head.call }
-        assert_equal "2011-01-02T13:14:15+00:00\t#{TMP_DIR}/#{@file_name}\t#{Yajl.dump(@record)}\n" * 5, out
+        assert_equal "2011-01-02T13:14:15+00:00\t#{TMP_DIR}/#{@file_name}\t#{Yajl.dump(@record)}#{@default_newline}" * 5, out
       end
     end
 
@@ -149,7 +157,7 @@ class TestHead < TestBaseCommand
         create_message_packed_file(@file_name, [event_time(@t).to_i] * 6, [@record] * 6)
         head = BinlogReaderCommand::Head.new(argv)
         out = capture_stdout { head.call }
-        assert_equal "2011-01-02T13:14:15+00:00\t#{TMP_DIR}/#{@file_name}\t#{Yajl.dump(@record)}\n", out
+        assert_equal "2011-01-02T13:14:15+00:00\t#{TMP_DIR}/#{@file_name}\t#{Yajl.dump(@record)}#{@default_newline}", out
       end
     end
 
@@ -169,7 +177,7 @@ class TestHead < TestBaseCommand
         create_message_packed_file(@file_name, [event_time(@t).to_i], [@record])
         head = BinlogReaderCommand::Head.new(argv)
         out = capture_stdout { head.call }
-        assert_equal "#{Yajl.dump(@record)}\n", out
+        assert_equal "#{Yajl.dump(@record)}#{@default_newline}", out
       end
     end
 
@@ -198,6 +206,14 @@ class TestHead < TestBaseCommand
 end
 
 class TestCat < TestBaseCommand
+  setup do
+    @default_newline = if Fluent.windows?
+                         "\r\n"
+                       else
+                         "\n"
+                       end
+  end
+
   sub_test_case 'initialize' do
     data(
       'file is not passed' => [],
@@ -254,7 +270,7 @@ class TestCat < TestBaseCommand
         create_message_packed_file(@file_name, [event_time(@t).to_i] * 6, [@record] * 6)
         head = BinlogReaderCommand::Cat.new(argv)
         out = capture_stdout { head.call }
-        assert_equal "2011-01-02T13:14:15+00:00\t#{TMP_DIR}/#{@file_name}\t#{Yajl.dump(@record)}\n" * 6, out
+        assert_equal "2011-01-02T13:14:15+00:00\t#{TMP_DIR}/#{@file_name}\t#{Yajl.dump(@record)}#{@default_newline}" * 6, out
       end
     end
 
@@ -265,7 +281,7 @@ class TestCat < TestBaseCommand
         create_message_packed_file(@file_name, [event_time(@t).to_i] * 6, [@record] * 6)
         head = BinlogReaderCommand::Cat.new(argv)
         out = capture_stdout { head.call }
-        assert_equal "2011-01-02T13:14:15+00:00\t#{TMP_DIR}/#{@file_name}\t#{Yajl.dump(@record)}\n", out
+        assert_equal "2011-01-02T13:14:15+00:00\t#{TMP_DIR}/#{@file_name}\t#{Yajl.dump(@record)}#{@default_newline}", out
       end
     end
 
@@ -276,7 +292,7 @@ class TestCat < TestBaseCommand
         create_message_packed_file(@file_name, [event_time(@t).to_i], [@record])
         head = BinlogReaderCommand::Cat.new(argv)
         out = capture_stdout { head.call }
-        assert_equal "#{Yajl.dump(@record)}\n", out
+        assert_equal "#{Yajl.dump(@record)}#{@default_newline}", out
       end
     end
 

--- a/test/plugin/test_filter_stdout.rb
+++ b/test/plugin/test_filter_stdout.rb
@@ -12,6 +12,11 @@ class StdoutFilterTest < Test::Unit::TestCase
     @old_tz = ENV["TZ"]
     ENV["TZ"] = "UTC"
     Timecop.freeze
+    @default_newline = if Fluent.windows?
+                         "\r\n"
+                       else
+                         "\n"
+                       end
   end
 
   def teardown
@@ -106,7 +111,7 @@ class StdoutFilterTest < Test::Unit::TestCase
     def test_format_json
       d = create_driver(CONFIG + config_element("", "", { "format" => "json" }))
       out = capture_log(d) { filter(d, event_time, {'test' => 'test'}) }
-      assert_equal "{\"test\":\"test\"}\n", out
+      assert_equal "{\"test\":\"test\"}#{@default_newline}", out
     end
   end
 

--- a/test/plugin/test_formatter_hash.rb
+++ b/test/plugin/test_formatter_hash.rb
@@ -19,11 +19,14 @@ class HashFormatterTest < ::Test::Unit::TestCase
     {'message' => 'awesome', 'greeting' => 'hello'}
   end
 
-  def test_format
-    d = create_driver({})
+  data("newline (LF)" => ["lf", "\n"],
+       "newline (CRLF)" => ["crlf", "\r\n"])
+  def test_format(data)
+    newline_conf, newline = data
+    d = create_driver({"newline" => newline_conf})
     formatted = d.instance.format(tag, @time, record)
 
-    assert_equal(%Q!{"message"=>"awesome", "greeting"=>"hello"}\n!, formatted.encode(Encoding::UTF_8))
+    assert_equal(%Q!{"message"=>"awesome", "greeting"=>"hello"}#{newline}!, formatted.encode(Encoding::UTF_8))
   end
 
   def test_format_without_newline

--- a/test/plugin/test_formatter_json.rb
+++ b/test/plugin/test_formatter_json.rb
@@ -25,12 +25,17 @@ class JsonFormatterTest < ::Test::Unit::TestCase
     {:message => :awesome}
   end
 
-  data('oj' => 'oj', 'yajl' => 'yajl')
+  data('oj with LF' => ['oj', "lf", "\n"],
+       'oj with CRLF' => ['oj', "crlf", "\r\n"],
+       'yajl with LF' => ['yajl', "lf", "\n"],
+       'yajl with CRLF' => ['yajl', "crlf", "\r\n"]
+      )
   def test_format(data)
-    d = create_driver('json_parser' => data)
+    parser, newline_conf, newline = data
+    d = create_driver('json_parser' => parser, 'newline' => newline_conf)
     formatted = d.instance.format(tag, @time, record)
 
-    assert_equal("#{JSON.generate(record)}\n", formatted)
+    assert_equal("#{JSON.generate(record)}#{newline}", formatted)
   end
 
   data('oj' => 'oj', 'yajl' => 'yajl')

--- a/test/plugin/test_formatter_json.rb
+++ b/test/plugin/test_formatter_json.rb
@@ -7,6 +7,11 @@ class JsonFormatterTest < ::Test::Unit::TestCase
 
   def setup
     @time = event_time
+    @default_newline = if Fluent.windows?
+                         "\r\n"
+                       else
+                         "\n"
+                       end
   end
 
   def create_driver(conf = "")
@@ -51,6 +56,6 @@ class JsonFormatterTest < ::Test::Unit::TestCase
     d = create_driver('json_parser' => data)
     formatted = d.instance.format(tag, @time, symbolic_record)
 
-    assert_equal("#{JSON.generate(record)}\n", formatted)
+    assert_equal("#{JSON.generate(record)}#{@default_newline}", formatted)
   end
 end

--- a/test/plugin/test_formatter_ltsv.rb
+++ b/test/plugin/test_formatter_ltsv.rb
@@ -36,11 +36,14 @@ class LabeledTSVFormatterTest < ::Test::Unit::TestCase
     assert_equal  false, d.instance.add_newline
   end
 
-  def test_format
-    d = create_driver({})
+  data("newline (LF)" => ["lf", "\n"],
+       "newline (CRLF)" => ["crlf", "\r\n"])
+  def test_format(data)
+    newline_conf, newline = data
+    d = create_driver({"newline" => newline_conf})
     formatted = d.instance.format(tag, @time, record)
 
-    assert_equal("message:awesome\tgreeting:hello\n", formatted)
+    assert_equal("message:awesome\tgreeting:hello#{newline}", formatted)
   end
 
   def test_format_without_newline
@@ -50,13 +53,18 @@ class LabeledTSVFormatterTest < ::Test::Unit::TestCase
     assert_equal("message:awesome\tgreeting:hello", formatted)
   end
 
-  def test_format_with_customized_delimiters
+  data("newline (LF)" => ["lf", "\n"],
+       "newline (CRLF)" => ["crlf", "\r\n"])
+  def test_format_with_customized_delimiters(data)
+    newline_conf, newline = data
+
     d = create_driver(
       'delimiter'       => ',',
       'label_delimiter' => '=',
+      'newline' => newline_conf,
     )
     formatted = d.instance.format(tag, @time, record)
 
-    assert_equal("message=awesome,greeting=hello\n", formatted)
+    assert_equal("message=awesome,greeting=hello#{newline}", formatted)
   end
 end

--- a/test/plugin/test_formatter_out_file.rb
+++ b/test/plugin/test_formatter_out_file.rb
@@ -5,6 +5,11 @@ require 'fluent/plugin/formatter_out_file'
 class OutFileFormatterTest < ::Test::Unit::TestCase
   def setup
     @time = event_time
+    @default_newline = if Fluent.windows?
+                         "\r\n"
+                       else
+                         "\n"
+                       end
   end
 
   def create_driver(conf = {})
@@ -48,7 +53,7 @@ class OutFileFormatterTest < ::Test::Unit::TestCase
       oldtz, ENV['TZ'] = ENV['TZ'], "UTC+07"
       d = create_driver(config_element('ROOT', '', {key => value}))
       tag = 'test'
-      assert_equal "#{expected}\t#{tag}\t#{Yajl.dump(record)}\n", d.instance.format(tag, time, record)
+      assert_equal "#{expected}\t#{tag}\t#{Yajl.dump(record)}#{@default_newline}", d.instance.format(tag, time, record)
     ensure
       ENV['TZ'] = oldtz
     end

--- a/test/plugin/test_formatter_out_file.rb
+++ b/test/plugin/test_formatter_out_file.rb
@@ -54,42 +54,58 @@ class OutFileFormatterTest < ::Test::Unit::TestCase
     end
   end
 
-  def test_format
-    d = create_driver({})
+  data("newline (LF)" => ["lf", "\n"],
+       "newline (CRLF)" => ["crlf", "\r\n"])
+  def test_format(data)
+    newline_conf, newline = data
+    d = create_driver({"newline" => newline_conf})
     formatted = d.instance.format(tag, @time, record)
 
-    assert_equal("#{time2str(@time)}\t#{tag}\t#{Yajl.dump(record)}\n", formatted)
+    assert_equal("#{time2str(@time)}\t#{tag}\t#{Yajl.dump(record)}#{newline}", formatted)
   end
 
-  def test_format_without_time
-    d = create_driver('output_time' => 'false')
+  data("newline (LF)" => ["lf", "\n"],
+       "newline (CRLF)" => ["crlf", "\r\n"])
+  def test_format_without_time(data)
+    newline_conf, newline = data
+    d = create_driver('output_time' => 'false', 'newline' => newline_conf)
     formatted = d.instance.format(tag, @time, record)
 
-    assert_equal("#{tag}\t#{Yajl.dump(record)}\n", formatted)
+    assert_equal("#{tag}\t#{Yajl.dump(record)}#{newline}", formatted)
   end
 
-  def test_format_without_tag
-    d = create_driver('output_tag' => 'false')
+  data("newline (LF)" => ["lf", "\n"],
+       "newline (CRLF)" => ["crlf", "\r\n"])
+  def test_format_without_tag(data)
+    newline_conf, newline = data
+    d = create_driver('output_tag' => 'false', 'newline' => newline_conf)
     formatted = d.instance.format(tag, @time, record)
 
-    assert_equal("#{time2str(@time)}\t#{Yajl.dump(record)}\n", formatted)
+    assert_equal("#{time2str(@time)}\t#{Yajl.dump(record)}#{newline}", formatted)
   end
 
+  data("newline (LF)" => ["lf", "\n"],
+       "newline (CRLF)" => ["crlf", "\r\n"])
   def test_format_without_time_and_tag
-    d = create_driver('output_tag' => 'false', 'output_time' => 'false')
+    newline_conf, newline = data
+    d = create_driver('output_tag' => 'false', 'output_time' => 'false', 'newline' => newline_conf)
     formatted = d.instance.format('tag', @time, record)
 
-    assert_equal("#{Yajl.dump(record)}\n", formatted)
+    assert_equal("#{Yajl.dump(record)}#{newline}", formatted)
   end
 
-  def test_format_without_time_and_tag_against_string_literal_configure
+  data("newline (LF)" => ["lf", "\n"],
+       "newline (CRLF)" => ["crlf", "\r\n"])
+  def test_format_without_time_and_tag_against_string_literal_configure(data)
+    newline_conf, newline = data
     d = create_driver(%[
                         utc         true
                         output_tag  false
                         output_time false
+                        newline     #{newline_conf}
                       ])
     formatted = d.instance.format('tag', @time, record)
 
-    assert_equal("#{Yajl.dump(record)}\n", formatted)
+    assert_equal("#{Yajl.dump(record)}#{newline}", formatted)
   end
 end

--- a/test/plugin/test_formatter_single_value.rb
+++ b/test/plugin/test_formatter_single_value.rb
@@ -17,10 +17,13 @@ class SingleValueFormatterTest < ::Test::Unit::TestCase
     assert_equal "foobar", d.instance.message_key
   end
 
-  def test_format
-    d = create_driver
+  data("newline (LF)" => ["lf", "\n"],
+       "newline (CRLF)" => ["crlf", "\r\n"])
+  def test_format(data)
+    newline_conf, newline = data
+    d = create_driver('newline' => newline_conf)
     formatted = d.instance.format('tag', event_time, {'message' => 'awesome'})
-    assert_equal("awesome\n", formatted)
+    assert_equal("awesome#{newline}", formatted)
   end
 
   def test_format_without_newline
@@ -29,10 +32,13 @@ class SingleValueFormatterTest < ::Test::Unit::TestCase
     assert_equal("awesome", formatted)
   end
 
-  def test_format_with_message_key
-    d = create_driver('message_key' => 'foobar')
+  data("newline (LF)" => ["lf", "\n"],
+       "newline (CRLF)" => ["crlf", "\r\n"])
+  def test_format_with_message_key(data)
+    newline_conf, newline = data
+    d = create_driver('message_key' => 'foobar', 'newline' => newline_conf)
     formatted = d.instance.format('tag', event_time, {'foobar' => 'foo'})
 
-    assert_equal("foo\n", formatted)
+    assert_equal("foo#{newline}", formatted)
   end
 end

--- a/test/plugin/test_formatter_tsv.rb
+++ b/test/plugin/test_formatter_tsv.rb
@@ -37,13 +37,17 @@ class TSVFormatterTest < ::Test::Unit::TestCase
     assert_equal false, d.instance.add_newline
   end
 
-  def test_format
+  data("newline (LF)" => ["lf", "\n"],
+       "newline (CRLF)" => ["crlf", "\r\n"])
+  def test_format(data)
+    newline_conf, newline = data
     d = create_driver(
       'keys' => 'message,greeting',
+      'newline' => newline_conf
     )
     formatted = d.instance.format(tag, @time, record)
 
-    assert_equal("awesome\thello\n", formatted)
+    assert_equal("awesome\thello#{newline}", formatted)
   end
 
   def test_format_without_newline
@@ -56,13 +60,17 @@ class TSVFormatterTest < ::Test::Unit::TestCase
     assert_equal("awesome\thello", formatted)
   end
 
-  def test_format_with_customized_delimiters
+  data("newline (LF)" => ["lf", "\n"],
+       "newline (CRLF)" => ["crlf", "\r\n"])
+  def test_format_with_customized_delimiters(data)
+    newline_conf, newline = data
     d = create_driver(
       'keys' => 'message,greeting',
       'delimiter' => ',',
+      'newline' => newline_conf,
     )
     formatted = d.instance.format(tag, @time, record)
 
-    assert_equal("awesome,hello\n", formatted)
+    assert_equal("awesome,hello#{newline}", formatted)
   end
 end

--- a/test/plugin_helper/test_compat_parameters.rb
+++ b/test/plugin_helper/test_compat_parameters.rb
@@ -10,6 +10,11 @@ class CompatParameterTest < Test::Unit::TestCase
   setup do
     Fluent::Test.setup
     @i = nil
+    @default_newline = if Fluent.windows?
+                         "\r\n"
+                       else
+                         "\n"
+                       end
   end
 
   teardown do
@@ -226,7 +231,7 @@ class CompatParameterTest < Test::Unit::TestCase
       t = event_time('2016-06-24 16:05:01') # localtime
       iso8601str = Time.at(t.to_i).iso8601
       formatted = @i.f.format('tag.test', t, @i.inject_values_to_record('tag.test', t, {"value" => 1}))
-      assert_equal "value%1,tag%tag.test,time%#{iso8601str}\n", formatted
+      assert_equal "value%1,tag%tag.test,time%#{iso8601str}#{@default_newline}", formatted
     end
 
     test 'plugin helper setups time injecting as unix time (integer from epoch)' do
@@ -260,7 +265,7 @@ class CompatParameterTest < Test::Unit::TestCase
       t = event_time('2016-06-24 16:05:01') # localtime
       iso8601str = Time.at(t.to_i).iso8601
       formatted = @i.f.format('tag.test', t, @i.inject_values_to_record('tag.test', t, {"value" => 1}))
-      assert_equal "value%1,tag%tag.test,time%#{iso8601str}\n", formatted
+      assert_equal "value%1,tag%tag.test,time%#{iso8601str}#{@default_newline}", formatted
     end
   end
 

--- a/test/test_formatter.rb
+++ b/test/test_formatter.rb
@@ -271,6 +271,7 @@ module FormatterTest
 
     def test_format
       formatter = Fluent::Plugin.new_formatter('single_value')
+      formatter.configure({})
       formatted = formatter.format('tag', Engine.now, {'message' => 'awesome'})
       assert_equal("awesome\n", formatted)
     end

--- a/test/test_formatter.rb
+++ b/test/test_formatter.rb
@@ -53,6 +53,11 @@ module FormatterTest
     def setup
       @formatter = Fluent::Test::FormatterTestDriver.new('out_file')
       @time = Engine.now
+      @newline = if Fluent.windows?
+                   "\r\n"
+                 else
+                   "\n"
+                 end
     end
 
     def configure(conf)
@@ -63,28 +68,28 @@ module FormatterTest
       configure({})
       formatted = @formatter.format(tag, @time, record)
 
-      assert_equal("#{time2str(@time)}\t#{tag}\t#{Yajl.dump(record)}\n", formatted)
+      assert_equal("#{time2str(@time)}\t#{tag}\t#{Yajl.dump(record)}#{@newline}", formatted)
     end
 
     def test_format_without_time
       configure('output_time' => 'false')
       formatted = @formatter.format(tag, @time, record)
 
-      assert_equal("#{tag}\t#{Yajl.dump(record)}\n", formatted)
+      assert_equal("#{tag}\t#{Yajl.dump(record)}#{@newline}", formatted)
     end
 
     def test_format_without_tag
       configure('output_tag' => 'false')
       formatted = @formatter.format(tag, @time, record)
 
-      assert_equal("#{time2str(@time)}\t#{Yajl.dump(record)}\n", formatted)
+      assert_equal("#{time2str(@time)}\t#{Yajl.dump(record)}#{@newline}", formatted)
     end
 
     def test_format_without_time_and_tag
       configure('output_tag' => 'false', 'output_time' => 'false')
       formatted = @formatter.format('tag', @time, record)
 
-      assert_equal("#{Yajl.dump(record)}\n", formatted)
+      assert_equal("#{Yajl.dump(record)}#{@newline}", formatted)
     end
 
     def test_format_without_time_and_tag_against_string_literal_configure
@@ -95,7 +100,7 @@ module FormatterTest
       ])
       formatted = @formatter.format('tag', @time, record)
 
-      assert_equal("#{Yajl.dump(record)}\n", formatted)
+      assert_equal("#{Yajl.dump(record)}#{@newline}", formatted)
     end
   end
 
@@ -105,6 +110,11 @@ module FormatterTest
     def setup
       @formatter = Fluent::Test::FormatterTestDriver.new(TextFormatter::JSONFormatter)
       @time = Engine.now
+      @newline = if Fluent.windows?
+                   "\r\n"
+                 else
+                   "\n"
+                 end
     end
 
     data('oj' => 'oj', 'yajl' => 'yajl')
@@ -112,7 +122,7 @@ module FormatterTest
       @formatter.configure('json_parser' => data)
       formatted = @formatter.format(tag, @time, record)
 
-      assert_equal("#{Yajl.dump(record)}\n", formatted)
+      assert_equal("#{Yajl.dump(record)}#{@newline}", formatted)
     end
   end
 
@@ -138,6 +148,11 @@ module FormatterTest
     def setup
       @formatter = TextFormatter::LabeledTSVFormatter.new
       @time = Engine.now
+      @newline = if Fluent.windows?
+                   "\r\n"
+                 else
+                   "\n"
+                 end
     end
 
     def test_config_params
@@ -157,7 +172,7 @@ module FormatterTest
       @formatter.configure({})
       formatted = @formatter.format(tag, @time, record)
 
-      assert_equal("message:awesome\tgreeting:hello\n", formatted)
+      assert_equal("message:awesome\tgreeting:hello#{@newline}", formatted)
     end
 
     def test_format_with_customized_delimiters
@@ -167,7 +182,7 @@ module FormatterTest
       )
       formatted = @formatter.format(tag, @time, record)
 
-      assert_equal("message=awesome,greeting=hello\n", formatted)
+      assert_equal("message=awesome,greeting=hello#{@newline}", formatted)
     end
   end
 
@@ -260,6 +275,14 @@ module FormatterTest
 
   class SingleValueFormatterTest < ::Test::Unit::TestCase
     include FormatterTest
+    def setup
+      @newline = if Fluent.windows?
+                   "\r\n"
+                 else
+                   "\n"
+                 end
+    end
+
 
     def test_config_params
       formatter = TextFormatter::SingleValueFormatter.new
@@ -273,7 +296,7 @@ module FormatterTest
       formatter = Fluent::Plugin.new_formatter('single_value')
       formatter.configure({})
       formatted = formatter.format('tag', Engine.now, {'message' => 'awesome'})
-      assert_equal("awesome\n", formatted)
+      assert_equal("awesome#{@newline}", formatted)
     end
 
     def test_format_without_newline
@@ -288,7 +311,7 @@ module FormatterTest
       formatter.configure('message_key' => 'foobar')
       formatted = formatter.format('tag', Engine.now, {'foobar' => 'foo'})
 
-      assert_equal("foo\n", formatted)
+      assert_equal("foo#{@newline}", formatted)
     end
   end
 

--- a/test/test_output.rb
+++ b/test/test_output.rb
@@ -230,6 +230,11 @@ module FluentOutputTest
       setup do
         @time = Time.parse("2011-01-02 13:14:15 UTC")
         Timecop.freeze(@time)
+        @newline = if Fluent.windows?
+                     "\r\n"
+                   else
+                     "\n"
+                   end
       end
 
       teardown do
@@ -265,7 +270,7 @@ module FluentOutputTest
         ])
         time = Time.parse("2016-11-08 12:00:00 UTC").to_i
         d.emit({"a" => 1}, time)
-        d.expect_format %[2016-11-08T12:00:00Z\ttest\t{"a":1,"time":"2016-11-08T12:00:00Z"}\n]
+        d.expect_format %[2016-11-08T12:00:00Z\ttest\t{"a":1,"time":"2016-11-08T12:00:00Z"}#{@newline}]
         d.run
       end
     end


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #3151 

**What this PR does / why we need it**: 
Currently, built-in formatter plugins use hard-coded LF newline.
We should provide CRLF style newline choice mainly for Windows users.

**Docs Changes**:
https://github.com/fluent/fluentd-docs-gitbook/pull/247

**Release Note**: 
Same as title.