### PR TITLE
output: Fix "placeholder chunk_id not replaced" warnings

### DIFF
--- a/test/plugin/test_output.rb
+++ b/test/plugin/test_output.rb
@@ -390,6 +390,18 @@ class OutputTest < Test::Unit::TestCase
       assert { logs.none? { |log| log.include?("${chunk_id}") } }
     end
 
+    test '#extract_placeholders does not log for ${chunk_id} placeholder (with @chunk_keys)' do
+      @i.configure(config_element('ROOT', '', {}, [config_element('buffer', 'key1')]))
+      tmpl = "/mypath/${chunk_id}/${key1}/tail"
+      t = event_time('2016-04-11 20:30:00 +0900')
+      v = {key1: "value1", key2: "value2"}
+      c = create_chunk(timekey: t, tag: 'fluentd.test.output', variables: v)
+      @i.log.out.logs.clear
+      @i.extract_placeholders(tmpl, c)
+      logs = @i.log.out.logs
+      assert { logs.none? { |log| log.include?("${chunk_id}") } }
+    end
+
     test '#extract_placeholders logs warn message with not replaced key' do
       @i.configure(config_element('ROOT', '', {}, [config_element('buffer', '')]))
       tmpl = "/mypath/${key1}/test"


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #3338

**What this PR does / why we need it**: 

On some setup, Fluentd warns about "chunk_id" being not found in
`@chunk_keys`.

This warning is misguided. `${chunk_id}` is a special field that
Fluentd should automatically fill it with `chunk.unique_id`. It
should never try to look up the key in `@chunk_keys`.

This patch fixes the warning by adjusting the evaluation order,
extending the preceding work f18640bf5 by Brian Atkinson.

**Docs Changes**:

None

**Release Note**: 

Fix incorrect warnings about `${chunk_id}` with `out_s3`