### PR TITLE
github: add a guide to google groups

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name:  Bug Report
-about: Create a report to help us improve. If you have questions about Fluentd and plugins, please direct these to https://groups.google.com/forum/#!forum/fluentd
+about: Create a report with a procedure for reproducing the bug
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a Question
+    url: https://groups.google.com/forum/#!forum/fluentd
+    about: I have questions about Fluentd and plugins. Please ask and answer questions here


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

Fixes N/A

**What this PR does / why we need it**: 

In the previous version, there are only two choices for
bug and feature request.

So Fluentd user tends to use "Bug Report" even though it is not a
bug report definitely.

This PR try to add third choice explicitly to guide to user forum.

Before:

  * Bug Report
  * Feature request

After:

  * Bug Report
  * Feature request
  * Ask a question

Additionally, the explanation about bug report is updated to emphasize
it is a "Bug Report".

**Docs Changes**:

N/A

**Release Note**: 

N/A
