### PR TITLE
test in_tail: use safer method to cleanup

### DIFF
--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -6,6 +6,7 @@ require 'fluent/system_config'
 require 'net/http'
 require 'flexmock/test_unit'
 require 'timecop'
+require 'tmpdir'
 require 'securerandom'
 
 class TailInputTest < Test::Unit::TestCase


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

N/A

**What this PR does / why we need it**: 

This PR aims to fix in_tail test cases on Windows.

On Windows, when the file or directory is removed and created
frequently, there is a case that creating file or directory will fail.
This situation is caused by pending file or directory deletion which
is mentioned on win32 API document.

ref. https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea#files

As a workaround, execute rename and remove method.

**Docs Changes**:

N/A

**Release Note**: 

N/A
