### PR TITLE
test: omit test case because exception is not raised with Ruby 3.0

### DIFF
--- a/test/plugin_helper/test_server.rb
+++ b/test/plugin_helper/test_server.rb
@@ -313,6 +313,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
       # 'server_create_connection unix' => [:server_create, :unix, {}],
     )
     test 'cannot create 2 or more servers using same bind address and port if shared option is false' do |(m, proto, kwargs)|
+      omit "enable test when fiddle is fixed https://github.com/ruby/fiddle/issues/72" if RUBY_VERSION.split(".").first.to_i >= 3
       begin
         d2 = Dummy.new; d2.start; d2.after_start
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

Related: #3263

**What this PR does / why we need it**: 

There is a case that expected exception is not raised with Ruby 3.0.

Because of that behavior, exception is assumed test case always fails.

It should be fixed in Fiddle so, when fixed version is
released, we should enable this test case again for Ruby 3.0.

ref. https://github.com/ruby/fiddle/issues/72

**Docs Changes**:

N/A

**Release Note**: 

N/A
