### PR TITLE
in_tail: Add missing nil check in IOHandler#eof?

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -762,7 +762,7 @@ module Fluent::Plugin
       end
 
       def eof?
-        @io_handler.eof?
+        @io_handler.nil? || @io_handler.eof?
       end
 
       def on_notify
@@ -1110,6 +1110,10 @@ module Fluent::Plugin
 
         def opened?
           false
+        end
+
+        def eof?
+          true
         end
       end
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #3499
Follow up for #3390

**What this PR does / why we need it**: 
`nil` check is lacked in IOHandler#eof?
In addition, `NullIOHandler` doesn't have `eof?`.

**Docs Changes**:
None

**Release Note**: 
Same with the title