### PR TITLE
CI: Drop Ruby 2.5

### DIFF
--- a/.github/workflows/linux-test.yaml
+++ b/.github/workflows/linux-test.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['3.0', '2.7', '2.6', '2.5']
+        ruby-version: ['3.0', '2.7', '2.6']
         os: [ubuntu-latest]
         experimental: [false]
         include:

--- a/.github/workflows/windows-test.yaml
+++ b/.github/workflows/windows-test.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.7', '2.6', '2.5']
+        ruby-version: ['2.7', '2.6']
         os:
           - windows-latest
         experimental: [false]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,16 +13,6 @@ stages:
   - build
   - tests
 
-2-5-8:
-  image: "ruby:2.5.8"
-  stage: build
-  extends: .install-template
-  script:
-    - bundle install --jobs=3 --retry=3
-  cache:
-    key: "$CI_COMMIT_REF_SLUG 2-5-8"
-    paths:
-
 2-6-6:
   image: "ruby:2.6.6"
   stage: build
@@ -61,18 +51,6 @@ rubyhead:
     - bundle install --jobs=3 --retry=3
   cache:
     key: "$CI_COMMIT_REF_SLUG latest"
-    paths:
-      - ./*
-
-2-5-8-test:
-  image: "ruby:2.5.8"
-  stage: tests
-  allow_failure: true
-  extends: .test-template
-  script:
-    - bundle exec rake test
-  cache:
-    key: "$CI_COMMIT_REF_SLUG 2-5-8"
     paths:
       - ./*
 


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
none

**What this PR does / why we need it**: 
Ruby 2.5 is already EOL:
https://www.ruby-lang.org/en/news/2021/04/05/ruby-2-5-9-released/

**Docs Changes**:
none

**Release Note**: 
none
