### PR TITLE
Fix fluentd architecture image location in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Drone CI for Arm64:
 [Fluentd](https://www.fluentd.org/) collects events from various data sources and writes them to files, RDBMS, NoSQL, IaaS, SaaS, Hadoop and so on. Fluentd helps you unify your logging infrastructure (Learn more about the [Unified Logging Layer](https://www.fluentd.org/blog/unified-logging-layer)).
 
 <p align="center">
-<img src="https://raw.githubusercontent.com/fluent/fluentd-docs-gitbook/1.0/images/fluentd-architecture.png" width="500px"/>
+<img src="https://www.fluentd.org/images/fluentd-architecture.png" width="500px"/>
 </p>
 
 An event consists of *tag*, *time* and *record*. Tag is a string separated with '.' (e.g. myapp.access). It is used to categorize events. Time is a UNIX time recorded at occurrence of an event. Record is a JSON object.


### PR DESCRIPTION
Seems not to be part of the fluentd-docs-gitbook repo anymore.
So let's use the image from the main website, like done in other parts
of the REAMDE.md.

**Which issue(s) this PR fixes**: 
Fixes a dead link the the README.md.

**Docs Changes**:
Update link location.