### PR TITLE
fluent-plugin-config-format: use markdown table

### DIFF
--- a/lib/fluent/command/plugin_config_formatter.rb
+++ b/lib/fluent/command/plugin_config_formatter.rb
@@ -162,9 +162,20 @@ class FluentPluginConfigFormatter
     else
       sections, params = base_section.partition {|_name, value| value[:section] }
     end
+    if @table and not params.empty?
+      dumped << "### Configuration\n\n"
+      dumped << "|parameter|type|description|default|\n"
+      dumped << "|---|---|---|---|\n"
+    end
     params.each do |name, config|
       next if name == :section
-      template_name = @compact ? "param.md-compact.erb" : "param.md.erb"
+      template_name = if @compact
+                        "param.md-compact.erb"
+                      elsif @table
+                        "param.md-table.erb"
+                      else
+                        "param.md.erb"
+                      end
       template = template_path(template_name).read
       dumped <<
         if ERB.instance_method(:initialize).parameters.assoc(:key) # Ruby 2.6+
@@ -256,6 +267,9 @@ BANNER
     end
     @parser.on("-p", "--plugin=DIR", "Add plugin directory") do |s|
       @plugin_dirs << s
+    end
+    @parser.on("-t", "--table", "Use table syntax to dump parameters") do
+      @table = true
     end
   end
 

--- a/templates/plugin_config_formatter/param.md-table.erb
+++ b/templates/plugin_config_formatter/param.md-table.erb
@@ -1,0 +1,10 @@
+<%-
+type = config[:type]
+required_label = config[:required] ? "required" : "optional"
+default = config[:default]
+alias_name = config[:alias]
+deprecated = config[:deprecated]
+obsoleted = config[:obsoleted]
+description = config[:desc]
+-%>
+|<%= name %>|<%= type %> (<%= required_label %>)|<%= description %><%- if type == :enum -%> (<%= config[:list].map{|x| "`#{x}`"}.join(", ") %>)<%- end -%><%- if alias_name -%><br>Alias: <%= alias_name %><%- end -%><%- if deprecated -%><br>Deprecated: <%= deprecated %><%- end -%><%- if obsoleted -%><br>Obsoleted: <%= :obsoleted %><%- end -%>|<%- if default -%>`<%= default %>`<%- end -%>|

--- a/test/command/test_plugin_config_formatter.rb
+++ b/test/command/test_plugin_config_formatter.rb
@@ -229,6 +229,30 @@ TEXT
       assert_equal(expected, dumped_config)
     end
 
+    test "input simple (table)" do
+      dumped_config = capture_stdout do
+        FluentPluginConfigFormatter.new(["--format=markdown", "--table", "input", "simple"]).call
+      end
+      expected = <<TEXT
+## Plugin helpers
+
+* [inject](https://docs.fluentd.org/v/1.0/plugin-helper-overview/api-plugin-helper-inject)
+* [compat_parameters](https://docs.fluentd.org/v/1.0/plugin-helper-overview/api-plugin-helper-compat_parameters)
+
+* See also: [Input Plugin Overview](https://docs.fluentd.org/v/1.0/input#overview)
+
+## TestFluentPluginConfigFormatter::SimpleInput
+
+### Configuration
+
+|parameter|type|description|default|
+|---|---|---|---|
+|path|string (required)|path to something||
+
+TEXT
+      assert_equal(expected, dumped_config)
+    end
+
     data("abbrev" => "sd",
          "normal" => "service_discovery")
     test "service_discovery simple" do |data|
@@ -295,6 +319,49 @@ Available values: easy, normal, hard
 
 Default value: `normal`.
 
+
+
+
+TEXT
+      assert_equal(expected, dumped_config)
+    end
+
+    test "output complex (table)" do
+      dumped_config = capture_stdout do
+        FluentPluginConfigFormatter.new(["--format=markdown", "--table", "output", "complex"]).call
+      end
+      expected = <<TEXT
+## Plugin helpers
+
+* [inject](https://docs.fluentd.org/v/1.0/plugin-helper-overview/api-plugin-helper-inject)
+* [compat_parameters](https://docs.fluentd.org/v/1.0/plugin-helper-overview/api-plugin-helper-compat_parameters)
+
+* See also: [Output Plugin Overview](https://docs.fluentd.org/v/1.0/output#overview)
+
+## TestFluentPluginConfigFormatter::ComplexOutput
+
+
+### \\<authentication\\> section (required) (single)
+
+### Configuration
+
+|parameter|type|description|default|
+|---|---|---|---|
+|username|string (required)|username||
+|password|string (required)|password||
+
+
+### \\<parent\\> section (optional) (multiple)
+
+
+#### \\<child\\> section (optional) (multiple)
+
+### Configuration
+
+|parameter|type|description|default|
+|---|---|---|---|
+|names|array (required)|names||
+|difficulty|enum (optional)|difficulty (`easy`, `normal`, `hard`)|`normal`|
 
 
 


### PR DESCRIPTION
You can see list of parameters at a glance with --compact option

Before:

```
  * name (type) (required?) description

  * Available values: ...

  * Default value: ...

  * Alias:

  * Deprecated:

  * Obsoleted:
```

After:

```
  ### Configuration

  |parameter|type|description|default|
  |---|---|---|---|
  |...|...|...|...|
```