### PR TITLE
Prevent retry.step from being called too many times in a short time

### DIFF
--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -1252,7 +1252,13 @@ module Fluent
             log.debug "buffer queue cleared"
             @retry = nil
           else
-            @retry.step
+            # Ensure that the current time is greater than or equal to @retry.next_time to avoid the situation when
+            # @retry.step is called almost as many times as the number of flush threads in a short time.
+            if Time.now >= @retry.next_time
+              @retry.step
+            else
+              @retry.recalc_next_time # to prevent all flush threads from retrying at the same time
+            end
             if error
               if using_secondary
                 msg = "failed to flush the buffer with secondary output."

--- a/lib/fluent/plugin_helper/retry_state.rb
+++ b/lib/fluent/plugin_helper/retry_state.rb
@@ -127,6 +127,10 @@ module Fluent
           nil
         end
 
+        def recalc_next_time
+          @next_time = calc_next_time
+        end
+
         def limit?
           if @forever
             false


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #2123

**What this PR does / why we need it**: 
This PR prevents `@retry.step` from being called too many times in a short time by ensuring that the current time is greater than or equal to `@retry.next_time` to call it.

As all the flush threads share `@retry`, `@retry.step` can be called almost as many times as the number of the threads in a short time, and there is a possibility that one of them reaches the retry limit before the plugin transits to the secondary output. That is the reason why all chunks are sometimes dropped without transition to the secondary.
You can confirm the behavior using the following files:

```conf
<source>
  @type sample
  auto_increment_key id
  rate 20
  tag sample
</source>

<match sample.**>
  @type sleep_and_fail # the definition is described later

  <buffer id>
    flush_thread_count 20
    flush_mode interval
    flush_interval 5s
    retry_max_times 10
    retry_max_interval 5s
  </buffer>

  <secondary>
    @type file
    path /tmp/log/fluentd-${id}
  </secondary>
</match>
```

```ruby
require 'fluent/plugin/output'

module Fluent::Plugin
  class SleepAndFailOutput < Output
    Fluent::Plugin.register_output('sleep_and_fail', self)

    def write(chunk)
      sleep 5
      raise "error"
    end
  end
end
```

Before

```
% bundle exec ./bin/fluentd -c fluent.conf
2020-12-15 04:25:17 +0900 [info]: parsing config file is succeeded path="fluent.conf"
-- snip --
2020-12-15 04:25:28 +0900 [warn]: #0 failed to flush the buffer. retry_time=0 next_retry_seconds=2020-12-15 04:25:29.559233 +0900 chunk="5b6719a385545582809a0097a0fe56be" error_class=RuntimeError error="error"
  2020-12-15 04:25:28 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/out_sleep_and_fail.rb:9:in `write'
  2020-12-15 04:25:28 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/output.rb:1136:in `try_flush'
  2020-12-15 04:25:28 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/output.rb:1442:in `flush_thread_run'
  2020-12-15 04:25:28 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/output.rb:462:in `block (2 levels) in start'
  2020-12-15 04:25:28 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin_helper/thread.rb:78:in `block in thread_create'
2020-12-15 04:25:28 +0900 [warn]: #0 failed to flush the buffer. retry_time=1 next_retry_seconds=2020-12-15 04:25:29 66084076824691131217/140737488355328000000 +0900 chunk="5b6719a38560e2f856db639c9bd54afd" error_class=RuntimeError error="error"
  2020-12-15 04:25:28 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/out_sleep_and_fail.rb:9:in `write'
  2020-12-15 04:25:28 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/output.rb:1136:in `try_flush'
  2020-12-15 04:25:28 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/output.rb:1442:in `flush_thread_run'
  2020-12-15 04:25:28 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/output.rb:462:in `block (2 levels) in start'
  2020-12-15 04:25:28 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin_helper/thread.rb:78:in `block in thread_create'
-- snip --
2020-12-15 04:25:29 +0900 [warn]: #0 failed to flush the buffer. retry_time=10 next_retry_seconds=2020-12-15 04:25:35 3305501866179944359/17592186044416000000 +0900 chunk="5b6719a403e8bf21e6f611201ca5dc42" error_class=RuntimeError error="error"
  2020-12-15 04:25:29 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/out_sleep_and_fail.rb:9:in `write'
  2020-12-15 04:25:29 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/output.rb:1136:in `try_flush'
  2020-12-15 04:25:29 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/output.rb:1442:in `flush_thread_run'
  2020-12-15 04:25:29 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/output.rb:462:in `block (2 levels) in start'
  2020-12-15 04:25:29 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin_helper/thread.rb:78:in `block in thread_create'
