### PR TITLE
test_child_process: Fix a failed test on rbenv

### DIFF
--- a/test/plugin_helper/test_child_process.rb
+++ b/test/plugin_helper/test_child_process.rb
@@ -560,7 +560,7 @@ class ChildProcessTest < Test::Unit::TestCase
       proc_lines = []
       Timeout.timeout(TEST_DEADLOCK_TIMEOUT) do
         ran = false
-        @d.child_process_execute(:t14, "ruby", arguments:['-e', 'sleep 10; puts "hello"'], subprocess_name: "sleeeeeeeeeper", mode: [:read]) do |readio|
+        @d.child_process_execute(:t14, "/bin/sh", arguments:['-c', 'sleep 10; echo "hello"'], subprocess_name: "sleeeeeeeeeper", mode: [:read]) do |readio|
           m.lock
           ran = true
           pids << @d.child_process_id


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
none

**What this PR does / why we need it**: 
The test "can specify subprocess name" is failed on rbenv because the
ruby command is executed via rbenv-exec.
This commit replace the ruby command with sh,
because this test doesn't require ruby.

```
Failure: test: can specify subprocess name(ChildProcessTest):
          assert{ proc_lines.select{|line| line =~ /^\s*#{pid}\s/ }.first.strip.split(/\s+/)[1] == "sleeeeeeeeeper" }
                  |          |                                      |     |     |           |   |
                  |          |                                      |     |     |           |   false
                  |          |                                      |     |     |           "bash"
                  |          |                                      |     |     ["557858", "bash", "/home/aho/.rbenv/libexec/rbenv-exec", "ruby", "-e", "sleep", "10;", "puts", "\"hello\""]
                  |          |                                      |     "557858 bash /home/aho/.rbenv/libexec/rbenv-exec ruby -e sleep 10; puts \"hello\""
                  |          |                                      " 557858 bash /home/aho/.rbenv/libexec/rbenv-exec ruby -e sleep 10; puts \"hello\"\n"
                  |          [" 557858 bash /home/aho/.rbenv/libexec/rbenv-exec ruby -e sleep 10; puts \"hello\"\n"]
                  ["    PID CMD\n", " 457382 /usr/libexec/gdm-wayland-session env GNOME_SHELL_SESSION_MODE=ubuntu /usr/bin/gnome-session --session=ubuntu\n", " 457385 /usr/libexec/gnome-session-binary --systemd --session=ubuntu\n", " 477521 bash\n", " 490520 bash\n", " 490781 bash\n", " 539652 emacs -nw test/plugin_helper/test_child_process.rb\n", " 556315 ruby -e Signal.trap(:TERM, nil); while sleep 0.1; puts 1; STDOUT.flush rescue nil; end\n", " 557215 ruby2.7 /home/aho/Projects/Fluentd/fluentd/vendor/bundle/ruby/2.7.0/bin/rake test TEST=test/plugin_helper/test_child_process.rb\n", " 557246 sh -c /usr/bin/ruby2.7 -w -I\"lib:test\" -Eascii-8bit:ascii-8bit /home/aho/Projects/Fluentd/fluentd/vendor/bundle/ruby/2.7.0/gems/rake-13.0.3/lib/rake/rake_test_loader.rb \"test/plugin_helper/test_child_process.rb\" \n", " 557247 /usr/bin/ruby2.7 -w -Ilib:test -Eascii-8bit:ascii-8bit /home/aho/Projects/Fluentd/fluentd/vendor/bundle/ruby/2.7.0/gems/rake-13.0.3/lib/rake/rake_test_loader.rb test/plugin_helper/test_child_process.rb\n", " 557554 ruby -e Signal.trap(:TERM, nil); while sleep 0.1; puts 1; STDOUT.flush rescue nil; end\n", " 557858 bash /home/aho/.rbenv/libexec/rbenv-exec ruby -e sleep 10; puts \"hello\"\n", " 557859 ps opid,cmd\n"]
/home/aho/Projects/Fluentd/fluentd/test/plugin_helper/test_child_process.rb:575:in `block (2 levels) in <class:ChildProcessTest>'
     572:         m.lock
     573:         pid = pids.first
     574:         # 16357 sleeeeeeeeeper -e sleep 10; puts "hello"
  => 575:         assert{ proc_lines.select{|line| line =~ /^\s*#{pid}\s/ }.first.strip.split(/\s+/)[1] == "sleeeeeeeeeper" }
     576:         @d.stop; @d.shutdown; @d.close; @d.terminate
     577:       end
     578:     end
/usr/lib/ruby/2.7.0/timeout.rb:95:in `block in timeout'
/usr/lib/ruby/2.7.0/timeout.rb:33:in `block in catch'
/usr/lib/ruby/2.7.0/timeout.rb:33:in `catch'
/usr/lib/ruby/2.7.0/timeout.rb:33:in `catch'
/usr/lib/ruby/2.7.0/timeout.rb:110:in `timeout'
/home/aho/Projects/Fluentd/fluentd/test/plugin_helper/test_child_process.rb:561:in `block in <class:ChildProcessTest>'
```

**Docs Changes**:
none

**Release Note**: 
none
