### PR TITLE
Add an option to disable shared socket forcedly

### DIFF
--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -163,6 +163,10 @@ op.on('--conf-encoding ENCODING', "specify configuration file encoding") { |s|
   opts[:conf_encoding] = s
 }
 
+op.on('--disable-shared-socket', "Don't open shared socket for multiple workers") { |b|
+  opts[:disable_shared_socket] = b
+}
+
 if Fluent.windows?
   require 'windows/library'
   include Windows::Library

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -27,7 +27,7 @@ module Fluent
       :log_event_verbose, :ignore_repeated_log_interval, :ignore_same_log_interval,
       :without_source, :rpc_endpoint, :enable_get_dump, :process_name,
       :file_permission, :dir_permission, :counter_server, :counter_client,
-      :strict_config_value, :enable_msgpack_time_support
+      :strict_config_value, :enable_msgpack_time_support, :disable_shared_socket
     ]
 
     config_param :workers,   :integer, default: 1
@@ -45,6 +45,7 @@ module Fluent
     config_param :process_name,    :string, default: nil
     config_param :strict_config_value, :bool, default: nil
     config_param :enable_msgpack_time_support, :bool, default: nil
+    config_param :disable_shared_socket, :bool, default: nil
     config_param :file_permission, default: nil do |v|
       v.to_i(8)
     end

--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -1065,4 +1065,34 @@ CONF
                          "secret xxxxxx", patterns_not_match: ["secret secret0", "secret secret1"])
     end
   end
+
+  sub_test_case 'sahred socket options' do
+    test 'enable shared socket by default' do
+      conf = ""
+      conf_path = create_conf_file('empty.conf', conf)
+      assert File.exist?(conf_path)
+      assert_log_matches(create_cmdline(conf_path),
+                         patterns_not_match: ["shared socket for multiple workers is disabled"])
+    end
+
+    test 'disable shared socket by command line option' do
+      conf = ""
+      conf_path = create_conf_file('empty.conf', conf)
+      assert File.exist?(conf_path)
+      assert_log_matches(create_cmdline(conf_path, "--disable-shared-socket"),
+                         "shared socket for multiple workers is disabled",)
+    end
+
+    test 'disable shared socket by system config' do
+      conf = <<CONF
+<system>
+  disable_shared_socket
+</system>
+CONF
+      conf_path = create_conf_file('empty.conf', conf)
+      assert File.exist?(conf_path)
+      assert_log_matches(create_cmdline(conf_path, "--disable-shared-socket"),
+                         "shared socket for multiple workers is disabled",)
+    end
+  end
 end

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -517,6 +517,31 @@ class SupervisorTest < ::Test::Unit::TestCase
     assert_equal Fluent::Log::LEVEL_ERROR, $log.level
   end
 
+  def test_enable_shared_socket
+    server = DummyServer.new
+    begin
+      server.before_run
+      assert_not_nil(ENV['SERVERENGINE_SOCKETMANAGER_PATH'])
+    ensure
+      server.after_run
+    end
+  end
+
+  def test_disable_shared_socket
+    server = DummyServer.new
+    def server.config
+      {
+        :disable_shared_socket => true,
+      }
+    end
+    begin
+      server.before_run
+      assert_nil(ENV['SERVERENGINE_SOCKETMANAGER_PATH'])
+    ensure
+      server.after_run
+    end
+  end
+
   def create_debug_dummy_logger
     dl_opts = {}
     dl_opts[:log_level] = ServerEngine::DaemonLogger::DEBUG

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -520,10 +520,12 @@ class SupervisorTest < ::Test::Unit::TestCase
   def test_enable_shared_socket
     server = DummyServer.new
     begin
+      ENV.delete('SERVERENGINE_SOCKETMANAGER_PATH')
       server.before_run
       assert_not_nil(ENV['SERVERENGINE_SOCKETMANAGER_PATH'])
     ensure
       server.after_run
+      ENV.delete('SERVERENGINE_SOCKETMANAGER_PATH')
     end
   end
 
@@ -535,10 +537,12 @@ class SupervisorTest < ::Test::Unit::TestCase
       }
     end
     begin
+      ENV.delete('SERVERENGINE_SOCKETMANAGER_PATH')
       server.before_run
       assert_nil(ENV['SERVERENGINE_SOCKETMANAGER_PATH'])
     ensure
       server.after_run
+      ENV.delete('SERVERENGINE_SOCKETMANAGER_PATH')
     end
   end
 

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -522,6 +522,7 @@ class SupervisorTest < ::Test::Unit::TestCase
     begin
       ENV.delete('SERVERENGINE_SOCKETMANAGER_PATH')
       server.before_run
+      sleep 0.1 if Fluent.windows? # Wait for starting windows event thread
       assert_not_nil(ENV['SERVERENGINE_SOCKETMANAGER_PATH'])
     ensure
       server.after_run
@@ -539,6 +540,7 @@ class SupervisorTest < ::Test::Unit::TestCase
     begin
       ENV.delete('SERVERENGINE_SOCKETMANAGER_PATH')
       server.before_run
+      sleep 0.1 if Fluent.windows? # Wait for starting windows event thread
       assert_nil(ENV['SERVERENGINE_SOCKETMANAGER_PATH'])
     ensure
       server.after_run


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
none

**What this PR does / why we need it**: 
Fluentd always creates ServerEngine::SocketManager's shared socket even if it's not required. The shared socket isn't needed if there is no plugin that uses it such as in_forward, in_http and in_syslog.
Although it can be disabled if Fluentd doesn't use multiple workers, this patch adds `disable_shared_socket` instead of checking number of workers to keep backward compatibility for third-party plugins (`PluginHelper::Server.create_server_connection` uses shared socket by default).

Opening a needless socket may cause conflict with other applications especially on Windows because `ServerEngine::SocketManager` uses TCP socket on Windows.

**Docs Changes**:

* Add `disable_shared_socket` to https://docs.fluentd.org/deployment/system-config#parameters.
* Add `--disable-shared-socket` to https://docs.fluentd.org/deployment/command-line-option

**Release Note**: 
Same with the title.