### PR TITLE
Add ability to get the root-router

### DIFF
--- a/lib/fluent/plugin_helper/event_emitter.rb
+++ b/lib/fluent/plugin_helper/event_emitter.rb
@@ -47,7 +47,7 @@ module Fluent
 
       def event_emitter_router(label_name)
         if label_name
-          if label_name == ""
+          if label_name == "@ROOT"
             Engine.root_agent.event_router
           else
             Engine.root_agent.find_label(label_name).event_router

--- a/lib/fluent/plugin_helper/event_emitter.rb
+++ b/lib/fluent/plugin_helper/event_emitter.rb
@@ -47,7 +47,11 @@ module Fluent
 
       def event_emitter_router(label_name)
         if label_name
-          Engine.root_agent.find_label(label_name).event_router
+          if label_name == ""
+            Engine.root_agent.event_router
+          else
+            Engine.root_agent.find_label(label_name).event_router
+          end
         elsif self.respond_to?(:as_secondary) && self.as_secondary
           if @primary_instance.has_router?
             @_event_emitter_lazy_init = true

--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -131,7 +131,7 @@ module Fluent
         end
         name = e.arg
         raise ConfigError, "Missing symbol argument on <label> directive" if name.empty?
-        raise ConfigError, "@ROOT for <label> is invalid, reserved for getting root router" if name == '@ROOT'
+        raise ConfigError, "@ROOT for <label> is not permitted, reserved for getting root router" if name == '@ROOT'
 
         if name == ERROR_LABEL
           error_label_config = e

--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -131,8 +131,7 @@ module Fluent
         end
         name = e.arg
         raise ConfigError, "Missing symbol argument on <label> directive" if name.empty?
-
-        raise ConfigError, "Invalid label name (@ROOT)" if name == '@ROOT'
+        raise ConfigError, "@ROOT for <label> is invalid, reserved for getting root router" if name == '@ROOT'
 
         if name == ERROR_LABEL
           error_label_config = e

--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -132,6 +132,8 @@ module Fluent
         name = e.arg
         raise ConfigError, "Missing symbol argument on <label> directive" if name.empty?
 
+        raise ConfigError, "Invalid label name (@ROOT)" if name == '@ROOT'
+
         if name == ERROR_LABEL
           error_label_config = e
         else

--- a/test/plugin_helper/test_event_emitter.rb
+++ b/test/plugin_helper/test_event_emitter.rb
@@ -56,8 +56,8 @@ class EventEmitterTest < Test::Unit::TestCase
   end
 
   test 'should have event_emitter_router' do
-    d0 = Dummy.new
-    assert d0.respond_to?(:event_emitter_router)
+    d = Dummy.new
+    assert d.respond_to?(:event_emitter_router)
   end
 
   test 'get router' do

--- a/test/plugin_helper/test_event_emitter.rb
+++ b/test/plugin_helper/test_event_emitter.rb
@@ -1,6 +1,7 @@
 require_relative '../helper'
 require 'fluent/plugin_helper/event_emitter'
 require 'fluent/plugin/base'
+require 'flexmock/test_unit'
 
 class EventEmitterTest < Test::Unit::TestCase
   setup do
@@ -47,5 +48,33 @@ class EventEmitterTest < Test::Unit::TestCase
     assert_nil d1.router
 
     d1.terminate
+  end
+
+  test 'should not have event_emitter_router' do
+    d0 = Dummy0.new
+    assert !d0.respond_to?(:event_emitter_router)
+  end
+
+  test 'should have event_emitter_router' do
+    d0 = Dummy.new
+    assert d0.respond_to?(:event_emitter_router)
+  end
+
+  test 'get router' do
+    router_mock = flexmock('mytest')
+    label_mock = flexmock('mylabel')
+    label_mock.should_receive(:event_router).twice.and_return(router_mock)
+    Fluent::Engine.root_agent.labels['@mytest'] = label_mock
+
+    d = Dummy.new
+    d.configure(config_element('ROOT', '', {'@label' => '@mytest'}))
+    router = d.event_emitter_router("@mytest")
+    assert_equal router_mock, router
+  end
+
+  test 'get root router' do
+    d = Dummy.new
+    router = d.event_emitter_router("@ROOT")
+    assert_equal Fluent::Engine.root_agent.event_router, router
   end
 end

--- a/test/test_root_agent.rb
+++ b/test/test_root_agent.rb
@@ -109,6 +109,34 @@ EOC
       end
     end
 
+    test 'raises configuration error for label without name' do
+      conf = <<-EOC
+<label>
+  @type test_out
+</label>
+EOC
+      errmsg = "Missing symbol argument on <label> directive"
+      assert_raise Fluent::ConfigError.new(errmsg) do
+        configure_ra(conf)
+      end
+    end
+
+    test 'raises configuration error for <label @ROOT>' do
+      conf = <<-EOC
+<source>
+  @type test_in
+  @label @ROOT
+</source>
+<label @ROOT>
+  @type test_out
+</label>
+EOC
+      errmsg = "@ROOT for <label> is not permitted, reserved for getting root router"
+      assert_raise Fluent::ConfigError.new(errmsg) do
+        configure_ra(conf)
+      end
+    end
+
     test 'raises configuration error if there are not match sections in label section' do
       conf = <<-EOC
 <source>


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**What this PR does / why we need it**: 
This patch adds a way in event_emitter_router(label_name) to get the root event router. To use an empty string "" for the default router is just a proposal, maybe `@DEFAULT` would fit better.
Why I needed it:
I did not see another way to get an event it is once assigned to a label back the default route. The concat filter can send timedout events to a special label. With the _route_ plugin the tag can be prefixed and with `@label ""` the event can be sent to the default filters and output.

**Docs Changes**:
Will be updated if there is any interest.

**Release Note**: 
Enable to get root router by `Fluent::PluginHelper::EventEmitter::event_emitter_router("@ROOT")`