### PR TITLE
Fix a bug that windows service isn't stopped gracefuly

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("msgpack", [">= 1.3.1", "< 2.0.0"])
   gem.add_runtime_dependency("yajl-ruby", ["~> 1.0"])
   gem.add_runtime_dependency("cool.io", [">= 1.4.5", "< 2.0.0"])
-  gem.add_runtime_dependency("serverengine", [">= 2.0.4", "< 3.0.0"])
+  gem.add_runtime_dependency("serverengine", [">= 2.2.2", "< 3.0.0"])
   gem.add_runtime_dependency("http_parser.rb", [">= 0.5.1", "< 0.7.0"])
   gem.add_runtime_dependency("sigdump", ["~> 0.2.2"])
   gem.add_runtime_dependency("tzinfo", [">= 1.0", "< 3.0"])

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -183,7 +183,6 @@ module Fluent
           until WaitForSingleObject(ev.handle, 0) == WAIT_OBJECT_0
             sleep 1
           end
-          kill_worker
           stop(true)
         ensure
           ev.close


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
None.

**What this PR does / why we need it**: 
[Fluentd uses win32 event](https://github.com/fluent/fluentd/blob/1c28d6ed0cf346c322fbca92bb4eafa65307c3eb/lib/fluent/supervisor.rb#L180) for shutting down windows service. In this mechanism, it uses `stop` method of `ServerEngine::Supervisor` to send a command to workers to stop them gracefully. But current implementation calls `kill_worker` before it so that [workers are killed forcedly](https://github.com/fluent/fluentd/blob/1c28d6ed0cf346c322fbca92bb4eafa65307c3eb/lib/fluent/supervisor.rb#L237) before sending commands. It doesn't make sense.

This PR removes the needless `kill_worker` call.

You can confirm the issue by shutting down a fluentd process by the following procedure

* Run fluentd with `--signame` or `-x` option: `fluentd -c path/to/conf -x fluentd`
* Shutting down it by the following ruby code:
```ruby
require 'win32/event'
Win32::Event.open("fluentd").set
```
* Compare logs for shutting down. Without this fix, logs for shutting down plugins aren't shown.
```
2020-11-03 10:45:38 +0900 [info]: #0 shutting down input plugin type=:forward plugin_id="forward_input"
2020-11-03 10:45:38 +0900 [info]: #0 shutting down input plugin type=:http plugin_id="http_input"
...
```

This fix should be applied with ServerEngine 2.2.2 or later, otherwise supervisor can't stop multiple workers: https://github.com/treasure-data/serverengine/pull/105 (current implementation kills all workers forcedly by `kill_worker` method)

**Docs Changes**:
None.

**Release Note**: 
Same with the title.