### PR TITLE
windows: use protocol-http2 0.14.0 explicitly

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,9 @@ install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - ruby --version
   - gem --version
+  # stay 0.14.0 for Windows CI until https://github.com/socketry/protocol-http2/issues/6 will be fixed
+  - ps: Write-Output "gem 'protocol-http2', ['<= 0.14.0']" | Out-File -FilePath Gemfile.local -Encoding default
+  - type Gemfile.local
   - ridk.cmd exec bundle install
 build: off
 test_script:


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

Via #3153 PR, I've found Windows CI fails.

**What this PR does / why we need it**: 

There is an install issue on Windows about http-protocol2.
It breaks Windows CI when executing bundle install.

ref. https://github.com/socketry/protocol-http2/issues/6

It seems that even though 0.14.0, it doesn't affect functionality because the only https://github.com/socketry/protocol-http2/commit/8769e9f8dfcb95c6e7bd015002a74a82bb14a83f is commited.

**Docs Changes**:

No need to change.

**Release Note**: 

No need to change.

