### PR TITLE
Update navigation link to https://discuss.fluentd.org/

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Ask a Question
-    url: https://groups.google.com/forum/#!forum/fluentd
-    about: I have questions about Fluentd and plugins. Please ask and answer questions here
+    url: https://discuss.fluentd.org/
+    about: I have questions about Fluentd and plugins. Please ask and answer questions at https://discuss.fluentd.org/.


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

N/A

**What this PR does / why we need it**: 

As migration to discource instance is announced, I've updated navigation link.

Moving to discourse forums
https://groups.google.com/g/fluentd/c/z6e4ziIfzdo

**Docs Changes**:

README.md should be updated in another PR.

**Release Note**: 

N/A