### PR TITLE
parser_csv, parser_syslog: Fix a naming conflict on parser_type

### DIFF
--- a/lib/fluent/plugin/parser_csv.rb
+++ b/lib/fluent/plugin/parser_csv.rb
@@ -28,13 +28,13 @@ module Fluent
       desc 'The delimiter character (or string) of CSV values'
       config_param :delimiter, :string, default: ','
       desc 'The parser type used to parse CSV line'
-      config_param :parser_type, :enum, list: [:normal, :fast], default: :normal
+      config_param :parser_engine, :enum, list: [:normal, :fast], default: :normal, alias: :parser_type
 
       def configure(conf)
         super
 
 
-        if @parser_type == :fast
+        if @parser_engine == :fast
           @quote_char = '"'
           @escape_pattern = Regexp.compile(@quote_char * 2)
 

--- a/lib/fluent/plugin/parser_syslog.rb
+++ b/lib/fluent/plugin/parser_syslog.rb
@@ -56,7 +56,7 @@ module Fluent
       desc 'Specify time format for event time for rfc5424 protocol'
       config_param :rfc5424_time_format, :string, default: "%Y-%m-%dT%H:%M:%S.%L%z"
       desc 'The parser type used to parse syslog message'
-      config_param :parser_type, :enum, list: [:regexp, :string], default: :regexp
+      config_param :parser_engine, :enum, list: [:regexp, :string], default: :regexp, alias: :parser_type
       desc 'support colonless ident in string parser'
       config_param :support_colonless_ident, :bool, default: true
 
@@ -79,7 +79,7 @@ module Fluent
       def configure(conf)
         super
 
-        @regexp_parser = @parser_type == :regexp
+        @regexp_parser = @parser_engine == :regexp
         @regexp = case @message_format
                   when :rfc3164
                     if @regexp_parser

--- a/test/plugin/test_parser_csv.rb
+++ b/test/plugin/test_parser_csv.rb
@@ -183,4 +183,18 @@ class CSVParserTest < ::Test::Unit::TestCase
       # And more...
     end
   end
+
+  # "parser_type" config shouldn't hide Fluent::Plugin::Parser#plugin_type
+  # https://github.com/fluent/fluentd/issues/3296
+  data('normal' => :normal, 'fast' => :fast)
+  def test_parser_type_method(engine)
+    d = create_driver('keys' => '["time"]','time_key' => 'time', 'parser_type' => engine.to_s)
+    assert_equal(:text_per_line, d.instance.parser_type)
+  end
+
+  data('normal' => :normal, 'fast' => :fast)
+  def test_parser_engine(engine)
+    d = create_driver('keys' => '["time"]', 'time_key' => 'time', 'parser_engine' => engine.to_s)
+    assert_equal(engine, d.instance.parser_engine)
+  end
 end

--- a/test/plugin/test_parser_syslog.rb
+++ b/test/plugin/test_parser_syslog.rb
@@ -633,4 +633,18 @@ class SyslogParserTest < ::Test::Unit::TestCase
       end
     end
   end
+
+  # "parser_type" config shouldn't hide Fluent::Plugin::Parser#plugin_type
+  # https://github.com/fluent/fluentd/issues/3296
+  data('regexp' => :regexp, 'fast' => :string)
+  def test_parser_type_method(engine)
+    @parser.configure({'parser_type' => engine.to_s})
+    assert_equal(:text_per_line, @parser.instance.parser_type)
+  end
+
+  data('regexp' => :regexp, 'string' => :string)
+  def test_parser_engine(engine)
+    d = @parser.configure({'parser_engine' => engine.to_s})
+    assert_equal(engine, @parser.instance.parser_engine)
+  end
 end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #3296

**What this PR does / why we need it**: 
These plugins accept a parameter `plugin_type` but it hides the parent
class's method `Fluent::Plugin::Parser#parser_type`, it causes
unexpected behavior on a plugin which uses this method such as in_exec.

**Docs Changes**:
We may need to update the following pages:

* https://docs.fluentd.org/parser/csv
* https://docs.fluentd.org/parser/syslog

But I think it's not needed because this patch keeps backward compatibility, and adding a new parameter name may confuse users.

**Release Note**: 
Same with the title