### PR TITLE
Filter plugin records count and record size metrics

### DIFF
--- a/lib/fluent/plugin/filter.rb
+++ b/lib/fluent/plugin/filter.rb
@@ -38,6 +38,13 @@ module Fluent
         @emit_records = 0
         @emit_size = 0
         @counter_mutex = Mutex.new
+        @enable_size_metrics = false
+      end
+
+      def configure(conf)
+        super
+
+        @enable_size_metrics = !!system_config.enable_size_metrics
       end
 
       def statistics
@@ -52,7 +59,7 @@ module Fluent
       def measure_metrics(es)
         @counter_mutex.synchronize do
           @emit_records += es.size
-          @emit_size += es.to_msgpack_stream.bytesize
+          @emit_size += es.to_msgpack_stream.bytesize if @enable_size_metrics
         end
       end
 

--- a/lib/fluent/plugin/filter.rb
+++ b/lib/fluent/plugin/filter.rb
@@ -35,6 +35,25 @@ module Fluent
       def initialize
         super
         @has_filter_with_time = has_filter_with_time?
+        @emit_records = 0
+        @emit_size = 0
+        @counter_mutex = Mutex.new
+      end
+
+      def statistics
+        stats = {
+          'emit_records' => @emit_records,
+          'emit_size' => @emit_size,
+        }
+
+        { 'filter' => stats }
+      end
+
+      def measure_metrics(es)
+        @counter_mutex.synchronize do
+          @emit_records += es.size
+          @emit_size += es.to_msgpack_stream.bytesize
+        end
       end
 
       def filter(tag, time, record)

--- a/lib/fluent/plugin/in_monitor_agent.rb
+++ b/lib/fluent/plugin/in_monitor_agent.rb
@@ -336,6 +336,7 @@ module Fluent::Plugin
 
       if pe.respond_to?(:statistics)
         obj.merge!(pe.statistics.dig('output') || {})
+        obj.merge!(pe.statistics.dig('filter') || {})
         obj.merge!(pe.statistics.dig('input') || {})
       end
 

--- a/test/plugin/test_in_monitor_agent.rb
+++ b/test/plugin/test_in_monitor_agent.rb
@@ -144,6 +144,7 @@ EOC
         tag test.monitor
         emit_interval 1
 CONF
+      @ra.inputs.first.context_router.emit("test.event", Fluent::Engine.now, {"message":"ok"})
       d = MetricInputDriver.new(Fluent::Plugin::MonitorAgentInput).configure(monitor_agent_conf)
       d.run(expect_emits: 1, timeout: 3)
 
@@ -164,7 +165,9 @@ CONF
         "plugin_category" => "filter",
         "plugin_id"       => "test_filter",
         "retry_count"     => nil,
-        "type"            => "test_filter"
+        "type"            => "test_filter",
+        "emit_records"   => Integer,
+        "emit_size"      => Integer,
       }
       filter_info.merge!("config" => {"@id" => "test_filter", "@type" => "test_filter"}) if with_config
       output_info = {
@@ -213,7 +216,12 @@ CONF
         "emit_records" => Integer,
         "emit_size" => Integer,
       }
+      filter_statistics_info = {
+        "emit_records" => Integer,
+        "emit_size" => Integer,
+      }
       assert_fuzzy_equal(monitor_agent_emit_info, d.instance.statistics["input"])
+      assert_fuzzy_equal(filter_statistics_info, @ra.filters.first.statistics["filter"])
     end
   end
 
@@ -296,7 +304,9 @@ EOC
         "plugin_category" => "filter",
         "plugin_id"       => "test_filter",
         "retry_count"     => nil,
-        "type"            => "test_filter"
+        "type"            => "test_filter",
+        "emit_records"   => 0,
+        "emit_size"      => 0,
       }
       filter_info.merge!("config" => {"@id" => "test_filter", "@type" => "test_filter"}) if with_config
       output_info = {
@@ -510,7 +520,7 @@ EOC
       expected_test_in_response = "\
 plugin_id:test_in\tplugin_category:input\ttype:test_in\toutput_plugin:false\tretry_count:\temit_records:0\temit_size:0"
       expected_test_filter_response = "\
-plugin_id:test_filter\tplugin_category:filter\ttype:test_filter\toutput_plugin:false\tretry_count:"
+plugin_id:test_filter\tplugin_category:filter\ttype:test_filter\toutput_plugin:false\tretry_count:\temit_records:0\temit_size:0"
 
       response = get("http://127.0.0.1:#{@port}/api/plugins").body
       test_in = response.split("\n")[0]


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 
Currently, Fluentd filter metrics do not have emit size and emitted record counts for calculating flow rate (per sec or per hour).
Fluentd filter should have emit_records and emit_size metrics.

But, currently, I disabled size metrics by default for performance concerns.

**Docs Changes**:
Needed.

**Release Note**: 
Same as title.