### PR TITLE
github workflow: ignore "feature request" from stale bot target

### DIFF
--- a/.github/workflows/stale-actions.yml
+++ b/.github/workflows/stale-actions.yml
@@ -18,5 +18,5 @@ jobs:
         close-pr-message: "This PR was automatically closed because of stale in 30 days"
         stale-pr-label: "stale"
         stale-issue-label: "stale"
-        exempt-issue-labels: "bug,enhancement,pending,work_in_progress,v1,v2"
-        exempt-pr-labels: "bug,enhancement,pending,work_in_progress,v1,v2"
+        exempt-issue-labels: "bug,enhancement,feature request,pending,work_in_progress,v1,v2"
+        exempt-pr-labels: "bug,enhancement,feature request,pending,work_in_progress,v1,v2"


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

N/A

**What this PR does / why we need it**: 

Disable mark as "stale" when the issue is marked as "feature request".
This is change for GitHub stale Actions.

**Docs Changes**:

N/A

**Release Note**: 

N/A
