### PR TITLE
Follow depended gem version by fluent-plugin-generate

### DIFF
--- a/lib/fluent/command/plugin_generator.rb
+++ b/lib/fluent/command/plugin_generator.rb
@@ -151,6 +151,36 @@ BANNER
     underscore_name
   end
 
+  def gem_file_path
+    File.expand_path(File.join(File.dirname(__FILE__),
+                               "../../../",
+                               "Gemfile"))
+  end
+
+  def lock_file_path
+    File.expand_path(File.join(File.dirname(__FILE__),
+                               "../../../",
+                               "Gemfile.lock"))
+  end
+
+  def locked_gem_version(gem_name)
+    d = Bundler::Definition.build(gem_file_path, lock_file_path, false)
+    d.locked_gems.dependencies[gem_name].requirement.requirements.first.last.version
+  end
+
+  def rake_version
+    locked_gem_version("rake")
+  end
+
+  def test_unit_version
+    locked_gem_version("test-unit")
+  end
+
+  def bundler_version
+    d = Bundler::Definition.build(gem_file_path, lock_file_path, false)
+    d.locked_gems.bundler_version.version
+  end
+
   def class_name
     "#{capitalized_name}#{type.capitalize}"
   end

--- a/templates/new_gem/fluent-plugin.gemspec.erb
+++ b/templates/new_gem/fluent-plugin.gemspec.erb
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = test_files
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.14"
-  spec.add_development_dependency "rake", "~> 12.0"
-  spec.add_development_dependency "test-unit", "~> 3.0"
+  spec.add_development_dependency "bundler", "~> <%= bundler_version %>"
+  spec.add_development_dependency "rake", "~> <%= rake_version %>"
+  spec.add_development_dependency "test-unit", "~> <%= test_unit_version %>"
   spec.add_runtime_dependency "fluentd", [">= 0.14.10", "< 2"]
 end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

Fixes N/A

**What this PR does / why we need it**: 

In the previous versions, generated .gemspec doesn't follow
depended gem version which is used in fluentd.gemspec at all.

Instead, it is changed to retrieve depended gem version from
Gemfile.lock to sync with it.

Before:

```
  spec.add_development_dependency "bundler", "~> 1.14"
  spec.add_development_dependency "rake", "~> 12.0"
  spec.add_development_dependency "test-unit", "~> 3.0"
```

It is required to update manually.

After:

```
  spec.add_development_dependency "bundler", "~> 2.2.15"
  spec.add_development_dependency "rake", "~> 13.0"
  spec.add_development_dependency "test-unit", "~> 3.3"
```

Above depended version is replaced by <%= %> in template.
No need to update manually.

**Docs Changes**:

N/A

**Release Note**: 

N/A
