### PR TITLE
Support pretty print Fluent::Config::Section for debugging

### DIFF
--- a/lib/fluent/config/section.rb
+++ b/lib/fluent/config/section.rb
@@ -50,6 +50,11 @@ module Fluent
         "<Fluent::Config::Section #{@params.to_json}>"
       end
 
+      # Used by PP and Pry
+      def pretty_print(q)
+        q.text(inspect)
+      end
+
       def nil?
         false
       end

--- a/test/config/test_section.rb
+++ b/test/config/test_section.rb
@@ -1,5 +1,6 @@
 require_relative '../helper'
 require 'fluent/config/section'
+require 'pp'
 
 module Fluent::Config
   class TestSection < ::Test::Unit::TestCase
@@ -175,6 +176,14 @@ module Fluent::Config
           h1 = {name: "s1", num: 10, klass: "A"}
           s1 = Fluent::Config::Section.new(h1)
           assert_equal(expected, s1.respond_to?(method))
+        end
+
+        test '#pretty_print' do
+          q = PP.new
+          h1 = {name: "s1", klass: "A"}
+          s1 = Fluent::Config::Section.new(h1)
+          s1.pretty_print(q)
+          assert_equal s1.inspect, q.output
         end
       end
     end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

Fixes N/A

**What this PR does / why we need it**: 

If pp instance of Fluent::Config::Section, it raises the following
exception:

  Unexpected error undefined method `pretty_print' for
  <Fluent::Config::Section {}>

This commit fixes such a case to make debugging easy.

(When debugging https://github.com/fluent/fluentd/pull/3396, I've found
that this feature is missing)

**Docs Changes**:

N/A

**Release Note**: 

N/A

