### PR TITLE
in_syslog: Add send_keepalive_packet option as same as in_forward

### DIFF
--- a/lib/fluent/plugin/in_syslog.rb
+++ b/lib/fluent/plugin/in_syslog.rb
@@ -89,6 +89,8 @@ module Fluent::Plugin
     config_param :source_hostname_key, :string, default: nil
     desc 'Try to resolve hostname from IP addresses or not.'
     config_param :resolve_hostname, :bool, default: nil
+    desc 'Check the remote connection is still available by sending a keepalive packet if this value is true.'
+    config_param :send_keepalive_packet, :bool, default: false
     desc 'The field name of source address of sender.'
     config_param :source_address_key, :string, default: nil
     desc 'The field name of the severity.'
@@ -143,6 +145,11 @@ module Fluent::Plugin
       end
 
       @_event_loop_run_timeout = @blocking_timeout
+
+      protocol = @protocol_type || @transport_config.protocol
+      if @send_keepalive_packet && protocol == :udp
+        raise Fluent::ConfigError, "send_keepalive_packet is available for tcp/tls"
+      end
     end
 
     def multi_workers_ready?
@@ -173,7 +180,12 @@ module Fluent::Plugin
 
       delimiter = octet_count_frame ? " " : @delimiter
       delimiter_size = delimiter.size
-      server_create_connection(tls ? :in_syslog_tls_server : :in_syslog_tcp_server, @port, bind: @bind, resolve_name: @resolve_hostname) do |conn|
+      server_create_connection(
+        tls ? :in_syslog_tls_server : :in_syslog_tcp_server, @port,
+        bind: @bind,
+        resolve_name: @resolve_hostname,
+        send_keepalive_packet: @send_keepalive_packet,
+      ) do |conn|
         conn.data do |data|
           buffer = conn.buffer
           buffer << data

--- a/lib/fluent/plugin/in_syslog.rb
+++ b/lib/fluent/plugin/in_syslog.rb
@@ -184,7 +184,7 @@ module Fluent::Plugin
         tls ? :in_syslog_tls_server : :in_syslog_tcp_server, @port,
         bind: @bind,
         resolve_name: @resolve_hostname,
-        send_keepalive_packet: @send_keepalive_packet,
+        send_keepalive_packet: @send_keepalive_packet
       ) do |conn|
         conn.data do |data|
           buffer = conn.buffer


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #3472

**What this PR does / why we need it**: 
TCP keepalive should be supported by in_syslog to avoid dead connection, as same as in_forward

**Docs Changes**:
`send_keepalive_packet` should be added to https://docs.fluentd.org/input/syslog

**Release Note**: 
Same with the title