### PR TITLE
test_out_forward: Extend ack timeout for a test

### DIFF
--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -641,7 +641,7 @@ EOL
 
     @d = d = create_driver(config + %[
       require_ack_response true
-      ack_response_timeout 1s
+      ack_response_timeout 10s
       <buffer tag>
         flush_mode immediate
         retry_type periodic


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
none

**What this PR does / why we need it**: 
It may be a cause of the following error:

https://github.com/fluent/fluentd/runs/2717168203

```
2021-06-01T09:28:12.9420478Z Error: test: a node supporting responses after stop(ForwardOutputTest): Fluent::Test::Driver::TestTimedOut: Test case timed out with hard limit.
2021-06-01T09:28:12.9423524Z /home/runner/work/fluentd/fluentd/lib/fluent/test/driver/base.rb:201:in `rescue in run_actual'
2021-06-01T09:28:12.9425798Z /home/runner/work/fluentd/fluentd/lib/fluent/test/driver/base.rb:196:in `run_actual'
2021-06-01T09:28:12.9427235Z /home/runner/work/fluentd/fluentd/lib/fluent/test/driver/base.rb:95:in `run'
2021-06-01T09:28:12.9428528Z /home/runner/work/fluentd/fluentd/lib/fluent/test/driver/base_owner.rb:130:in `run'
2021-06-01T09:28:12.9430107Z /home/runner/work/fluentd/fluentd/test/plugin/test_out_forward.rb:664:in `block in <class:ForwardOutputTest>'
```

With this fix, the test seems to be able to wait 5 seconds or more.
Without it, the test cannot waint only 1 seconds.
I confirmed it by putting `sleep` after `d.feed`.

**Docs Changes**:
none

**Release Note**: 
none
