### PR TITLE
bin: fluentd: Specify trace_instruction as false if available

### DIFF
--- a/bin/fluentd
+++ b/bin/fluentd
@@ -1,6 +1,11 @@
 #!/usr/bin/env ruby
 # -*- coding: utf-8 -*-
 
+# In recent CRuby, RubyVM::InstructionSequence is always defined.
+# This optimization aims to reduce memory (avg 0.5 megabytes) at startup.
+# ref: http://atdot.net/~ko1/activities/2017_fukuoka_rubykaigi_02.pdf
+# But other implementation such as truffleruby does not provide such
+# class.
 if defined?(RubyVM::InstructionSequence)
   RubyVM::InstructionSequence.compile_option = {trace_instruction: false}
 end

--- a/bin/fluentd
+++ b/bin/fluentd
@@ -1,7 +1,9 @@
 #!/usr/bin/env ruby
 # -*- coding: utf-8 -*-
 
-RubyVM::InstructionSequence.compile_option = {trace_instruction: false} rescue nil
+if defined?(RubyVM::InstructionSequence)
+  RubyVM::InstructionSequence.compile_option = {trace_instruction: false}
+end
 
 here = File.dirname(__FILE__)
 $LOAD_PATH << File.expand_path(File.join(here, '..', 'lib'))


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Related to #3375 

**What this PR does / why we need it**: 
In recent CRuby, RubyVM::InstructionSequence is always defined.
But other implementation such as truffleruby does not provide such
class.

But even if this commit, fluentd does not work correctly with truffleruby. 
Especially, Fluentd sometimes does not terminate correctly with TERM signal.

**Docs Changes**:

No needed.

**Release Note**: 

Same as title.

**Additional Note**:

`TruffleRuby` can be installed with `rbenv install truffleruby-21.0.0`. We can use it to investigate issue which is caused by truffleruby.