### PR TITLE
out_forward: Include node statictics information correctly

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -419,7 +419,7 @@ module Fluent::Plugin
       stats = super
       services = service_discovery_services
       healthy_nodes_count = 0
-      registed_nodes_count = services.size
+      registered_nodes_count = services.size
       services.each do |s|
         if s.available?
           healthy_nodes_count += 1
@@ -427,8 +427,10 @@ module Fluent::Plugin
       end
 
       stats.merge(
-        'healthy_nodes_count' => healthy_nodes_count,
-        'registered_nodes_count' => registed_nodes_count,
+        'output' => {
+          'healthy_nodes_count' => healthy_nodes_count,
+          'registered_nodes_count' => registered_nodes_count,
+        },
       )
     end
 


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
None.

**What this PR does / why we need it**: 
In monitor_agent, it assumes output plugin metrics are put in under `output` branch.
With current implementation, they will be ignored on retrieving with https://github.com/fluent/fluentd/blob/master/lib/fluent/plugin/in_monitor_agent.rb#L338

**Docs Changes**:
No needed.

**Release Note**: 
Same as title.