### PR TITLE
Use rr 3.0 on unit tests for Ruby 3.0 kwargs changes

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("flexmock", ["~> 2.0"])
   gem.add_development_dependency("parallel_tests", ["~> 0.15.3"])
   gem.add_development_dependency("simplecov", ["~> 0.7"])
-  gem.add_development_dependency("rr", ["~> 1.0"])
+  gem.add_development_dependency("rr", ["~> 3.0"])
   gem.add_development_dependency("timecop", ["~> 0.9"])
   gem.add_development_dependency("test-unit", ["~> 3.3"])
   gem.add_development_dependency("test-unit-rr", ["~> 1.0"])

--- a/test/plugin/out_forward/test_connection_manager.rb
+++ b/test/plugin/out_forward/test_connection_manager.rb
@@ -81,8 +81,6 @@ class ConnectionManager < Test::Unit::TestCase
 
     sub_test_case 'when socket_cache exists' do
       test 'calls connect_keepalive' do
-        omit "Proxy of RR doesn't support kwargs of Ruby 3 yet" if RUBY_VERSION.split('.')[0].to_i >= 3
-
         cache = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
         mock(cache).checkin('sock').never
 
@@ -101,8 +99,6 @@ class ConnectionManager < Test::Unit::TestCase
       end
 
       test 'calls connect_keepalive and closes socket with block' do
-        omit "Proxy of RR doesn't support kwargs of Ruby 3 yet" if RUBY_VERSION.split('.')[0].to_i >= 3
-
         cache = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
         mock(cache).checkin('sock').once
 
@@ -122,8 +118,6 @@ class ConnectionManager < Test::Unit::TestCase
       end
 
       test 'does not call dec_ref when ack is passed' do
-        omit "Proxy of RR doesn't support kwargs of Ruby 3 yet" if RUBY_VERSION.split('.')[0].to_i >= 3
-
         cache = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
         mock(cache).checkin('sock').never
         sock = 'sock'

--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -1061,11 +1061,9 @@ EOL
   end
 
   test 'when out_forward has @id' do
-    omit "Proxy of RR doesn't support kwargs of Ruby 3 yet" if RUBY_VERSION.split('.')[0].to_i >= 3
-
     # cancel https://github.com/fluent/fluentd/blob/077508ac817b7637307434d0c978d7cdc3d1c534/lib/fluent/plugin_id.rb#L43-L53
     # it always return true in test
-    mock.proxy(Fluent::Plugin).new_sd(:static, anything) { |v|
+    mock.proxy(Fluent::Plugin).new_sd(:static, parent: anything) { |v|
       stub(v).plugin_id_for_test? { false }
     }.once
 
@@ -1296,7 +1294,7 @@ EOL
 
         begin
           chunk = Fluent::Plugin::Buffer::MemoryChunk.new(Fluent::Plugin::Buffer::Metadata.new(nil, nil, nil))
-          mock.proxy(d.instance).socket_create_tcp(TARGET_HOST, TARGET_PORT, anything) { |sock| mock(sock).close.once; sock }.twice
+          mock.proxy(d.instance).socket_create_tcp(TARGET_HOST, TARGET_PORT, linger_timeout: anything, send_timeout: anything, recv_timeout: anything, connect_timeout: anything) { |sock| mock(sock).close.once; sock }.twice
 
           target_input_driver.run(timeout: 15) do
             d.run(shutdown: false) do

--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -1294,7 +1294,13 @@ EOL
 
         begin
           chunk = Fluent::Plugin::Buffer::MemoryChunk.new(Fluent::Plugin::Buffer::Metadata.new(nil, nil, nil))
-          mock.proxy(d.instance).socket_create_tcp(TARGET_HOST, TARGET_PORT, linger_timeout: anything, send_timeout: anything, recv_timeout: anything, connect_timeout: anything) { |sock| mock(sock).close.once; sock }.twice
+          mock.proxy(d.instance).socket_create_tcp(TARGET_HOST, TARGET_PORT,
+                                                   linger_timeout: anything,
+                                                   send_timeout: anything,
+                                                   recv_timeout: anything,
+                                                   connect_timeout: anything) { |sock|
+            mock(sock).close.once; sock
+          }.twice
 
           target_input_driver.run(timeout: 15) do
             d.run(shutdown: false) do

--- a/test/plugin/test_output.rb
+++ b/test/plugin/test_output.rb
@@ -868,7 +868,7 @@ class OutputTest < Test::Unit::TestCase
       test "Warn if primary type is different from secondary type and either primary or secondary has custom_format" do
         o = create_output(:buffered)
         mock(o.log).warn("Use different plugin for secondary. Check the plugin works with primary like secondary_file",
-                         { primary: o.class.to_s, secondary: "Fluent::Plugin::TestOutput" })
+                         primary: o.class.to_s, secondary: "Fluent::Plugin::TestOutput")
 
         o.configure(config_element('ROOT','',{},[config_element('secondary','',{'@type'=>'test', 'name' => "cool"})]))
         assert_not_nil o.instance_variable_get(:@secondary)
