### PR TITLE
in_tail: position_file: Define path based equalities on TargetInfo (for v1.12)

### DIFF
--- a/lib/fluent/plugin/in_tail/position_file.rb
+++ b/lib/fluent/plugin/in_tail/position_file.rb
@@ -248,6 +248,20 @@ module Fluent::Plugin
       end
     end
 
-    TargetInfo = Struct.new(:path, :ino)
+    TargetInfo = Struct.new(:path, :ino) do
+      def ==(other)
+        return false unless other.is_a?(TargetInfo)
+        self.path == other.path
+      end
+
+      def hash
+        self.path.hash
+      end
+
+      def eql?(other)
+        return false unless other.is_a?(TargetInfo)
+        self.path == other.path
+      end
+    end
   end
 end

--- a/test/plugin/in_tail/test_position_file.rb
+++ b/test/plugin/in_tail/test_position_file.rb
@@ -282,4 +282,29 @@ class IntailPositionFileTest < Test::Unit::TestCase
       assert_equal 2, f.read_inode
     end
   end
+
+  sub_test_case "TargetInfo" do
+    def test_equal
+      t1 = Fluent::Plugin::TailInput::TargetInfo.new("test", 1234)
+      t2 = Fluent::Plugin::TailInput::TargetInfo.new("test", 1235)
+
+      assert_equal t1, t2
+    end
+
+    def test_eql?
+      t1 = Fluent::Plugin::TailInput::TargetInfo.new("test", 1234)
+      t2 = Fluent::Plugin::TailInput::TargetInfo.new("test", 5321)
+
+      assert do
+        t1.eql? t2
+      end
+    end
+
+    def test_hash
+      t1 = Fluent::Plugin::TailInput::TargetInfo.new("test", 1234)
+      t2 = Fluent::Plugin::TailInput::TargetInfo.new("test", 7321)
+
+      assert_equal t1.hash, t2.hash
+    end
+  end
 end

--- a/test/plugin/in_tail/test_position_file.rb
+++ b/test/plugin/in_tail/test_position_file.rb
@@ -291,6 +291,13 @@ class IntailPositionFileTest < Test::Unit::TestCase
       assert_equal t1, t2
     end
 
+    def test_not_equal
+      t1 = Fluent::Plugin::TailInput::TargetInfo.new("test", 1234)
+      t2 = Fluent::Plugin::TailInput::TargetInfo.new("test2", 1234)
+
+      assert_not_equal t1, t2
+    end
+
     def test_eql?
       t1 = Fluent::Plugin::TailInput::TargetInfo.new("test", 1234)
       t2 = Fluent::Plugin::TailInput::TargetInfo.new("test", 5321)
@@ -300,9 +307,14 @@ class IntailPositionFileTest < Test::Unit::TestCase
       end
     end
 
-    def test_hash
-      t1 = Fluent::Plugin::TailInput::TargetInfo.new("test", 1234)
-      t2 = Fluent::Plugin::TailInput::TargetInfo.new("test", 7321)
+    def test_not_eql?
+      t1 = Fluent::Plugin::TailInput::TargetInfo.new("test2", 1234)
+      t2 = Fluent::Plugin::TailInput::TargetInfo.new("test3", 1234)
+
+      assert do
+        !t1.eql? t2
+      end
+    end
 
       assert_equal t1.hash, t2.hash
     end

--- a/test/plugin/in_tail/test_position_file.rb
+++ b/test/plugin/in_tail/test_position_file.rb
@@ -283,40 +283,57 @@ class IntailPositionFileTest < Test::Unit::TestCase
     end
   end
 
-  sub_test_case "TargetInfo" do
-    def test_equal
-      t1 = Fluent::Plugin::TailInput::TargetInfo.new("test", 1234)
-      t2 = Fluent::Plugin::TailInput::TargetInfo.new("test", 1235)
+  sub_test_case "TargetInfo equality rules" do
+    sub_test_case "== operator" do
+      def test_equal
+        t1 = Fluent::Plugin::TailInput::TargetInfo.new("test", 1234)
+        t2 = Fluent::Plugin::TailInput::TargetInfo.new("test", 1235)
 
-      assert_equal t1, t2
-    end
+        assert_equal t1, t2
+      end
 
-    def test_not_equal
-      t1 = Fluent::Plugin::TailInput::TargetInfo.new("test", 1234)
-      t2 = Fluent::Plugin::TailInput::TargetInfo.new("test2", 1234)
+      def test_not_equal
+        t1 = Fluent::Plugin::TailInput::TargetInfo.new("test", 1234)
+        t2 = Fluent::Plugin::TailInput::TargetInfo.new("test2", 1234)
 
-      assert_not_equal t1, t2
-    end
-
-    def test_eql?
-      t1 = Fluent::Plugin::TailInput::TargetInfo.new("test", 1234)
-      t2 = Fluent::Plugin::TailInput::TargetInfo.new("test", 5321)
-
-      assert do
-        t1.eql? t2
+        assert_not_equal t1, t2
       end
     end
 
-    def test_not_eql?
-      t1 = Fluent::Plugin::TailInput::TargetInfo.new("test2", 1234)
-      t2 = Fluent::Plugin::TailInput::TargetInfo.new("test3", 1234)
+    sub_test_case "eql? method" do
+      def test_eql?
+        t1 = Fluent::Plugin::TailInput::TargetInfo.new("test", 1234)
+        t2 = Fluent::Plugin::TailInput::TargetInfo.new("test", 5321)
 
-      assert do
-        !t1.eql? t2
+        assert do
+          t1.eql? t2
+        end
+      end
+
+      def test_not_eql?
+        t1 = Fluent::Plugin::TailInput::TargetInfo.new("test2", 1234)
+        t2 = Fluent::Plugin::TailInput::TargetInfo.new("test3", 1234)
+
+        assert do
+          !t1.eql? t2
+        end
       end
     end
 
-      assert_equal t1.hash, t2.hash
+    sub_test_case "hash" do
+      def test_equal
+        t1 = Fluent::Plugin::TailInput::TargetInfo.new("test", 1234)
+        t2 = Fluent::Plugin::TailInput::TargetInfo.new("test", 7321)
+
+        assert_equal t1.hash, t2.hash
+      end
+
+      def test_not_equal
+        t1 = Fluent::Plugin::TailInput::TargetInfo.new("test", 1234)
+        t2 = Fluent::Plugin::TailInput::TargetInfo.new("test2", 1234)
+
+        assert_not_equal t1.hash, t2.hash
+      end
     end
   end
 end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
#3365
Same change with #3391. This PR is for v1.12

**What this PR does / why we need it**: 
(from #3365)
In the previous Fluentd v1.11.x implementation uses path based tailing keys.
We wouldn't rewrite tailing mechanism entirely.
And also we're implicitly assuming path based equality for TargetInfo in tailing logic.
We should handle TargetInfo with path based equality instead of path and
inode based equality.

**Docs Changes**:
none

**Release Note**: 
in_tail: Fix a bug that in_tail fails to handle file rotations