### PR TITLE
in_tail: Implement file metrics

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -678,14 +678,12 @@ module Fluent::Plugin
 
     def statistics
       stats = super
-      opened_file_count = @metrics.opened.get
-      closed_file_count = @metrics.closed.get
-      rotated_file_count = @metrics.rotated.get
+
       stats = {
         'input' => stats["input"].merge({
-          'opened_file_count' => opened_file_count,
-          'closed_file_count' => closed_file_count,
-          'rotated_file_count' => rotated_file_count,
+          'opened_file_count' => @metrics.opened.get,
+          'closed_file_count' => @metrics.closed.get,
+          'rotated_file_count' => @metrics.rotated.get,
         })
       }
       stats

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -57,6 +57,9 @@ module Fluent::Plugin
       @pf = nil
       @ignore_list = []
       @shutdown_start_time = nil
+      @total_opened_file_metrics = nil
+      @total_closed_file_metrics = nil
+      @total_rotated_file_metrics = nil
     end
 
     desc 'The paths to read. Multiple paths can be specified, separated by comma.'
@@ -191,6 +194,9 @@ module Fluent::Plugin
           @read_bytes_limit_per_second = min_bytes
         end
       end
+      @total_opened_file_metrics = metrics_create(namespace: "fluentd", subsystem: "input", name: "files_opened_total", help_text: "Total number of opened files")
+      @total_closed_file_metrics = metrics_create(namespace: "fluentd", subsystem: "input", name: "files_closed_total", help_text: "Total number of closed files")
+      @total_rotated_file_metrics = metrics_create(namespace: "fluentd", subsystem: "input", name: "files_rotated_total", help_text: "Total number of rotated files")
     end
 
     def configure_tag
@@ -375,7 +381,7 @@ module Fluent::Plugin
 
     def setup_watcher(target_info, pe)
       line_buffer_timer_flusher = @multiline_mode ? TailWatcher::LineBufferTimerFlusher.new(log, @multiline_flush_interval, &method(:flush_buffer)) : nil
-      tw = TailWatcher.new(target_info, pe, log, @read_from_head, @follow_inodes, method(:update_watcher), line_buffer_timer_flusher, method(:io_handler))
+      tw = TailWatcher.new(target_info, pe, log, @read_from_head, @follow_inodes, method(:update_watcher), line_buffer_timer_flusher, method(:io_handler), @total_rotated_file_metrics)
 
       if @enable_watch_timer
         tt = TimerTrigger.new(1, log) { tw.on_notify }
@@ -670,6 +676,21 @@ module Fluent::Plugin
       es
     end
 
+    def statistics
+      stats = super
+      opened_file_count = @total_opened_file_metrics.get
+      closed_file_count = @total_closed_file_metrics.get
+      rotated_file_count = @total_rotated_file_metrics.get
+      stats = {
+        'input' => stats["input"].merge({
+          'opened_file_count' => opened_file_count,
+          'closed_file_count' => closed_file_count,
+          'rotated_file_count' => rotated_file_count,
+        })
+      }
+      stats
+    end
+
     private
 
     def io_handler(watcher, path)
@@ -682,6 +703,8 @@ module Fluent::Plugin
         open_on_every_update: @open_on_every_update,
         from_encoding: @from_encoding,
         encoding: @encoding,
+        total_opened_file_metrics: @total_opened_file_metrics,
+        total_closed_file_metrics: @total_closed_file_metrics,
         &method(:receive_lines)
       )
     end
@@ -717,7 +740,7 @@ module Fluent::Plugin
     end
 
     class TailWatcher
-      def initialize(target_info, pe, log, read_from_head, follow_inodes, update_watcher, line_buffer_timer_flusher, io_handler_build)
+      def initialize(target_info, pe, log, read_from_head, follow_inodes, update_watcher, line_buffer_timer_flusher, io_handler_build, total_file_rotate_metrics)
         @path = target_info.path
         @ino = target_info.ino
         @pe = pe || MemoryPositionEntry.new
@@ -729,6 +752,7 @@ module Fluent::Plugin
         @line_buffer_timer_flusher = line_buffer_timer_flusher
         @io_handler = nil
         @io_handler_build = io_handler_build
+        @total_file_rotate_metrics = total_file_rotate_metrics
         @watchers = []
       end
 
