### PR TITLE
test: mark Ruby 3.0 as experimental on windows

### DIFF
--- a/.github/workflows/windows-test.yaml
+++ b/.github/workflows/windows-test.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/windows-test.yaml
+++ b/.github/workflows/windows-test.yaml
@@ -13,9 +13,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['3.0', '2.7', '2.6', '2.5']
+        ruby-version: ['2.7', '2.6', '2.5']
         os:
           - windows-latest
+        experimental: [false]
+        include:
+          - ruby-version: '3.0'
+            os: windows-latest
+            experimental: true
 
     name: Unit testing with Ruby ${{ matrix.ruby-version }} on ${{ matrix.os }}
     steps:


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

Related #3263

**What this PR does / why we need it**: 

There are some failed unit test with Ruby 3.0 on windows,
Instead of omitting those test cases, it may be better
to mark "experimental" to clarify the issues.

**Docs Changes**:

N/A

**Release Note**: 

N/A
