### PR TITLE
WindowsFile: Show the path when Win32Error is occured

### DIFF
--- a/lib/fluent/plugin/file_wrapper.rb
+++ b/lib/fluent/plugin/file_wrapper.rb
@@ -50,10 +50,11 @@ module Fluent
     require 'windows/error'
     include Windows::Error
 
-    attr_reader :errcode
+    attr_reader :errcode, :msg
 
-    def initialize(errcode)
+    def initialize(errcode, msg = nil)
       @errcode = errcode
+      @msg = msg
     end
 
     def format_english_message(errcode)
@@ -65,12 +66,14 @@ module Fluent
     end
 
     def message
-      "code: #{@errcode}, #{format_english_message(@errcode)}"
+      msg = "code: #{@errcode}, #{format_english_message(@errcode)}"
+      msg << ": #{@msg}" if @msg
+      msg
     end
 
     def ==(other)
       return false if other.class != Win32Error
-      @errcode == other.errcode
+      @errcode == other.errcode && @msg == other.msg
     end
   end
 
@@ -109,7 +112,7 @@ module Fluent
         if err == ERROR_FILE_NOT_FOUND || err == ERROR_PATH_NOT_FOUND || err == ERROR_ACCESS_DENIED
           raise Errno::ENOENT
         end
-        raise Win32Error.new(err)
+        raise Win32Error.new(err, path)
       end
     end
 

--- a/test/plugin/test_file_wrapper.rb
+++ b/test/plugin/test_file_wrapper.rb
@@ -19,13 +19,18 @@ class FileWrapperTest < Test::Unit::TestCase
 
   sub_test_case 'Win32Error' do
     test 'equal' do
-      assert_equal(Fluent::Win32Error.new(ERROR_SHARING_VIOLATION),
-                   Fluent::Win32Error.new(ERROR_SHARING_VIOLATION))
+      assert_equal(Fluent::Win32Error.new(ERROR_SHARING_VIOLATION, "message"),
+                   Fluent::Win32Error.new(ERROR_SHARING_VIOLATION, "message"))
     end
 
     test 'different error code' do
       assert_not_equal(Fluent::Win32Error.new(ERROR_FILE_NOT_FOUND),
                        Fluent::Win32Error.new(ERROR_SHARING_VIOLATION))
+    end
+
+    test 'different error message' do
+      assert_not_equal(Fluent::Win32Error.new(ERROR_FILE_NOT_FOUND, "message1"),
+                       Fluent::Win32Error.new(ERROR_FILE_NOT_FOUND, "message2"))
     end
 
     test 'different class' do
@@ -36,6 +41,12 @@ class FileWrapperTest < Test::Unit::TestCase
     test 'ERROR_SHARING_VIOLATION message' do
       assert_equal(Fluent::Win32Error.new(ERROR_SHARING_VIOLATION).message,
                    "code: 32, The process cannot access the file because it is being used by another process.")
+    end
+
+    test 'ERROR_SHARING_VIOLATION with a message' do
+      assert_equal(Fluent::Win32Error.new(ERROR_SHARING_VIOLATION, "cannot open the file").message,
+                   "code: 32, The process cannot access the file because it is being used by another process." +
+                   ": cannot open the file")
     end
   end
 
@@ -71,7 +82,7 @@ class FileWrapperTest < Test::Unit::TestCase
         path = "#{TMP_DIR}/test_windows_file.txt"
         file1 = file2 = nil
         file1 = File.open(path, "wb")
-        assert_raise(Fluent::Win32Error.new(ERROR_SHARING_VIOLATION)) do
+        assert_raise(Fluent::Win32Error.new(ERROR_SHARING_VIOLATION, path)) do
           file2 = Fluent::WindowsFile.new(path, 'r', FILE_SHARE_READ)
         ensure
           file2.close if file2


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
none

**What this PR does / why we need it**: 
In #3325 we added Win32Error to show Windows specific errors correctly,
but it's not enough for debugging because it doesn't show which file
causes the error.

**Docs Changes**:
none

**Release Note**: 
none, same with #3325