### PR TITLE
Support unixtime_micros and unixtime_nanos to inject time

### DIFF
--- a/lib/fluent/plugin_helper/inject.rb
+++ b/lib/fluent/plugin_helper/inject.rb
@@ -132,7 +132,7 @@ module Fluent
           if @_inject_time_key
             @_inject_time_formatter = case @inject_config.time_type
                                       when :float then ->(time){ time.to_r.truncate(+6).to_f } # microsecond floating point value
-                                      when :unixtime_millis then ->(time) { time.to_f.floor(3) * 1000 }
+                                      when :unixtime_millis then ->(time) { time.respond_to?(:nsec) ? time.to_i * 1_000 + time.nsec / 1_000_000 : (time * 1_000).floor }
                                       when :unixtime then ->(time){ time.to_i }
                                       else
                                         localtime = @inject_config.localtime && !@inject_config.utc

--- a/lib/fluent/plugin_helper/inject.rb
+++ b/lib/fluent/plugin_helper/inject.rb
@@ -76,7 +76,7 @@ module Fluent
           config_param :time_key, :string, default: nil
 
           # To avoid defining :time_type twice
-          config_param :time_type, :enum, list: [:float, :unixtime, :unixtime_millis, :string], default: :float
+          config_param :time_type, :enum, list: [:float, :unixtime, :unixtime_millis, :unixtime_micros, :unixtime_nanos, :string], default: :float
 
           Fluent::TimeMixin::TIME_PARAMETERS.each do |name, type, opts|
             config_param(name, type, **opts)
@@ -133,6 +133,8 @@ module Fluent
             @_inject_time_formatter = case @inject_config.time_type
                                       when :float then ->(time){ time.to_r.truncate(+6).to_f } # microsecond floating point value
                                       when :unixtime_millis then ->(time) { time.respond_to?(:nsec) ? time.to_i * 1_000 + time.nsec / 1_000_000 : (time * 1_000).floor }
+                                      when :unixtime_micros then ->(time) { time.respond_to?(:nsec) ? time.to_i * 1_000_000 + time.nsec / 1_000 : (time * 1_000_000).floor }
+                                      when :unixtime_nanos then ->(time) { time.respond_to?(:nsec) ? time.to_i * 1_000_000_000 + time.nsec : (time * 1_000_000_000).floor }
                                       when :unixtime then ->(time){ time.to_i }
                                       else
                                         localtime = @inject_config.localtime && !@inject_config.utc

--- a/lib/fluent/time.rb
+++ b/lib/fluent/time.rb
@@ -50,6 +50,7 @@ module Fluent
     def to_int
       @sec
     end
+    alias :to_i :to_int
 
     def to_f
       @sec + @nsec / 1_000_000_000.0

--- a/test/plugin_helper/test_inject.rb
+++ b/test/plugin_helper/test_inject.rb
@@ -190,6 +190,34 @@ class InjectHelperTest < Test::Unit::TestCase
       assert_equal record.merge({"timedata" => time_in_unix * 1_000}), @d.inject_values_to_record('tag', time_in_unix, record)
     end
 
+    test 'injects time as unix time micros into specified key' do
+      time_in_unix = Time.parse("2016-06-21 08:10:11 +0900").to_i
+      time_subsecond = 320_101_224
+      time = Fluent::EventTime.new(time_in_unix, time_subsecond)
+      unixtime_micros = 1466464211320101
+
+      @d.configure(config_inject_section("time_key" => "timedata", "time_type" => "unixtime_micros"))
+      @d.start
+
+      record = {"key1" => "value1", "key2" => 2}
+      assert_equal record.merge({"timedata" => unixtime_micros}), @d.inject_values_to_record('tag', time, record)
+      assert_equal record.merge({"timedata" => time_in_unix * 1_000_000}), @d.inject_values_to_record('tag', time_in_unix, record)
+    end
+
+    test 'injects time as unix time nanos into specified key' do
+      time_in_unix = Time.parse("2016-06-21 08:10:11 +0900").to_i
+      time_subsecond = 320_101_224
+      time = Fluent::EventTime.new(time_in_unix, time_subsecond)
+      unixtime_nanos = 1466464211320101224
+
+      @d.configure(config_inject_section("time_key" => "timedata", "time_type" => "unixtime_nanos"))
+      @d.start
+
+      record = {"key1" => "value1", "key2" => 2}
+      assert_equal record.merge({"timedata" => unixtime_nanos}), @d.inject_values_to_record('tag', time, record)
+      assert_equal record.merge({"timedata" => time_in_unix * 1_000_000_000}), @d.inject_values_to_record('tag', time_in_unix, record)
+    end
+
     test 'injects time as unix time into specified key' do
       time_in_unix = Time.parse("2016-06-21 08:10:11 +0900").to_i
       time_subsecond = 320_101_224

--- a/test/plugin_helper/test_inject.rb
+++ b/test/plugin_helper/test_inject.rb
@@ -187,6 +187,7 @@ class InjectHelperTest < Test::Unit::TestCase
 
       record = {"key1" => "value1", "key2" => 2}
       assert_equal record.merge({"timedata" => unixtime_millis}), @d.inject_values_to_record('tag', time, record)
+      assert_equal record.merge({"timedata" => time_in_unix * 1_000}), @d.inject_values_to_record('tag', time_in_unix, record)
     end
 
     test 'injects time as unix time into specified key' do


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**What this PR does / why we need it**: 

This PR adds new time types "unixtime_micros" and "unixtime_nanos" to inject time for the same reason as https://github.com/fluent/fluentd/pull/3145.

If we collect docker container logs using the fluentd logging driver, we need to sort the logs by the time to merge logs from various containers. Although we can now specify unixtime_millis, logs with line feed sometimes have the same time in milliseconds. As a result, the logs are sorted in the wrong order. This PR will resolve the problem by introducing new types of unixtime with higher precision.

**Docs Changes**:
Needed. I'll create a pull request to change [configuration/inject-section.md#time-parameters](https://github.com/fluent/fluentd-docs-gitbook/blob/71e49c869fb4e5416a528f6d77b35f8a67b17bac/configuration/inject-section.md#time-parameters) if this PR is merged.

**Release Note**: 
Same as title