### PR TITLE
Block excessive gracefulReload requests

### DIFF
--- a/lib/fluent/rpc.rb
+++ b/lib/fluent/rpc.rb
@@ -58,6 +58,9 @@ module Fluent
           header = {'Content-Type' => 'application/json'} if header.nil?
           body = if response.nil?
                    '{"ok":true}'
+                 elsif response.is_a?(Hash)
+                   response['ok'] = code == 200
+                   response.to_json
                  else
                    response.body['ok'] = code == 200
                    response.body.to_json

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -195,7 +195,14 @@ module Fluent
 
       trap :USR2 do
         $log.debug 'fluentd supervisor process got SIGUSR2'
-        supervisor_sigusr2_handler
+        if @block_reload_until > Fluent::Clock.now
+          $log.warn "block gracefulReload until: #{Time.now + @block_reload_until - Fluent::Clock.now} " +
+                    "remaining: #{(@block_reload_until - Fluent::Clock.now).to_i} seconds"
+        else
+          @block_reload_until = Fluent::Clock.now + @blocking_reload_interval
+          $log.debug("accept next gracefulReload after: #{Time.now + @block_reload_until - Fluent::Clock.now}")
+          supervisor_sigusr2_handler
+        end
       end
     end
 

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -27,8 +27,11 @@ module Fluent
       :log_event_verbose, :ignore_repeated_log_interval, :ignore_same_log_interval,
       :without_source, :rpc_endpoint, :enable_get_dump, :process_name,
       :file_permission, :dir_permission, :counter_server, :counter_client,
-      :strict_config_value, :enable_msgpack_time_support, :disable_shared_socket
+      :strict_config_value, :enable_msgpack_time_support, :disable_shared_socket,
+      :blocking_reload_interval
     ]
+
+    DEFAULT_BLOCKING_RELOAD_INTERVAL = 15
 
     config_param :workers,   :integer, default: 1
     config_param :root_dir,  :string, default: nil
@@ -46,6 +49,7 @@ module Fluent
     config_param :strict_config_value, :bool, default: nil
     config_param :enable_msgpack_time_support, :bool, default: nil
     config_param :disable_shared_socket, :bool, default: nil
+    config_param :blocking_reload_interval, :time, default: DEFAULT_BLOCKING_RELOAD_INTERVAL
     config_param :file_permission, default: nil do |v|
       v.to_i(8)
     end

--- a/test/config/test_system_config.rb
+++ b/test/config/test_system_config.rb
@@ -80,6 +80,7 @@ module Fluent::Config
       assert_nil(sc.enable_msgpack_time_support)
       assert_equal(:text, sc.log.format)
       assert_equal('%Y-%m-%d %H:%M:%S %z', sc.log.time_format)
+      assert_equal(Fluent::SystemConfig::DEFAULT_BLOCKING_RELOAD_INTERVAL, sc.blocking_reload_interval)
     end
 
     data(
@@ -93,6 +94,7 @@ module Fluent::Config
       'without_source' => ['without_source', true],
       'strict_config_value' => ['strict_config_value', true],
       'enable_msgpack_time_support' => ['enable_msgpack_time_support', true],
+      'blocking_reload_interval' => ['blocking_reload_interval', 10],
     )
     test "accepts parameters" do |(k, v)|
       conf = parse_text(<<-EOS)

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -16,7 +16,7 @@ end
 class SupervisorTest < ::Test::Unit::TestCase
   class DummyServer
     include Fluent::ServerModule
-    attr_accessor :rpc_endpoint, :enable_get_dump
+    attr_accessor :rpc_endpoint, :enable_get_dump, :blocking_reload_interval
     def config
       {}
     end
@@ -230,6 +230,7 @@ class SupervisorTest < ::Test::Unit::TestCase
 
     server = DummyServer.new
     server.rpc_endpoint = sys_conf.rpc_endpoint
+    server.blocking_reload_interval = sys_conf.blocking_reload_interval
     server.enable_get_dump = sys_conf.enable_get_dump
 
     server.run_rpc_server
@@ -273,6 +274,7 @@ class SupervisorTest < ::Test::Unit::TestCase
       }
     end
     server.rpc_endpoint = sys_conf.rpc_endpoint
+    server.blocking_reload_interval = sys_conf.blocking_reload_interval
 
     server.run_rpc_server
 
