### PR TITLE
fluent-plugin-generate: add note about plugin name

### DIFF
--- a/lib/fluent/command/plugin_generator.rb
+++ b/lib/fluent/command/plugin_generator.rb
@@ -105,7 +105,7 @@ Generate a project skeleton for creating a Fluentd plugin
 
 Arguments:
 \ttype: #{SUPPORTED_TYPES.join(",")}
-\tname: Your plugin name
+\tname: Your plugin name (fluent-plugin- prefix will be added to <name>)
 
 Options:
 BANNER


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

Fixes N/A

**What this PR does / why we need it**: 

In the previous version, <name> of prefix is not mentioned in fluent-plugin-generate -h

Before:

```
Usage: fluent-plugin-generate [options] <type> <name>

  Generate a project skeleton for creating a Fluentd plugin

  Arguments:
          type: input,output,filter,parser,formatter
          name: Your plugin name

  Options:
          --[no-]license=NAME          Specify license name (default: Apache-2.0)
```

After:

```
Usage: fluent-plugin-generate [options] <type> <name>

  Generate a project skeleton for creating a Fluentd plugin

  Arguments:
          type: input,output,filter,parser,formatter
          name: Your plugin name (fluent-plugin- prefix will be added to <name>)

  Options:
          --[no-]license=NAME          Specify license name (default: Apache-2.0)
```


**Docs Changes**:

N/A

**Release Note**: 

N/A
