### PR TITLE
storage_local: change LocalStorage.save() to be atomic

### DIFF
--- a/lib/fluent/plugin/storage_local.rb
+++ b/lib/fluent/plugin/storage_local.rb
@@ -130,7 +130,7 @@ module Fluent
 
       def save
         return if @on_memory
-        tmp_path = @path + '.tmp'
+        tmp_path = @path + '.tmp.' + Fluent::UniqueId.hex(Fluent::UniqueId.generate)
         begin
           json_string = Yajl::Encoder.encode(@store, pretty: @pretty_print)
           File.open(tmp_path, 'w:utf-8', @mode) { |io| io.write json_string; io.fsync }


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Potentially fixes #3332

**What this PR does / why we need it**: 

Let's use unique names for temporary files like this:

    kubernetes.json.tmp.5c04a66a9731459acb723c5ee7d8d279

instead of:

    kubernetes.json.tmp

This makes LocalStorage.save() practically atomic, and hence allows
Fluentd not to corrupt data even in a race condition.

**Docs Changes**:

Not required.

**Release Note**: 

Fix position file corruption issue on concurrent gracefulReloads.