### PR TITLE
WindowsFile: Retrieve correct Win32 error codes

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |gem|
   fake_platform = ENV['GEM_BUILD_FAKE_PLATFORM'].to_s
   gem.platform = fake_platform unless fake_platform.empty?
   if /mswin|mingw/ =~ fake_platform || (/mswin|mingw/ =~ RUBY_PLATFORM && fake_platform.empty?)
+    gem.add_runtime_dependency("win32-api", [">= 1.10", "< 2.0.0"])
     gem.add_runtime_dependency("win32-service", ["~> 2.1.5"])
     gem.add_runtime_dependency("win32-ipc", ["~> 0.7.0"])
     gem.add_runtime_dependency("win32-event", ["~> 0.6.3"])

--- a/lib/fluent/plugin/file_wrapper.rb
+++ b/lib/fluent/plugin/file_wrapper.rb
@@ -113,7 +113,7 @@ module Fluent
       @file_handle = CreateFile.call(@path, access, sharemode,
                      0, creationdisposition, FILE_ATTRIBUTE_NORMAL, 0)
       if @file_handle == INVALID_HANDLE_VALUE
-        err = GetLastError.call
+        err = Win32::API.last_error
         if err == ERROR_FILE_NOT_FOUND || err == ERROR_PATH_NOT_FOUND || err == ERROR_ACCESS_DENIED
           raise Errno::ENOENT
         end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
none

**What this PR does / why we need it**: 
WindowsFile calls GetLastError via win32-api to retrieve win32 error
code but the error code may be already reset by Ruby's internal code
so that it can't retrive a correct error code. Sometimes it causes
random unrecoverable errors when in_tail plugin tries to read a
non-existent file like the following:

      2021-04-14 03:15:45 +0000 [error]: #2 Fluent::Win32Error code: 158, The segment is already unlocked.: C:/path/to/log.txt

Fiddle or FFI has a method to avoid this issue:

  * Fiddle.win32_last_error
    https://ruby-doc.org/stdlib-3.0.0/libdoc/fiddle/rdoc/Fiddle.html#method-c-win32_last_error
  * FFI::LastError.winapi_error
    https://www.rubydoc.info/github/ffi/ffi/FFI/LastError#winapi_error-instance_method

We've added an equivalent method for win32-api:

  * https://github.com/cosmo0920/win32-api/pull/55

This commit replaces the retrieving the error code with this method.

**Docs Changes**:
none

**Release Note**: 
Same with the title.