### PR TITLE
Handle both of stat and timer watchers are enabled and steady growing file case

### DIFF
--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -422,7 +422,11 @@ class TailInputTest < Test::Unit::TestCase
             require 'fluent/config/types'
             limit_bytes_value = Fluent::Config.size_value(limit_bytes)
             io_handler.instance_variable_set(:@number_bytes_read, limit_bytes_value)
-            mock.proxy(io_handler).handle_notify.at_least(5)
+            if Fluent.linux?
+              mock.proxy(io_handler).handle_notify.at_least(5)
+            else
+              mock.proxy(io_handler).handle_notify.twice
+            end
             io_handler
           end
 

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -378,19 +378,20 @@ class TailInputTest < Test::Unit::TestCase
           d = create_driver(config)
           msg = 'test' * 2000 # in_tail reads 8192 bytes at once.
 
+          start_time = Fluent::Clock.now
+
           # We should not do shutdown here due to hard timeout.
           d.run(expect_emits: 2, shutdown: false) do
             File.open("#{TMP_DIR}/tail.txt", "ab") {|f|
-              for x in 0..30
+              100.times do
                 f.puts msg
               end
             }
           end
 
-          events = d.events
-          assert_true(events.length <= num_events)
-          assert_equal({"message" => msg}, events[0][2])
-          assert_equal({"message" => msg}, events[1][2])
+          assert_true(Fluent::Clock.now - start_time > 1)
+          assert_equal(num_events.times.map { {"message" => msg} },
+                       d.events.collect { |event| event[2] })
 
           # Teardown in_tail plugin instance here.
           d.instance.shutdown
@@ -421,81 +422,29 @@ class TailInputTest < Test::Unit::TestCase
             require 'fluent/config/types'
             limit_bytes_value = Fluent::Config.size_value(limit_bytes)
             io_handler.instance_variable_set(:@number_bytes_read, limit_bytes_value)
+            mock.proxy(io_handler).handle_notify.at_least(5)
             io_handler
           end
 
-          # We should not do shutdown here due to hard timeout.
-          d.run(expect_emits: 2, shutdown: false) do
-            File.open("#{TMP_DIR}/tail.txt", "ab") {|f|
-              for _x in 0..30
-                f.puts msg
-              end
-            }
-          end
-
-          events = d.events
-          assert_true(events.length <= num_events)
-          assert_equal({"message" => msg}, events[0][2])
-          assert_equal({"message" => msg}, events[1][2])
-
-          # Teardown in_tail plugin instance here.
-          d.instance.shutdown
-        end
-      end
-
-      sub_test_case "reads_bytes_per_second with several writing points" do
-        class Fluent::Plugin::TailInput::TailWatcher::IOHandler
-          alias_method :orig_limit_bytes_per_second_reached?, :limit_bytes_per_second_reached?
-          def limit_bytes_per_second_reached?(&block)
-            yield if block_given?
-
-            orig_limit_bytes_per_second_reached?
-          end
-        end
-
-        data("flat 8192 bytes, 2 events"        => [:flat, 100, 8192, 2],
-             "flat #{8192*10} bytes, 20 events"  => [:flat, 100, (8192 * 10), 20],
-             "parse #{8192*4} bytes, 8 events"  => [:parse, 100, (8192 * 4), 8],
-             "parse #{8192*10} bytes, 20 events" => [:parse, 100, (8192 * 10), 20],
-             "flat 8k bytes with unit, 2 events"        => [:flat, 100, "8k", 2],
-             "flat #{8*10}k bytes with unit, 20 events"  => [:flat, 100, "#{8*10}k", 20],
-             "parse #{8*4}k bytes with unit, 8 events"  => [:parse, 100, "#{8*4}k", 8],
-             "parse #{8*10}k bytes with unit, 20 events" => [:parse, 100, "#{8*10}k", 20])
-        def test_emit_with_read_bytes_limit_per_second(data)
-          config_style, limit, limit_bytes, num_events = data
-          case config_style
-          when :flat
-            config = CONFIG_READ_FROM_HEAD + SINGLE_LINE_CONFIG + config_element("", "", { "read_lines_limit" => limit, "read_bytes_limit_per_second" => limit_bytes })
-          when :parse
-            config = CONFIG_READ_FROM_HEAD + config_element("", "", { "read_lines_limit" => limit, "read_bytes_limit_per_second" => limit_bytes }) + PARSE_SINGLE_LINE_CONFIG
-          end
-          d = create_driver(config)
-          msg = 'test' * 2000 # in_tail reads 8192 bytes at once.
-
-          mock.proxy(d.instance).io_handler(anything, anything) do |io_handler|
-            io_handler.limit_bytes_per_second_reached? do
-              File.open("#{TMP_DIR}/tail.txt", "ab") {|f|
-                for _x in 0..5
-                  f.puts msg
-                end
-              }
+          File.open("#{TMP_DIR}/tail.txt", "ab") do |f|
+            100.times do
+              f.puts msg
             end
