### PR TITLE
test_out_exec_filter: Make sure to shutdown test drivers

### DIFF
--- a/test/plugin/test_out_exec_filter.rb
+++ b/test/plugin/test_out_exec_filter.rb
@@ -524,6 +524,9 @@ class ExecFilterOutputTest < Test::Unit::TestCase
     assert_equal pid_list[1], events[1][2]['child_pid']
     assert_equal pid_list[0], events[2][2]['child_pid']
     assert_equal pid_list[1], events[3][2]['child_pid']
+
+  ensure
+    d.run(start: false, shutdown: true)
   end
 
   # child process exits per 3 lines
@@ -597,6 +600,7 @@ class ExecFilterOutputTest < Test::Unit::TestCase
     assert_equal 2, logs.select { |l| l.include?('child process exits with error code') }.size
     assert_equal 2, logs.select { |l| l.include?('respawning child process') }.size
 
+  ensure
     d.run(start: false, shutdown: true)
   end
 end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
none

**What this PR does / why we need it**: 
Some processes executed by test_out_exec_filter are remained until finishing all tests.
I found them when I was investigating #3543

**Docs Changes**:
none

**Release Note**: 
none
