### PR TITLE
fluent-plugin-generate: fix crash bug without bundler

### DIFF
--- a/lib/fluent/command/plugin_generator.rb
+++ b/lib/fluent/command/plugin_generator.rb
@@ -164,8 +164,13 @@ BANNER
   end
 
   def locked_gem_version(gem_name)
-    d = Bundler::Definition.build(gem_file_path, lock_file_path, false)
-    d.locked_gems.dependencies[gem_name].requirement.requirements.first.last.version
+    if File.exist?(lock_file_path)
+      d = Bundler::Definition.build(gem_file_path, lock_file_path, false)
+      d.locked_gems.dependencies[gem_name].requirement.requirements.first.last.version
+    else
+      # fallback even though Fluentd is installed without bundler
+      Gem::Specification.find_by_name(gem_name).version.version
+    end
   end
 
   def rake_version
@@ -177,8 +182,13 @@ BANNER
   end
 
   def bundler_version
-    d = Bundler::Definition.build(gem_file_path, lock_file_path, false)
-    d.locked_gems.bundler_version.version
+    if File.exist?(lock_file_path)
+      d = Bundler::Definition.build(gem_file_path, lock_file_path, false)
+      d.locked_gems.bundler_version.version
+    else
+      # fallback even though Fluentd is installed without bundler
+      Gem::Specification.find_by_name("bundler").version.version
+    end
   end
 
   def class_name


### PR DESCRIPTION

**Which issue(s) this PR fixes**: 

Fixes #3442

**What this PR does / why we need it**: 

In the previous versions, it expected that Fluentd is installed
via bundler, thus it assumes that Gemfile.lock exists.

It is not always true because it may be installed via gem command.
In such a case, we use Gem::Specification.find_by_gem (Gem::Version)
as a fallback.

**Docs Changes**:

N/A

**Release Note**: 

N/A
