### PR TITLE
Handle linux capability if available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ branches:
 before_install: |
   gem update --system=3.1.2
   if [[ "x${USE_CAPNG}" == "xtrue" ]]; then
-    gem install capng_c --no-document
+    echo 'gem "capng_c"' >> Gemfile.local
   fi
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,44 +9,63 @@ matrix:
   include:
     - rvm: 2.4.9
       os: linux
+      env: USE_CAPNG=false
     - rvm: 2.4.9
       os: linux-ppc64le
+      env: USE_CAPNG=false
     - rvm: 2.5.7
       os: linux
+      env: USE_CAPNG=false
     - rvm: 2.5.7
       os: linux
       arch: s390x
       dist: xenial
+      env: USE_CAPNG=false
     - rvm: 2.6.5
       os: linux
+      env: USE_CAPNG=false
+    - rvm: 2.6.6
+      os: linux
+      env: USE_CAPNG=true
     - rvm: 2.7.0
       os: linux
+      env: USE_CAPNG=false
     - rvm: ruby-head
       os: linux
+      env: USE_CAPNG=false
     - rvm: ruby-head
       os: linux-ppc64le
+      env: USE_CAPNG=false
     - rvm: 2.4.6
       os: osx
       osx_image: xcode8.3 # OSX 10.12
+      env: USE_CAPNG=false
     - rvm: ruby-head
       os: osx
       osx_image: xcode8.3 # OSX 10.12
+      env: USE_CAPNG=false
   allow_failures:
     - rvm: 2.4.6
       os: osx
       osx_image: xcode8.3
+      env: USE_CAPNG=false
     - rvm: 2.5.7
       os: linux
       arch: s390x
       dist: xenial
+      env: USE_CAPNG=false
     - rvm: ruby-head
+      env: USE_CAPNG=false
 
 branches:
   only:
     - master
 
-before_install:
-  - gem update --system=3.1.2
+before_install: |
+  gem update --system=3.1.2
+  if [[ "x${USE_CAPNG}" == "xtrue" ]]; then
+    gem install capng_c --no-document
+  fi
 
 sudo: false
 dist: trusty # for TLSv1.2 support
@@ -55,3 +74,4 @@ addons:
   apt:
     packages:
       - libgmp3-dev
+      - libcap-ng-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ branches:
 
 before_install: |
   gem update --system=3.1.2
-  if [[ "x${USE_CAPNG}" == "xtrue" ]]; then
+  if [[ x"${USE_CAPNG}" == "xtrue" ]]; then
     echo 'gem "capng_c"' >> Gemfile.local
   fi
 

--- a/lib/fluent/capability.rb
+++ b/lib/fluent/capability.rb
@@ -26,7 +26,7 @@ end
 module Fluent
   if defined?(CapNG)
     class Capability
-      def initialize(target = :current_process, pid = nil)
+      def initialize(target = nil, pid = nil)
         @capng = CapNG.new(target, pid)
       end
 
@@ -56,7 +56,7 @@ module Fluent
     end
   else
     class Capability
-      def initialize(target = :current_process, pid = nil)
+      def initialize(target = nil, pid = nil)
       end
 
       def usable?

--- a/lib/fluent/capability.rb
+++ b/lib/fluent/capability.rb
@@ -1,0 +1,71 @@
+#
+# Fluent
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require "fluent/env"
+
+if Fluent.linux?
+  begin
+    require 'capng'
+  rescue LoadError
+  end
+end
+
+module Fluent
+  class Capability
+    def initialize(target = :current_process, pid_or_path = nil)
+      if defined?(CapNG)
+        @usable = true
+        @capng = CapNG.new(target, pid_or_path)
+      else
+        @usable = false
+      end
+    end
+
+    def usable?
+      @usable
+    end
+
+    def apply(select_set)
+      return nil unless usable?
+
+      @capng.apply(select_set)
+    end
+
+    def clear(select_set)
+      return nil unless usable?
+
+      @capng.clear(select_set)
+    end
+
+    def have_capability?(type, capability)
+      return false unless usable?
+
+      @capng.have_capability?(type, capability)
+    end
+
+    def update(action, type, capability_or_capability_array)
+      return nil unless usable?
+
+      @capng.update(action, type, capability_or_capability_array)
+    end
+
+    def have_capabilities?(select_set)
+      return false unless usable?
+
+      @capng.have_capabilities?(select_set)
+    end
+  end
+end

--- a/lib/fluent/capability.rb
+++ b/lib/fluent/capability.rb
@@ -26,8 +26,8 @@ end
 module Fluent
   if defined?(CapNG)
     class Capability
-      def initialize(target = :current_process, pid_or_path = nil)
-        @capng = CapNG.new(target, pid_or_path)
+      def initialize(target = :current_process, pid = nil)
+        @capng = CapNG.new(target, pid)
       end
 
       def usable?
