### PR TITLE
replace bad characters before logging them out

### DIFF
--- a/lib/fluent/plugin/base.rb
+++ b/lib/fluent/plugin/base.rb
@@ -72,8 +72,8 @@ module Fluent
 
       def string_safe_encoding(str)
         unless str.valid_encoding?
-          log.info "invalid byte sequence is replaced in `#{str}`" if self.respond_to?(:log)
           str = str.scrub('?')
+          log.info "invalid byte sequence is replaced in `#{str}`" if self.respond_to?(:log)
         end
         yield str
       end


### PR DESCRIPTION
Signed-off-by: Maksym Lisogorskyi <m.lisogorskyi@gmail.com>

**Which issue(s) this PR fixes**: 
Fixes [#3595](https://github.com/fluent/fluentd/issues/3595)

**What this PR does / why we need it**: 

Replace an invalid character before it is logged out again.

**Docs Changes**:

_none_

**Release Note**:

`invalid byte sequence is replaced in` log line will not log out the invalid character.
