### PR TITLE
formatter_ltsv: suppress delimiters in output

### DIFF
--- a/lib/fluent/plugin/formatter_ltsv.rb
+++ b/lib/fluent/plugin/formatter_ltsv.rb
@@ -27,6 +27,7 @@ module Fluent
 
       config_param :delimiter, :string, default: "\t".freeze
       config_param :label_delimiter, :string, default: ":".freeze
+      config_param :replacement, :string, default: " ".freeze
       config_param :add_newline, :bool, default: true
 
       # TODO: escaping for \t in values
@@ -34,7 +35,7 @@ module Fluent
         formatted = ""
         record.each do |label, value|
           formatted << @delimiter if formatted.length.nonzero?
-          formatted << "#{label}#{@label_delimiter}#{value}"
+          formatted << "#{label}#{@label_delimiter}#{value.to_s.gsub(@delimiter, @replacement)}"
         end
         formatted << @newline if @add_newline
         formatted

--- a/lib/fluent/plugin/formatter_ltsv.rb
+++ b/lib/fluent/plugin/formatter_ltsv.rb
@@ -30,7 +30,6 @@ module Fluent
       config_param :replacement, :string, default: " ".freeze
       config_param :add_newline, :bool, default: true
 
-      # TODO: escaping for \t in values
       def format(tag, time, record)
         formatted = ""
         record.each do |label, value|

--- a/test/test_formatter.rb
+++ b/test/test_formatter.rb
@@ -184,6 +184,36 @@ module FormatterTest
 
       assert_equal("message=awesome,greeting=hello#{@newline}", formatted)
     end
+
+    def record_with_tab
+      {'message' => "awe\tsome", 'greeting' => "hello\t"}
+    end
+
+    def test_format_suppresses_tab
+      @formatter.configure({})
+      formatted = @formatter.format(tag, @time, record_with_tab)
+
+      assert_equal("message:awe some\tgreeting:hello \n", formatted)
+    end
+
+    def test_format_suppresses_tab_custom_replacement
+      @formatter.configure(
+        'replacement'      => 'X',
+      )
+      formatted = @formatter.format(tag, @time, record_with_tab)
+
+      assert_equal("message:aweXsome\tgreeting:helloX\n", formatted)
+    end
+
+    def test_format_suppresses_custom_delimiter
+      @formatter.configure(
+        'delimiter'       => 'w',
+        'label_delimiter' => '=',
+      )
+      formatted = @formatter.format(tag, @time, record)
+
+      assert_equal("message=a esomewgreeting=hello\n", formatted)
+    end
   end
 
   class CsvFormatterTest < ::Test::Unit::TestCase


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Revise #1666

**What this PR does / why we need it**: 
formatter_ltsv creates malformed LTSV files when values include tabs.
This PR prevent it by replacing tabs with spaces.

**Docs Changes**:
`replacement` should be added to https://docs.fluentd.org/parser/ltsv

**Release Note**: 
Same with the title