### PR TITLE
CI: Use fiddle 1.0.8 for Ruby 3.0 on Windows

### DIFF
--- a/.github/workflows/windows-test.yaml
+++ b/.github/workflows/windows-test.yaml
@@ -28,7 +28,7 @@ jobs:
             # * https://github.com/ruby/fiddle/issues/72
             # * https://bugs.ruby-lang.org/issues/17813
             # * https://github.com/oneclick/rubyinstaller2/blob/8225034c22152d8195bc0aabc42a956c79d6c712/lib/ruby_installer/build/dll_directory.rb
-            ruby-lib-opt: RUBYLIB=C:/hostedtoolcache/windows/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/fiddle-1.0.8/lib
+            ruby-lib-opt: RUBYLIB=%RUNNER_TOOL_CACHE%/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/fiddle-1.0.8/lib
 
     name: Unit testing with Ruby ${{ matrix.ruby-version }} on ${{ matrix.os }}
     steps:

--- a/.github/workflows/windows-test.yaml
+++ b/.github/workflows/windows-test.yaml
@@ -18,9 +18,17 @@ jobs:
           - windows-latest
         experimental: [false]
         include:
-          - ruby-version: '3.0'
+          - ruby-version: '3.0.1'
             os: windows-latest
             experimental: true
+            # On Ruby 3.0, we need to use fiddle 1.0.8 or later to retrieve correct
+            # error code. In addition, we have to specify the path of fiddle by RUBYLIB
+            # because RubyInstaller loads Ruby's bundled fiddle before initializing gem.
+            # See also:
+            # * https://github.com/ruby/fiddle/issues/72
+            # * https://bugs.ruby-lang.org/issues/17813
+            # * https://github.com/oneclick/rubyinstaller2/blob/8225034c22152d8195bc0aabc42a956c79d6c712/lib/ruby_installer/build/dll_directory.rb
+            ruby-lib-opt: RUBYLIB=C:/hostedtoolcache/windows/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/fiddle-1.0.8/lib
 
     name: Unit testing with Ruby ${{ matrix.ruby-version }} on ${{ matrix.os }}
     steps:
@@ -29,7 +37,10 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
+      - name: Add Fiddle 1.0.8
+        if: ${{ matrix.ruby-version == '3.0.1' }}
+        run: gem install fiddle --version 1.0.8
       - name: Install dependencies
         run: ridk exec bundle install
       - name: Run tests
-        run: bundle exec rake test TESTOPTS=-v
+        run: bundle exec rake test TESTOPTS=-v ${{ matrix.ruby-lib-opt }}


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #3263

**What this PR does / why we need it**: 
On Ruby 3.0, we need to use fiddle 1.0.8 or later to retrieve correct
error code. In addition, we have to specify the path of fiddle by RUBYLIB
because RubyInstaller loads Ruby's bundled fiddle before initializing gem.
See also:
* https://github.com/ruby/fiddle/issues/72
* https://bugs.ruby-lang.org/issues/17813
* https://github.com/oneclick/rubyinstaller2/blob/8225034c22152d8195bc0aabc42a956c79d6c712/lib/ruby_installer/build/dll_directory.rb

**Docs Changes**:
none

**Release Note**: 
none