### PR TITLE
in_http: Add support for HTTP GET requests

### DIFF
--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -461,6 +461,12 @@ module Fluent::Plugin
       RES_200_STATUS = "200 OK".freeze
       RES_403_STATUS = "403 Forbidden".freeze
 
+      # Azure App Service sends GET requests for health checking purpose.
+      # Respond with `200 OK` to accommodate it.
+      def handle_get_request
+          return send_response_and_close(RES_200_STATUS, {}, "")
+      end
+
       # Web browsers can send an OPTIONS request before performing POST
       # to check if cross-origin requests are supported.
       def handle_options_request
@@ -493,6 +499,10 @@ module Fluent::Plugin
 
       def on_message_complete
         return if closing?
+
+        if @parser.http_method == 'GET'.freeze
+          return handle_get_request()
+        end
 
         if @parser.http_method == 'OPTIONS'.freeze
           return handle_options_request()

--- a/test/plugin/test_in_http.rb
+++ b/test/plugin/test_in_http.rb
@@ -770,6 +770,15 @@ class HttpInputTest < Test::Unit::TestCase
     end
   end
 
+  def test_get_request
+    d = create_driver(CONFIG)
+
+    d.run do
+      res = get("/cors.test", {}, {})
+      assert_equal "200", res.code
+    end
+  end
+
   def test_cors_preflight
     d = create_driver(CONFIG + 'cors_allow_origins ["*"]')
 
@@ -983,6 +992,12 @@ class HttpInputTest < Test::Unit::TestCase
     assert_equal(['application/json', ''], $test_in_http_content_types)
     # Asserting keepalive
     assert_equal $test_in_http_connection_object_ids[0], $test_in_http_connection_object_ids[1]
+  end
+
+  def get(path, params, header = {})
+    http = Net::HTTP.new("127.0.0.1", PORT)
+    req = Net::HTTP::Get.new(path, header)
+    http.request(req)
   end
 
   def options(path, params, header = {})


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #3372

**What this PR does / why we need it**: 

Azure App uses GET requests to check if the HTTP server is working all right.
Since Fluentd responds with "400 Bad Requests" to HTTP GET, it does not work well.

Teach Fluentd to respond nicely with "200 OK" to HTTP GET.

**Docs Changes**:

Not needed

**Release Note**: 

* Starting this version,  `in_http` responds with `200 OK` to GET requests (instead of `404 Bad request`)