### PR TITLE
Revise feat ignore_if_prev_successes to copy plugin

### DIFF
--- a/lib/fluent/plugin/out_copy.rb
+++ b/lib/fluent/plugin/out_copy.rb
@@ -46,6 +46,9 @@ module Fluent::Plugin
         @ignore_errors << (store.arg.include?('ignore_error'))
         @ignore_if_prev_successes << (store.arg.include?('ignore_if_prev_success'))
       }
+      if @ignore_errors.uniq.size == 1 && @ignore_errors.include?(true) && @ignore_if_prev_successes.include?(false)
+        log.warn "ignore_errors are specified in all <store>, but ignore_if_prev_success is not specified. Is this intended?"
+      end
     end
 
     def multi_workers_ready?

--- a/lib/fluent/plugin/out_copy.rb
+++ b/lib/fluent/plugin/out_copy.rb
@@ -39,7 +39,10 @@ module Fluent::Plugin
       super
 
       @copy_proc = gen_copy_proc
-      @stores.each { |store|
+      @stores.each_with_index { |store, i|
+        if i == 0 && store.arg.include?('ignore_if_prev_success')
+          raise Fluent::ConfigError, "ignore_if_prev_success must specify 2nd or later <store> directives"
+        end
         @ignore_errors << (store.arg.include?('ignore_error'))
         @ignore_if_prev_successes << (store.arg.include?('ignore_if_prev_success'))
       }

--- a/lib/fluent/plugin/out_copy.rb
+++ b/lib/fluent/plugin/out_copy.rb
@@ -40,8 +40,8 @@ module Fluent::Plugin
 
       @copy_proc = gen_copy_proc
       @stores.each { |store|
-        @ignore_errors << (store.arg == 'ignore_error')
-        @ignore_if_prev_successes << (store.arg == 'ignore_if_prev_success')
+        @ignore_errors << (store.arg.include?('ignore_error'))
+        @ignore_if_prev_successes << (store.arg.include?('ignore_if_prev_success'))
       }
     end
 
@@ -57,14 +57,14 @@ module Fluent::Plugin
         }
         es = m
       end
-      success = []
+      success = Array.new(outputs.size)
       outputs.each_with_index do |output, i|
         begin
           if i > 0 && success[i - 1] && @ignore_if_prev_successes[i]
-            log.info "ignore copy because prev_success in #{output.plugin_id}", index: i
+            log.debug "ignore copy because prev_success in #{output.plugin_id}", index: i
           else
             output.emit_events(tag, @copy_proc ? @copy_proc.call(es) : es)
-            success[i] = true;
+            success[i] = true
           end
         rescue => e
           if @ignore_errors[i]

--- a/test/plugin/test_out_copy.rb
+++ b/test/plugin/test_out_copy.rb
@@ -77,6 +77,28 @@ class CopyOutputTest < Test::Unit::TestCase
     end
   end
 
