### PR TITLE
test: Fix stalled tests on Ruby 3.1

### DIFF
--- a/test/plugin/test_bare_output.rb
+++ b/test/plugin/test_bare_output.rb
@@ -83,7 +83,7 @@ class BareOutputTest < Test::Unit::TestCase
 
     @p.configure(config_element('ROOT', '', {'@log_level' => 'debug'}))
 
-    assert{ @p.log.object_id != original_logger.object_id }
+    assert(@p.log.object_id != original_logger.object_id)
     assert_equal Fluent::Log::LEVEL_DEBUG, @p.log.level
   end
 

--- a/test/plugin/test_filter.rb
+++ b/test/plugin/test_filter.rb
@@ -153,7 +153,7 @@ class FilterPluginTest < Test::Unit::TestCase
 
       @p.configure(config_element('ROOT', '', {'@log_level' => 'debug'}))
 
-      assert{ @p.log.object_id != original_logger.object_id }
+      assert(@p.log.object_id != original_logger.object_id)
       assert_equal Fluent::Log::LEVEL_DEBUG, @p.log.level
     end
 

--- a/test/plugin/test_input.rb
+++ b/test/plugin/test_input.rb
@@ -73,7 +73,7 @@ class InputTest < Test::Unit::TestCase
 
     @p.configure(config_element('ROOT', '', {'@log_level' => 'debug'}))
 
-    assert{ @p.log.object_id != original_logger.object_id }
+    assert(@p.log.object_id != original_logger.object_id)
     assert_equal Fluent::Log::LEVEL_DEBUG, @p.log.level
   end
 

--- a/test/plugin/test_output_as_buffered_secondary.rb
+++ b/test/plugin/test_output_as_buffered_secondary.rb
@@ -775,7 +775,7 @@ class BufferedOutputSecondaryTest < Test::Unit::TestCase
       assert_equal [ 'test.tag.1', event_time('2016-04-13 18:33:13').to_i, {"name" => "moris", "age" => 36, "message" => "data2"} ], written[1]
       assert_equal [ 'test.tag.1', event_time('2016-04-13 18:33:32').to_i, {"name" => "moris", "age" => 36, "message" => "data3"} ], written[2]
 
-      assert{ @i.log.out.logs.any?{|l| l.include?("[warn]: retry succeeded by secondary.") } }
+      assert(@i.log.out.logs.any?{|l| l.include?("[warn]: retry succeeded by secondary.") })
     end
 
     test 'exponential backoff interval will be initialized when switched to secondary' do

--- a/test/plugin_helper/test_timer.rb
+++ b/test/plugin_helper/test_timer.rb
@@ -90,8 +90,8 @@ class TimerTest < Test::Unit::TestCase
     assert{ counter1 >= 4 && counter1 <= 5 }
     assert{ counter2 == 2 }
     msg = "Unexpected error raised. Stopping the timer. title=:t2"
-    assert{ d1.log.out.logs.any?{|line| line.include?("[error]:") && line.include?(msg) && line.include?("abort!!!!!!") } }
-    assert{ d1.log.out.logs.any?{|line| line.include?("[error]:") && line.include?("Timer detached. title=:t2") } }
+    assert(d1.log.out.logs.any?{|line| line.include?("[error]:") && line.include?(msg) && line.include?("abort!!!!!!") })
+    assert(d1.log.out.logs.any?{|line| line.include?("[error]:") && line.include?("Timer detached. title=:t2") })
 
     d1.shutdown; d1.close; d1.terminate
   end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #3543

**What this PR does / why we need it**: 
Several tests are stalled since Ruby 3.1, I found that it's caused by
the followig Ruby's change:

  https://github.com/ruby/ruby/commit/2d98593bf54a37397c6e4886ccc7e3654c2eaf85

It seems that there are some conditions to reproduce it:

  * `attr_reader` is defined in a class
  * `$log` is accessed by it
  * `assert` is called with a block
  * `assert` refers the `$log` via the `attr_reader`
  * ... (some other conditions seem needed but not clarified yet)

Here is the sample test case to reproduce it:

```ruby
require 'fluent/test'

class StallTest < Test::Unit::TestCase
  class Stall
    attr_reader :log
    def initialize
      @log = $log
    end
  end

  setup do
    Fluent::Test.setup
  end

  20.times do |i|
    test "stall #{i}" do
      assert { Stall.new.log }
    end
  end
end
```

Becasue all stalled tests don't need to use block, I remove these blocks
to avoid this issue.

**Docs Changes**:
None.

**Release Note**: 
Same with the title.