### PR TITLE
metrics: metrics_local: Remove key argument to optimize performance

### DIFF
--- a/lib/fluent/plugin/metrics.rb
+++ b/lib/fluent/plugin/metrics.rb
@@ -67,27 +67,27 @@ module Fluent
         # This API is for cmetrics type.
       end
 
-      def get(key)
+      def get
         raise NotImplementedError, "Implement this method in child class"
       end
 
-      def inc(key)
+      def inc
         raise NotImplementedError, "Implement this method in child class"
       end
 
-      def dec(key)
+      def dec
         raise NotImplementedError, "Implement this method in child class"
       end
 
-      def add(key, value)
+      def add(value)
         raise NotImplementedError, "Implement this method in child class"
       end
 
-      def sub(key, value)
+      def sub(value)
         raise NotImplementedError, "Implement this method in child class"
       end
 
-      def set(key, value)
+      def set(value)
         raise NotImplementedError, "Implement this method in child class"
       end
 

--- a/lib/fluent/plugin/metrics_local.rb
+++ b/lib/fluent/plugin/metrics_local.rb
@@ -24,7 +24,7 @@ module Fluent
 
       def initialize
         super
-        @store = Hash.new(0)
+        @store = 0
         @monitor = Monitor.new
       end
 
@@ -48,47 +48,47 @@ module Fluent
         true
       end
 
-      def get(key)
+      def get
         @monitor.synchronize do
-          @store[key.to_s]
+          @store
         end
       end
 
-      def inc(key)
+      def inc
         @monitor.synchronize do
-          @store[key.to_s] += 1
+          @store += 1
         end
       end
 
-      def dec_gauge(key)
+      def dec_gauge
         @monitor.synchronize do
-          @store[key.to_s] -= 1
+          @store -= 1
         end
       end
 
-      def add(key, value)
+      def add(value)
         @monitor.synchronize do
-          @store[key.to_s] += value
+          @store += value
         end
       end
 
-      def sub_gauge(key, value)
+      def sub_gauge(value)
         @monitor.synchronize do
-          @store[key.to_s] -= value
+          @store -= value
         end
       end
 
-      def set_counter(key, value)
-        return if @store[key.to_s] > value
+      def set_counter(value)
+        return if @store > value
 
         @monitor.synchronize do
-          @store[key.to_s] = value
+          @store = value
         end
       end
 
-      def set_gauge(key, value)
+      def set_gauge(value)
         @monitor.synchronize do
-          @store[key.to_s] = value
+          @store = value
         end
       end
     end

--- a/test/plugin/test_metrics.rb
+++ b/test/plugin/test_metrics.rb
@@ -21,22 +21,22 @@ class BasicCounterMetrics < Fluent::Plugin::Metrics
 
   def initialize
     super
-    @data = Hash.new(0)
+    @data = 0
   end
-  def get(key)
-    @data[key.to_s]
+  def get
+    @data
   end
-  def inc(key)
-    @data[key.to_s] +=1
+  def inc
+    @data +=1
   end
-  def add(key, value)
-    @data[key.to_s] += value
+  def add(value)
+    @data += value
   end
-  def set(key, value)
-    @data[key.to_s] = value
+  def set(value)
+    @data = value
   end
   def close
-    @data = {}
+    @data = 0
     super
   end
 end
@@ -48,7 +48,7 @@ class AliasedCounterMetrics < Fluent::Plugin::Metrics
 
   def initialize
     super
-    @data = Hash.new(0)
+    @data = 0
   end
   def configure(conf)
     super
@@ -56,20 +56,20 @@ class AliasedCounterMetrics < Fluent::Plugin::Metrics
       alias_method :set, :set_counter
     end
   end
-  def get(key)
-    @data[key.to_s]
+  def get
+    @data
   end
-  def inc(key)
-    @data[key.to_s] +=1
+  def inc
+    @data +=1
   end
-  def add(key, value)
-    @data[key.to_s] += value
+  def add(value)
+    @data += value
   end
-  def set_counter(key, value)
-    @data[key.to_s] = value
+  def set_counter(value)
+    @data = value
   end
   def close
-    @data = {}
+    @data = 0
     super
   end
 end
@@ -81,28 +81,28 @@ class BasicGaugeMetrics < Fluent::Plugin::Metrics
 
   def initialize
     super
-    @data = Hash.new(0)
+    @data = 0
   end
-  def get(key)
-    @data[key.to_s]
+  def get
+    @data
   end
