### PR TITLE
test: fix ArgumentError(<wrong number of arguments (given 2, expected 1)>) on arm64v8

### DIFF
--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -995,7 +995,7 @@ EOL
   test 'when out_forward has @id' do
     # cancel https://github.com/fluent/fluentd/blob/077508ac817b7637307434d0c978d7cdc3d1c534/lib/fluent/plugin_id.rb#L43-L53
     # it always return true in test
-    mock.proxy(Fluent::Plugin).new_sd(:static, anything) { |v|
+    mock.proxy(Fluent::Plugin).new_sd(:static, parent: anything) { |v|
       stub(v).plugin_id_for_test? { false }
     }.once
 


### PR DESCRIPTION
This PR fixes the following error:

 CI drone test: fix implicit parent: parameter
    
    This PR fixes the following error:
    
    Failure: test: when out_forward has @id(ForwardOutputTest):
      Exception raised:
      ArgumentError(<wrong number of arguments (given 2, expected 1)>)
      /drone/src/lib/fluent/plugin.rb:120:in `new_sd'
      /drone/src/vendor/bundle/ruby/3.0.0/gems/rr-1.2.1/lib/rr/method_dispatches/method_dispatch.rb:30:in `call_original_method'
      /drone/src/vendor/bundle/ruby/3.0.0/gems/rr-1.2.1/lib/rr/method_dispatches/method_dispatch.rb:41:in `call_implementation'
      /drone/src/vendor/bundle/ruby/3.0.0/gems/rr-1.2.1/lib/rr/method_dispatches/method_dispatch.rb:16:in `call'
      /drone/src/vendor/bundle/ruby/3.0.0/gems/rr-1.2.1/lib/rr/injections/double_injection.rb:183:in `dispatch_method'
      /drone/src/vendor/bundle/ruby/3.0.0/gems/rr-1.2.1/lib/rr/injections/double_injection.rb:40:in `dispatch_method'
      /drone/src/vendor/bundle/ruby/3.0.0/gems/rr-1.2.1/lib/rr/injections/double_injection.rb:148:in `new_sd'
      /drone/src/lib/fluent/plugin_helper/service_discovery/manager.rb:37:in
      `block in configure'

This error is detected by implicit parent: parameter.

**Which issue(s) this PR fixes**: 

One of the broken test cases ( 1/3 ) #3263

**What this PR does / why we need it**: 

With Drone CI, there are some test cases with failure. This PR fix one of them.

**Docs Changes**:

N/A

**Release Note**: 

N/A