### PR TITLE
Handle service_discovery type on fluent-plugin-config-formatter

### DIFF
--- a/lib/fluent/command/plugin_config_formatter.rb
+++ b/lib/fluent/command/plugin_config_formatter.rb
@@ -29,7 +29,8 @@ class FluentPluginConfigFormatter
   AVAILABLE_FORMATS = [:markdown, :txt, :json]
   SUPPORTED_TYPES = [
     "input", "output", "filter",
-    "buffer", "parser", "formatter", "storage"
+    "buffer", "parser", "formatter", "storage",
+    "service_discovery"
   ]
 
   DOCS_BASE_URL = "https://docs.fluentd.org/v/1.0"

--- a/lib/fluent/plugin.rb
+++ b/lib/fluent/plugin.rb
@@ -121,6 +121,11 @@ module Fluent
       new_impl('sd', SD_REGISTRY, type, parent)
     end
 
+    class << self
+      # This should be defined for fluent-plugin-config-formatter type arguments.
+      alias_method :new_service_discovery, :new_sd
+    end
+
     def self.new_parser(type, parent: nil)
       if type[0] == '/' && type[-1] == '/'
         # This usage is not recommended for new API... create RegexpParser directly

--- a/test/command/test_plugin_config_formatter.rb
+++ b/test/command/test_plugin_config_formatter.rb
@@ -56,6 +56,13 @@ class TestFluentPluginConfigFormatter < Test::Unit::TestCase
     end
   end
 
+  class FakeServiceDiscovery < ::Fluent::Plugin::ServiceDiscovery
+    ::Fluent::Plugin.register_sd('fake', self)
+
+    desc "hostname"
+    config_param :hostname, :string
+  end
+
   class SimpleInput < ::Fluent::Plugin::Input
     ::Fluent::Plugin.register_input("simple", self)
     helpers :inject, :compat_parameters
@@ -280,7 +287,7 @@ TEXT
   sub_test_case "arguments" do
     data do
       hash = {}
-      ["input", "output", "filter", "parser", "formatter"].each do |type|
+      ["input", "output", "filter", "parser", "formatter", "service_discovery"].each do |type|
         ["txt", "json", "markdown"].each do |format|
           argv = ["--format=#{format}"]
           [

--- a/test/command/test_plugin_config_formatter.rb
+++ b/test/command/test_plugin_config_formatter.rb
@@ -88,6 +88,13 @@ class TestFluentPluginConfigFormatter < Test::Unit::TestCase
     end
   end
 
+  class SimpleServiceDiscovery < ::Fluent::Plugin::ServiceDiscovery
+    ::Fluent::Plugin.register_sd('simple', self)
+
+    desc "servers"
+    config_param :servers, :array
+  end
+
   sub_test_case "json" do
     data(input: [FakeInput, "input"],
          output: [FakeOutput, "output"],
@@ -195,6 +202,28 @@ path to something
 TEXT
       assert_equal(expected, dumped_config)
     end
+
+    data("abbrev" => "sd",
+         "normal" => "service_discovery")
+    test "service_discovery simple" do |data|
+      plugin_type = data
+      dumped_config = capture_stdout do
+        FluentPluginConfigFormatter.new(["--format=markdown", plugin_type, "simple"]).call
+      end
+      expected = <<TEXT
+* See also: [ServiceDiscovery Plugin Overview](https://docs.fluentd.org/v/1.0/servicediscovery#overview)
+
+## TestFluentPluginConfigFormatter::SimpleServiceDiscovery
+
+### servers (array) (required)
+
+servers
+
+
+TEXT
+      assert_equal(expected, dumped_config)
+    end
+
 
     test "output complex" do
       dumped_config = capture_stdout do

--- a/test/command/test_plugin_config_formatter.rb
+++ b/test/command/test_plugin_config_formatter.rb
@@ -295,7 +295,7 @@ TEXT
             ["--verbose"],
             ["--compact"]
           ].each do |options|
-            hash[(argv + options).join(" ")] = argv + options + [type, "fake"]
+            hash["[#{type}] " + (argv + options).join(" ")] = argv + options + [type, "fake"]
           end
         end
       end

--- a/test/command/test_plugin_config_formatter.rb
+++ b/test/command/test_plugin_config_formatter.rb
@@ -56,6 +56,25 @@ class TestFluentPluginConfigFormatter < Test::Unit::TestCase
     end
   end
 
+  class FakeStorage < ::Fluent::Plugin::Storage
+    ::Fluent::Plugin.register_storage('fake', self)
+
+    def get(key)
+    end
+
+    def fetch(key, defval)
+    end
+
+    def put(key, value)
+    end
+
+    def delete(key)
+    end
+
+    def update(key, &block)
+    end
+  end
+
   class FakeServiceDiscovery < ::Fluent::Plugin::ServiceDiscovery
     ::Fluent::Plugin.register_sd('fake', self)
 
@@ -287,7 +306,7 @@ TEXT
   sub_test_case "arguments" do
     data do
       hash = {}
-      ["input", "output", "filter", "parser", "formatter", "service_discovery"].each do |type|
+      ["input", "output", "filter", "parser", "formatter", "storage", "service_discovery"].each do |type|
         ["txt", "json", "markdown"].each do |format|
           argv = ["--format=#{format}"]
           [


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 
Non abbreviate form of `new_service_discovery` is needed for fluent-plugin-config-formatter comand.

**Docs Changes**:
No needed?

**Release Note**: 
Same as title.