### PR TITLE
filter plugin add track_key to track the forward info, and  add record_size_key to record source data size

### DIFF
--- a/lib/fluent/plugin/filter_record_transformer.rb
+++ b/lib/fluent/plugin/filter_record_transformer.rb
@@ -40,7 +40,7 @@ module Fluent::Plugin
     desc 'When set to true, the full Ruby syntax is enabled in the ${...} expression.'
     config_param :enable_ruby, :bool, default: false
     desc 'Use original value type.'
-    config_param :auto_typecast, :bool, default: false # false for lower version compatibility
+    config_param :auto_typecast, :bool, default: true
     desc 'Add forward tracking info.'
     config_param :track_key, :string, default: nil
     desc 'Add record length info.'


### PR DESCRIPTION
Which issue(s) this PR fixes:
None

What this PR does / why we need it:
In our use scenario, we need to monitor and track the data flow link status, and do some cleaning according to the size of the data, so we have added two fields of original data size and data flow node information to solve this need

Docs Changes:
None

Release Note:
Same as title