### PR TITLE
Don't echo back the provided path on a 404 error

### DIFF
--- a/lib/fluent/plugin_helper/http_server/router.rb
+++ b/lib/fluent/plugin_helper/http_server/router.rb
@@ -22,7 +22,7 @@ module Fluent
       class Router
         class NotFoundApp
           def self.call(req)
-            [404, { 'Content-Type' => 'text/plain' }, "404 Not Found: #{req.path}\n"]
+            [404, { 'Content-Type' => 'text/plain' }, "404 Not Found\n"]
           end
         end
 

--- a/test/plugin_helper/http_server/test_route.rb
+++ b/test/plugin_helper/http_server/test_route.rb
@@ -20,7 +20,7 @@ unless skip
       test 'use default app if path is not found' do
         router = Fluent::PluginHelper::HttpServer::Router.new
         req = flexmock('request', path: 'path/')
-        assert_equal(router.route!(:get, '/path/', req), [404, { 'Content-Type' => 'text/plain' }, "404 Not Found: #{req.path}\n"])
+        assert_equal(router.route!(:get, '/path/', req), [404, { 'Content-Type' => 'text/plain' }, "404 Not Found\n"])
       end
 
       test 'default app is configurable' do


### PR DESCRIPTION
I had a security scan flag up a potential XSS vulnerability on the fluentd Prometheus metrics port:

```
The request string used to detect this flaw was :
/cgi-bin/<script>cross_site_scripting.nasl</script>.asp
The output was :
HTTP/1.1 404 Not Found
Content-Type: text/plain
connection: close
content-length: 71
404 Not Found: /cgi-bin/<script>cross_site_scripting.nasl</script>.asp
Note that this XSS attack may only work against web browsers
that have "content sniffing" enabled.
```

This is because `<script>` tags in the URL are echoed back in plaintext.

I don't think this represents a real security vulnerability:
- you're unlikely to be interacting with fluentd in a browser
- the Content-Type is text/plain, so the browser would need to ignore it ("may only work against web browsers that have "content sniffing" enabled")
- even if the attack worked I think you'd only be able to steal information cached in the fluentd browser session, and I suspect it won't set cookies etc.

but I don't think echoing back the path adds much value, so I'd like to just remove it to avoid false positives.

I couldn't see a good way to HTML-escape this without pulling in a new dependency, and I didn't think that was worth doing.

I haven't opened an issue for this, just raised a PR - let me know if I should also raise an issue.