### PR TITLE
in_http: Fix default value of cors_allow_credentials

### DIFF
--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -75,7 +75,7 @@ module Fluent::Plugin
     desc 'Set a allow list of domains that can do CORS (Cross-Origin Resource Sharing)'
     config_param :cors_allow_origins, :array, default: nil
     desc 'Tells browsers whether to expose the response to frontend when the credentials mode is "include".'
-    config_param :cors_allow_credentials, :bool, default: nil
+    config_param :cors_allow_credentials, :bool, default: false
     desc 'Respond with empty gif image of 1x1 pixel.'
     config_param :respond_with_empty_img, :bool, default: false
     desc 'Respond status code with 204.'


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Follow up for #3481

**What this PR does / why we need it**: 
There is no reason I chose the default value `nil` for `cors_allow_credentials` at #3481.
It should be `false`.

**Docs Changes**:
none

**Release Note**: 
none
