### PR TITLE
out_copy: Suppress a wrong warning for ignore_if_prev_success

### DIFF
--- a/lib/fluent/plugin/out_copy.rb
+++ b/lib/fluent/plugin/out_copy.rb
@@ -46,7 +46,7 @@ module Fluent::Plugin
         @ignore_errors << (store.arg.include?('ignore_error'))
         @ignore_if_prev_successes << (store.arg.include?('ignore_if_prev_success'))
       }
-      if @ignore_errors.uniq.size == 1 && @ignore_errors.include?(true) && @ignore_if_prev_successes.include?(false)
+      if @ignore_errors.uniq.size == 1 && @ignore_errors.include?(true) && !@ignore_if_prev_successes.include?(true)
         log.warn "ignore_errors are specified in all <store>, but ignore_if_prev_success is not specified. Is this intended?"
       end
     end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None.
I found the bug while checking #3508

**What this PR does / why we need it**: 
out_copy outputs a following warning even if a user set `ignore_if_prev_success`:

```
2021-09-24 14:10:54 +0900 [warn]: #0 ignore_errors are specified in all <store>, but ignore_if_prev_success is not specified. Is this intended?
```

This commit fixes it.

**Docs Changes**:
None

**Release Note**: 
Same with the title.