### PR TITLE
in_tail: Fix a regression of retrying unaccessible files

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -1063,7 +1063,7 @@ module Fluent::Plugin
         rescue RangeError
           io.close if io
           raise WatcherSetupError, "seek error with #{@path}: file position = #{@watcher.pe.read_pos.to_s(16)}, reading bytesize = #{@fifo.bytesize.to_s(16)}"
-        rescue Errno::ENOENT, Errno::EACCES
+        rescue Errno::ENOENT
           nil
         end
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None.
Follow up of #3378

**What this PR does / why we need it**: 
When a fluentd proccess doesn't have permision to read a file, it should
retry to open it again. But the current implementation doesn't do it due
to a bug introduced at #3378. This pull request intend to rescue EACCESS
on stat(2) but it also rescue it on open(2) wrongly.

**Docs Changes**:
None

**Release Note**: 
Same with the title.