-  def inc(key)
-    @data[key.to_s] +=1
+  def inc
+    @data +=1
   end
-  def dec(key)
-    @data[key.to_s] -=1
+  def dec
+    @data -=1
   end
-  def add(key, value)
-    @data[key.to_s] += value
+  def add(value)
+    @data += value
   end
-  def sub(key, value)
-    @data[key.to_s] -= value
+  def sub(value)
+    @data -= value
   end
-  def set(key, value)
-    @data[key.to_s] = value
+  def set(value)
+    @data = value
   end
   def close
-    @data = {}
+    @data = 0
     super
   end
 end
@@ -114,7 +114,7 @@ class AliasedGaugeMetrics < Fluent::Plugin::Metrics
 
   def initialize
     super
-    @data = Hash.new(0)
+    @data = 0
   end
   def configure(conf)
     super
@@ -124,26 +124,26 @@ class AliasedGaugeMetrics < Fluent::Plugin::Metrics
       alias_method :sub, :sub_gauge
     end
   end
-  def get(key)
-    @data[key.to_s]
+  def get
+    @data
   end
-  def inc(key)
-    @data[key.to_s] +=1
+  def inc
+    @data +=1
   end
-  def dec_gauge(key)
-    @data[key.to_s] -=1
+  def dec_gauge
+    @data -=1
   end
-  def add(key, value)
-    @data[key.to_s] += value
+  def add(value)
+    @data += value
   end
-  def sub_gauge(key, value)
-    @data[key.to_s] -= value
+  def sub_gauge(value)
+    @data -= value
   end
-  def set_gauge(key, value)
-    @data[key.to_s] = value
+  def set_gauge(value)
+    @data = value
   end
   def close
-    @data = {}
+    @data = 0
     super
   end
 end
@@ -166,22 +166,22 @@ class StorageTest < Test::Unit::TestCase
 
     test 'all bare operations are not defined yet' do
       assert_raise NotImplementedError do
-        @m.get('key')
+        @m.get
       end
       assert_raise NotImplementedError do
-        @m.inc('key')
+        @m.inc
       end
       assert_raise NotImplementedError do
-        @m.dec('key')
+        @m.dec
       end
       assert_raise NotImplementedError do
-        @m.add('key', 10)
+        @m.add(10)
       end
       assert_raise NotImplementedError do
-        @m.sub('key', 11)
+        @m.sub(11)
       end
       assert_raise NotImplementedError do
-        @m.set('key', 123)
+        @m.set(123)
       end
     end
   end
@@ -196,19 +196,19 @@ class StorageTest < Test::Unit::TestCase
       assert_true @m.has_methods_for_counter
       assert_false @m.has_methods_for_gauge
 
-      assert_equal 0, @m.get('key')
-      assert_equal 1, @m.inc('key')
+      assert_equal 0, @m.get
+      assert_equal 1, @m.inc
 
-      @m.add('key', 20)
-      assert_equal 21, @m.get('key')
+      @m.add(20)
+      assert_equal 21, @m.get
       assert_raise NotImplementedError do
-        @m.dec('key')
+        @m.dec
       end
 
-      @m.set('key', 100)
-      assert_equal 100, @m.get('key')
+      @m.set(100)
+      assert_equal 100, @m.get
       assert_raise NotImplementedError do
-        @m.sub('key', 11)
+        @m.sub(11)
       end
     end
   end
@@ -223,19 +223,19 @@ class StorageTest < Test::Unit::TestCase
       assert_true @m.has_methods_for_counter
       assert_false @m.has_methods_for_gauge
 
-      assert_equal 0, @m.get('key')
-      assert_equal 1, @m.inc('key')
+      assert_equal 0, @m.get
+      assert_equal 1, @m.inc
 
-      @m.add('key', 20)
-      assert_equal 21, @m.get('key')
+      @m.add(20)
+      assert_equal 21, @m.get
       assert_raise NotImplementedError do
-        @m.dec('key')
+        @m.dec
       end
 
-      @m.set('key', 100)
-      assert_equal 100, @m.get('key')
+      @m.set(100)
+      assert_equal 100, @m.get
       assert_raise NotImplementedError do
-        @m.sub('key', 11)
+        @m.sub(11)
       end
     end
   end
@@ -251,18 +251,18 @@ class StorageTest < Test::Unit::TestCase
       assert_false @m.has_methods_for_counter
       assert_true @m.has_methods_for_gauge
 