@@ -281,6 +283,85 @@ class SupervisorTest < ::Test::Unit::TestCase
 
     server.stop_rpc_server
     assert_equal('{"ok":true}', response)
+  end
+
+  sub_test_case "gracefulReload" do
+    SUCCEEDED_RELOADING_RESPONSE = {"ok": true}.to_json
+    FAILED_RELOADING_RESPONSE = {"message": "failed to reload config", "ok":false}.to_json
+
+    def setup
+      opts = Fluent::Supervisor.default_options
+      @sv = Fluent::Supervisor.new(opts)
+      @server = DummyServer.new
+      @port = unused_port
+    end
+
+    def teardown
+      @server.stop_rpc_server
+    end
+
+    def test_fail_graceful_reload_immediately
+      conf_data = <<-EOC
+    <system>
+      rpc_endpoint 0.0.0.0:#{@port}
+    </system>
+    EOC
+      conf = Fluent::Config.parse(conf_data, "(test)", "(test_dir)", true)
+      sys_conf = @sv.__send__(:build_system_config, conf)
+      @server.rpc_endpoint = sys_conf.rpc_endpoint
+      @server.blocking_reload_interval = sys_conf.blocking_reload_interval
+      @server.run_rpc_server
+      uri = URI.parse("http://127.0.0.1:#{@port}/api/config.gracefulReload")
+      response = Net::HTTP.get(uri)
+      assert_equal(FAILED_RELOADING_RESPONSE, response)
+    end
+
+    def test_graceful_reload_until_succeeds
+      conf_data = <<-EOC
+    <system>
+      rpc_endpoint 0.0.0.0:#{@port}
+    </system>
+    EOC
+      conf = Fluent::Config.parse(conf_data, "(test)", "(test_dir)", true)
+      sys_conf = @sv.__send__(:build_system_config, conf)
+      @server.rpc_endpoint = sys_conf.rpc_endpoint
+      @server.blocking_reload_interval = sys_conf.blocking_reload_interval
+      @server.run_rpc_server
+      uri = URI.parse("http://127.0.0.1:#{@port}/api/config.gracefulReload")
+      responses = []
+      threads = []
+      Fluent::SystemConfig::DEFAULT_BLOCKING_RELOAD_INTERVAL.times do |i|
+        threads << Thread.new do
+          sleep i
+          responses << JSON.parse(Net::HTTP.get(uri))
+        end
+      end
+      threads.each { |t| t.join }
+      warn_logs = $log.out.logs.collect { |log| log if log =~ /\[warn\]/ }.compact
+      sleep 1 # Ensure remaining time has passed
+      assert_equal([true, true, SUCCEEDED_RELOADING_RESPONSE],
+                   [responses.none? { |response| response["ok"] == true },
+                    warn_logs.all? { |log| log =~ /remaining:/ },
+                   Net::HTTP.get(uri)])
+    end
+
+    def test_blocking_reload_interval
+      conf_data = <<-EOC
+    <system>
+      rpc_endpoint 0.0.0.0:#{@port}
+      blocking_reload_interval 3
+    </system>
+    EOC
+      conf = Fluent::Config.parse(conf_data, "(test)", "(test_dir)", true)
+      sys_conf = @sv.__send__(:build_system_config, conf)
+      @server.rpc_endpoint = sys_conf.rpc_endpoint
+      @server.blocking_reload_interval = sys_conf.blocking_reload_interval
+      @server.install_supervisor_signal_handlers
+      @server.run_rpc_server
+      sleep 3 # Ensure remaining time has passed
+      uri = URI.parse("http://127.0.0.1:#{@port}/api/config.gracefulReload")
+      assert_equal(SUCCEEDED_RELOADING_RESPONSE, Net::HTTP.get(uri))
+    end
   end
 
   def test_load_config


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

Fixes #3341

**What this PR does / why we need it**: 

In the previous versions, /api/config.gracefulReload call doesn't
restrict excessive API calls. It causes the following error when
already gracefulReload is executing.

  Worker 0 finished unexpectedly with signal SIGKILL

This commit mitigates such a situation by limit a API call.
(it gives an interval in 60 seconds by default)

**Docs Changes**:

https://docs.fluentd.org/deployment/system-config
`@blocking_reload_interval` should be added in another PR.

**Release Note**: 

N/A

 NOTE: Ideally it should wait and detects graceful reload finish, but
    there is no easy way to synchronize internal state between
    ServerModule(RPC::Server#mount_proc) and WorkerModule (reload_config).

