### PR TITLE
Win32Error: Add to_s and inspect methods

### DIFF
--- a/lib/fluent/plugin/file_wrapper.rb
+++ b/lib/fluent/plugin/file_wrapper.rb
@@ -65,10 +65,15 @@ module Fluent
       buf.force_encoding(Encoding.default_external).strip
     end
 
-    def message
-      msg = "code: #{@errcode}, #{format_english_message(@errcode)}"
-      msg << ": #{@msg}" if @msg
+    def to_s
+      msg = super
+      msg << ": code: #{@errcode}, #{format_english_message(@errcode)}"
+      msg << " - #{@msg}" if @msg
       msg
+    end
+
+    def inspect
+      "#<#{to_s}>"
     end
 
     def ==(other)

--- a/test/plugin/test_file_wrapper.rb
+++ b/test/plugin/test_file_wrapper.rb
@@ -40,13 +40,23 @@ class FileWrapperTest < Test::Unit::TestCase
 
     test 'ERROR_SHARING_VIOLATION message' do
       assert_equal(Fluent::Win32Error.new(ERROR_SHARING_VIOLATION).message,
-                   "code: 32, The process cannot access the file because it is being used by another process.")
+                   "Fluent::Win32Error: code: 32, The process cannot access the file because it is being used by another process.")
     end
 
     test 'ERROR_SHARING_VIOLATION with a message' do
       assert_equal(Fluent::Win32Error.new(ERROR_SHARING_VIOLATION, "cannot open the file").message,
-                   "code: 32, The process cannot access the file because it is being used by another process." +
-                   ": cannot open the file")
+                   "Fluent::Win32Error: code: 32, The process cannot access the file because it is being used by another process." +
+                   " - cannot open the file")
+    end
+
+    test 'to_s' do
+      assert_equal("Fluent::Win32Error: code: 32, The process cannot access the file because it is being used by another process. - C:\file.txt",
+                   Fluent::Win32Error.new(ERROR_SHARING_VIOLATION, "C:\file.txt").to_s)
+    end
+
+    test 'inspect' do
+      assert_equal("#<Fluent::Win32Error: code: 32, The process cannot access the file because it is being used by another process. - C:\file.txt>",
+                   Fluent::Win32Error.new(ERROR_SHARING_VIOLATION, "C:\file.txt").inspect)
     end
   end
 


### PR DESCRIPTION

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
none

**What this PR does / why we need it**: 
Additional fix for #3325 and #3329.
Since the previous code doesn't have to_s method, it shows only` Fluent::Win32Error`, doesn't show the detail.

**Docs Changes**:
none

**Release Note**: 
Same with #3325