### PR TITLE
Ensure to specify dir permission

### DIFF
--- a/lib/fluent/command/ca_generate.rb
+++ b/lib/fluent/command/ca_generate.rb
@@ -2,6 +2,7 @@ require 'openssl'
 require 'optparse'
 require 'fileutils'
 require 'fluent/version'
+require 'fluent/env'
 
 module Fluent
   class CaGenerate
@@ -40,7 +41,7 @@ HELP
         exit 1
       end
 
-      FileUtils.mkdir_p(ca_dir)
+      FileUtils.mkdir_p(ca_dir, mode: Fluent::DEFAULT_DIR_PERMISSION)
 
       cert, key = Fluent::CaGenerate.generate_ca_pair(@options)
 

--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -253,7 +253,7 @@ end
 
 if setup_path = opts[:setup_path]
   require 'fileutils'
-  FileUtils.mkdir_p File.join(setup_path, "plugin")
+  FileUtils.mkdir_p File.join(setup_path, "plugin"), mode: Fluent::DEFAULT_DIR_PERMISSION
   confpath = File.join(setup_path, "fluent.conf")
   if File.exist?(confpath)
     puts "#{confpath} already exists."

--- a/lib/fluent/command/plugin_generator.rb
+++ b/lib/fluent/command/plugin_generator.rb
@@ -20,6 +20,7 @@ require "fileutils"
 require "erb"
 require "open-uri"
 
+require "fluent/env"
 require "fluent/registry"
 require 'fluent/version'
 
@@ -39,7 +40,7 @@ class FluentPluginGenerator
 
   def call
     parse_options!
-    FileUtils.mkdir_p(gem_name)
+    FileUtils.mkdir_p(gem_name, mode: Fluent::DEFAULT_DIR_PERMISSION)
     Dir.chdir(gem_name) do
       copy_license
       template_directory.find do |path|

--- a/lib/fluent/plugin/in_unix.rb
+++ b/lib/fluent/plugin/in_unix.rb
@@ -68,7 +68,7 @@ module Fluent::Plugin
         log.warn "Found existing '#{@path}'. Remove this file for in_unix plugin"
         File.unlink(@path)
       end
-      FileUtils.mkdir_p(File.dirname(@path))
+      FileUtils.mkdir_p(File.dirname(@path), mode: Fluent::DEFAULT_DIR_PERMISSION)
 
       log.info "listening fluent socket on #{@path}"
       s = Coolio::UNIXServer.new(@path, Handler, log, method(:on_message))

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -496,7 +496,7 @@ module Fluent
 
         if @path && @path != "-"
           unless File.exist?(@path)
-            FileUtils.mkdir_p(File.dirname(@path))
+            FileUtils.mkdir_p(File.dirname(@path), mode: @opts[:dir_permission] || Fluent::DEFAULT_DIR_PERMISSION)
           end
 
           @logdev = if @log_rotate_age || @log_rotate_size

--- a/test/test_logger_initializer.rb
+++ b/test/test_logger_initializer.rb
@@ -17,7 +17,7 @@ class LoggerInitializerTest < ::Test::Unit::TestCase
 
     assert_false File.exist?(TMP_DIR)
     logger = Fluent::Supervisor::LoggerInitializer.new(path, Fluent::Log::LEVEL_DEBUG, nil, nil, {})
-    mock.proxy(File).chmod(0o777, TMP_DIR).never
+    mock.proxy(File).chmod(Fluent::DEFAULT_DIR_PERMISSION, TMP_DIR).once
 
     assert_nothing_raised do
       logger.init(:supervisor, 0)
@@ -34,6 +34,7 @@ class LoggerInitializerTest < ::Test::Unit::TestCase
     assert_false File.exist?(TMP_DIR)
     logger = Fluent::Supervisor::LoggerInitializer.new(path, Fluent::Log::LEVEL_DEBUG, nil, nil, {})
     mock.proxy(File).chmod(0o777, TMP_DIR).once
+    mock.proxy(File).chmod(Fluent::DEFAULT_DIR_PERMISSION, TMP_DIR).once
 
     assert_nothing_raised do
       logger.init(:supervisor, 0)


### PR DESCRIPTION

**Which issue(s) this PR fixes**: 

Fixes #3521

**What this PR does / why we need it**: 

FileUtils.mkdir_p is not used with mode: so even though
system_config.dir_permission is specified, it was not used at all.

**Docs Changes**:

N/A

**Release Note**: 

N/A