@@ -855,6 +879,7 @@ module Fluent::Plugin
             @log.info "detected rotation of #{@path}"
             @io_handler = io_handler
           end
+          @total_file_rotate_metrics.inc
         end
       end
 
@@ -934,7 +959,7 @@ module Fluent::Plugin
 
         attr_accessor :shutdown_timeout
 
-        def initialize(watcher, path:, read_lines_limit:, read_bytes_limit_per_second:, log:, open_on_every_update:, from_encoding: nil, encoding: nil, &receive_lines)
+        def initialize(watcher, path:, read_lines_limit:, read_bytes_limit_per_second:, log:, open_on_every_update:, from_encoding: nil, encoding: nil, total_opened_file_metrics:, total_closed_file_metrics:, &receive_lines)
           @watcher = watcher
           @path = path
           @read_lines_limit = read_lines_limit
@@ -953,6 +978,8 @@ module Fluent::Plugin
           @shutdown_timeout = SHUTDOWN_TIMEOUT
           @shutdown_mutex = Mutex.new
           @eof = false
+          @total_opened_file_metrics = total_opened_file_metrics
+          @total_closed_file_metrics = total_closed_file_metrics
 
           @log.info "following tail of #{@path}"
         end
@@ -972,6 +999,7 @@ module Fluent::Plugin
           if @io && !@io.closed?
             @io.close
             @io = nil
+            @total_closed_file_metrics.inc
           end
         end
 
@@ -1059,6 +1087,7 @@ module Fluent::Plugin
         def open
           io = Fluent::FileWrapper.open(@path)
           io.seek(@watcher.pe.read_pos + @fifo.bytesize)
+          @total_opened_file_metrics.inc
           io
         rescue RangeError
           io.close if io

--- a/test/plugin/in_tail/test_io_handler.rb
+++ b/test/plugin/in_tail/test_io_handler.rb
@@ -7,10 +7,13 @@ require 'tempfile'
 class IntailIOHandlerTest < Test::Unit::TestCase
   setup do
     @file = Tempfile.new('intail_io_handler').binmode
-    @total_opened_file_metrics = Fluent::Plugin::LocalMetrics.new
-    @total_opened_file_metrics.configure(config_element('metrics', '', {}))
-    @total_closed_file_metrics = Fluent::Plugin::LocalMetrics.new
-    @total_closed_file_metrics.configure(config_element('metrics', '', {}))
+    opened_file_metrics = Fluent::Plugin::LocalMetrics.new
+    opened_file_metrics.configure(config_element('metrics', '', {}))
+    closed_file_metrics = Fluent::Plugin::LocalMetrics.new
+    closed_file_metrics.configure(config_element('metrics', '', {}))
+    rotated_file_metrics = Fluent::Plugin::LocalMetrics.new
+    rotated_file_metrics.configure(config_element('metrics', '', {}))
+    @metrics = Fluent::Plugin::TailInput::MetricsInfo.new(opened_file_metrics, closed_file_metrics, rotated_file_metrics)
   end
 
   teardown do
@@ -35,7 +38,7 @@ class IntailIOHandlerTest < Test::Unit::TestCase
     end
 
     returned_lines = ''
-    r = Fluent::Plugin::TailInput::TailWatcher::IOHandler.new(watcher, path: @file.path, read_lines_limit: 100, read_bytes_limit_per_second: -1, log: $log, open_on_every_update: false, total_opened_file_metrics: @total_opened_file_metrics, total_closed_file_metrics: @total_closed_file_metrics) do |lines, _watcher|
+    r = Fluent::Plugin::TailInput::TailWatcher::IOHandler.new(watcher, path: @file.path, read_lines_limit: 100, read_bytes_limit_per_second: -1, log: $log, open_on_every_update: false, metrics: @metrics) do |lines, _watcher|
       returned_lines << lines.join
       true
     end
@@ -67,7 +70,7 @@ class IntailIOHandlerTest < Test::Unit::TestCase
       end
 
       returned_lines = ''
