### PR TITLE
Fill an uninitialized instance variable of FluentPluginConfigFormatter

### DIFF
--- a/lib/fluent/command/plugin_config_formatter.rb
+++ b/lib/fluent/command/plugin_config_formatter.rb
@@ -44,6 +44,7 @@ class FluentPluginConfigFormatter
     @verbose = false
     @libs = []
     @plugin_dirs = []
+    @table = false
     @options = {}
 
     prepare_option_parser


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Follow up for #3240.

**What this PR does / why we need it**: 
Suppress the following message while testing FluentPluginConfigFormatter:

```
2021-03-17T05:57:52.3545997Z /home/runner/work/fluentd/fluentd/lib/fluent/command/plugin_config_formatter.rb:165: warning: instance variable @table not initialized
```

**Docs Changes**:
none

**Release Note**: 
none