### PR TITLE
out_forward: Include before merging stats information correctly

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -426,12 +426,13 @@ module Fluent::Plugin
         end
       end
 
-      stats.merge(
-        'output' => {
+      stats = {
+        'output' => stats["output"].merge({
           'healthy_nodes_count' => healthy_nodes_count,
           'registered_nodes_count' => registered_nodes_count,
-        },
-      )
+        })
+      }
+      stats
     end
 
     # MessagePack FixArray length is 3


### PR DESCRIPTION

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 

Follows up #3503
**What this PR does / why we need it**: 
Hash#merge does not merge within nested values.
They should be handled by hands.

**Docs Changes**:
No needed.
**Release Note**: 
Same as title.