-      r = Fluent::Plugin::TailInput::TailWatcher::IOHandler.new(watcher, path: @file.path, read_lines_limit: 100, read_bytes_limit_per_second: -1, log: $log, open_on_every_update: true, total_opened_file_metrics: @total_opened_file_metrics, total_closed_file_metrics: @total_closed_file_metrics) do |lines, _watcher|
+      r = Fluent::Plugin::TailInput::TailWatcher::IOHandler.new(watcher, path: @file.path, read_lines_limit: 100, read_bytes_limit_per_second: -1, log: $log, open_on_every_update: true, metrics: @metrics) do |lines, _watcher|
         returned_lines << lines.join
         true
       end
@@ -98,7 +101,7 @@ class IntailIOHandlerTest < Test::Unit::TestCase
       end
 
       returned_lines = []
-      r = Fluent::Plugin::TailInput::TailWatcher::IOHandler.new(watcher, path: @file.path, read_lines_limit: 5, read_bytes_limit_per_second: -1, log: $log, open_on_every_update: false, total_opened_file_metrics: @total_opened_file_metrics, total_closed_file_metrics: @total_closed_file_metrics) do |lines, _watcher|
+      r = Fluent::Plugin::TailInput::TailWatcher::IOHandler.new(watcher, path: @file.path, read_lines_limit: 5, read_bytes_limit_per_second: -1, log: $log, open_on_every_update: false, metrics: @metrics) do |lines, _watcher|
         returned_lines << lines.dup
         true
       end
@@ -124,7 +127,7 @@ class IntailIOHandlerTest < Test::Unit::TestCase
       end
 
       returned_lines = []
-      r = Fluent::Plugin::TailInput::TailWatcher::IOHandler.new(watcher, path: @file.path, read_lines_limit: 5, read_bytes_limit_per_second: -1, log: $log, open_on_every_update: false, total_opened_file_metrics: @total_opened_file_metrics, total_closed_file_metrics: @total_closed_file_metrics) do |lines, _watcher|
+      r = Fluent::Plugin::TailInput::TailWatcher::IOHandler.new(watcher, path: @file.path, read_lines_limit: 5, read_bytes_limit_per_second: -1, log: $log, open_on_every_update: false, metrics: @metrics) do |lines, _watcher|
         returned_lines << lines.dup
         true
       end

--- a/test/plugin/in_tail/test_io_handler.rb
+++ b/test/plugin/in_tail/test_io_handler.rb
@@ -1,11 +1,16 @@
 require_relative '../../helper'
 
 require 'fluent/plugin/in_tail'
+require 'fluent/plugin/metrics_local'
 require 'tempfile'
 
 class IntailIOHandlerTest < Test::Unit::TestCase
   setup do
     @file = Tempfile.new('intail_io_handler').binmode
+    @total_opened_file_metrics = Fluent::Plugin::LocalMetrics.new
+    @total_opened_file_metrics.configure(config_element('metrics', '', {}))
+    @total_closed_file_metrics = Fluent::Plugin::LocalMetrics.new
+    @total_closed_file_metrics.configure(config_element('metrics', '', {}))
   end
 
   teardown do
@@ -30,7 +35,7 @@ class IntailIOHandlerTest < Test::Unit::TestCase
     end
 
     returned_lines = ''
-    r = Fluent::Plugin::TailInput::TailWatcher::IOHandler.new(watcher, path: @file.path, read_lines_limit: 100, read_bytes_limit_per_second: -1, log: $log, open_on_every_update: false) do |lines, _watcher|
+    r = Fluent::Plugin::TailInput::TailWatcher::IOHandler.new(watcher, path: @file.path, read_lines_limit: 100, read_bytes_limit_per_second: -1, log: $log, open_on_every_update: false, total_opened_file_metrics: @total_opened_file_metrics, total_closed_file_metrics: @total_closed_file_metrics) do |lines, _watcher|
       returned_lines << lines.join
       true
     end
@@ -62,7 +67,7 @@ class IntailIOHandlerTest < Test::Unit::TestCase
       end
 
       returned_lines = ''
-      r = Fluent::Plugin::TailInput::TailWatcher::IOHandler.new(watcher, path: @file.path, read_lines_limit: 100, read_bytes_limit_per_second: -1, log: $log, open_on_every_update: true) do |lines, _watcher|
+      r = Fluent::Plugin::TailInput::TailWatcher::IOHandler.new(watcher, path: @file.path, read_lines_limit: 100, read_bytes_limit_per_second: -1, log: $log, open_on_every_update: true, total_opened_file_metrics: @total_opened_file_metrics, total_closed_file_metrics: @total_closed_file_metrics) do |lines, _watcher|
         returned_lines << lines.join
         true
       end
