### PR TITLE
Add ignore_if_prev_successes to copy plugin

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,3 @@
+---
+BUNDLE_RETRY: "3"
+BUNDLE_JOBS: "3"

--- a/test/plugin/test_out_copy.rb
+++ b/test/plugin/test_out_copy.rb
@@ -217,5 +217,37 @@ class CopyOutputTest < Test::Unit::TestCase
       end
     end
   end
+
+  IGNORE_IF_PREV_SUCCESS_CONFIG = %[
+    <store ignore_error>
+      @type test
+      name c0
+    </store>
+    <store ignore_if_prev_success ignore_error>
+      @type test
+      name c1
+    </store>
+    <store ignore_if_prev_success>
+      @type test
+      name c2
+    </store>
+  ]
+
+  def test_ignore_if_prev_success
+    d = create_driver(IGNORE_IF_PREV_SUCCESS_CONFIG)
+
+    # override to raise an error
+    d.instance.outputs[0].define_singleton_method(:process) do |tag, es|
+      raise ArgumentError, 'Failed'
+    end
+
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    assert_nothing_raised do
+      d.run(default_tag: 'test') do
+        d.feed(time, {"a"=>1})
+      end
+    end
+  end
+
 end
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 

This PR makes a change in the Copy Output plugin so you can inform the fluentd to ignore said copy if the previous output succeeded.

This enables having multiple nested outputs as backup of each other by doing:

```
    <store ignore_error>
      @type test
      name c0
    </store>
    <store ignore_if_prev_success ignore_error>
      @type test
      name c1
    </store>
    <store ignore_if_prev_success>
      @type test
      name c2
    </store>
```

**Docs Changes**:

Adding the defined ignore_if_prev_successes attribute to the <store> tag makes the copy plugin ignore said store if the previous store succeed in pushing the output.