### PR TITLE
Use more concrete error class on plugin not found

### DIFF
--- a/lib/fluent/config/error.rb
+++ b/lib/fluent/config/error.rb
@@ -29,4 +29,16 @@ module Fluent
 
   class SetDefault < Exception
   end
+
+  class NotFoundPluginError < ConfigError
+    attr_reader :type, :kind
+
+    def initialize(msg, type: nil, kind: nil)
+      @msg = msg
+      @type = type
+      @kind = kind
+
+      super(msg)
+    end
+  end
 end

--- a/lib/fluent/registry.rb
+++ b/lib/fluent/registry.rb
@@ -45,7 +45,8 @@ module Fluent
       if value = @map[type]
         return value
       end
-      raise ConfigError, "Unknown #{@kind} plugin '#{type}'. Run 'gem search -rd fluent-plugin' to find plugins"  # TODO error class
+      raise NotFoundPluginError.new("Unknown #{@kind} plugin '#{type}'. Run 'gem search -rd fluent-plugin' to find plugins",
+                                    kind: @kind, type: type)
     end
 
     def reverse_lookup(value)

--- a/test/compat/test_parser.rb
+++ b/test/compat/test_parser.rb
@@ -22,7 +22,7 @@ class TextParserTest < ::Test::Unit::TestCase
   Fluent::TextParser.register_template('multi_event_test', Proc.new { MultiEventTestParser.new })
 
   def test_lookup_unknown_format
-    assert_raise Fluent::ConfigError do
+    assert_raise Fluent::NotFoundPluginError do
       Fluent::Plugin.new_parser('unknown')
     end
   end

--- a/test/plugin/test_filter_parser.rb
+++ b/test/plugin/test_filter_parser.rb
@@ -46,7 +46,7 @@ class ParserFilterTest < Test::Unit::TestCase
     assert_raise(Fluent::ConfigError) {
       create_driver('')
     }
-    assert_raise(Fluent::ConfigError) {
+    assert_raise(Fluent::NotFoundPluginError) {
       create_driver %[
         key_name foo
         <parse>

--- a/test/plugin/test_filter_stdout.rb
+++ b/test/plugin/test_filter_stdout.rb
@@ -63,7 +63,7 @@ class StdoutFilterTest < Test::Unit::TestCase
       end
 
       def test_invalid_output_type
-        assert_raise(Fluent::ConfigError) do
+        assert_raise(Fluent::NotFoundPluginError) do
           d = create_driver(CONFIG + config_element("", "", { "output_type" => "foo" }))
           d.run {}
         end
@@ -139,7 +139,7 @@ class StdoutFilterTest < Test::Unit::TestCase
       def test_invalid_output_type
         conf = config_element
         conf.elements << config_element("format", "", { "@type" => "stdout", "output_type" => "foo" })
-        assert_raise(Fluent::ConfigError) do
+        assert_raise(Fluent::NotFoundPluginError) do
           d = create_driver(conf)
           d.run {}
         end

--- a/test/plugin/test_out_stdout.rb
+++ b/test/plugin/test_out_stdout.rb
@@ -32,7 +32,7 @@ class StdoutOutputTest < Test::Unit::TestCase
       assert_kind_of Fluent::Plugin::StdoutFormatter, d.instance.formatter
       assert_equal 'hash', d.instance.formatter.output_type
 
-      assert_raise(Fluent::ConfigError) do
+      assert_raise(Fluent::NotFoundPluginError) do
         d = create_driver(CONFIG + "\noutput_type foo")
       end
     end
@@ -126,7 +126,7 @@ class StdoutOutputTest < Test::Unit::TestCase
       assert_kind_of Fluent::Plugin::StdoutFormatter, d.instance.formatter
       assert_equal 'hash', d.instance.formatter.output_type
 
-      assert_raise(Fluent::ConfigError) do
+      assert_raise(Fluent::NotFoundPluginError) do
         create_driver(config_element("ROOT", "", {"output_type" => "foo"}, [config_element("buffer")]))
       end
     end

--- a/test/test_formatter.rb
+++ b/test/test_formatter.rb
@@ -349,7 +349,7 @@ module FormatterTest
     include FormatterTest
 
     def test_unknown_format
-      assert_raise ConfigError do
+      assert_raise NotFoundPluginError do
         Fluent::Plugin.new_formatter('unknown')
       end
     end


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
None.

**What this PR does / why we need it**: 
Not found plugin is basically config error but we need to use another error class to customize this error for config validation.
In general, cloud service does not permit to install plugins via user operations.

This patch does not affect for error message for ordinary cases.
Perhaps, it might affect error handling but this should be a corner case.

**Docs Changes**:
No needed.

**Release Note**: 
Same as title.