### PR TITLE
in_tail: Always read from head for new/rotated files after startup

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -387,7 +387,7 @@ module Fluent::Plugin
 
     def setup_watcher(target_info, pe)
       line_buffer_timer_flusher = @multiline_mode ? TailWatcher::LineBufferTimerFlusher.new(log, @multiline_flush_interval, &method(:flush_buffer)) : nil
-      read_from_head = @startup ? @read_from_head : true
+      read_from_head = !@startup || @read_from_head
       tw = TailWatcher.new(target_info, pe, log, read_from_head, @follow_inodes, method(:update_watcher), line_buffer_timer_flusher, method(:io_handler), @metrics)
 
       if @enable_watch_timer

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -379,7 +379,7 @@ module Fluent::Plugin
 
       unwatched_hash = existence_paths_hash.reject {|key, value| target_paths_hash.key?(key)}
       added_hash = target_paths_hash.reject {|key, value| existence_paths_hash.key?(key)}
-      
+
       stop_watchers(unwatched_hash, immediate: false, unwatched: true) unless unwatched_hash.empty?
       start_watchers(added_hash) unless added_hash.empty?
       @startup = false if @startup

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -59,6 +59,7 @@ module Fluent::Plugin
       @ignore_list = []
       @shutdown_start_time = nil
       @metrics = nil
+      @startup = true
     end
 
     desc 'The paths to read. Multiple paths can be specified, separated by comma.'
@@ -250,7 +251,7 @@ module Fluent::Plugin
         end
       end
 
-      refresh_watchers(true) unless @skip_refresh_on_startup
+      refresh_watchers unless @skip_refresh_on_startup
       timer_execute(:in_tail_refresh_watchers, @refresh_interval, &method(:refresh_watchers))
     end
 
@@ -366,22 +367,23 @@ module Fluent::Plugin
     # It will cause log duplication after updated watch files.
     # In such case, you should separate log directory and specify two paths in path parameter.
     # e.g. path /path/to/dir/*,/path/to/rotated_logs/target_file
-    def refresh_watchers(startup = false)
+    def refresh_watchers
       target_paths_hash = expand_paths
       existence_paths_hash = existence_path
 
       log.debug { "tailing paths: target = #{target_paths.join(",")} | existing = #{existence_paths.join(",")}" }
-
+      
       unwatched_hash = existence_paths_hash.reject {|key, value| target_paths_hash.key?(key)}
       added_hash = target_paths_hash.reject {|key, value| existence_paths_hash.key?(key)}
-
+      
       stop_watchers(unwatched_hash, immediate: false, unwatched: true) unless unwatched_hash.empty?
-      start_watchers(added_hash, startup) unless added_hash.empty?
+      start_watchers(added_hash) unless added_hash.empty?
+      @startup = false if @startup
     end
 
-    def setup_watcher(target_info, pe, startup = false)
+    def setup_watcher(target_info, pe)
       line_buffer_timer_flusher = @multiline_mode ? TailWatcher::LineBufferTimerFlusher.new(log, @multiline_flush_interval, &method(:flush_buffer)) : nil
-      read_from_head = startup ? @read_from_head : true
+      read_from_head = @startup ? @read_from_head : true
       tw = TailWatcher.new(target_info, pe, log, read_from_head, @follow_inodes, method(:update_watcher), line_buffer_timer_flusher, method(:io_handler), @metrics)
 
       if @enable_watch_timer
@@ -411,7 +413,7 @@ module Fluent::Plugin
       raise e
     end
 
-    def construct_watcher(target_info, startup)
+    def construct_watcher(target_info)
       pe = nil
       if @pf
         pe = @pf[target_info]
@@ -425,7 +427,7 @@ module Fluent::Plugin
       end
 
       begin
-        tw = setup_watcher(target_info, pe, startup)
+        tw = setup_watcher(target_info, pe)
       rescue WatcherSetupError => e
         log.warn "Skip #{target_info.path} because unexpected setup error happens: #{e}"
         return
@@ -444,9 +446,9 @@ module Fluent::Plugin
       end
     end
 
-    def start_watchers(targets_info, startup)
+    def start_watchers(targets_info)
       targets_info.each_value {|target_info|
-        construct_watcher(target_info, startup)
+        construct_watcher(target_info)
         break if before_shutdown?
       }
     end

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -516,13 +516,21 @@ class TailInputTest < Test::Unit::TestCase
           rotated = false
           detached = false
           d = create_driver(config)
