### PR TITLE
test: Omit test_EACCES_error_after_setup_watcher if current user is root

### DIFF
--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -2088,6 +2088,7 @@ class TailInputTest < Test::Unit::TestCase
   end
 
   def test_EACCES_error_after_setup_watcher
+    omit "Cannot test with root user" if Process::UID.eid == 0
     path = "#{TMP_DIR}/noaccess/tail.txt"
     begin
       FileUtils.mkdir_p("#{TMP_DIR}/noaccess")
@@ -2110,8 +2111,10 @@ class TailInputTest < Test::Unit::TestCase
       assert($log.out.logs.any?{|log| log.include?("stat() for #{path} failed with Errno::EACCES. Drop tail watcher for now.\n") })
     end
   ensure
-    FileUtils.chmod(0755, "#{TMP_DIR}/noaccess")
-    FileUtils.rm_rf("#{TMP_DIR}/noaccess")
+    if File.exist?("#{TMP_DIR}/noaccess")
+      FileUtils.chmod(0755, "#{TMP_DIR}/noaccess")
+      FileUtils.rm_rf("#{TMP_DIR}/noaccess")
+    end
   end unless Fluent.windows?
 
   def test_EACCES


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
none

**What this PR does / why we need it**: 
Suppress a test failure on Drone CI:
https://cloud.drone.io/fluent/fluentd/1444/1/2

**Docs Changes**:
none

**Release Note**: 
none