@@ -56,7 +56,7 @@ module Fluent
     end
   else
     class Capability
-      def initialize(target = :current_process, pid_or_path = nil)
+      def initialize(target = :current_process, pid = nil)
       end
 
       def usable?

--- a/lib/fluent/capability.rb
+++ b/lib/fluent/capability.rb
@@ -24,48 +24,64 @@ if Fluent.linux?
 end
 
 module Fluent
-  class Capability
-    def initialize(target = :current_process, pid_or_path = nil)
-      if defined?(CapNG)
-        @usable = true
+  if defined?(CapNG)
+    class Capability
+      def initialize(target = :current_process, pid_or_path = nil)
         @capng = CapNG.new(target, pid_or_path)
-      else
-        @usable = false
+      end
+
+      def usable?
+        true
+      end
+
+      def apply(select_set)
+        @capng.apply(select_set)
+      end
+
+      def clear(select_set)
+        @capng.clear(select_set)
+      end
+
+      def have_capability?(type, capability)
+        @capng.have_capability?(type, capability)
+      end
+
+      def update(action, type, capability_or_capability_array)
+        @capng.update(action, type, capability_or_capability_array)
+      end
+
+      def have_capabilities?(select_set)
+        @capng.have_capabilities?(select_set)
       end
     end
+  else
+    class Capability
+      def initialize(target = :current_process, pid_or_path = nil)
+      end
 
-    def usable?
-      @usable
-    end
+      def usable?
+        false
+      end
 
-    def apply(select_set)
-      return nil unless usable?
+      def apply(select_set)
+        false
+      end
 
-      @capng.apply(select_set)
-    end
+      def clear(select_set)
+        false
+      end
 
-    def clear(select_set)
-      return nil unless usable?
+      def have_capability?(type, capability)
+        false
+      end
 
-      @capng.clear(select_set)
-    end
+      def update(action, type, capability_or_capability_array)
+        false
+      end
 
-    def have_capability?(type, capability)
-      return false unless usable?
-
-      @capng.have_capability?(type, capability)
-    end
-
-    def update(action, type, capability_or_capability_array)
-      return nil unless usable?
-
-      @capng.update(action, type, capability_or_capability_array)
-    end
-
-    def have_capabilities?(select_set)
-      return false unless usable?
-
-      @capng.have_capabilities?(select_set)
+      def have_capabilities?(select_set)
+        false
+      end
     end
   end
 end

--- a/lib/fluent/env.rb
+++ b/lib/fluent/env.rb
@@ -28,4 +28,8 @@ module Fluent
   def self.windows?
     ServerEngine.windows?
   end
