### PR TITLE
Permit to install with win32-service 2.2.0 on Windows

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |gem|
   gem.platform = fake_platform unless fake_platform.empty?
   if /mswin|mingw/ =~ fake_platform || (/mswin|mingw/ =~ RUBY_PLATFORM && fake_platform.empty?)
     gem.add_runtime_dependency("win32-api", [">= 1.10", "< 2.0.0"])
-    gem.add_runtime_dependency("win32-service", ["~> 2.1.5"])
+    gem.add_runtime_dependency("win32-service", ["~> 2.2.0"])
     gem.add_runtime_dependency("win32-ipc", ["~> 0.7.0"])
     gem.add_runtime_dependency("win32-event", ["~> 0.6.3"])
     gem.add_runtime_dependency("windows-pr", ["~> 1.2.6"])


### PR DESCRIPTION
We recommend to use win32-service v2.2.0 or later for updating outdated
win32-serivce gem.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
None
**What this PR does / why we need it**: 

see: https://github.com/fluent-plugins-nursery/td-agent-builder/pull/288/checks?check_run_id=2387368140#step:3:62002

**Docs Changes**:

No needed
**Release Note**: 

Same as title.