### PR TITLE
in_tail: read_bytes_limit_per_second should precede read_lines_limit

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -965,14 +965,14 @@ module Fluent::Plugin
                     @fifo.read_lines(@lines)
 
                     @log.debug("reading file: #{@path}")
-                    if @lines.size >= @read_lines_limit
-                      # not to use too much memory in case the file is very large
-                      read_more = true
-                      break
-                    end
                     if limit_bytes_per_second_reached?
                       # Just get out from tailing loop.
                       read_more = false
+                      break
+                    end
+                    if @lines.size >= @read_lines_limit
+                      # not to use too much memory in case the file is very large
+                      read_more = true
                       break
                     end
                   end

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -375,13 +375,12 @@ class TailInputTest < Test::Unit::TestCase
           when :parse_without_stat
             config = CONFIG_READ_FROM_HEAD + CONFIG_DISABLE_STAT_WATCHER + config_element("", "", { "read_lines_limit" => limit, "read_bytes_limit_per_second" => limit_bytes }) + PARSE_SINGLE_LINE_CONFIG
           end
-          d = create_driver(config)
-          msg = 'test' * 2000 # in_tail reads 8192 bytes at once.
 
+          msg = 'test' * 2000 # in_tail reads 8192 bytes at once.
           start_time = Fluent::Clock.now
 
-          # We should not do shutdown here due to hard timeout.
-          d.run(expect_emits: 2, shutdown: false) do
+          d = create_driver(config)
+          d.run(expect_emits: 2) do
             File.open("#{TMP_DIR}/tail.txt", "ab") {|f|
               100.times do
                 f.puts msg
@@ -392,9 +391,6 @@ class TailInputTest < Test::Unit::TestCase
           assert_true(Fluent::Clock.now - start_time > 1)
           assert_equal(num_events.times.map { {"message" => msg} },
                        d.events.collect { |event| event[2] })
-
-          # Teardown in_tail plugin instance here.
-          d.instance.shutdown
         end
 
         def test_read_bytes_limit_precede_read_lines_limit
@@ -460,7 +456,7 @@ class TailInputTest < Test::Unit::TestCase
           end
 
           # We should not do shutdown here due to hard timeout.
-          d.run(shutdown: false) do
+          d.run do
             start_time = Fluent::Clock.now
             while Fluent::Clock.now - start_time < 0.8 do
               File.open("#{TMP_DIR}/tail.txt", "ab") do |f|
@@ -472,9 +468,6 @@ class TailInputTest < Test::Unit::TestCase
           end
 
           assert_equal([], d.events)
-
-          # Teardown in_tail plugin instance here.
-          d.instance.shutdown
         end
       end
     end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Follow up #3185

**What this PR does / why we need it**: 
in_tail: read_bytes_limit_per_second should precede read_lines_limit
    
Otherwise it doesn't limit reading pace on reading many short lines.

**Docs Changes**:
none

**Release Note**: 
Same with #3185