+
+  def self.linux?
+    /linux/ === RUBY_PLATFORM
+  end
 end

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -270,9 +270,7 @@ module Fluent::Plugin
           paths += Dir.glob(path).select { |p|
             begin
               is_file = !File.directory?(p)
-              if (File.readable?(p) ||
-                  have_read_capability?) &&
-                 is_file
+              if (File.readable?(p) || have_read_capability?) && is_file
                 if @limit_recently_modified && File.mtime(p) < (date.to_time - @limit_recently_modified)
                   false
                 else

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -22,6 +22,7 @@ require 'fluent/event'
 require 'fluent/plugin/buffer'
 require 'fluent/plugin/parser_multiline'
 require 'fluent/variable_store'
+require 'fluent/capability'
 require 'fluent/plugin/in_tail/position_file'
 
 if Fluent.windows?
@@ -171,6 +172,7 @@ module Fluent::Plugin
       @dir_perm = system_config.dir_permission || Fluent::DEFAULT_DIR_PERMISSION
       # parser is already created by parser helper
       @parser = parser_create(usage: parser_config['usage'] || @parser_configs.first.usage)
+      @capability = Fluent::Capability.new(:current_process)
     end
 
     def configure_tag
@@ -250,6 +252,11 @@ module Fluent::Plugin
       close_watcher_handles
     end
 
+    def have_read_capability?
+      @capability.have_capability?(:effective, :dac_read_search) ||
+        @capability.have_capability?(:effective, :dac_override)
+    end
+
     def expand_paths
       date = Fluent::EventTime.now
       paths = []
@@ -263,7 +270,9 @@ module Fluent::Plugin
           paths += Dir.glob(path).select { |p|
             begin
               is_file = !File.directory?(p)
-              if File.readable?(p) && is_file
+              if (File.readable?(p) ||
+                  have_read_capability?) &&
+                 is_file
                 if @limit_recently_modified && File.mtime(p) < (date.to_time - @limit_recently_modified)
                   false
                 else

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -86,6 +86,9 @@ class TailInputTest < Test::Unit::TestCase
       assert_equal "#{TMP_DIR}/tail.pos", d.instance.pos_file
       assert_equal 1000, d.instance.read_lines_limit
       assert_equal false, d.instance.ignore_repeated_permission_error
+      assert_nothing_raised do
+        d.instance.have_read_capability?
+      end
     end
 
     data("empty" => config_element,

--- a/test/test_capability.rb
+++ b/test/test_capability.rb
@@ -1,0 +1,74 @@
+require_relative 'helper'
+require 'fluent/test'
+require 'fluent/capability'
+
+class FluentCapabilityTest < ::Test::Unit::TestCase
+  setup do
+    @capability = Fluent::Capability.new(:current_process)
+    omit "Fluent::Capability class is not usable on this environment" unless @capability.usable?
+  end
+
+  sub_test_case "check capability" do
+    test "effective" do
+      @capability.clear(:both)
+      assert_true @capability.update(:add, :effective, :dac_read_search)
+      assert_equal CapNG::Result::PARTIAL, @capability.have_capabilities?(:caps)
+      assert_nothing_raised do
+        @capability.apply(:caps)
+      end
+      assert_equal CapNG::Result::NONE, @capability.have_capabilities?(:bounds)
+      assert_true @capability.have_capability?(:effective, :dac_read_search)
+      assert_false @capability.have_capability?(:inheritable, :dac_read_search)
+      assert_false @capability.have_capability?(:permitted, :dac_read_search)
+    end
+
+    test "inheritable" do
+      @capability.clear(:both)
+      capabilities = [:chown, :dac_override]
+      assert_equal [true, true], @capability.update(:add, :inheritable, capabilities)
+      assert_equal CapNG::Result::NONE, @capability.have_capabilities?(:caps)
+      assert_nothing_raised do
+        @capability.apply(:caps)
+      end
+      assert_equal CapNG::Result::NONE, @capability.have_capabilities?(:bounds)
+      capabilities.each do |capability|
+        assert_false @capability.have_capability?(:effective, capability)
+        assert_true @capability.have_capability?(:inheritable, capability)
+        assert_false @capability.have_capability?(:permitted, capability)
+      end
+    end
+
+    test "permitted" do
+      @capability.clear(:both)
+      capabilities = [:fowner, :fsetid, :kill]
+      assert_equal [true, true, true], @capability.update(:add, :permitted, capabilities)
+      assert_equal CapNG::Result::NONE, @capability.have_capabilities?(:caps)
+      assert_nothing_raised do
+        @capability.apply(:caps)
+      end
+      assert_equal CapNG::Result::NONE, @capability.have_capabilities?(:bounds)
+      capabilities.each do |capability|
+        assert_false @capability.have_capability?(:effective, capability)
+        assert_false @capability.have_capability?(:inheritable, capability)
+        assert_true @capability.have_capability?(:permitted, capability)
+      end
+    end
+
+    test "effective/inheritable/permitted" do
+      @capability.clear(:both)
+      capabilities = [:setpcap, :net_admin, :net_raw, :sys_boot, :sys_time]
+      update_type = CapNG::Type::EFFECTIVE | CapNG::Type::INHERITABLE | CapNG::Type::PERMITTED
+      assert_equal [true, true, true, true, true], @capability.update(:add, update_type, capabilities)
+      assert_equal CapNG::Result::PARTIAL, @capability.have_capabilities?(:caps)
+      assert_nothing_raised do
+        @capability.apply(:caps)
+      end
+      assert_equal CapNG::Result::NONE, @capability.have_capabilities?(:bounds)
+      capabilities.each do |capability|
+        assert_true @capability.have_capability?(:effective, capability)
+        assert_true @capability.have_capability?(:inheritable, capability)
+        assert_true @capability.have_capability?(:permitted, capability)
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #3053 

**What this PR does / why we need it**: 
Currently, Fluentd core does not handle/refer Linux capability.
This class should handle/refer Linux capability.
Note that this class implementation is only working for Linux with
libcap-ng binding (capng_c) installed platform.
In other platform, this class only returns stubbed results.

in_tail should handle Linux capabilities.
In in_tail, File.readable? does not handles Linux capabilities.
So, we should handle them by libcap-ng binding wrapped class
which is Fluent::Capability.

On in_tail, the following capabilities should be handled:

* CAP_DAC_READ_SEARCH(:dac_read_search on capng_c)
* CAP_DAC_OVERRIDE(:dac_override on capng_c)


**Docs Changes**:
Needed. ~~I'll write and register Linux capability documentation for Fluentd later.~~
https://github.com/fluent/fluentd-docs-gitbook/pull/248

**Release Note**: 

Same as title.

**Additional Context**:

This PR should be reviewed with some Linux box. (macOS and Windows box is not installable capng_c that is Linux capability bindings for Ruby)