### PR TITLE
Fix missing runtime bundler dependency

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.4'
 
+  gem.add_runtime_dependency("bundler")
   gem.add_runtime_dependency("msgpack", [">= 1.3.1", "< 2.0.0"])
   gem.add_runtime_dependency("yajl-ruby", ["~> 1.0"])
   gem.add_runtime_dependency("cool.io", [">= 1.4.5", "< 2.0.0"])


### PR DESCRIPTION
Fixes #1481

**What this PR does / why we need it**: 

It fixes the following error with `fluentd --gemfile Gemfile`
when bundler is not installed.

  error: Gem::MissingSpecError

**Docs Changes**:

No need to change

**Release Note**: 

NOTE: since ruby 2.6 or later, bundler is bundled with ruby itself,
so this error has occurred with ruby 2.5 which will reach EOL
at 2021-03-31.