### PR TITLE
Configure Service Discovery using plugin helper with automatically loaded configurations

### DIFF
--- a/lib/fluent/plugin_helper/service_discovery.rb
+++ b/lib/fluent/plugin_helper/service_discovery.rb
@@ -66,11 +66,19 @@ module Fluent
             @config.elements(name: static_default_service_directive.to_s).map{|e| Fluent::Config::Element.new('service', e.arg, e.dup, e.elements, e.unused) }
           )
         end
-        service_discovery_create_manager(title, configurations: configs)
+        service_discovery_create_manager(title, configurations: configs, load_balancer: load_balancer, custom_build_method: custom_build_method, interval: interval)
       end
 
       def service_discovery_select_service(&block)
         @discovery_manager.select_service(&block)
+      end
+
+      def service_discovery_services
+        @discovery_manager.services
+      end
+
+      def service_discovery_rebalance
+        @discovery_manager.rebalance
       end
 
       # @param title [Symbol] the thread name. this value should be unique.

--- a/lib/fluent/plugin_helper/service_discovery.rb
+++ b/lib/fluent/plugin_helper/service_discovery.rb
@@ -22,8 +22,17 @@ module Fluent
     module ServiceDiscovery
       include Fluent::PluginHelper::Timer
 
+      # For the compatibility with older versions without `param_name: :service_discovery_configs`
+      attr_reader :service_discovery
+
       def self.included(mod)
         mod.include ServiceDiscoveryParams
+      end
+
+      def configure(conf)
+        super
+        # For the compatibility with older versions without `param_name: :service_discovery_configs`
+        @service_discovery = @service_discovery_configs
       end
 
       def start

--- a/lib/fluent/plugin_helper/service_discovery/manager.rb
+++ b/lib/fluent/plugin_helper/service_discovery/manager.rb
@@ -32,17 +32,23 @@ module Fluent
           @static_config = true
         end
 
-        def configure(opts, parent: nil)
-          opts.each do |opt|
-            sd = Fluent::Plugin.new_sd(opt[:type], parent: parent)
-            sd.configure(opt[:conf])
+        def configure(configs, parent: nil)
+          configs.each do |config|
+            type, conf = if config.has_key?(:conf) # for compatibility with initial API
+                           [config[:type], config[:conf]]
+                         else
+                           [config['@type'], config]
+                         end
+
+            sd = Fluent::Plugin.new_sd(type, parent: parent)
+            sd.configure(conf)
 
             sd.services.each do |s|
               @services[s.discovery_id] = build_service(s)
             end
             @discoveries << sd
 
-            if @static_config && opt[:type] != :static
+            if @static_config && type.to_sym != :static
               @static_config = false
             end
           end

--- a/test/plugin_helper/test_service_discovery.rb
+++ b/test/plugin_helper/test_service_discovery.rb
@@ -17,6 +17,24 @@ class ServiceDiscoveryHelper < Test::Unit::TestCase
     end
   end
 
+  class DummyPlugin < Fluent::Plugin::TestBase
+    helpers :service_discovery
+
+    def configure(conf)
+      super
+      service_discovery_configure(:service_discovery_helper_test, static_default_service_directive: 'node')
+    end
+
+    def select_service(&block)
+      service_discovery_select_service(&block)
+    end
+
+    # Make these mehtod public
+    def discovery_manager
+      super
+    end
+  end
+
   setup do
     @sd_file_dir = File.expand_path('../plugin/data/sd_file', __dir__)
 
@@ -33,7 +51,7 @@ class ServiceDiscoveryHelper < Test::Unit::TestCase
     end
   end
 
