### PR TITLE
in_tail: Fix an incorrect error handling on catching a short-lived log

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -419,7 +419,8 @@ module Fluent::Plugin
         rescue Errno::ENOENT
           $log.warn "stat() for #{target_info.path} failed with ENOENT. Drop tail watcher for now."
           # explicitly detach and unwatch watcher `tw`.
-          stop_watchers(target_info, immediate: true, unwatched: true)
+          tw.unwatched = true
+          detach_watcher(tw, target_info.ino, false)
         end
       }
     end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #3327

**What this PR does / why we need it**: 
#3275 fixes a crash bug of in_tail, but it introduces another crash bug which may occur on catching a very short-lived log.

**Docs Changes**:
none

**Release Note**: 
Same as title