-      assert_equal 0, @m.get('key')
-      assert_equal 1, @m.inc('key')
+      assert_equal 0, @m.get
+      assert_equal 1, @m.inc
 
-      @m.add('key', 20)
-      assert_equal 21, @m.get('key')
-      @m.dec('key')
-      assert_equal 20, @m.get('key')
+      @m.add(20)
+      assert_equal 21, @m.get
+      @m.dec
+      assert_equal 20, @m.get
 
-      @m.set('key', 100)
-      assert_equal 100, @m.get('key')
-      @m.sub('key', 11)
-      assert_equal 89, @m.get('key')
+      @m.set(100)
+      assert_equal 100, @m.get
+      @m.sub(11)
+      assert_equal 89, @m.get
     end
   end
 
@@ -277,18 +277,18 @@ class StorageTest < Test::Unit::TestCase
       assert_false @m.has_methods_for_counter
       assert_true @m.has_methods_for_gauge
 
-      assert_equal 0, @m.get('key')
-      assert_equal 1, @m.inc('key')
+      assert_equal 0, @m.get
+      assert_equal 1, @m.inc
 
-      @m.add('key', 20)
-      assert_equal 21, @m.get('key')
-      @m.dec('key')
-      assert_equal 20, @m.get('key')
+      @m.add(20)
+      assert_equal 21, @m.get
+      @m.dec
+      assert_equal 20, @m.get
 
-      @m.set('key', 100)
-      assert_equal 100, @m.get('key')
-      @m.sub('key', 11)
-      assert_equal 89, @m.get('key')
+      @m.set(100)
+      assert_equal 100, @m.get
+      @m.sub(11)
+      assert_equal 89, @m.get
     end
   end
 end

--- a/test/plugin/test_metrics_local.rb
+++ b/test/plugin/test_metrics_local.rb
@@ -41,22 +41,22 @@ class LocalMetricsTest < ::Test::Unit::TestCase
       end
 
       test 'all local counter operations work well' do
-        assert_equal 0, @m.get('key')
-        assert_equal 1, @m.inc('key')
+        assert_equal 0, @m.get
+        assert_equal 1, @m.inc
 
-        @m.add('key', 20)
-        assert_equal 21, @m.get('key')
+        @m.add(20)
+        assert_equal 21, @m.get
         assert_raise NotImplementedError do
-          @m.dec('key')
+          @m.dec
         end
 
-        @m.set('key', 100)
-        assert_equal 100, @m.get('key')
+        @m.set(100)
+        assert_equal 100, @m.get
 
-        @m.set('key', 10)
-        assert_equal 100, @m.get('key') # On counter, value should be overwritten bigger than stored one.
+        @m.set(10)
+        assert_equal 100, @m.get # On counter, value should be overwritten bigger than stored one.
         assert_raise NotImplementedError do
-          @m.sub('key', 11)
+          @m.sub(11)
         end
       end
     end
@@ -74,22 +74,22 @@ class LocalMetricsTest < ::Test::Unit::TestCase
       end
 
       test 'all local gauge operations work well' do
-        assert_equal 0, @m.get('key')
-        assert_equal 1, @m.inc('key')
+        assert_equal 0, @m.get
+        assert_equal 1, @m.inc
 
-        @m.add('key', 20)
-        assert_equal 21, @m.get('key')
-        @m.dec('key')
-        assert_equal 20, @m.get('key')
+        @m.add(20)
+        assert_equal 21, @m.get
+        @m.dec
+        assert_equal 20, @m.get
 
-        @m.set('key', 100)
-        assert_equal 100, @m.get('key')
+        @m.set(100)
+        assert_equal 100, @m.get
 
-        @m.sub('key', 11)
-        assert_equal 89, @m.get('key')
+        @m.sub(11)
+        assert_equal 89, @m.get
 
-        @m.set('key', 10)
-        assert_equal 10, @m.get('key') # On gauge, value always should be overwritten.
+        @m.set(10)
+        assert_equal 10, @m.get # On gauge, value always should be overwritten.
       end
     end
   end


### PR DESCRIPTION


Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Folows up #3440 

**What this PR does / why we need it**: 
This is because our use cases doesn't need key for distinguish plugins
and agents.
One of the use cases to specify plugin_id calling has a possibility to become the bottleneck for performance.
The reason is Kernel#instance_variable_defined? method is relatively
heavy operation.

**Docs Changes**:

No needed.

**Release Note**: 

Same as title.