### PR TITLE
Clear RUBYOPT while running some tests for fluentd command

### DIFF
--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -878,6 +878,8 @@ CONF
     end
 
     test "without RUBYOPT" do
+      saved_ruby_opt = ENV["RUBYOPT"]
+      ENV["RUBYOPT"] = nil
       conf = <<CONF
 <source>
   @type dummy
@@ -889,6 +891,8 @@ CONF
 CONF
       conf_path = create_conf_file('rubyopt_test.conf', conf)
       assert_log_matches(create_cmdline(conf_path), '-Eascii-8bit:ascii-8bit')
+    ensure
+      ENV["RUBYOPT"] = saved_ruby_opt
     end
 
     test 'invalid values are set to RUBYOPT' do
@@ -912,6 +916,8 @@ CONF
 
     # https://github.com/fluent/fluentd/issues/2915
     test "ruby path contains spaces" do
+      saved_ruby_opt = ENV["RUBYOPT"]
+      ENV["RUBYOPT"] = nil
       conf = <<CONF
 <source>
   @type dummy
@@ -940,6 +946,8 @@ CONF
         'spawn command to main:',
         '-Eascii-8bit:ascii-8bit'
       )
+    ensure
+      ENV["RUBYOPT"] = saved_ruby_opt
     end
 
     test 'success to start workers when file buffer is configured in non-workers way only for specific worker' do


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
none

**What this PR does / why we need it**: 
RubyInstaller sets RUBYOPT=-Eutf8 by default as of 2.7, it breaks
precondition of these tests.

```
Failure: test: ruby path contains spaces(TestFluentdCommand::configured to run 2 workers):
  execution timeout.
  <"\r\n" +
  "aho@SKYLAKE C:\\Users\\aho\\Projects\\fluentd\\test\\tmp\\command\\fluentd>C:/Ruby27-x64/bin/ruby.exe C:/Users/aho/Projects/fluentd/bin/fl
uentd -c C:/Users/aho/Projects/fluentd/test/tmp/command/fluentd/space_mixed_ruby_path_test.conf \r\n" +
  "2021-02-23 10:39:35 +0900 [info]: parsing config file is succeeded path=\"C:/Users/aho/Projects/fluentd/test/tmp/command/fluentd/space_mix
ed_ruby_path_test.conf\"\r\n" +
  "2021-02-23 10:39:35 +0900 [info]: gem 'fluentd' version '1.12.1'\r\n" +
  "2021-02-23 10:39:35 +0900 [warn]: both of Plugin @id and path for <storage> are not specified. Using on-memory store.\r\n" +
  "2021-02-23 10:39:35 +0900 [warn]: both of Plugin @id and path for <storage> are not specified. Using on-memory store.\r\n" +
  "2021-02-23 10:39:35 +0900 [warn]: define <match fluent.**> to capture fluentd logs in top level is deprecated. Use <label @FLUENT_LOG> ins
tead\r\n" +
  "2021-02-23 10:39:35 +0900 [info]: using configuration file: <ROOT>\r\n" +
  "  <source>\r\n" +
  "    @type dummy\r\n" +
  "    tag \"dummy\"\r\n" +
  "  </source>\r\n" +
  "  <match>\r\n" +
  "    @type null\r\n" +
  "  </match>\r\n" +
  "</ROOT>\r\n" +
  "2021-02-23 10:39:35 +0900 [info]: starting fluentd-1.12.1 pid=7312 ruby=\"2.7.2\"\r\n" +
  "2021-02-23 10:39:35 +0900 [info]: spawn command to main:  cmdline=[\"C:/Users/aho/Projects/fluentd/test/tmp/command/fluentd/ruby with spac
es.bat\", \"-rC:/Ruby27-x64/lib/ruby/gems/2.7.0/gems/bundler-2.2.6/lib/bundler/setup\", \"-Eutf-8\", \"C:/Users/aho/Projects/fluentd/bin/flue
ntd\", \"-c\", \"C:/Users/aho/Projects/fluentd/test/tmp/command/fluentd/space_mixed_ruby_path_test.conf\", \"--under-supervisor\"]\r\n" +    
  "\r\n" +
  "aho@SKYLAKE C:\\Users\\aho\\Projects\\fluentd\\test\\tmp\\command\\fluentd>C:/Ruby27-x64/bin/ruby.exe -rC:/Ruby27-x64/lib/ruby/gems/2.7.0/
gems/bundler-2.2.6/lib/bundler/setup -Eutf-8 C:/Users/aho/Projects/fluentd/bin/fluentd -c C:/Users/aho/Projects/fluentd/test/tmp/command/flue
ntd/space_mixed_ruby_path_test.conf --under-supervisor \r\n" +
  "2021-02-23 10:39:37 +0900 [info]: adding match pattern=\"**\" type=\"null\"\r\n" +
  "2021-02-23 10:39:37 +0900 [info]: adding source type=\"dummy\"\r\n" +
  "2021-02-23 10:39:37 +0900 [warn]: #0 both of Plugin @id and path for <storage> are not specified. Using on-memory store.\r\n" +
  "2021-02-23 10:39:37 +0900 [warn]: #0 both of Plugin @id and path for <storage> are not specified. Using on-memory store.\r\n" +
  "2021-02-23 10:39:37 +0900 [warn]: #0 define <match fluent.**> to capture fluentd logs in top level is deprecated. Use <label @FLUENT_LOG> 
instead\r\n" +
  "2021-02-23 10:39:37 +0900 [info]: #0 starting fluentd worker pid=12048 ppid=19860 worker=0\r\n" +
  "2021-02-23 10:39:37 +0900 [info]: #0 fluentd worker is now running worker=0\r\n">
  was expected to include:
  <["spawn command to main:", "-Eascii-8bit:ascii-8bit"]>
C:/Users/aho/Projects/fluentd/test/command/test_fluentd.rb:163:in `assert_log_matches'
C:/Users/aho/Projects/fluentd/test/command/test_fluentd.rb:947:in `block (2 levels) in <class:TestFluentdCommand>'
     944:       cmd_path = File.expand_path(File.dirname(__FILE__) + "../../../bin/fluentd")
     945:       conf_path = create_conf_file('space_mixed_ruby_path_test.conf', conf)
     946:       args = ["bundle", "exec", tmp_ruby_path, cmd_path, "-c", conf_path]
  => 947:       assert_log_matches(
     948:         args,
     949:         'spawn command to main:',
     950:         '-Eascii-8bit:ascii-8bit'
=============================================================================================================================================
```

**Docs Changes**:
none

**Release Note**: 
none
