### PR TITLE
plugin_helper: server: compat: Suppress keyword arguments incompatibiity warnings

### DIFF
--- a/lib/fluent/plugin_helper/http_server/compat/server.rb
+++ b/lib/fluent/plugin_helper/http_server/compat/server.rb
@@ -81,7 +81,7 @@ module Fluent
 
           def build_handler
             @methods.group_by(&:first).each do |(path, rest)|
-              klass = Fluent::PluginHelper::HttpServer::Compat::WebrickHandler.build(Hash[rest.map { |e| [e[1], e[2]] }])
+              klass = Fluent::PluginHelper::HttpServer::Compat::WebrickHandler.build(**Hash[rest.map { |e| [e[1], e[2]] }])
               @server.mount(path, klass)
             end
           end


### PR DESCRIPTION

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 
Otherwise, Ruby 2.7 complains with the following warnings (also Fluentd master doesn't take care of it):

```log
/usr/lib/ruby/gems/2.7.0/gems/fluentd-1.11.5/lib/fluent/plugin_helper/http_server/compat/server.rb:84: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/usr/lib/ruby/gems/2.7.0/gems/fluentd-1.11.5/lib/fluent/plugin_helper/http_server/compat/webrick_handler.rb:26: warning: The called method `build' is defined here
```

**Docs Changes**:
No need.

**Release Note**: 
Same as title.