### PR TITLE
Build x64-mingw-ucrt gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ namespace :build do
   desc 'Build gems for all platforms'
   task :all do
     Bundler.with_clean_env do
-      %w[ruby x86-mingw32 x64-mingw32].each do |name|
+      %w[ruby x86-mingw32 x64-mingw32 x64-mingw-ucrt].each do |name|
         ENV['GEM_BUILD_FAKE_PLATFORM'] = name
         Rake::Task["build"].execute
       end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
RubyInstaller 3.1 has switched C-Runtime to UCRT so that RUBY_PLATFORM
has been changed to `x64-mingw-ucrt`:

https://rubyinstaller.org/2021/12/31/rubyinstaller-3.1.0-1-released.html

Without it, Windows specific dependent gems aren't install on RubyInstaller 3.1:
https://github.com/fluent/fluent-plugin-windows-eventlog/pull/83#issuecomment-1026909993

**Docs Changes**:
None

**Release Note**: 
Same with the title