### PR TITLE
output: Don't output nanoseconds field of next retry time in warning log

### DIFF
--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -1275,7 +1275,7 @@ module Fluent
           unless @retry
             @retry = retry_state(@buffer_config.retry_randomize)
             if error
-              log.warn "failed to flush the buffer.", retry_time: @retry.steps, next_retry_seconds: @retry.next_time, chunk: chunk_id_hex, error: error
+              log.warn "failed to flush the buffer.", retry_times: @retry.steps, next_retry_time: @retry.next_time.round, chunk: chunk_id_hex, error: error
               log.warn_backtrace error.backtrace
             end
             return
@@ -1304,11 +1304,11 @@ module Fluent
             if error
               if using_secondary
                 msg = "failed to flush the buffer with secondary output."
-                log.warn msg, retry_time: @retry.steps, next_retry_seconds: @retry.next_time, chunk: chunk_id_hex, error: error
+                log.warn msg, retry_times: @retry.steps, next_retry_time: @retry.next_time.round, chunk: chunk_id_hex, error: error
                 log.warn_backtrace error.backtrace
               else
                 msg = "failed to flush the buffer."
-                log.warn msg, retry_time: @retry.steps, next_retry_seconds: @retry.next_time, chunk: chunk_id_hex, error: error
+                log.warn msg, retry_times: @retry.steps, next_retry_time: @retry.next_time.round, chunk: chunk_id_hex, error: error
                 log.warn_backtrace error.backtrace
               end
             end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #3463

**What this PR does / why we need it**: 
It might output unfriendly fractions due to Time class's behavior as of Ruby 2.7, and actual retry time isn't so accurate.

In addition, fix inappropriate labels:

```diff
- retry_time
+ retry_times
```

```diff
- next_retry_seconds
+ next_retry_time
```

e.g.)

```diff
- [warn]: #0 failed to flush the buffer. retry_time=9 next_retry_seconds=2021-07-19 13:00:22 24648004639507749129/34359738368000000000
+ [warn]: #0 failed to flush the buffer. retry_times=9 next_retry_time=2021-07-19 13:00:22
```

**Docs Changes**:
none

**Release Note**: 
Same with the title