### PR TITLE
Fix creating TLS certification files which include broken extensions

### DIFF
--- a/lib/fluent/command/ca_generate.rb
+++ b/lib/fluent/command/ca_generate.rb
@@ -75,6 +75,8 @@ HELP
 
       digest = OpenSSL::Digest::SHA256.new
 
+      factory = OpenSSL::X509::ExtensionFactory.new
+
       cert = OpenSSL::X509::Certificate.new
       cert.not_before = Time.at(0)
       cert.not_after = Time.now + 5 * 365 * 86400 # 5 years after
@@ -82,7 +84,7 @@ HELP
       cert.serial = 1
       cert.issuer = issuer
       cert.subject = subject
-      cert.add_extension OpenSSL::X509::Extension.new('basicConstraints', OpenSSL::ASN1.Sequence([OpenSSL::ASN1::Boolean(true)]))
+      cert.add_extension(factory.create_extension('basicConstraints', 'CA:TRUE'))
       cert.sign(key, digest)
 
       return cert, key
@@ -111,8 +113,9 @@ HELP
       cert.issuer = issuer
       cert.subject = subject
 
-      cert.add_extension OpenSSL::X509::Extension.new('basicConstraints', OpenSSL::ASN1.Sequence([OpenSSL::ASN1::Boolean(false)]))
-      cert.add_extension OpenSSL::X509::Extension.new('nsCertType', 'server')
+      factory = OpenSSL::X509::ExtensionFactory.new
+      server_cert.add_extension(factory.create_extension('basicConstraints', 'CA:FALSE'))
+      server_cert.add_extension(factory.create_extension('nsCertType', 'server'))
 
       cert.sign ca_key, digest
 

--- a/test/plugin_helper/test_http_server_helper.rb
+++ b/test/plugin_helper/test_http_server_helper.rb
@@ -132,7 +132,9 @@ class HttpHelperTest < Test::Unit::TestCase
         error = e
       end
 
-      resp = Response.new(response.status.to_s, response.body.read, response.headers)
+      if response
+        resp = Response.new(response.status.to_s, response.body.read, response.headers)
+      end
     end
 
     if error

--- a/test/plugin_helper/test_server.rb
+++ b/test/plugin_helper/test_server.rb
@@ -832,8 +832,9 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     chain_cert.sign(root_key, "sha256")
 
     server_cert, server_key, _ = CertUtil.cert_option_generate_pair(create_server_options, chain_cert.subject)
-    server_cert.add_extension OpenSSL::X509::Extension.new('basicConstraints', OpenSSL::ASN1.Sequence([OpenSSL::ASN1::Boolean(false)]))
-    server_cert.add_extension OpenSSL::X509::Extension.new('nsCertType', 'server')
+    factory = OpenSSL::X509::ExtensionFactory.new
+    server_cert.add_extension(factory.create_extension('basicConstraints', 'CA:FALSE'))
+    server_cert.add_extension(factory.create_extension('nsCertType', 'server'))
     server_cert.sign(chain_key, "sha256")
 
     # write chained cert


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
none

**What this PR does / why we need it**: 
Some TLS related tests are failed as of OpenSSL 1.1.1f due to creating
broken certification files. Although a value of `nsCertType` extension
should be `OpenSSL::ASN1::BitString` but previous code passed raw string.
OpenSSL 1.1.1e or before doesn't reject such certifications.

To create valid extensions, use `OpenSSL::X509::ExtensionFactory` instead.

**Docs Changes**:
none

**Release Note**: 
same with the title