### PR TITLE
Stay Async's version to 1.x

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -51,5 +51,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("test-unit", ["~> 3.3"])
   gem.add_development_dependency("test-unit-rr", ["~> 1.0"])
   gem.add_development_dependency("oj", [">= 2.14", "< 4"])
+  gem.add_development_dependency("async", "~> 1.23")
   gem.add_development_dependency("async-http", ">= 0.50.0")
 end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
Async::HTTP unlocks using Async-2.x since v0.56.4.
But we aren't ready for Async-2.0 yet, one of the known issue is that
it causes the following error:

https://github.com/fluent/fluentd/pull/3585#issuecomment-1005280129:

```
2021-12-27T14:53:29.8037858Z Error: test: monunt given path(HttpHelperTest::Create a HTTP server): ArgumentError: unknown keyword: :logger
2021-12-27T14:53:29.8040011Z /opt/hostedtoolcache/Ruby/3.1.0/x64/lib/ruby/gems/3.1.0/gems/async-2.0.0/lib/async/scheduler.rb:39:in `initialize'
2021-12-27T14:53:29.8041621Z /opt/hostedtoolcache/Ruby/3.1.0/x64/lib/ruby/gems/3.1.0/gems/async-2.0.0/lib/async/reactor.rb:32:in `initialize'
2021-12-27T14:53:29.8043219Z /home/runner/work/fluentd/fluentd/lib/fluent/plugin_helper/http_server/server.rb:41:in `new'
2021-12-27T14:53:29.8045446Z /home/runner/work/fluentd/fluentd/lib/fluent/plugin_helper/http_server/server.rb:41:in `initialize'
2021-12-27T14:53:29.8046959Z /home/runner/work/fluentd/fluentd/lib/fluent/plugin_helper/http_server.rb:69:in `new'
2021-12-27T14:53:29.8048253Z /home/runner/work/fluentd/fluentd/lib/fluent/plugin_helper/http_server.rb:69:in `http_server_create_http_server'
2021-12-27T14:53:29.8049705Z /home/runner/work/fluentd/fluentd/test/plugin_helper/test_http_server_helper.rb:157:in `block (3 levels) in <class:HttpHelperTest>'
2021-12-27T14:53:29.8051313Z /home/runner/work/fluentd/fluentd/test/plugin_helper/test_http_server_helper.rb:36:in `on_driver'
2021-12-27T14:53:29.8052768Z /home/runner/work/fluentd/fluentd/test/plugin_helper/test_http_server_helper.rb:156:in `block (2 levels) in <class:HttpHelperTest>'
```

Even when I fix above issue, I don't yet succeed to get working.
Further check is needed to upgrade it.

**Docs Changes**:
none

**Release Note**: 
Same with the title
