### PR TITLE
Enable system.log.rotate_... system configuration

### DIFF
--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -85,9 +85,8 @@ op.on('-o', '--log PATH', "log file path") {|s|
   opts[:log_path] = s
 }
 
-ROTATE_AGE = %w(daily weekly monthly)
 op.on('--log-rotate-age AGE', 'generations to keep rotated log files') {|age|
-  if ROTATE_AGE.include?(age)
+  if Fluent::Log::LOG_ROTATE_AGE.include?(age)
     opts[:log_rotate_age] = age
   else
     begin

--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -49,6 +49,7 @@ module Fluent
     LOG_TYPE_DEFAULT = :default # show logs in all supervisor/workers, with worker id in workers (default)
 
     LOG_TYPES = [LOG_TYPE_SUPERVISOR, LOG_TYPE_WORKER0, LOG_TYPE_DEFAULT].freeze
+    LOG_ROTATE_AGE = %w(daily weekly monthly)
 
     def self.str_to_level(log_level_str)
       case log_level_str.downcase

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -55,6 +55,20 @@ module Fluent
     config_section :log, required: false, init: true, multi: false do
       config_param :format, :enum, list: [:text, :json], default: :text
       config_param :time_format, :string, default: '%Y-%m-%d %H:%M:%S %z'
+      config_param :rotate_age, default: nil do |v|
+        if %w(daily weekly monthly).include?(v)
+          v.to_sym
+        else
+          begin
+            Integer(v)
+          rescue ArgumentError => e
+            raise Fluent::ConfigError, e.message
+          else
+            v.to_i
+          end
+        end
+      end
+      config_param :rotate_size, :size, default: nil
     end
 
     config_section :counter_server, multi: false do

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -56,7 +56,7 @@ module Fluent
       config_param :format, :enum, list: [:text, :json], default: :text
       config_param :time_format, :string, default: '%Y-%m-%d %H:%M:%S %z'
       config_param :rotate_age, default: nil do |v|
-        if %w(daily weekly monthly).include?(v)
+        if Fluent::Log::LOG_ROTATE_AGE.include?(v)
           v.to_sym
         else
           begin

--- a/test/config/test_system_config.rb
+++ b/test/config/test_system_config.rb
@@ -143,5 +143,51 @@ module Fluent::Config
       sc.overwrite_variables(**s.for_system_config)
       assert_equal(level, sc.log_level)
     end
+
+    sub_test_case "log rotation" do
+      data('daily' => "daily",
+           'weekly' => 'weekly',
+           'monthly' => 'monthly')
+      test "symbols for rotate_age" do |age|
+        conf = parse_text(<<-EOS)
+          <system>
+            <log>
+              rotate_age #{age}
+            </log>
+          </system>
+        EOS
+        sc = Fluent::SystemConfig.new(conf)
+        assert_equal(age.to_sym, sc.log.rotate_age)
+      end
+
+      test "numeric number for rotate age" do
+        conf = parse_text(<<-EOS)
+          <system>
+            <log>
+              rotate_age 3
+            </log>
+          </system>
+        EOS
+        s = FakeSupervisor.new
+        sc = Fluent::SystemConfig.new(conf)
+        assert_equal(3, sc.log.rotate_age)
+      end
+
+      data(h: ['100', 100],
+           k: ['1k', 1024],
+           m: ['1m', 1024 * 1024],
+           g: ['1g', 1024 * 1024 * 1024])
+      test "numeric and SI prefix for rotate_size" do |(label, size)|
+        conf = parse_text(<<-EOS)
+          <system>
+            <log>
+              rotate_size #{label}
+            </log>
+          </system>
+        EOS
+        sc = Fluent::SystemConfig.new(conf)
+        assert_equal(size, sc.log.rotate_size)
+      end
+    end
   end
 end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -160,7 +160,8 @@ class ConfigTest < Test::Unit::TestCase
     prepare_config
     opts = {
       :config_path => "#{TMP_DIR}/config_test_1.conf",
-      :inline_config => "<source>\n  type http\n  port 2222\n </source>"
+      :inline_config => "<source>\n  type http\n  port 2222\n </source>",
+      :use_v1_config => false
     }
     assert_nothing_raised do
       Fluent::Supervisor.new(opts)


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

Fixes N/A

**What this PR does / why we need it**: 

In the previous versions, log rotation options were supported as
--log-rotate-age or --log-rotate-size via command line options.

On Windows, as fluentd is launched as a windows service, it is
required to configure again via --reg-winsvc-fluentdopt or edit
fluentdopt registry key for customization.

This approach is not convenient for Windows users, so it may be better
to support more comprehensive solution - customize via configuration
file.

This commit introduces such a configurable parameter in .conf

```
  <system>
   <log>
     rotate_age 5
     rotate_size 1048576
   </log>
  </system>
```

**Docs Changes**:

TODO: https://docs.fluentd.org/deployment/logging#by-config-file should be updated.

**Release Note**: 

N/A