### PR TITLE
Make out_file append option work without compression

### DIFF
--- a/lib/fluent/env.rb
+++ b/lib/fluent/env.rb
@@ -33,4 +33,8 @@ module Fluent
   def self.linux?
     /linux/ === RUBY_PLATFORM
   end
+
+  def self.macos?
+    /darwin/ =~ RUBY_PLATFORM
+  end
 end

--- a/lib/fluent/plugin/out_file.rb
+++ b/lib/fluent/plugin/out_file.rb
@@ -181,6 +181,13 @@ module Fluent::Plugin
       @dir_perm = system_config.dir_permission || Fluent::DEFAULT_DIR_PERMISSION
       @file_perm = system_config.file_permission || Fluent::DEFAULT_FILE_PERMISSION
       @need_lock = system_config.workers > 1
+
+      # https://github.com/fluent/fluentd/issues/3569
+      @need_ruby_on_macos_workaround = false
+      if @append && Fluent.macos?
+        condition = Gem::Dependency.new('', [">= 2.7.0", "< 3.1.0"])
+        @need_ruby_on_macos_workaround = true if condition.match?('', RUBY_VERSION)
+      end
     end
 
     def multi_workers_ready?
@@ -223,7 +230,7 @@ module Fluent::Plugin
 
     def write_without_compression(path, chunk)
       File.open(path, "ab", @file_perm) do |f|
-        if @append
+        if @need_ruby_on_macos_workaround
           content = chunk.read()
           f.puts content
         else

--- a/lib/fluent/plugin/out_file.rb
+++ b/lib/fluent/plugin/out_file.rb
@@ -223,7 +223,12 @@ module Fluent::Plugin
 
     def write_without_compression(path, chunk)
       File.open(path, "ab", @file_perm) do |f|
-        chunk.write_to(f)
+        if @append
+          content = chunk.read()
+          f.puts content
+        else
+          chunk.write_to(f)
+        end
       end
     end
 


### PR DESCRIPTION
For Ruby 2.7.x and 3.0.x, out_file append option without compression
does not work. The cause is the following Ruby language bug:

https://bugs.ruby-lang.org/issues/18388.

This commit is a workaround for this problem.

See #3569.

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #3569

**What this PR does / why we need it**: 

**Docs Changes**:
none

**Release Note**: 
out_file: Work around for a bug of Ruby on macOS that `IO.copy_stream` doesn't work as expected with append mode