### PR TITLE
Add follow_inodes parameter on in_tail

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -325,7 +325,7 @@ module Fluent::Plugin
 
     def existence_path
       hash = {}
-      @tails.keys.each {|path_ino|
+      @tails.each_key {|path_ino|
         if @follow_inodes
           hash[path_ino.ino] = path_ino
         else

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -221,7 +221,7 @@ module Fluent::Plugin
         FileUtils.mkdir_p(pos_file_dir, mode: @dir_perm) unless Dir.exist?(pos_file_dir)
         @pf_file = File.open(@pos_file, File::RDWR|File::CREAT|File::BINARY, @file_perm)
         @pf_file.sync = true
-        @pf = PositionFile.load(@pf_file, @follow_inodes, logger: log)
+        @pf = PositionFile.load(@pf_file, @follow_inodes, expand_paths, logger: log)
 
         if @pos_file_compaction_interval
           timer_execute(:in_tail_refresh_compact_pos_file, @pos_file_compaction_interval) do

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -245,7 +245,7 @@ module Fluent::Plugin
 
     def shutdown
       # during shutdown phase, don't close io. It should be done in close after all threads are stopped. See close.
-      stop_watchers(existence_path.values, immediate: true, remove_watcher: false)
+      stop_watchers(existence_path, immediate: true, remove_watcher: false)
       @pf_file.close if @pf_file
 
       super
@@ -349,8 +349,8 @@ module Fluent::Plugin
       unwatched_hash = existence_paths_hash.reject {|key, value| target_paths_hash.key?(key)}
       added_hash = target_paths_hash.reject {|key, value| existence_paths_hash.key?(key)}
 
-      stop_watchers(unwatched_hash.values, immediate: false, unwatched: true) unless unwatched_hash.empty?
-      start_watchers(added_hash.values) unless added_hash.empty?
+      stop_watchers(unwatched_hash, immediate: false, unwatched: true) unless unwatched_hash.empty?
+      start_watchers(added_hash) unless added_hash.empty?
     end
 
     def setup_watcher(path, ino, pe)
@@ -387,7 +387,7 @@ module Fluent::Plugin
     end
 
     def start_watchers(paths_with_inodes)
-      paths_with_inodes.each { |path_with_inode|
+      paths_with_inodes.each_value { |path_with_inode|
         path = path_with_inode.path
         ino = path_with_inode.ino
         pe = nil
@@ -414,7 +414,7 @@ module Fluent::Plugin
     end
 
     def stop_watchers(paths_with_inodes, immediate: false, unwatched: false, remove_watcher: true)
-      paths_with_inodes.each { |path_with_inode|
+      paths_with_inodes.each_value { |path_with_inode|
         if remove_watcher
           tw = @tails.delete(path_with_inode)
         else

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -448,7 +448,7 @@ module Fluent::Plugin
     end
 
     # refresh_watchers calls @tails.keys so we don't use stop_watcher -> start_watcher sequence for safety.
-    def update_watcher(path, ino, pe)
+    def update_watcher(path, inode, pe)
       log.info("detected rotation of #{path}; waiting #{@rotate_wait} seconds")
 
       if @pf
@@ -458,9 +458,7 @@ module Fluent::Plugin
         end
       end
 
-      @tails[path] = setup_watcher(path, ino, pe)
       tuple = PathInodeTuple.new(path, pe.read_inode)
-      detach_watcher_after_rotate_wait(rotated_tw) if rotated_tw
       rotated_tw = @tails[tuple]
 
       new_tuple = PathInodeTuple.new(path, inode)

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -313,11 +313,11 @@ module Fluent::Plugin
       (paths - excluded).select { |path|
         FileTest.exist?(path)
       }.each { |path|
-        tuple = PathInodeTuple.new(path, Fluent::FileWrapper.stat(path).ino)
+        target_info = TargetInfo.new(path, Fluent::FileWrapper.stat(path).ino)
         if @follow_inodes
-          hash[tuple.ino] = tuple
+          hash[target_info.ino] = target_info
         else
-          hash[tuple.path] = tuple
+          hash[target_info.path] = target_info
         end
       }
       hash
@@ -408,8 +408,8 @@ module Fluent::Plugin
           log.warn "Skip #{path} because unexpected setup error happens: #{e}"
           next
         end
-        tuple = PathInodeTuple.new(path, Fluent::FileWrapper.stat(path).ino)
-        @tails[tuple] = tw
+        target_info = TargetInfo.new(path, Fluent::FileWrapper.stat(path).ino)
+        @tails[target_info] = tw
       }
     end
 
@@ -451,19 +451,19 @@ module Fluent::Plugin
         end
       end
 
-      tuple = PathInodeTuple.new(path, pe.read_inode)
-      rotated_tw = @tails[tuple]
+      target_info = TargetInfo.new(path, pe.read_inode)
+      rotated_tw = @tails[target_info]
 
-      new_tuple = PathInodeTuple.new(path, inode)
+      new_target_info = TargetInfo.new(path, inode)
 
       if @follow_inodes
         new_position_entry = @pf[path, inode]
 
         if new_position_entry.read_inode == 0
-          @tails[new_tuple] = setup_watcher(path, inode, new_position_entry)
+          @tails[new_target_info] = setup_watcher(path, inode, new_position_entry)
         end
       else
-        @tails[new_tuple] = setup_watcher(path, inode, pe)
+        @tails[new_target_info] = setup_watcher(path, inode, pe)
       end
       detach_watcher_after_rotate_wait(rotated_tw, pe.read_inode) if rotated_tw
     end

--- a/lib/fluent/plugin/in_tail/position_file.rb
+++ b/lib/fluent/plugin/in_tail/position_file.rb
@@ -255,6 +255,6 @@ module Fluent::Plugin
       end
     end
 
-    PathInodeTuple = Struct.new(:path, :ino)
+    TargetInfo = Struct.new(:path, :ino)
   end
 end

--- a/lib/fluent/plugin/in_tail/position_file.rb
+++ b/lib/fluent/plugin/in_tail/position_file.rb
@@ -18,15 +18,6 @@ require 'fluent/plugin/input'
 
 module Fluent::Plugin
   class TailInput < Fluent::Plugin::Input
-    class PathWithInode
-      def initialize(path, inode)
-        @path = path
-        @inode = inode
-      end
-
-      attr_accessor :path, :inode
-    end
-
     class PositionFile
       UNWATCHED_POSITION = 0xffffffffffffffff
       POSITION_FILE_ENTRY_REGEX = /^([^\t]+)\t([0-9a-fA-F]+)\t([0-9a-fA-F]+)/.freeze

--- a/lib/fluent/plugin/in_tail/position_file.rb
+++ b/lib/fluent/plugin/in_tail/position_file.rb
@@ -64,9 +64,15 @@ module Fluent::Plugin
         }
       end
 
-      def unwatch(path)
-        if (entry = @map.delete(path))
-          entry.update_pos(UNWATCHED_POSITION)
+      def unwatch(path, inode)
+        if @follow_inodes
+          if (entry = @map.delete(inode))
+            entry.update_pos(UNWATCHED_POSITION)
+          end
+        else
+          if (entry = @map.delete(path))
+            entry.update_pos(UNWATCHED_POSITION)
+          end
         end
       end
 

--- a/test/plugin/in_tail/test_position_file.rb
+++ b/test/plugin/in_tail/test_position_file.rb
@@ -1,5 +1,6 @@
 require_relative '../../helper'
 require 'fluent/plugin/in_tail/position_file'
+require 'fluent/plugin/in_tail'
 
 require 'fileutils'
 require 'tempfile'
@@ -27,9 +28,15 @@ class IntailPositionFileTest < Test::Unit::TestCase
     f.seek(0)
   end
 
+  def follow_inodes_block
+    [true, false].each do |follow_inodes|
+      yield follow_inodes
+    end
+  end
+
   test '.load' do
     write_data(@file, TEST_CONTENT)
-    Fluent::Plugin::TailInput::PositionFile.load(@file, logger: $log)
+    Fluent::Plugin::TailInput::PositionFile.load(@file, false, **{logger: $log})
 
     @file.seek(0)
     lines = @file.readlines
@@ -41,7 +48,7 @@ class IntailPositionFileTest < Test::Unit::TestCase
   sub_test_case '#try_compact' do
     test 'compact invalid and convert 32 bit inode value' do
       write_data(@file, TEST_CONTENT)
-      Fluent::Plugin::TailInput::PositionFile.new(@file, logger: $log).try_compact
+      Fluent::Plugin::TailInput::PositionFile.new(@file, false, **{logger: $log}).try_compact
 
       @file.seek(0)
       lines = @file.readlines
@@ -55,7 +62,7 @@ class IntailPositionFileTest < Test::Unit::TestCase
         valid_path\t0000000000000002\t0000000000000001
         valid_path\t0000000000000003\t0000000000000004
       EOF
-      Fluent::Plugin::TailInput::PositionFile.new(@file, logger: $log).try_compact
+      Fluent::Plugin::TailInput::PositionFile.new(@file, false, **{logger: $log}).try_compact
 
       @file.seek(0)
       lines = @file.readlines
@@ -64,7 +71,7 @@ class IntailPositionFileTest < Test::Unit::TestCase
 
     test 'does not change when the file is changed' do
       write_data(@file, TEST_CONTENT)
-      pf = Fluent::Plugin::TailInput::PositionFile.new(@file, logger: $log)
+      pf = Fluent::Plugin::TailInput::PositionFile.new(@file, false, **{logger: $log})
 
       mock.proxy(pf).fetch_compacted_entries do |r|
         @file.write("unwatched\t#{UNWATCHED_STR}\t0000000000000000\n")
@@ -79,10 +86,10 @@ class IntailPositionFileTest < Test::Unit::TestCase
     end
 
     test 'update seek postion of remained position entry' do
-      pf = Fluent::Plugin::TailInput::PositionFile.new(@file, logger: $log)
-      pf['path1']
-      pf['path2']
-      pf['path3']
+      pf = Fluent::Plugin::TailInput::PositionFile.new(@file, false, **{logger: $log})
+      pf['path1', -1]
+      pf['path2', -1]
+      pf['path3', -1]
       pf.unwatch('path1')
 
       pf.try_compact
@@ -106,7 +113,7 @@ class IntailPositionFileTest < Test::Unit::TestCase
   sub_test_case '#load' do
     test 'compact invalid and convert 32 bit inode value' do
       write_data(@file, TEST_CONTENT)
-      Fluent::Plugin::TailInput::PositionFile.load(@file, logger: $log)
+      Fluent::Plugin::TailInput::PositionFile.load(@file, false, **{logger: $log})
 
       @file.seek(0)
       lines = @file.readlines
@@ -120,7 +127,7 @@ class IntailPositionFileTest < Test::Unit::TestCase
         valid_path\t0000000000000002\t0000000000000001
         valid_path\t0000000000000003\t0000000000000004
       EOF
-      Fluent::Plugin::TailInput::PositionFile.new(@file, logger: $log).load
+      Fluent::Plugin::TailInput::PositionFile.new(@file, false, **{logger: $log}).load
 
       @file.seek(0)
       lines = @file.readlines
@@ -131,9 +138,9 @@ class IntailPositionFileTest < Test::Unit::TestCase
   sub_test_case '#[]' do
     test 'return entry' do
       write_data(@file, TEST_CONTENT)
-      pf = Fluent::Plugin::TailInput::PositionFile.load(@file, logger: $log)
+      pf = Fluent::Plugin::TailInput::PositionFile.load(@file, false, **{logger: $log})
 
-      f = pf['valid_path']
+      f = pf['valid_path', Fluent::FileWrapper.stat(@file).ino]
       assert_equal Fluent::Plugin::TailInput::FilePositionEntry, f.class
       assert_equal 2, f.read_pos
       assert_equal 1, f.read_inode
@@ -142,7 +149,7 @@ class IntailPositionFileTest < Test::Unit::TestCase
       lines = @file.readlines
       assert_equal 2, lines.size
 
-      f = pf['nonexist_path']
+      f = pf['nonexist_path', -1]
       assert_equal Fluent::Plugin::TailInput::FilePositionEntry, f.class
       assert_equal 0, f.read_pos
       assert_equal 0, f.read_inode
@@ -155,19 +162,19 @@ class IntailPositionFileTest < Test::Unit::TestCase
 
     test 'does not change other value position if other entry try to write' do
       write_data(@file, TEST_CONTENT)
-      pf = Fluent::Plugin::TailInput::PositionFile.load(@file, logger: $log)
+      pf = Fluent::Plugin::TailInput::PositionFile.load(@file, false, logger: $log)
 
-      f = pf['nonexist_path']
+      f = pf['nonexist_path', -1]
       assert_equal 0, f.read_inode
       assert_equal 0, f.read_pos
 
-      pf['valid_path'].update(1, 2)
+      pf['valid_path', Fluent::FileWrapper.stat(@file).ino].update(1, 2)
 
-      f = pf['nonexist_path']
+      f = pf['nonexist_path', -1]
       assert_equal 0, f.read_inode
       assert_equal 0, f.read_pos
 
-      pf['nonexist_path'].update(1, 2)
+      pf['nonexist_path', -1].update(1, 2)
       assert_equal 1, f.read_inode
       assert_equal 2, f.read_pos
     end
@@ -176,14 +183,14 @@ class IntailPositionFileTest < Test::Unit::TestCase
   sub_test_case '#unwatch' do
     test 'deletes entry by path' do
       write_data(@file, TEST_CONTENT)
-      pf = Fluent::Plugin::TailInput::PositionFile.load(@file, logger: $log)
-      p1 = pf['valid_path']
+      pf = Fluent::Plugin::TailInput::PositionFile.load(@file, false, logger: $log)
+      p1 = pf['valid_path', Fluent::FileWrapper.stat(@file).ino]
       assert_equal Fluent::Plugin::TailInput::FilePositionEntry, p1.class
 
       pf.unwatch('valid_path')
       assert_equal p1.read_pos, Fluent::Plugin::TailInput::PositionFile::UNWATCHED_POSITION
 
-      p2 = pf['valid_path']
+      p2 = pf['valid_path', Fluent::FileWrapper.stat(@file).ino]
       assert_equal Fluent::Plugin::TailInput::FilePositionEntry, p2.class
 
       assert_not_equal p1, p2

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -17,6 +17,7 @@ class TailInputTest < Test::Unit::TestCase
 
   def teardown
     super
+    cleanup_directory(TMP_DIR)
     Fluent::Engine.stop
   end
 
@@ -28,18 +29,42 @@ class TailInputTest < Test::Unit::TestCase
     FileUtils.mkdir_p(path)
   end
 
+  def cleanup_file(path)
+    FileUtils.rm_f(path, secure: true)
+    if File.exist?(path)
+      # ensure files are closed for Windows, on which deleted files
+      # are still visible from filesystem
+      GC.start(full_mark: true, immediate_mark: true, immediate_sweep: true)
+      FileUtils.remove_entry_secure(path, true)
+    end
+  end
+
+  def path_to_tuple(path)
+    Fluent::Plugin::TailInput::PathInodeTuple.new(path, Fluent::FileWrapper.stat(path).ino)
+  end
+
   TMP_DIR = File.dirname(__FILE__) + "/../tmp/tail#{ENV['TEST_ENV_NUMBER']}"
 
   CONFIG = config_element("ROOT", "", {
                             "path" => "#{TMP_DIR}/tail.txt",
                             "tag" => "t1",
-                            "rotate_wait" => "2s"
+                            "rotate_wait" => "2s",
+                            "refresh_interval" => "1s"
                           })
   COMMON_CONFIG = CONFIG + config_element("", "", { "pos_file" => "#{TMP_DIR}/tail.pos" })
   CONFIG_READ_FROM_HEAD = config_element("", "", { "read_from_head" => true })
   CONFIG_ENABLE_WATCH_TIMER = config_element("", "", { "enable_watch_timer" => false })
   CONFIG_DISABLE_STAT_WATCHER = config_element("", "", { "enable_stat_watcher" => false })
   CONFIG_OPEN_ON_EVERY_UPDATE = config_element("", "", { "open_on_every_update" => true })
+  COMMON_FOLLOW_INODE_CONFIG = config_element("ROOT", "", {
+                                                "path" => "#{TMP_DIR}/tail.txt*",
+                                                "pos_file" => "#{TMP_DIR}/tail.pos",
+                                                "tag" => "t1",
+                                                "refresh_interval" => "1s",
+                                                "read_from_head" => "true",
+                                                "format" => "none",
+                                                "follow_inodes" => "true"
+                                              })
   SINGLE_LINE_CONFIG = config_element("", "", { "format" => "/(?<message>.*)/" })
   PARSE_SINGLE_LINE_CONFIG = config_element("", "", {}, [config_element("parse", "", { "@type" => "/(?<message>.*)/" })])
   MULTILINE_CONFIG = config_element(
@@ -115,6 +140,12 @@ class TailInputTest < Test::Unit::TestCase
       c = config_element("ROOT", "", { "path" => "tail.txt|test2|tmp,dev", "tag" => "t1", "path_delimiter" => "*" })
       assert_raise(Fluent::ConfigError) do
         create_driver(c + PARSE_SINGLE_LINE_CONFIG, false)
+      end
+    end
+
+    test "follow_inodes w/o pos file" do
+      assert_raise(Fluent::ConfigError) do
+        create_driver(CONFIG + config_element('', '', {'follow_inodes' => 'true'}))
       end
     end
 
@@ -1002,6 +1033,7 @@ class TailInputTest < Test::Unit::TestCase
     # * path test
     # TODO: Clean up tests
     EX_ROTATE_WAIT = 0
+    EX_FOLLOW_INODES = false
 
     EX_CONFIG = config_element("", "", {
                                  "tag" => "tail",
@@ -1011,38 +1043,43 @@ class TailInputTest < Test::Unit::TestCase
                                  "read_from_head" => true,
                                  "refresh_interval" => 30,
                                  "rotate_wait" => "#{EX_ROTATE_WAIT}s",
+                                 "follow_inodes" => "#{EX_FOLLOW_INODES}",
                                })
-    EX_PATHS = [
-      'test/plugin/data/2010/01/20100102-030405.log',
-      'test/plugin/data/log/foo/bar.log',
-      'test/plugin/data/log/test.log'
-    ]
-
     def test_expand_paths
+      ex_paths = [
+        path_to_tuple('test/plugin/data/2010/01/20100102-030405.log'),
+        path_to_tuple('test/plugin/data/log/foo/bar.log'),
+        path_to_tuple('test/plugin/data/log/test.log')
+      ]
       plugin = create_driver(EX_CONFIG, false).instance
       flexstub(Time) do |timeclass|
         timeclass.should_receive(:now).with_no_args.and_return(Time.new(2010, 1, 2, 3, 4, 5))
-        assert_equal EX_PATHS, plugin.expand_paths.sort
+        assert_equal ex_paths, plugin.expand_paths.values.sort_by { |path_ino| path_ino.path }
       end
 
       # Test exclusion
-      exclude_config = EX_CONFIG + config_element("", "", { "exclude_path" => %Q(["#{EX_PATHS.last}"]) })
+      exclude_config = EX_CONFIG + config_element("", "", { "exclude_path" => %Q(["#{ex_paths.last.path}"]) })
       plugin = create_driver(exclude_config, false).instance
-      assert_equal EX_PATHS - [EX_PATHS.last], plugin.expand_paths.sort
+      assert_equal ex_paths - [ex_paths.last], plugin.expand_paths.values.sort_by { |path_ino| path_ino.path }
     end
 
     def test_expand_paths_with_duplicate_configuration
       expanded_paths = [
-        'test/plugin/data/log/foo/bar.log',
-        'test/plugin/data/log/test.log'
+        path_to_tuple('test/plugin/data/log/foo/bar.log'),
+        path_to_tuple('test/plugin/data/log/test.log')
       ]
       duplicate_config = EX_CONFIG.dup
       duplicate_config["path"]="test/plugin/data/log/**/*.log, test/plugin/data/log/**/*.log"
       plugin = create_driver(EX_CONFIG, false).instance
-      assert_equal expanded_paths, plugin.expand_paths.sort
+      assert_equal expanded_paths, plugin.expand_paths.values.sort_by { |path_ino| path_ino.path }
     end
 
     def test_expand_paths_with_timezone
+      ex_paths = [
+        path_to_tuple('test/plugin/data/2010/01/20100102-030405.log'),
+        path_to_tuple('test/plugin/data/log/foo/bar.log'),
+        path_to_tuple('test/plugin/data/log/test.log')
+      ]
       ['Asia/Taipei', '+08'].each do |tz_type|
         taipei_config = EX_CONFIG + config_element("", "", {"path_timezone" => tz_type})
         plugin = create_driver(taipei_config, false).instance
@@ -1056,8 +1093,8 @@ class TailInputTest < Test::Unit::TestCase
             # env : 2010-01-01 19:04:05 (UTC), tail path : 2010-01-02 03:04:05 (Asia/Taipei)
             timeclass.should_receive(:now).with_no_args.and_return(Time.new(2010, 1, 1, 19, 4, 5))
 
-            assert_equal EX_PATHS, plugin.expand_paths.sort
-            assert_equal EX_PATHS - [EX_PATHS.first], exclude_plugin.expand_paths.sort
+            assert_equal ex_paths, plugin.expand_paths.values.sort_by { |path_ino| path_ino.path }
+            assert_equal ex_paths - [ex_paths.first], exclude_plugin.expand_paths.values.sort_by { |path_ino| path_ino.path }
           end
         end
       end
@@ -1065,10 +1102,10 @@ class TailInputTest < Test::Unit::TestCase
 
     def test_log_file_without_extension
       expected_files = [
-        'test/plugin/data/log/bar',
-        'test/plugin/data/log/foo/bar.log',
-        'test/plugin/data/log/foo/bar2',
-        'test/plugin/data/log/test.log'
+        path_to_tuple('test/plugin/data/log/bar'),
+        path_to_tuple('test/plugin/data/log/foo/bar.log'),
+        path_to_tuple('test/plugin/data/log/foo/bar2'),
+        path_to_tuple('test/plugin/data/log/test.log')
       ]
 
       config = config_element("", "", {
@@ -1079,7 +1116,7 @@ class TailInputTest < Test::Unit::TestCase
       })
 
       plugin = create_driver(config, false).instance
-      assert_equal expected_files, plugin.expand_paths.sort
+      assert_equal expected_files, plugin.expand_paths.values.sort_by { |path_ino| path_ino.path }
     end
 
     def test_unwatched_files_should_be_removed
@@ -1205,15 +1242,20 @@ class TailInputTest < Test::Unit::TestCase
   end
 
   def test_z_refresh_watchers
+    ex_paths = [
+      path_to_tuple('test/plugin/data/2010/01/20100102-030405.log'),
+      path_to_tuple('test/plugin/data/log/foo/bar.log'),
+      path_to_tuple('test/plugin/data/log/test.log'),
+    ]
     plugin = create_driver(EX_CONFIG, false).instance
     sio = StringIO.new
     plugin.instance_eval do
-      @pf = Fluent::Plugin::TailInput::PositionFile.load(sio, logger: $log)
+      @pf = Fluent::Plugin::TailInput::PositionFile.load(sio, EX_FOLLOW_INODES, logger: $log)
       @loop = Coolio::Loop.new
     end
 
     Timecop.freeze(2010, 1, 2, 3, 4, 5) do
-      EX_PATHS.each do |path|
+      ex_paths.each do |path|
         mock.proxy(Fluent::Plugin::TailInput::TailWatcher).new(path, anything, anything, true, anything, nil, anything).once
       end
 
@@ -1369,6 +1411,307 @@ class TailInputTest < Test::Unit::TestCase
     end
   end
 
+  sub_test_case 'inode_processing' do
+    def test_should_delete_file_pos_entry_for_non_existing_file_with_follow_inodes
+      config = COMMON_FOLLOW_INODE_CONFIG
+
+      path = "#{TMP_DIR}/tail.txt"
+      ino = 1
+      pos = 1234
+      File.open("#{TMP_DIR}/tail.pos", "wb") {|f|
+        f.puts ("%s\t%016x\t%016x\n" % [path, pos, ino])
+      }
+
+      d = create_driver(config, false)
+      d.run
+
+      pos_file = File.open("#{TMP_DIR}/tail.pos", "r")
+      pos_file.pos = 0
+
+      assert_raise(EOFError) do
+        pos_file.readline
+      end
+    end
+
+    def test_should_write_latest_offset_after_rotate_wait
+      config = COMMON_FOLLOW_INODE_CONFIG
+      File.open("#{TMP_DIR}/tail.txt", "wb") {|f|
+        f.puts "test1"
+        f.puts "test2"
+      }
+
+      d = create_driver(config, false)
+      d.run(expect_emits: 2, shutdown: false) do
+        File.open("#{TMP_DIR}/tail.txt", "ab") {|f| f.puts "test3\n"}
+        FileUtils.move("#{TMP_DIR}/tail.txt", "#{TMP_DIR}/tail.txt" + "1")
+        sleep 1
+        File.open("#{TMP_DIR}/tail.txt" + "1", "ab") {|f| f.puts "test4\n"}
+      end
+
+      pos_file = File.open("#{TMP_DIR}/tail.pos", "r")
+      pos_file.pos = 0
+      line_parts = /^([^\t]+)\t([0-9a-fA-F]+)\t([0-9a-fA-F]+)/.match(pos_file.readline)
+      waiting(5) {
+        while line_parts[2].to_i(16) != 24
+          sleep(0.1)
+          pos_file.pos = 0
+          line_parts = /^([^\t]+)\t([0-9a-fA-F]+)\t([0-9a-fA-F]+)/.match(pos_file.readline)
+        end
+      }
+      assert_equal(24, line_parts[2].to_i(16))
+      d.instance_shutdown
+    end
+
+    def test_should_keep_and_update_existing_file_pos_entry_for_deleted_file_when_new_file_with_same_name_created
+      config = config_element("", "", {"format" => "none"})
+
+      path = "#{TMP_DIR}/tail.txt"
+      ino = 1
+      pos = 1234
+      File.open("#{TMP_DIR}/tail.pos", "wb") {|f|
+        f.puts ("%s\t%016x\t%016x\n" % [path, pos, ino])
+      }
+
+      d = create_driver(config)
+      d.run(shutdown: false)
+
+      pos_file = File.open("#{TMP_DIR}/tail.pos", "r")
+      pos_file.pos = 0
+
+      path_pos_ino = /^([^\t]+)\t([0-9a-fA-F]+)\t([0-9a-fA-F]+)/.match(pos_file.readline)
+      assert_equal(path, path_pos_ino[1])
+      assert_equal(pos, path_pos_ino[2].to_i(16))
+      assert_equal(ino, path_pos_ino[3].to_i(16))
+
+      File.open("#{TMP_DIR}/tail.txt", "wb") {|f|
+        f.puts "test1"
+        f.puts "test2"
+      }
+      Timecop.travel(Time.now + 10) do
+        sleep 5
+        pos_file.pos = 0
+        tuple = path_to_tuple("#{TMP_DIR}/tail.txt")
+        path_pos_ino = /^([^\t]+)\t([0-9a-fA-F]+)\t([0-9a-fA-F]+)/.match(pos_file.readline)
+        assert_equal(tuple.path, path_pos_ino[1])
+        assert_equal(12, path_pos_ino[2].to_i(16))
+        assert_equal(tuple.ino, path_pos_ino[3].to_i(16))
+      end
+      d.instance_shutdown
+    end
+
+    def test_should_mark_file_unwatched_after_limit_recently_modified_and_rotate_wait
+      config = config_element("ROOT", "", {
+          "path" => "#{TMP_DIR}/tail.txt*",
+          "pos_file" => "#{TMP_DIR}/tail.pos",
+          "tag" => "t1",
+          "rotate_wait" => "1s",
+          "refresh_interval" => "1s",
+          "limit_recently_modified" => "1s",
+          "read_from_head" => "true",
+          "format" => "none"
+      })
+
+      d = create_driver(config, false)
+
+      File.open("#{TMP_DIR}/tail.txt", "wb") {|f|
+        f.puts "test1"
+        f.puts "test2"
+      }
+      path_ino = path_to_tuple("#{TMP_DIR}/tail.txt")
+
+      d.run(expect_emits: 1, shutdown: false) do
+        File.open("#{TMP_DIR}/tail.txt", "ab") {|f| f.puts "test3\n"}
+      end
+
+
+      Timecop.travel(Time.now + 10) do
+        waiting(5) {sleep 0.1 until d.instance.instance_variable_get(:@pf)[path_ino.path, path_ino.ino].read_pos == Fluent::Plugin::TailInput::PositionFile::UNWATCHED_POSITION}
+      end
+
+      assert_equal(Fluent::Plugin::TailInput::PositionFile::UNWATCHED_POSITION, d.instance.instance_variable_get(:@pf)[path_ino.path, path_ino.ino].read_pos)
+
+      d.instance_shutdown
+    end
+
+    def test_should_read_from_head_on_file_renaming_with_star_in_pattern
+      config = config_element("ROOT", "", {
+          "path" => "#{TMP_DIR}/tail.txt*",
+          "pos_file" => "#{TMP_DIR}/tail.pos",
+          "tag" => "t1",
+          "rotate_wait" => "10s",
+          "refresh_interval" => "1s",
+          "limit_recently_modified" => "60s",
+          "read_from_head" => "true",
+          "format" => "none"
+      })
+
+      d = create_driver(config, false)
+
+      File.open("#{TMP_DIR}/tail.txt", "wb") {|f|
+        f.puts "test1"
+        f.puts "test2"
+      }
+
+      d.run(expect_emits: 2, shutdown: false) do
+        File.open("#{TMP_DIR}/tail.txt", "ab") {|f| f.puts "test3\n"}
+        FileUtils.move("#{TMP_DIR}/tail.txt", "#{TMP_DIR}/tail.txt1")
+      end
+
+      events = d.events
+      assert_equal(6, events.length)
+      d.instance_shutdown
+    end
+
+    def test_should_not_read_from_head_on_rotation_when_watching_inodes
+      config = COMMON_FOLLOW_INODE_CONFIG
+
+      d = create_driver(config, false)
+
+      File.open("#{TMP_DIR}/tail.txt", "wb") {|f|
+        f.puts "test1"
+        f.puts "test2"
+      }
+
+      d.run(expect_emits: 1, shutdown: false) do
+        File.open("#{TMP_DIR}/tail.txt", "ab") {|f| f.puts "test3\n"}
+      end
+
+      FileUtils.move("#{TMP_DIR}/tail.txt", "#{TMP_DIR}/tail.txt1")
+      Timecop.travel(Time.now + 10) do
+        sleep 2
+        events = d.events
+        assert_equal(3, events.length)
+      end
+
+      d.instance_shutdown
+    end
+
+    def test_should_mark_file_unwatched_if_same_name_file_created_with_different_inode
+      config = COMMON_FOLLOW_INODE_CONFIG
+
+      d = create_driver(config, false)
+
+      File.open("#{TMP_DIR}/tail.txt", "wb") {|f|
+        f.puts "test1"
+        f.puts "test2"
+      }
+      path_ino = path_to_tuple("#{TMP_DIR}/tail.txt")
+
+      d.run(expect_emits: 2, shutdown: false) do
+        File.open("#{TMP_DIR}/tail.txt", "ab") {|f| f.puts "test3\n"}
+        cleanup_file("#{TMP_DIR}/tail.txt")
+        File.open("#{TMP_DIR}/tail.txt", "wb") {|f| f.puts "test4\n"}
+      end
+
+      new_path_ino = path_to_tuple("#{TMP_DIR}/tail.txt")
+
+      pos_file = d.instance.instance_variable_get(:@pf)
+
+      waiting(10) {sleep 0.1 until pos_file[path_ino.path, path_ino.ino].read_pos == Fluent::Plugin::TailInput::PositionFile::UNWATCHED_POSITION}
+      new_position = pos_file[new_path_ino.path, new_path_ino.ino].read_pos
+      assert_equal(6, new_position)
+
+      d.instance_shutdown
+    end
+
+    def test_should_close_watcher_after_rotate_wait
+      now = Time.now
+      config = COMMON_FOLLOW_INODE_CONFIG + config_element('', '', {"rotate_wait" => "1s", "limit_recently_modified" => "1s"})
+
+      d = create_driver(config, false)
+
+      File.open("#{TMP_DIR}/tail.txt", "wb") {|f|
+        f.puts "test1"
+        f.puts "test2"
+      }
+      path_ino = path_to_tuple("#{TMP_DIR}/tail.txt")
+
+      flexstub(Fluent::Plugin::TailInput::TailWatcher) do |watcherclass|
+        watcherclass.should_receive(:new).with(path_ino.path, path_ino.ino, 1, Fluent::Plugin::TailInput::FilePositionEntry, any, true, true, 1000, any, any, any, any, any, true, any).once.and_return do
+          flexmock('TailWatcher') {|watcher|
+            watcher.should_receive(:attach).once
+            watcher.should_receive(:unwatched=).once
+            watcher.should_receive(:detach).once
+            watcher.should_receive(:close).once
+            watcher.should_receive(:line_buffer).zero_or_more_times.and_return nil
+          }
+        end
+        d.run(shutdown: false)
+      end
+
+      Timecop.travel(now + 10) do
+        sleep 3
+        d.instance.instance_eval do
+          @tails[path_ino.path] == nil
+        end
+      end
+      d.instance_shutdown
+    end
+
+    def test_should_create_new_watcher_for_new_file_with_same_name
+      now = Time.now
+      config = COMMON_FOLLOW_INODE_CONFIG + config_element('', '', {"limit_recently_modified" => "2s"})
+
+      d = create_driver(config, false)
+
+      File.open("#{TMP_DIR}/tail.txt", "wb") {|f|
+        f.puts "test1"
+        f.puts "test2"
+      }
+      path_ino = path_to_tuple("#{TMP_DIR}/tail.txt")
+
+      d.run(expect_emits: 1, shutdown: false) do
+        File.open("#{TMP_DIR}/tail.txt", "ab") {|f| f.puts "test3\n"}
+      end
+
+      cleanup_file("#{TMP_DIR}/tail.txt")
+      File.open("#{TMP_DIR}/tail.txt", "wb") {|f|
+        f.puts "test3"
+        f.puts "test4"
+      }
+      new_path_ino = path_to_tuple("#{TMP_DIR}/tail.txt")
+
+      Timecop.travel(now + 10) do
+        sleep 3
+        d.instance.instance_eval do
+          @tails[path_ino] == nil
+          @tails[new_path_ino] != nil
+        end
+      end
+
+      events = d.events
+
+      assert_equal(5, events.length)
+
+      d.instance_shutdown
+    end
+
+    def test_truncate_file_with_follow_inodes
+      config = COMMON_FOLLOW_INODE_CONFIG
+
+      d = create_driver(config, false)
+
+      File.open("#{TMP_DIR}/tail.txt", "wb") {|f|
+        f.puts "test1"
+        f.puts "test2"
+      }
+
+      d.run(expect_emits: 3, shutdown: false) do
+        File.open("#{TMP_DIR}/tail.txt", "ab") {|f| f.puts "test3\n"}
+        sleep 2
+        File.open("#{TMP_DIR}/tail.txt", "w+b") {|f| f.puts "test4\n"}
+      end
+
+      events = d.events
+      assert_equal(4, events.length)
+      assert_equal({"message" => "test1"}, events[0][2])
+      assert_equal({"message" => "test2"}, events[1][2])
+      assert_equal({"message" => "test3"}, events[2][2])
+      assert_equal({"message" => "test4"}, events[3][2])
+      d.instance_shutdown
+    end
+  end
+
   sub_test_case "tail_path" do
     def test_tail_path_with_singleline
       File.open("#{TMP_DIR}/tail.txt", "wb") {|f|
@@ -1498,13 +1841,13 @@ class TailInputTest < Test::Unit::TestCase
     })
 
     expected_files = [
-      "#{TMP_DIR}/tail_watch1.txt",
-      "#{TMP_DIR}/tail_watch2.txt"
+      path_to_tuple("#{TMP_DIR}/tail_watch1.txt"),
+      path_to_tuple("#{TMP_DIR}/tail_watch2.txt")
     ]
 
     Timecop.freeze(now) do
       plugin = create_driver(config, false).instance
-      assert_equal expected_files, plugin.expand_paths.sort
+      assert_equal expected_files, plugin.expand_paths.values.sort_by { |path_ino| path_ino.path }
     end
   end
 

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -1623,7 +1623,10 @@ class TailInputTest < Test::Unit::TestCase
 
       pos_file = d.instance.instance_variable_get(:@pf)
 
-      waiting(10) {sleep 0.1 until pos_file[path_ino.path, path_ino.ino].read_pos == Fluent::Plugin::TailInput::PositionFile::UNWATCHED_POSITION}
+      waiting(10) {
+        # @pos will be reset as 0 when UNWATCHED_POSITION is specified.
+        sleep 0.1 until pos_file[path_ino.path, path_ino.ino].read_pos == 0
+      }
       new_position = pos_file[new_path_ino.path, new_path_ino.ino].read_pos
       assert_equal(6, new_position)
 

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -1258,7 +1258,7 @@ class TailInputTest < Test::Unit::TestCase
     plugin = create_driver(EX_CONFIG, false).instance
     sio = StringIO.new
     plugin.instance_eval do
-      @pf = Fluent::Plugin::TailInput::PositionFile.load(sio, EX_FOLLOW_INODES, logger: $log)
+      @pf = Fluent::Plugin::TailInput::PositionFile.load(sio, EX_FOLLOW_INODES, {}, logger: $log)
       @loop = Coolio::Loop.new
     end
 

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -1263,8 +1263,8 @@ class TailInputTest < Test::Unit::TestCase
     end
 
     Timecop.freeze(2010, 1, 2, 3, 4, 5) do
-      ex_paths.each do |path|
-        mock.proxy(Fluent::Plugin::TailInput::TailWatcher).new(path.path, path.ino , anything, anything, true, false, anything, nil, anything).once
+      ex_paths.each do |path_with_inode|
+        mock.proxy(Fluent::Plugin::TailInput::TailWatcher).new(path_with_inode , anything, anything, true, false, anything, nil, anything).once
       end
 
       plugin.refresh_watchers
@@ -1277,7 +1277,8 @@ class TailInputTest < Test::Unit::TestCase
     Timecop.freeze(2010, 1, 2, 3, 4, 6) do
       path = "test/plugin/data/2010/01/20100102-030406.log"
       inode = Fluent::FileWrapper.stat(path).ino
-      mock.proxy(Fluent::Plugin::TailInput::TailWatcher).new(path, inode, anything, anything, true, false, anything, nil, anything).once
+      target_info = Fluent::Plugin::TailInput::TargetInfo.new(path, inode)
+      mock.proxy(Fluent::Plugin::TailInput::TailWatcher).new(target_info, anything, anything, true, false, anything, nil, anything).once
       plugin.refresh_watchers
 
       flexstub(Fluent::Plugin::TailInput::TailWatcher) do |watcherclass|
@@ -1645,7 +1646,7 @@ class TailInputTest < Test::Unit::TestCase
         f.puts "test2"
       }
       path_ino = path_to_tuple("#{TMP_DIR}/tail.txt")
-      mock.proxy(Fluent::Plugin::TailInput::TailWatcher).new(path_ino.path, path_ino.ino, anything, anything, true, true, anything, nil, anything).once
+      mock.proxy(Fluent::Plugin::TailInput::TailWatcher).new(path_ino, anything, anything, true, true, anything, nil, anything).once
       d.run(shutdown: false)
       assert d.instance.instance_variable_get(:@tails)[path_ino]
 

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -1558,7 +1558,8 @@ class TailInputTest < Test::Unit::TestCase
           "refresh_interval" => "1s",
           "limit_recently_modified" => "60s",
           "read_from_head" => "true",
-          "format" => "none"
+          "format" => "none",
+          "follow_inodes" => "true"
       })
 
       d = create_driver(config, false)
@@ -1574,7 +1575,7 @@ class TailInputTest < Test::Unit::TestCase
       end
 
       events = d.events
-      assert_equal(6, events.length)
+      assert_equal(3, events.length)
       d.instance_shutdown
     end
 

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -48,7 +48,7 @@ class TailInputTest < Test::Unit::TestCase
   end
 
   def path_to_tuple(path)
-    Fluent::Plugin::TailInput::PathInodeTuple.new(path, Fluent::FileWrapper.stat(path).ino)
+    Fluent::Plugin::TailInput::TargetInfo.new(path, Fluent::FileWrapper.stat(path).ino)
   end
 
   TMP_DIR = File.dirname(__FILE__) + "/../tmp/tail#{ENV['TEST_ENV_NUMBER']}"
@@ -1271,8 +1271,8 @@ class TailInputTest < Test::Unit::TestCase
     end
 
     path = 'test/plugin/data/2010/01/20100102-030405.log'
-    tuple = Fluent::Plugin::TailInput::PathInodeTuple.new(path, Fluent::FileWrapper.stat(path).ino)
-    mock.proxy(plugin).detach_watcher_after_rotate_wait(plugin.instance_variable_get(:@tails)[tuple], tuple.ino)
+    target_info = Fluent::Plugin::TailInput::TargetInfo.new(path, Fluent::FileWrapper.stat(path).ino)
+    mock.proxy(plugin).detach_watcher_after_rotate_wait(plugin.instance_variable_get(:@tails)[target_info], target_info.ino)
 
     Timecop.freeze(2010, 1, 2, 3, 4, 6) do
       path = "test/plugin/data/2010/01/20100102-030406.log"

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -22,7 +22,11 @@ class TailInputTest < Test::Unit::TestCase
   end
 
   def cleanup_directory(path)
-    FileUtils.rm_rf(path, secure: true)
+    begin
+      FileUtils.rm_f(path, secure: true)
+    rescue ArgumentError
+      FileUtils.rm_f(path) # For Ruby 2.6 or before.
+    end
     if File.exist?(path)
       FileUtils.remove_entry_secure(path, true)
     end
@@ -30,7 +34,11 @@ class TailInputTest < Test::Unit::TestCase
   end
 
   def cleanup_file(path)
-    FileUtils.rm_f(path, secure: true)
+    begin
+      FileUtils.rm_f(path, secure: true)
+    rescue ArgumentError
+      FileUtils.rm_f(path) # For Ruby 2.6 or before.
+    end
     if File.exist?(path)
       # ensure files are closed for Windows, on which deleted files
       # are still visible from filesystem


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Revive of #1660  

**What this PR does / why we need it**: 
From #1660:

> Add ability to track inodes inside fluentd in_tail plugin to enable combination of '*' in `path` configuration with rotation inside same directory and `read_from_head` set to true. In proposed solution we add `follow_inodes` flag (set to `false` by default to preserve current behavior). When `follow_inodes` is set to `true` and file rotation is detected - we do not reread file, instead we are checking if such inode is present inside pos file - if yes, we don't recreate TailWatcher. TailWatcher is closed after `rotate_wait` period and file marked as unwatched inside position file after `limit_recently_modified` time passed. Pos file is cleaned on startup as it was before, but also delete entries for non-existing files.


And we also think that this following inodes feature is useful for tracking k8s related logs.

**Docs Changes**:
Needed for `follow_inodes` parameter. I'll register a PR for it.

**Release Note**: 

Same as title.