### PR TITLE
Remove duplicated license text

### DIFF
--- a/lib/fluent/plugin/service_discovery.rb
+++ b/lib/fluent/plugin/service_discovery.rb
@@ -13,21 +13,6 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
-#
-# Fluentd
-#
-#    Licensed under the Apache License, Version 2.0 (the "License");
-#    you may not use this file except in compliance with the License.
-#    You may obtain a copy of the License at
-#
-#        http://www.apache.org/licenses/LICENSE-2.0
-#
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS,
-#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#    See the License for the specific language governing permissions and
-#    limitations under the License.
-#
 
 require 'fluent/plugin/base'
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

Fixes N/A

**What this PR does / why we need it**: 

The license text is duplicated in service_discovery.rb

This is introduced by https://github.com/fluent/fluentd/commit/ce870c4a2f8af84d925c15a5c12b79e66e7e6546.
But I guess that it is not intended.

**Docs Changes**:

N/A

**Release Note**: 

N/A
