### PR TITLE
config: Use URI.open directly

### DIFF
--- a/lib/fluent/config/parser.rb
+++ b/lib/fluent/config/parser.rb
@@ -93,7 +93,7 @@ module Fluent
           basepath = '/'
           fname = path
           require 'open-uri'
-          open(uri) {|f|
+          URI.open(uri) {|f|
             Parser.new(basepath, f.each_line, fname).parse!(allow_include, nil, attrs, elems)
           }
         end

--- a/lib/fluent/config/v1_parser.rb
+++ b/lib/fluent/config/v1_parser.rb
@@ -172,7 +172,7 @@ module Fluent
           require 'open-uri'
           basepath = '/'
           fname = path
-          data = open(uri) { |f| f.read }
+          data = URI.open(uri) { |f| f.read }
           data.force_encoding('UTF-8')
           ss = StringScanner.new(data)
           V1Parser.new(ss, basepath, fname, @eval_context).parse_element(true, nil, attrs, elems)


### PR DESCRIPTION

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 

URI.open via Kernel#open is already obsoleted on Ruby 3.0.
Otherwise, the following error is occurred when using http or https
scheme URI on `@include` directive:
```aconf
@include "https://raw.githubusercontent.com/fluent/fluentd/master/example/in_forward.conf"
```

```log
bundler: failed to load command: fluentd (~/GitHub/fluentd/vendor/bundle/ruby/3.0.0/bin/fluentd)
~/GitHub/fluentd/lib/fluent/config/v1_parser.rb:175:in `initialize': include error https://raw.githubusercontent.com/fluent/fluentd/master/example/in_forward.conf - No such file or directory @ rb_sysopen - https://raw.githubusercontent.com/fluent/fluentd/master/example/in_forward.conf (Fluent::ConfigParseError)
	from ~/GitHub/fluentd/lib/fluent/config/v1_parser.rb:175:in `open'
	from ~/GitHub/fluentd/lib/fluent/config/v1_parser.rb:175:in `eval_include'
	from ~/GitHub/fluentd/lib/fluent/config/v1_parser.rb:146:in `parse_include'
	from ~/GitHub/fluentd/lib/fluent/config/v1_parser.rb:105:in `parse_element'
	from ~/GitHub/fluentd/lib/fluent/config/v1_parser.rb:44:in `parse!'
	from ~/GitHub/fluentd/lib/fluent/config/v1_parser.rb:33:in `parse'
	from ~/GitHub/fluentd/lib/fluent/config.rb:58:in `parse'
	from ~/GitHub/fluentd/lib/fluent/config.rb:39:in `build'
	from ~/GitHub/fluentd/lib/fluent/supervisor.rb:615:in `initialize'
	from ~/GitHub/fluentd/lib/fluent/command/fluentd.rb:350:in `new'
	from ~/GitHub/fluentd/lib/fluent/command/fluentd.rb:350:in `<top (required)>'
	from ~/GitHub/fluentd/bin/fluentd:15:in `require'
	from ~/GitHub/fluentd/bin/fluentd:15:in `<top (required)>'
	from ~/GitHub/fluentd/vendor/bundle/ruby/3.0.0/bin/fluentd:23:in `load'
	from ~/GitHub/fluentd/vendor/bundle/ruby/3.0.0/bin/fluentd:23:in `<top (required)>'
	from ~/.rbenv/versions/3.0.2/lib/ruby/3.0.0/bundler/cli/exec.rb:63:in `load'
	from ~/.rbenv/versions/3.0.2/lib/ruby/3.0.0/bundler/cli/exec.rb:63:in `kernel_load'
	from ~/.rbenv/versions/3.0.2/lib/ruby/3.0.0/bundler/cli/exec.rb:28:in `run'
	from ~/.rbenv/versions/3.0.2/lib/ruby/3.0.0/bundler/cli.rb:474:in `exec'
	from ~/.rbenv/versions/3.0.2/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	from ~/.rbenv/versions/3.0.2/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from ~/.rbenv/versions/3.0.2/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	from ~/.rbenv/versions/3.0.2/lib/ruby/3.0.0/bundler/cli.rb:30:in `dispatch'
	from ~/.rbenv/versions/3.0.2/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	from ~/.rbenv/versions/3.0.2/lib/ruby/3.0.0/bundler/cli.rb:24:in `start'
	from ~/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/bundler-2.2.22/libexec/bundle:49:in `block in <top (required)>'
	from ~/.rbenv/versions/3.0.2/lib/ruby/3.0.0/bundler/friendly_errors.rb:128:in `with_friendly_errors'
	from ~/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/bundler-2.2.22/libexec/bundle:37:in `<top (required)>'
	from ~/.rbenv/versions/3.0.2/bin/bundle:23:in `load'
	from ~/.rbenv/versions/3.0.2/bin/bundle:23:in `<main>'
~/GitHub/fluentd/lib/fluent/config/v1_parser.rb:175:in `initialize': No such file or directory @ rb_sysopen - https://raw.githubusercontent.com/fluent/fluentd/master/example/in_forward.conf (Errno::ENOENT)
	from ~/GitHub/fluentd/lib/fluent/config/v1_parser.rb:175:in `open'
	from ~/GitHub/fluentd/lib/fluent/config/v1_parser.rb:175:in `eval_include'
	from ~/GitHub/fluentd/lib/fluent/config/v1_parser.rb:146:in `parse_include'
	from ~/GitHub/fluentd/lib/fluent/config/v1_parser.rb:105:in `parse_element'
	from ~/GitHub/fluentd/lib/fluent/config/v1_parser.rb:44:in `parse!'
	from ~/GitHub/fluentd/lib/fluent/config/v1_parser.rb:33:in `parse'
	from ~/GitHub/fluentd/lib/fluent/config.rb:58:in `parse'
	from ~/GitHub/fluentd/lib/fluent/config.rb:39:in `build'
	from ~/GitHub/fluentd/lib/fluent/supervisor.rb:615:in `initialize'
	from ~/GitHub/fluentd/lib/fluent/command/fluentd.rb:350:in `new'
	from ~/GitHub/fluentd/lib/fluent/command/fluentd.rb:350:in `<top (required)>'
	from ~/GitHub/fluentd/bin/fluentd:15:in `require'
	from ~/GitHub/fluentd/bin/fluentd:15:in `<top (required)>'
	from ~/GitHub/fluentd/vendor/bundle/ruby/3.0.0/bin/fluentd:23:in `load'
	from ~/GitHub/fluentd/vendor/bundle/ruby/3.0.0/bin/fluentd:23:in `<top (required)>'
	from ~/.rbenv/versions/3.0.2/lib/ruby/3.0.0/bundler/cli/exec.rb:63:in `load'
	from ~/.rbenv/versions/3.0.2/lib/ruby/3.0.0/bundler/cli/exec.rb:63:in `kernel_load'
	from ~/.rbenv/versions/3.0.2/lib/ruby/3.0.0/bundler/cli/exec.rb:28:in `run'
	from ~/.rbenv/versions/3.0.2/lib/ruby/3.0.0/bundler/cli.rb:474:in `exec'
	from ~/.rbenv/versions/3.0.2/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	from ~/.rbenv/versions/3.0.2/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from ~/.rbenv/versions/3.0.2/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	from ~/.rbenv/versions/3.0.2/lib/ruby/3.0.0/bundler/cli.rb:30:in `dispatch'
	from ~/.rbenv/versions/3.0.2/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	from ~/.rbenv/versions/3.0.2/lib/ruby/3.0.0/bundler/cli.rb:24:in `start'
	from ~/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/bundler-2.2.22/libexec/bundle:49:in `block in <top (required)>'
	from ~/.rbenv/versions/3.0.2/lib/ruby/3.0.0/bundler/friendly_errors.rb:128:in `with_friendly_errors'
	from ~/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/bundler-2.2.22/libexec/bundle:37:in `<top (required)>'
	from ~/.rbenv/versions/3.0.2/bin/bundle:23:in `load'
	from ~/.rbenv/versions/3.0.2/bin/bundle:23:in `<main>'
```

**Docs Changes**:

No needed.

**Release Note**: 

Same as title on Bug fix section.