-            io_handler
           end
 
           # We should not do shutdown here due to hard timeout.
-          d.run(expect_emits: 2, shutdown: false) do
-            File.open("#{TMP_DIR}/tail.txt", "ab") {|f|
-              for _x in 0..30
+          d.run(shutdown: false) do
+            start_time = Fluent::Clock.now
+            while Fluent::Clock.now - start_time < 0.8 do
+              File.open("#{TMP_DIR}/tail.txt", "ab") do |f|
                 f.puts msg
+                f.flush
               end
-            }
+              sleep 0.05
+            end
           end
 
-          events = d.events
-          assert_true(events.length <= num_events)
-          assert_equal({"message" => msg}, events[0][2])
-          assert_equal({"message" => msg}, events[1][2])
+          assert_equal([], d.events)
 
           # Teardown in_tail plugin instance here.
           d.instance.shutdown

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -345,53 +345,102 @@ class TailInputTest < Test::Unit::TestCase
         cleanup_file("#{TMP_DIR}/tail.txt")
       end
 
-      data("flat 8192 bytes, 2 events"        => [:flat, 100, 8192, 2],
-           "flat 8192 bytes, 2 events w/o stat watcher" => [:flat_without_stat, 100, 8192, 2],
-           "flat #{8192*10} bytes, 20 events"  => [:flat, 100, (8192 * 10), 20],
-           "flat #{8192*10} bytes, 20 events w/o stat watcher"  => [:flat_without_stat, 100, (8192 * 10), 20],
-           "parse #{8192*4} bytes, 8 events"  => [:parse, 100, (8192 * 4), 8],
-           "parse #{8192*4} bytes, 8 events w/o stat watcher"  => [:parse_without_stat, 100, (8192 * 4), 8],
-           "parse #{8192*10} bytes, 20 events" => [:parse, 100, (8192 * 10), 20],
-           "parse #{8192*10} bytes, 20 events w/o stat watcher" => [:parse_without_stat, 100, (8192 * 10), 20],
-           "flat 8k bytes with unit, 2 events"        => [:flat, 100, "8k", 2],
-           "flat 8k bytes with unit, 2 events w/o stat watcher"        => [:flat_without_stat, 100, "8k", 2],
-           "flat #{8*10}k bytes with unit, 20 events"  => [:flat, 100, "#{8*10}k", 20],
-           "flat #{8*10}k bytes with unit, 20 events w/o stat watcher"  => [:flat_without_stat, 100, "#{8*10}k", 20],
-           "parse #{8*4}k bytes with unit, 8 events"  => [:parse, 100, "#{8*4}k", 8],
-           "parse #{8*4}k bytes with unit, 8 events w/o stat watcher"  => [:parse_without_stat, 100, "#{8*4}k", 8],
-           "parse #{8*10}k bytes with unit, 20 events" => [:parse, 100, "#{8*10}k", 20],
-           "parse #{8*10}k bytes with unit, 20 events w/o stat watcher" => [:parse_without_stat, 100, "#{8*10}k", 20])
-      def test_emit_with_read_bytes_limit_per_second(data)
-        config_style, limit, limit_bytes, num_events = data
-        case config_style
-        when :flat
-          config = CONFIG_READ_FROM_HEAD + SINGLE_LINE_CONFIG + config_element("", "", { "read_lines_limit" => limit, "read_bytes_limit_per_second" => limit_bytes })
-        when :parse
-          config = CONFIG_READ_FROM_HEAD + config_element("", "", { "read_lines_limit" => limit, "read_bytes_limit_per_second" => limit_bytes }) + PARSE_SINGLE_LINE_CONFIG
-        when :flat_without_stat
-          config = CONFIG_READ_FROM_HEAD + SINGLE_LINE_CONFIG + CONFIG_DISABLE_STAT_WATCHER + config_element("", "", { "read_lines_limit" => limit, "read_bytes_limit_per_second" => limit_bytes })
-        when :parse_without_stat
-          config = CONFIG_READ_FROM_HEAD + CONFIG_DISABLE_STAT_WATCHER + config_element("", "", { "read_lines_limit" => limit, "read_bytes_limit_per_second" => limit_bytes }) + PARSE_SINGLE_LINE_CONFIG
+      sub_test_case "reads_bytes_per_second w/o throttled" do
+        data("flat 8192 bytes, 2 events"        => [:flat, 100, 8192, 2, false],
+             "flat 8192 bytes, 2 events already read limit reached" => [:flat, 100, 8192, 2, true],
+             "flat 8192 bytes, 2 events w/o stat watcher" => [:flat_without_stat, 100, 8192, 2, false],
+             "flat #{8192*10} bytes, 20 events"  => [:flat, 100, (8192 * 10), 20],
+             "flat #{8192*10} bytes, 20 events w/o stat watcher"  => [:flat_without_stat, 100, (8192 * 10), 20],
+             "parse #{8192*4} bytes, 8 events"  => [:parse, 100, (8192 * 4), 8],
+             "parse #{8192*4} bytes, 8 events w/o stat watcher"  => [:parse_without_stat, 100, (8192 * 4), 8],
+             "parse #{8192*10} bytes, 20 events" => [:parse, 100, (8192 * 10), 20],
+             "parse #{8192*10} bytes, 20 events w/o stat watcher" => [:parse_without_stat, 100, (8192 * 10), 20],
+             "flat 8k bytes with unit, 2 events"        => [:flat, 100, "8k", 2],
+             "flat 8k bytes with unit, 2 events w/o stat watcher"        => [:flat_without_stat, 100, "8k", 2],
+             "flat #{8*10}k bytes with unit, 20 events"  => [:flat, 100, "#{8*10}k", 20],
+             "flat #{8*10}k bytes with unit, 20 events w/o stat watcher"  => [:flat_without_stat, 100, "#{8*10}k", 20],
+             "parse #{8*4}k bytes with unit, 8 events"  => [:parse, 100, "#{8*4}k", 8],
+             "parse #{8*4}k bytes with unit, 8 events w/o stat watcher"  => [:parse_without_stat, 100, "#{8*4}k", 8],
+             "parse #{8*10}k bytes with unit, 20 events" => [:parse, 100, "#{8*10}k", 20],
+             "parse #{8*10}k bytes with unit, 20 events w/o stat watcher" => [:parse_without_stat, 100, "#{8*10}k", 20])
+        def test_emit_with_read_bytes_limit_per_second(data)
+          config_style, limit, limit_bytes, num_events = data
+          case config_style
+          when :flat
+            config = CONFIG_READ_FROM_HEAD + SINGLE_LINE_CONFIG + config_element("", "", { "read_lines_limit" => limit, "read_bytes_limit_per_second" => limit_bytes })
+          when :parse
+            config = CONFIG_READ_FROM_HEAD + config_element("", "", { "read_lines_limit" => limit, "read_bytes_limit_per_second" => limit_bytes }) + PARSE_SINGLE_LINE_CONFIG
+          when :flat_without_stat
+            config = CONFIG_READ_FROM_HEAD + SINGLE_LINE_CONFIG + CONFIG_DISABLE_STAT_WATCHER + config_element("", "", { "read_lines_limit" => limit, "read_bytes_limit_per_second" => limit_bytes })
+          when :parse_without_stat
+            config = CONFIG_READ_FROM_HEAD + CONFIG_DISABLE_STAT_WATCHER + config_element("", "", { "read_lines_limit" => limit, "read_bytes_limit_per_second" => limit_bytes }) + PARSE_SINGLE_LINE_CONFIG
+          end
+          d = create_driver(config)
+          msg = 'test' * 2000 # in_tail reads 8192 bytes at once.
+
+          # We should not do shutdown here due to hard timeout.
+          d.run(expect_emits: 2, shutdown: false) do
+            File.open("#{TMP_DIR}/tail.txt", "ab") {|f|
+              for x in 0..30
+                f.puts msg
+              end
+            }
+          end
+
+          events = d.events
+          assert_true(events.length <= num_events)
+          assert_equal({"message" => msg}, events[0][2])
+          assert_equal({"message" => msg}, events[1][2])
+
+          # Teardown in_tail plugin instance here.
+          d.instance.shutdown
         end