+          mock.proxy(d.instance).setup_watcher(anything, anything, anything) do |tw|
+            mock.proxy(tw).detach(anything) do |v|
+              detached = true
+              v
+            end
+            tw
+          end.once
+
           mock.proxy(d.instance).setup_watcher(anything, anything) do |tw|
             mock.proxy(tw).detach(anything) do |v|
               detached = true
               v
             end
             tw
-          end.twice
+          end.once
 
           d.run(timeout: 10) do
             until detached do
@@ -2188,7 +2196,7 @@ class TailInputTest < Test::Unit::TestCase
                               'format' => 'none',
                             })
     d = create_driver(config)
-    mock.proxy(d.instance).setup_watcher(anything, anything) do |tw|
+    mock.proxy(d.instance).setup_watcher(anything, anything, anything) do |tw|
       cleanup_file(path)
       tw
     end
@@ -2213,7 +2221,7 @@ class TailInputTest < Test::Unit::TestCase
                                 'format' => 'none',
                               })
       d = create_driver(config, false)
-      mock.proxy(d.instance).setup_watcher(anything, anything) do |tw|
+      mock.proxy(d.instance).setup_watcher(anything, anything, anything) do |tw|
         FileUtils.chmod(0000, "#{TMP_DIR}/noaccess")
         tw
       end

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -516,21 +516,13 @@ class TailInputTest < Test::Unit::TestCase
           rotated = false
           detached = false
           d = create_driver(config)
-          mock.proxy(d.instance).setup_watcher(anything, anything, anything) do |tw|
-            mock.proxy(tw).detach(anything) do |v|
-              detached = true
-              v
-            end
-            tw
-          end.once
-
           mock.proxy(d.instance).setup_watcher(anything, anything) do |tw|
             mock.proxy(tw).detach(anything) do |v|
               detached = true
               v
             end
             tw
-          end.once
+          end.twice
 
           d.run(timeout: 10) do
             until detached do
@@ -2196,7 +2188,7 @@ class TailInputTest < Test::Unit::TestCase
                               'format' => 'none',
                             })
     d = create_driver(config)
-    mock.proxy(d.instance).setup_watcher(anything, anything, anything) do |tw|
+    mock.proxy(d.instance).setup_watcher(anything, anything) do |tw|
       cleanup_file(path)
       tw
     end
@@ -2221,7 +2213,7 @@ class TailInputTest < Test::Unit::TestCase
                                 'format' => 'none',
                               })
       d = create_driver(config, false)
-      mock.proxy(d.instance).setup_watcher(anything, anything, anything) do |tw|
+      mock.proxy(d.instance).setup_watcher(anything, anything) do |tw|
         FileUtils.chmod(0000, "#{TMP_DIR}/noaccess")
         tw
       end

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -651,6 +651,23 @@ class TailInputTest < Test::Unit::TestCase
       assert_equal({"message" => "test3"}, events[0][2])
       assert_equal({"message" => "test4"}, events[1][2])
     end
+
+    def test_always_read_from_head_on_detecting_a_new_file
+      d = create_driver(SINGLE_LINE_CONFIG)
+
+      d.run(expect_emits: 1, timeout: 3) do
+        File.open("#{TMP_DIR}/tail.txt", "wb") {|f|
+          f.puts "test1\ntest2\n"
+        }
+      end
+
+      assert_equal(
+        [
+          {"message" => "test1"},
+          {"message" => "test2"},
+        ],
+        d.events.collect { |event| event[2] })
+    end
   end
 
   class TestWithSystem < self


### PR DESCRIPTION
Signed-off-by: majimenez-stratio <majimenez@stratio.com>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 
I noticed that read_from_head affect files read during startup and new files equally. I see a few drawbacks with the current situation if `read_from_head = false` and path includes '*', namely:
- New files detected on refresh are not read from the beggining and initial lines are lost.
- Same as above for rotated files

As a result, I think we can improve the way read_from_head is applied, so that it only affects new files detected during startup. This PR changes the behavior so that:
- During startup, files are read from the position stored in the position file, if available. If not, they are read as specified in `read_from_head`.
- After startup, if a new file is detected (or rotated), it is **always** read from the beginning.
- If `skip_refresh_on_startup = true`, new files are **always** read from the beggining. I'm not sure about this side effect, but I think `skip_refresh_on_startup` only makes sense in combination with `read_from_head = true`, so I think we're fine here.

I tried to mimic the way fluent-bit tail input works as it makes more sense to me. However, I'm quite new to Ruby, fluentd and logging in general, so I'm open to discussion if you feel this change is not appropiate or should be approached from another angle.

**Docs Changes**:
Pending

**Release Note**:
Always read from head for new/rotated files after startup
