### PR TITLE
Bump up required ServerEngine to v2.2.5

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("msgpack", [">= 1.3.1", "< 2.0.0"])
   gem.add_runtime_dependency("yajl-ruby", ["~> 1.0"])
   gem.add_runtime_dependency("cool.io", [">= 1.4.5", "< 2.0.0"])
-  gem.add_runtime_dependency("serverengine", [">= 2.2.2", "< 3.0.0"])
+  gem.add_runtime_dependency("serverengine", [">= 2.2.5", "< 3.0.0"])
   gem.add_runtime_dependency("http_parser.rb", [">= 0.5.1", "< 0.9.0"])
   gem.add_runtime_dependency("sigdump", ["~> 0.2.2"])
   gem.add_runtime_dependency("tzinfo", [">= 1.0", "< 3.0"])


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 
ServerEngine v2.2.4 or former doesn't work on RubyInstaller 3.1:
https://github.com/treasure-data/serverengine/issues/114

**Docs Changes**:
None

**Release Note**: 
Same with the title