+  ALL_IGNORE_ERROR_WITHOUT_IGNORE_IF_PREV_SUCCESS_CONFIG = %[
+    @log_level info
+    <store ignore_error>
+      @type test
+      name c0
+    </store>
+    <store ignore_error>
+      @type test
+      name c1
+    </store>
+    <store ignore_error>
+      @type test
+      name c2
+    </store>
+  ]
+  def test_configure_all_ignore_errors_without_ignore_if_prev_success
+    d = create_driver(ALL_IGNORE_ERROR_WITHOUT_IGNORE_IF_PREV_SUCCESS_CONFIG)
+    expected = /ignore_errors are specified in all <store>, but ignore_if_prev_success is not specified./
+    matches = d.logs.grep(expected)
+    assert_equal(1, matches.length, "Logs do not contain '#{expected}' '#{d.logs}'")
+  end
+
   def test_configure_with_deep_copy_and_use_shallow_copy_mode
     d = create_driver(%[
       deep_copy true

--- a/test/plugin/test_out_copy.rb
+++ b/test/plugin/test_out_copy.rb
@@ -57,6 +57,26 @@ class CopyOutputTest < Test::Unit::TestCase
     assert_equal :no_copy, d.instance.copy_mode
   end
 
+  ERRORNEOUS_IGNORE_IF_PREV_SUCCESS_CONFIG = %[
+    <store ignore_if_prev_success ignore_error>
+      @type test
+      name c0
+    </store>
+    <store ignore_if_prev_success ignore_error>
+      @type test
+      name c1
+    </store>
+    <store ignore_if_prev_success>
+      @type test
+      name c2
+    </store>
+  ]
+  def test_configure_with_errorneus_ignore_if_prev_success
+    assert_raise(Fluent::ConfigError) do
+      create_driver(ERRORNEOUS_IGNORE_IF_PREV_SUCCESS_CONFIG)
+    end
+  end
+
   def test_configure_with_deep_copy_and_use_shallow_copy_mode
     d = create_driver(%[
       deep_copy true

--- a/test/plugin/test_out_copy.rb
+++ b/test/plugin/test_out_copy.rb
@@ -2,8 +2,11 @@ require_relative '../helper'
 require 'fluent/test/driver/multi_output'
 require 'fluent/plugin/out_copy'
 require 'fluent/event'
+require 'flexmock/test_unit'
 
 class CopyOutputTest < Test::Unit::TestCase
+  include FlexMock::TestCase
+
   class << self
     def startup
       $LOAD_PATH.unshift File.expand_path(File.join(File.dirname(__FILE__), '..', 'scripts'))
@@ -239,6 +242,16 @@ class CopyOutputTest < Test::Unit::TestCase
     # override to raise an error
     d.instance.outputs[0].define_singleton_method(:process) do |tag, es|
       raise ArgumentError, 'Failed'
+    end
+
+    # check ingore_if_prev_success functionality:
+    # 1. output 2 is succeeded.
+    # 2. output 3 is not cailed.
+    flexstub(d.instance.outputs[1]) do |output|
+      output.should_receive(:process).once
+    end
+    flexstub(d.instance.outputs[2]) do |output|
+      output.should_receive(:process).never
     end
 
     time = Time.parse("2011-01-02 13:14:15 UTC").to_i

--- a/test/plugin/test_out_copy.rb
+++ b/test/plugin/test_out_copy.rb
@@ -246,7 +246,7 @@ class CopyOutputTest < Test::Unit::TestCase
 
     # check ingore_if_prev_success functionality:
     # 1. output 2 is succeeded.
-    # 2. output 3 is not cailed.
+    # 2. output 3 is not called.
     flexstub(d.instance.outputs[1]) do |output|
       output.should_receive(:process).once
     end

--- a/test/plugin/test_out_copy.rb
+++ b/test/plugin/test_out_copy.rb
@@ -217,5 +217,37 @@ class CopyOutputTest < Test::Unit::TestCase
       end
     end
   end
+
+  IGNORE_IF_PREV_SUCCESS_CONFIG = %[
+    <store ignore_error>
+      @type test
+      name c0
+    </store>
+    <store ignore_if_prev_success ignore_error>
+      @type test
+      name c1
+    </store>
+    <store ignore_if_prev_success>
+      @type test
+      name c2
+    </store>
+  ]
+
+  def test_ignore_if_prev_success
+    d = create_driver(IGNORE_IF_PREV_SUCCESS_CONFIG)
+
+    # override to raise an error
+    d.instance.outputs[0].define_singleton_method(:process) do |tag, es|
+      raise ArgumentError, 'Failed'
+    end
+
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    assert_nothing_raised do
+      d.run(default_tag: 'test') do
+        d.feed(time, {"a"=>1})
+      end
+    end
+  end
+
 end
 


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Revised #3190

In this revised version, I added a testcase fix for https://github.com/fluent/fluentd/pull/3190#discussion_r538052270.

**What this PR does / why we need it**: 

According to #3130:

> This PR makes a change in the Copy Output plugin so you can inform the fluentd to ignore said copy if the previous output succeeded.

> This enables having multiple nested outputs as backup of each other by doing:

> ```aconf
>    <store ignore_error>
>      @type test
>      name c0
>    </store>
>    <store ignore_if_prev_success ignore_error>
>      @type test
>      name c1
>    </store>
>    <store ignore_if_prev_success>
>      @type test
>      name c2
>    </store>
> ```


**Docs Changes**:

> Adding the defined ignore_if_prev_successes attribute to the tag makes the copy plugin ignore said store if the previous store succeed in pushing the output.

**Release Note**: 

Same as title.