### PR TITLE
WindowsFile: Add testing for DeletePending

### DIFF
--- a/test/plugin/test_file_wrapper.rb
+++ b/test/plugin/test_file_wrapper.rb
@@ -96,6 +96,17 @@ class FileWrapperTest < Test::Unit::TestCase
       end
     end
 
+    test 'Errno::ENOENT raised on DeletePending' do
+      path = "#{TMP_DIR}/deletepending.txt"
+      file = Fluent::WindowsFile.new(path, mode='w')
+      File.delete(path)
+      assert_raise(Errno::ENOENT) do
+        file.stat
+      ensure
+        file.close if file
+      end
+    end
+
     test 'ERROR_SHARING_VIOLATION raised' do
       begin
         path = "#{TMP_DIR}/test_windows_file.txt"


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

Ammend #3457

**What this PR does / why we need it**: 

I think I found a way to add testing for the changeset f61c08ca.

 1. Create a test file with FILE_SHARE_DELETE mode.
 2. Call `DeleteFile()` on that file.
 3. Call `WindowsFile.stat()` on that file.
 4. Check if ENOENT is raised after step 3.

Confirmed to work fine on GitHub Action:

    WindowsFile exceptions:
     test: ERROR_SHARING_VIOLATION raised:        .: (0.001220)
     test: Errno::ENOENT raised:                  .: (0.000633)
     test: Errno::ENOENT raised on DeletePending: .: (0.000717)
     test: nothing raised:                        .: (0.000835)

**Docs Changes**:

Not required.

**Release Note**: 

Not required.