### PR TITLE
Remove too much verbose debug logging

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -993,7 +993,6 @@ module Fluent::Plugin
                     @fifo << data
                     @fifo.read_lines(@lines)
 
-                    @log.debug("reading file: #{@path}")
                     if limit_bytes_per_second_reached? || should_shutdown_now?
                       # Just get out from tailing loop.
                       read_more = false


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

Fixes #3416

**What this PR does / why we need it**: 

By #3185, log throttling per file feature was merged, but
it also introduces too much debug logging code in #handle_notify.

Before:

```ruby
  def handle_notify
     ...
     while true
       ...
       @log.debug("reading file: ...")
       ...
     end
     ...
```

**Docs Changes**:

N/A

**Release Note**: 

N/A