### PR TITLE
Add ignore_if_prev_successes to copy plugin

### DIFF
--- a/lib/fluent/plugin/out_copy.rb
+++ b/lib/fluent/plugin/out_copy.rb
@@ -40,8 +40,8 @@ module Fluent::Plugin
 
       @copy_proc = gen_copy_proc
       @stores.each { |store|
-        @ignore_errors << (store.arg == 'ignore_error')
-        @ignore_if_prev_successes << (store.arg == 'ignore_if_prev_success')
+        @ignore_errors << (store.arg.include?('ignore_error'))
+        @ignore_if_prev_successes << (store.arg.include?('ignore_if_prev_success'))
       }
     end
 
@@ -57,14 +57,14 @@ module Fluent::Plugin
         }
         es = m
       end
-      success = []
+      success = Array.new(outputs.size)
       outputs.each_with_index do |output, i|
         begin
           if i > 0 && success[i - 1] && @ignore_if_prev_successes[i]
-            log.info "ignore copy because prev_success in #{output.plugin_id}", index: i
+            log.debug "ignore copy because prev_success in #{output.plugin_id}", index: i
           else
             output.emit_events(tag, @copy_proc ? @copy_proc.call(es) : es)
-            success[i] = true;
+            success[i] = true
           end
         rescue => e
           if @ignore_errors[i]

--- a/test/plugin/test_out_copy.rb
+++ b/test/plugin/test_out_copy.rb
@@ -217,5 +217,37 @@ class CopyOutputTest < Test::Unit::TestCase
       end
     end
   end
+
+  IGNORE_IF_PREV_SUCCESS_CONFIG = %[
+    <store ignore_error>
+      @type test
+      name c0
+    </store>
+    <store ignore_if_prev_success ignore_error>
+      @type test
+      name c1
+    </store>
+    <store ignore_if_prev_success>
+      @type test
+      name c2
+    </store>
+  ]
+
+  def test_ignore_if_prev_success
+    d = create_driver(IGNORE_IF_PREV_SUCCESS_CONFIG)
+
+    # override to raise an error
+    d.instance.outputs[0].define_singleton_method(:process) do |tag, es|
+      raise ArgumentError, 'Failed'
+    end
+
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    assert_nothing_raised do
+      d.run(default_tag: 'test') do
+        d.feed(time, {"a"=>1})
+      end
+    end
+  end
+
 end
 


### PR DESCRIPTION
Signed-off-by: Tiago Goddard <tiago.goddard@hotmart.com>

**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 
This PR makes a change in the Copy Output plugin so you can inform the fluentd to ignore said copy if the previous output succeeded.

This enables having multiple nested outputs as backup of each other by doing:

```
    <store ignore_error>
      @type test
      name c0
    </store>
    <store ignore_if_prev_success ignore_error>
      @type test
      name c1
    </store>
    <store ignore_if_prev_success>
      @type test
      name c2
    </store>
```

**Docs Changes**:

Adding the defined ignore_if_prev_successes attribute to the tag makes the copy plugin ignore said store if the previous store succeed in pushing the output.