### PR TITLE
test: add tiny wait not to lose globbed entries

### DIFF
--- a/test/plugin/test_output_as_buffered_backup.rb
+++ b/test/plugin/test_output_as_buffered_backup.rb
@@ -173,6 +173,8 @@ class BufferedOutputBackupTest < Test::Unit::TestCase
       waiting(5) {
         target_dir = File.join(File.dirname(target_file), "*")
         while Dir.glob(target_dir).size.zero?
+          # Avoid to lose globbed entries on Windows in busy loop
+          sleep 0.1 if Fluent.windows?
         end
       }
     end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

Related #3263

**What this PR does / why we need it**: 

In busy loop with wait_flush, there may be a case that Dir.glob() lose
existing entries under target directory in some test cases.

As a result Timeout::Error: execution expired will be raised.

These failures in test/plugin/test_output_as_buffered_backup
are observed with Ruby 3.0 on Windows.

**Docs Changes**:

N/A

**Release Note**: 

N/A