@@ -877,7 +877,7 @@ class OutputTest < Test::Unit::TestCase
       test "don't warn if primary type is the same as secondary type" do
         o = Fluent::Plugin::TestOutput.new
         mock(o.log).warn("Use different plugin for secondary. Check the plugin works with primary like secondary_file",
-                         { primary: o.class.to_s, secondary: "Fluent::Plugin::TestOutput" }).never
+                         primary: o.class.to_s, secondary: "Fluent::Plugin::TestOutput" ).never
 
         o.configure(config_element('ROOT','',{'name' => "cool2"},
                                    [config_element('secondary','',{'@type'=>'test', 'name' => "cool"}),
@@ -889,7 +889,7 @@ class OutputTest < Test::Unit::TestCase
       test "don't warn if primary type is different from secondary type and both don't have custom_format" do
         o = create_output(:standard)
         mock(o.log).warn("Use different plugin for secondary. Check the plugin works with primary like secondary_file",
-                         { primary: o.class.to_s, secondary: "Fluent::Plugin::TestOutput" }).never
+                         primary: o.class.to_s, secondary: "Fluent::Plugin::TestOutput").never
 
         o.configure(config_element('ROOT','',{},[config_element('secondary','',{'@type'=>'test', 'name' => "cool"})]))
         assert_not_nil o.instance_variable_get(:@secondary)

--- a/test/plugin_helper/service_discovery/test_manager.rb
+++ b/test/plugin_helper/service_discovery/test_manager.rb
@@ -71,7 +71,7 @@ class TestServiceDiscoveryManager < ::Test::Unit::TestCase
     test 'if new service added and deleted' do
       sdm = Fluent::PluginHelper::ServiceDiscovery::Manager.new(log: $log)
       t = TestSdPlugin.new
-      mock(Fluent::Plugin).new_sd(:sd_test, anything) { t }
+      mock(Fluent::Plugin).new_sd(:sd_test, parent: anything) { t }
       sdm.configure([{ type: :sd_test, conf: config_element('service_discovery', '', {})}])
       sdm.start
 

--- a/test/plugin_helper/test_http_server_helper.rb
+++ b/test/plugin_helper/test_http_server_helper.rb
@@ -354,7 +354,7 @@ class HttpHelperTest < Test::Unit::TestCase
           watcher.should_receive(:stop).once
         end
 
-        stub(Fluent::PluginHelper::HttpServer::Server).new(anything) { server }
+        stub(Fluent::PluginHelper::HttpServer::Server).new(addr: anything, port: anything, logger: anything, default_app: anything) { server }
         driver.http_server_create_http_server(:http_server_helper_test, addr: '127.0.0.1', port: PORT, logger: NULL_LOGGER) do
           # nothing
         end

--- a/test/test_output.rb
+++ b/test/test_output.rb
@@ -133,7 +133,7 @@ module FluentOutputTest
       d = Fluent::Test::BufferedOutputTestDriver.new(Fluent::ObjectBufferedOutput)
 
       mock(d.instance.log).warn("Use different plugin for secondary. Check the plugin works with primary like secondary_file",
-                                { primary: d.instance.class.to_s, secondary: "Fluent::Plugin::Test2Output" }).never
+                                primary: d.instance.class.to_s, secondary: "Fluent::Plugin::Test2Output").never
       d.configure(CONFIG + %[
         <secondary>
           type test2

--- a/test/test_output.rb
+++ b/test/test_output.rb
@@ -117,7 +117,7 @@ module FluentOutputTest
       end
 
       mock(d.instance.log).warn("Use different plugin for secondary. Check the plugin works with primary like secondary_file",
-                                { primary: d.instance.class.to_s, secondary: "Fluent::Plugin::Test2Output" })
+                                primary: d.instance.class.to_s, secondary: "Fluent::Plugin::Test2Output")
       d.configure(CONFIG + %[
         <secondary>
           type test2


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Related to #3263

**What this PR does / why we need it**: 

Older rr did not support Ruby 3.0. We should upgrade rr to 3.0.

**Docs Changes**:
No needed.

**Release Note**: 

Same as title.