-  test 'start discovery manager' do
+  test 'support calling #service_discovery_create_manager and #discovery_manager from plugin' do
     d = @d = Dummy.new
 
     d.service_discovery_create_manager(
@@ -55,13 +73,30 @@ class ServiceDiscoveryHelper < Test::Unit::TestCase
     assert_equal 1234, services[0].port
   end
 
-  test 'call timer_execute if dynamic configuration' do
-    d = @d = Dummy.new
+  test 'start discovery manager' do
+    d = @d = DummyPlugin.new
 
-    d.service_discovery_create_manager(
-      :service_discovery_helper_test,
-      configurations: [{ type: :file, conf: config_element('file_config', '', { 'path' => File.join(@sd_file_dir, 'config.yml') }) }],
-    )
+    services = [config_element('service', '', { 'host' => '127.0.0.1', 'port' => '1234' })]
+    d.configure(config_element('root', '', {}, [config_element('service_discovery', '', {'@type' => 'static'}, services)]))
+
+    assert_true !!d.discovery_manager
+
+    mock.proxy(d.discovery_manager).start.once
+    mock.proxy(d).timer_execute(:service_discovery_helper_test, anything).never
+
+    d.start
+    d.event_loop_wait_until_start
+
+    assert_equal 1, d.discovery_manager.services.size
+    d.select_service do |serv|
+      assert_equal "127.0.0.1", serv.host
+      assert_equal 1234, serv.port
+    end
+  end
+
+  test 'call timer_execute if dynamic configuration' do
+    d = @d = DummyPlugin.new
+    d.configure(config_element('root', '', {}, [config_element('service_discovery', '', { '@type' => 'file', 'path' => File.join(@sd_file_dir, 'config.yml' )})]))
 
     assert_true !!d.discovery_manager
     mock.proxy(d.discovery_manager).start.once
@@ -71,25 +106,22 @@ class ServiceDiscoveryHelper < Test::Unit::TestCase
   end
 
   test 'exits service discovery instances without any errors' do
-    d = @d = Dummy.new
+    d = @d = DummyPlugin.new
     mockv = flexmock('dns_resolver', getaddress: '127.0.0.1')
               .should_receive(:getresources)
               .and_return([Resolv::DNS::Resource::IN::SRV.new(1, 10, 8081, 'service1.example.com')])
               .mock
     mock(Resolv::DNS).new { mockv }
 
-    d.service_discovery_create_manager(
-      :service_discovery_helper_test2,
-      configurations: [{ type: :srv, conf: config_element('service_discovery', '', { 'service' => 'service1', 'hostname' => 'example.com' }) }],
-    )
+    d.configure(config_element('root', '', {}, [config_element('service_discovery', '', { '@type' => 'srv', 'service' => 'service1', 'hostname' => 'example.com' })]))
 
     assert_true !!d.discovery_manager
     mock.proxy(d.discovery_manager).start.once
-    mock(d).timer_execute(:service_discovery_helper_test2, anything).once
+    mock(d).timer_execute(:service_discovery_helper_test, anything).once
 
     # To avoid claring `@logs` during `terminate` step
     # https://github.com/fluent/fluentd/blob/bc78d889f93dad8c2a4e0ad1ca802546185dacba/lib/fluent/test/log.rb#L33
-    mock(d.log).reset.twice
+    mock(d.log).reset.times(3)
 
     d.start
     d.event_loop_wait_until_start
@@ -101,5 +133,33 @@ class ServiceDiscoveryHelper < Test::Unit::TestCase
     d.terminate unless d.terminated?
 
     assert_false(d.log.out.logs.any? { |e| e.match?(/thread doesn't exit correctly/) })
+  end
+
+  test 'static service discovery will be configured automatically when default service directive is specified' do
+    d = @d = DummyPlugin.new
+
+    nodes = [
+      config_element('node', '', { 'host' => '192.168.0.1', 'port' => '24224' }),
+      config_element('node', '', { 'host' => '192.168.0.2', 'port' => '24224' })
+    ]
+    d.configure(config_element('root', '', {}, nodes))
+
+    assert_true !!d.discovery_manager
+
+    mock.proxy(d.discovery_manager).start.once
+    mock.proxy(d).timer_execute(:service_discovery_helper_test, anything).never
+
+    d.start
+    d.event_loop_wait_until_start
+
+    assert_equal 2, d.discovery_manager.services.size
+    d.select_service do |serv|
+      assert_equal "192.168.0.1", serv.host
+      assert_equal 24224, serv.port
+    end
+    d.select_service do |serv|
+      assert_equal "192.168.0.2", serv.host
+      assert_equal 24224, serv.port
+    end
   end
 end


### PR DESCRIPTION
**What this PR does / why we need it**: 
The current `service_discovery` plugin helper requires users (plugin authors) to build `configurations` structure as shown in [this document](https://docs.fluentd.org/plugin-helper-overview/api-plugin-helper-service_discovery).
But in most cases, service discovery types and configurations are written in `conf` and they can be read from the plugin helper scope. So, the current API requires additional things to plugins.

This change is to:
* Configure `discovery_manager` almost automatically only by calling `#service_discovery_configure` method in `Plugin#configure`
* Support service directives without `<service_discovery>` directive (the pattern of `out_forward`)
* Follow the manner about method names with `service_discovery_` prefix

**Docs Changes**:
Required. Will make a PR for it.

**Release Note**: 
TBD