@@ -93,7 +98,7 @@ class IntailIOHandlerTest < Test::Unit::TestCase
       end
 
       returned_lines = []
-      r = Fluent::Plugin::TailInput::TailWatcher::IOHandler.new(watcher, path: @file.path, read_lines_limit: 5, read_bytes_limit_per_second: -1, log: $log, open_on_every_update: false) do |lines, _watcher|
+      r = Fluent::Plugin::TailInput::TailWatcher::IOHandler.new(watcher, path: @file.path, read_lines_limit: 5, read_bytes_limit_per_second: -1, log: $log, open_on_every_update: false, total_opened_file_metrics: @total_opened_file_metrics, total_closed_file_metrics: @total_closed_file_metrics) do |lines, _watcher|
         returned_lines << lines.dup
         true
       end
@@ -119,7 +124,7 @@ class IntailIOHandlerTest < Test::Unit::TestCase
       end
 
       returned_lines = []
-      r = Fluent::Plugin::TailInput::TailWatcher::IOHandler.new(watcher, path: @file.path, read_lines_limit: 5, read_bytes_limit_per_second: -1, log: $log, open_on_every_update: false) do |lines, _watcher|
+      r = Fluent::Plugin::TailInput::TailWatcher::IOHandler.new(watcher, path: @file.path, read_lines_limit: 5, read_bytes_limit_per_second: -1, log: $log, open_on_every_update: false, total_opened_file_metrics: @total_opened_file_metrics, total_closed_file_metrics: @total_closed_file_metrics) do |lines, _watcher|
         returned_lines << lines.dup
         true
       end

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -1524,8 +1524,13 @@ class TailInputTest < Test::Unit::TestCase
     plugin.instance_eval do
       @pf = Fluent::Plugin::TailInput::PositionFile.load(sio, EX_FOLLOW_INODES, {}, logger: $log)
       @loop = Coolio::Loop.new
-      @total_rotated_file_metrics = Fluent::Plugin::LocalMetrics.new
-      @total_rotated_file_metrics.configure(config_element('metrics', '', {}))
+      opened_file_metrics = Fluent::Plugin::LocalMetrics.new
+      opened_file_metrics.configure(config_element('metrics', '', {}))
+      closed_file_metrics = Fluent::Plugin::LocalMetrics.new
+      closed_file_metrics.configure(config_element('metrics', '', {}))
+      rotated_file_metrics = Fluent::Plugin::LocalMetrics.new
+      rotated_file_metrics.configure(config_element('metrics', '', {}))
+      @metrics = Fluent::Plugin::TailInput::MetricsInfo.new(opened_file_metrics, closed_file_metrics, rotated_file_metrics)
     end
 
     Timecop.freeze(2010, 1, 2, 3, 4, 5) do
@@ -1888,8 +1893,13 @@ class TailInputTest < Test::Unit::TestCase
 
       d = create_driver(config, false)
       d.instance.instance_eval do
-        @total_rotated_file_metrics = Fluent::Plugin::LocalMetrics.new
-        @total_rotated_file_metrics.configure(config_element('metrics', '', {}))
+        opened_file_metrics = Fluent::Plugin::LocalMetrics.new
+        opened_file_metrics.configure(config_element('metrics', '', {}))
+        closed_file_metrics = Fluent::Plugin::LocalMetrics.new
+        closed_file_metrics.configure(config_element('metrics', '', {}))
+        rotated_file_metrics = Fluent::Plugin::LocalMetrics.new
+        rotated_file_metrics.configure(config_element('metrics', '', {}))
+        @metrics = Fluent::Plugin::TailInput::MetricsInfo.new(opened_file_metrics, closed_file_metrics, rotated_file_metrics)
       end
 
       File.open("#{TMP_DIR}/tail.txt", "wb") {|f|


### PR DESCRIPTION


Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 
* opened file count
* closed file count
* rotated file count

These metrics should be collected same as fluent-bit's in_tail.
They are useful to debug how much Fluentd handles tailing files on in_tail.

**Docs Changes**:
No needed.
**Release Note**: 
Same as title.