### PR TITLE
buffer: Use metrics plugin mechanism on a plugin base class

### DIFF
--- a/lib/fluent/plugin_helper/metrics.rb
+++ b/lib/fluent/plugin_helper/metrics.rb
@@ -42,7 +42,11 @@ module Fluent
         @plugin_type_or_id = if self.plugin_id_configured?
                                self.plugin_id
                              else
-                               "#{conf["@type"] || conf["type"]}.#{self.plugin_id}"
+                               if type = (conf["@type"] || conf["type"])
+                                 "#{type}.#{self.plugin_id}"
+                               else
+                                 "#{self.class.to_s.split("::").last.downcase}.#{self.plugin_id}"
+                               end
                              end
       end
 

--- a/test/plugin/test_buffer.rb
+++ b/test/plugin/test_buffer.rb
@@ -238,8 +238,14 @@ class BufferTest < Test::Unit::TestCase
       assert_nil @p.queue
       assert_nil @p.dequeued
       assert_nil @p.queued_num
-      assert_equal 0, @p.stage_size
-      assert_equal 0, @p.queue_size
+      assert_nil @p.stage_length_metrics
+      assert_nil @p.stage_size_metrics
+      assert_nil @p.queue_length_metrics
+      assert_nil @p.queue_size_metrics
+      assert_nil @p.available_buffer_space_ratios_metrics
+      assert_nil @p.total_queued_size_metrics
+      assert_nil @p.newest_timekey_metrics
+      assert_nil @p.oldest_timekey_metrics
       assert_equal [], @p.timekeys
     end
 

--- a/test/plugin_helper/test_metrics.rb
+++ b/test/plugin_helper/test_metrics.rb
@@ -39,15 +39,21 @@ class MetricsTest < Test::Unit::TestCase
 
   test 'creates metrics instances' do
     d = Dummy.new
-    d.configure(config_element())
     i = d.metrics_create(namespace: "fluentd_test", subsystem: "unit-test", name: "metrics1", help_text: "metrics testing")
+    d.configure(config_element())
+    assert do
+      d.instance_variable_get(:@plugin_type_or_id).include?("dummy.object")
+    end
     assert{ i.is_a?(Fluent::Plugin::LocalMetrics) }
     assert_true i.has_methods_for_counter
     assert_false i.has_methods_for_gauge
 
     d = Dummy.new
-    d.configure(config_element())
     i = d.metrics_create(namespace: "fluentd_test", subsystem: "unit-test", name: "metrics2", help_text: "metrics testing", prefer_gauge: true)
+    d.configure(config_element())
+    assert do
+      d.instance_variable_get(:@plugin_type_or_id).include?("dummy.object")
+    end
     assert{ i.is_a?(Fluent::Plugin::LocalMetrics) }
     assert_false i.has_methods_for_counter
     assert_true i.has_methods_for_gauge
@@ -55,10 +61,13 @@ class MetricsTest < Test::Unit::TestCase
 
   test 'calls lifecycle methods for all plugin instances via owner plugin' do
     @d = d = Dummy.new
-    d.configure(config_element())
     i1 = d.metrics_create(namespace: "fluentd_test", subsystem: "unit-test", name: "metrics1", help_text: "metrics testing")
     i2 = d.metrics_create(namespace: "fluentd_test", subsystem: "unit-test", name: "metrics2", help_text: "metrics testing", prefer_gauge: true)
     i3 = d.metrics_create(namespace: "fluentd_test", subsystem: "unit-test", name: "metrics3", help_text: "metrics testing")
+    d.configure(config_element())
+    assert do
+      d.instance_variable_get(:@plugin_type_or_id).include?("dummy.object")
+    end
     d.start
 
     assert i1.started?


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 
We should add more metrics plugin supported plugin base classes.
With these changes, our cmetrics metrics plugin also can work with Fluentd and Fluentd can handle native metrics to send prometheus format encodable metrics via fluent-plugin-metrics-cmetrics which binds [cmetrics library](https://github.com/calyptia/cmetrics).

Almost metrics plugin support will be handled in `#statistics` methods. So, it won't be caused significant performance degradation.

**Docs Changes**:
Needed.

**Release Note**: 

Same as title.