-        d = create_driver(config)
-        msg = 'test' * 2000 # in_tail reads 8192 bytes at once.
+      end
 
-        # We should not do shutdown here due to hard timeout.
-        d.run(expect_emits: 2, shutdown: false) do
-          File.open("#{TMP_DIR}/tail.txt", "ab") {|f|
-            for _x in 0..30
-              f.puts msg
-            end
-          }
+      sub_test_case "reads_bytes_per_second w/ throttled already" do
+        data("flat 8192 bytes, 2 events"        => [:flat, 100, 8192, 2],
+             "flat #{8192*10} bytes, 20 events"  => [:flat, 100, (8192 * 10), 20],
+             "parse #{8192*4} bytes, 8 events"  => [:parse, 100, (8192 * 4), 8],
+             "parse #{8192*10} bytes, 20 events" => [:parse, 100, (8192 * 10), 20],
+             "flat 8k bytes with unit, 2 events"        => [:flat, 100, "8k", 2],
+             "flat #{8*10}k bytes with unit, 20 events"  => [:flat, 100, "#{8*10}k", 20],
+             "parse #{8*4}k bytes with unit, 8 events"  => [:parse, 100, "#{8*4}k", 8],
+             "parse #{8*10}k bytes with unit, 20 events" => [:parse, 100, "#{8*10}k", 20])
+        def test_emit_with_read_bytes_limit_per_second(data)
+          config_style, limit, limit_bytes, num_events = data
+          case config_style
+          when :flat
+            config = CONFIG_READ_FROM_HEAD + SINGLE_LINE_CONFIG + config_element("", "", { "read_lines_limit" => limit, "read_bytes_limit_per_second" => limit_bytes })
+          when :parse
+            config = CONFIG_READ_FROM_HEAD + config_element("", "", { "read_lines_limit" => limit, "read_bytes_limit_per_second" => limit_bytes }) + PARSE_SINGLE_LINE_CONFIG
+          end
+          d = create_driver(config)
+          msg = 'test' * 2000 # in_tail reads 8192 bytes at once.
+
+          mock.proxy(d.instance).io_handler(anything, anything) do |io_handler|
+            require 'fluent/config/types'
+            limit_bytes_value = Fluent::Config.size_value(limit_bytes)
+            io_handler.instance_variable_set(:@number_bytes_read, limit_bytes_value)
+            io_handler
+          end
+
+          # We should not do shutdown here due to hard timeout.
+          d.run(expect_emits: 2, shutdown: false) do
+            File.open("#{TMP_DIR}/tail.txt", "ab") {|f|
+              for _x in 0..30
+                f.puts msg
+              end
+            }
+          end
+
+          events = d.events
+          assert_true(events.length <= num_events)
+          assert_equal({"message" => msg}, events[0][2])
+          assert_equal({"message" => msg}, events[1][2])
+
+          # Teardown in_tail plugin instance here.
+          d.instance.shutdown
         end
-
-        events = d.events
-        assert_true(events.length <= num_events)
-        assert_equal({"message" => msg}, events[0][2])
-        assert_equal({"message" => msg}, events[1][2])
-
-        # Teardown in_tail plugin instance here.
-        d.instance.shutdown
       end
     end
 


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Follows up #3185 

**What this PR does / why we need it**: 
In this case, timer watcher tells file contents every 1 seconds and file
contents changes is also notified from stats watcher.

In such circumstances, if some tailing files are steadily growing,
previous implementation does not prevent log ingestion for written
contents which is notified by stat watcher.

This commit also prevents log ingestion in such cases.

**Docs Changes**:

No needed.

**Release Note**: 

Same as title.

**Additional context**

I can implement this edge case patch, but how can we write down into test cases...?