### PR TITLE
formatter: Add a missing fluent/env require

### DIFF
--- a/lib/fluent/command/binlog_reader.rb
+++ b/lib/fluent/command/binlog_reader.rb
@@ -18,7 +18,6 @@ require 'optparse'
 require 'msgpack'
 
 require 'fluent/msgpack_factory'
-require 'fluent/env'
 require 'fluent/formatter'
 require 'fluent/plugin'
 require 'fluent/config/element'

--- a/lib/fluent/command/binlog_reader.rb
+++ b/lib/fluent/command/binlog_reader.rb
@@ -18,6 +18,7 @@ require 'optparse'
 require 'msgpack'
 
 require 'fluent/msgpack_factory'
+require 'fluent/env'
 require 'fluent/formatter'
 require 'fluent/plugin'
 require 'fluent/config/element'

--- a/lib/fluent/plugin/formatter.rb
+++ b/lib/fluent/plugin/formatter.rb
@@ -14,6 +14,7 @@
 #    limitations under the License.
 #
 
+require 'fluent/env'
 require 'fluent/plugin/base'
 require 'fluent/plugin/owned_by_mixin'
 require 'fluent/time'


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 
I got a following error when I use to `binlog_reader`:

```
`<module:Mixin>': undefined method `windows?' for Fluent:Module (NoMethodError)
```

**Docs Changes**:
No needed.
**Release Note**: 

Same as title.