### PR TITLE
in_http: Verify Authroization token on HTTP headers

### DIFF
--- a/test/plugin/test_in_http.rb
+++ b/test/plugin/test_in_http.rb
@@ -887,6 +887,32 @@ class HttpInputTest < Test::Unit::TestCase
     )
   end
 
+  def test_with_authorization
+    d = create_driver(config + %[
+          authorization_token "Basic Zmx1ZW50OnBhc3N3b3Jk"
+        ])
+
+    time = event_time("2011-01-02 13:14:15 UTC")
+    event = ["tag1", time, {"a"=>1}]
+    res_code = nil
+    res_header = nil
+
+    d.run do
+      res = post("/#{event[0]}", {"json"=>event[2].to_json, "time"=>time.to_i.to_s}, {"Authorization"=>"Basic Zmx1ZW50OnBhc3N3b3Jk"})
+      res_code = res.code
+    end
+    assert_equal(
+      {
+        response_code: "200",
+        events: [event]
+      },
+      {
+        response_code: res_code,
+        events: d.events
+      }
+    )
+  end
+
   def test_cors_allow_credentials_for_wildcard_origins
     assert_raise(Fluent::ConfigError) do
       create_driver(config + %[


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes https://github.com/fluent/fluentd/issues/3193

**What this PR does / why we need it**: 

`in_http` plugins does not provide `Authorization` header verification.
This PR adds Authorization headers handling in `in_http` plugin.
And this logic can be handle not only basic authentication but also other types of authentications.
ref: https://developer.mozilla.org/ja/docs/Web/HTTP/Headers/Authorization

**Docs Changes**:

Related doc PR is: https://github.com/fluent/fluentd-docs-gitbook/pull/382

**Release Note**: 

Same as title.