### PR TITLE
plugin_helper: Allow TLS to use keep-alive socket option

### DIFF
--- a/lib/fluent/plugin_helper/socket_option.rb
+++ b/lib/fluent/plugin_helper/socket_option.rb
@@ -38,8 +38,8 @@ module Fluent
           end
         end
         if send_keepalive_packet
-          if protocol != :tcp
-            raise ArgumentError, "BUG: send_keepalive_packet is available for tcp"
+          if protocol != :tcp && protocol != :tls
+            raise ArgumentError, "BUG: send_keepalive_packet is available for tcp/tls"
           end
         end
       end

--- a/test/plugin_helper/test_server.rb
+++ b/test/plugin_helper/test_server.rb
@@ -234,7 +234,13 @@ class ServerPluginHelperTest < Test::Unit::TestCase
       assert_raise(ArgumentError.new("BUG: backlog is available for tcp/tls")) do
         @d.__send__(m, :myserver, PORT, proto: proto, backlog: 500){|x| x }
       end
-      assert_raise(ArgumentError.new("BUG: send_keepalive_packet is available for tcp")) do
+    end
+
+    data(
+      'server_create udp' => [:server_create, :udp],
+    )
+    test 'raise error if tcp/tls send_keepalive_packet option is specified for udp' do |(m, proto)|
+      assert_raise(ArgumentError.new("BUG: send_keepalive_packet is available for tcp/tls")) do
         @d.__send__(m, :myserver, PORT, proto: proto, send_keepalive_packet: true){|x| x }
       end
     end
@@ -1300,7 +1306,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
 
     test 'can accept all keyword arguments valid for tcp/tls server' do
       assert_nothing_raised do
-        @d.server_create_tls(:s, PORT, bind: '127.0.0.1', shared: false, resolve_name: true, linger_timeout: 10, backlog: 500, tls_options: @tls_options) do |data, conn|
+        @d.server_create_tls(:s, PORT, bind: '127.0.0.1', shared: false, resolve_name: true, linger_timeout: 10, backlog: 500, tls_options: @tls_options, send_keepalive_packet: true) do |data, conn|
           # ...
         end
       end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

Allow incoming TLS connections to use keep-alive socket option when a listener is created, such as the`send_keepalive_packet` option in `forward` input. It's currently blocked by `socket_option_validate!`

We've been using this on several busy production servers for 2 months and haven't experienced any problem.

**What this PR does / why we need it**: 

`send_keepalive_packet` is critical in some network setup, for instance in ours where AWS sometimes turned connections from private network into zombies - they linger and keep accumulating until fluentd is restarted, while according to clients they should have been closed normally days or weeks earlier. (I suspect there might be some bug in async socket closing but  couldn't confirm or investigate)

Signed-off-by: Ji-Ping Shen <ji-ping.shen@relexsolutions.com>