2020-12-15 04:25:29 +0900 [error]: #0 failed to flush the buffer, and hit limit for retries. dropping all chunks in the buffer queue. retry_times=10 records=32 error_class=RuntimeError error="error"
  2020-12-15 04:25:29 +0900 [error]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/out_sleep_and_fail.rb:9:in `write'
  2020-12-15 04:25:29 +0900 [error]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/output.rb:1136:in `try_flush'
  2020-12-15 04:25:29 +0900 [error]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/output.rb:1442:in `flush_thread_run'
  2020-12-15 04:25:29 +0900 [error]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/output.rb:462:in `block (2 levels) in start'
  2020-12-15 04:25:29 +0900 [error]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin_helper/thread.rb:78:in `block in thread_create'
```


After

```
% bundle exec ./bin/fluentd -c fluent.conf
2020-12-15 04:22:24 +0900 [info]: parsing config file is succeeded path="fluent.conf"
-- snip --
2020-12-15 04:22:34 +0900 [warn]: #0 failed to flush the buffer. retry_time=0 next_retry_seconds=2020-12-15 04:22:35.914498 +0900 chunk="5b6718fdf4a4db9e35c6062104d0c033" error_class=RuntimeError error="error"
  2020-12-15 04:22:34 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/out_sleep_and_fail.rb:9:in `write'
  2020-12-15 04:22:34 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/output.rb:1136:in `try_flush'
  2020-12-15 04:22:34 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/output.rb:1448:in `flush_thread_run'
  2020-12-15 04:22:34 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/output.rb:462:in `block (2 levels) in start'
  2020-12-15 04:22:34 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin_helper/thread.rb:78:in `block in thread_create'
2020-12-15 04:22:34 +0900 [warn]: #0 failed to flush the buffer. retry_time=0 next_retry_seconds=2020-12-15 04:22:35 6184238159315397301/14073748835532800000 +0900 chunk="5b6718fdf4ad83c1d884154b11659694" error_class=RuntimeError error="error"
  2020-12-15 04:22:34 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/out_sleep_and_fail.rb:9:in `write'
  2020-12-15 04:22:34 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/output.rb:1136:in `try_flush'
  2020-12-15 04:22:34 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/output.rb:1448:in `flush_thread_run'
  2020-12-15 04:22:34 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin/output.rb:462:in `block (2 levels) in start'
  2020-12-15 04:22:34 +0900 [warn]: #0 /Users/arabiki/ghq/src/github.com/fluent/fluentd/lib/fluent/plugin_helper/thread.rb:78:in `block in thread_create'
-- snip --
2020-12-15 04:22:59 +0900 [warn]: #0 failed to flush the buffer. retry_time=4 next_retry_seconds=2020-12-15 04:23:04 6659213068370813633/17592186044416000000 +0900 chunk="5b6718fe276fa6f3debbf1d9bd8e4feb" error_class=RuntimeError error="error"
  2020-12-15 04:22:59 +0900 [warn]: #0 suppressed same stacktrace
2020-12-15 04:23:09 +0900 [warn]: #0 failed to flush the buffer. retry_time=5 next_retry_seconds=2020-12-15 04:23:10 14524536712345323567/35184372088832000000 +0900 chunk="5b6718fe40b20d9f3e05c6fee2696adc" error_class=RuntimeError error="error"
  2020-12-15 04:23:09 +0900 [warn]: #0 suppressed same stacktrace
-- snip --
2020-12-15 04:23:09 +0900 [warn]: #0 failed to flush the buffer. retry_time=5 next_retry_seconds=2020-12-15 04:23:10 8403108537431549743/14073748835532800000 +0900 chunk="5b6718fe0dc096ace93ca7bacfe8ecbe" error_class=RuntimeError error="error"
  2020-12-15 04:23:09 +0900 [warn]: #0 suppressed same stacktrace
2020-12-15 04:23:09 +0900 [warn]: #0 failed to flush the buffer. retry_time=5 next_retry_seconds=2020-12-15 04:23:10 51679129342425599477/70368744177664000000 +0900 chunk="5b6718fe0dc9ac4e5a5440852baeeff5" error_class=RuntimeError error="error"
  2020-12-15 04:23:09 +0900 [warn]: #0 suppressed same stacktrace
2020-12-15 04:23:10 +0900 [warn]: #0 retry succeeded by secondary. chunk_id="5b6718fea515c9dea6e1c4628b24aa50"
```

I think the retry interval also become expected by this change.


**Docs Changes**:
No needed

**Release Note**: 
Same as title