### PR TITLE
Tweak CI

### DIFF
--- a/.github/workflows/linux-test.yaml
+++ b/.github/workflows/linux-test.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['3.0', '2.7', '2.6']
+        ruby-version: ['3.1', '3.0', '2.7', '2.6']
         os: [ubuntu-latest]
         experimental: [false]
         include:

--- a/.github/workflows/macos-test.yaml
+++ b/.github/workflows/macos-test.yaml
@@ -13,9 +13,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['head', '2.7']
+        ruby-version: ['3.1', '3.0', '2.7']
         os: [macos-latest]
         experimental: [true]
+        include:
+          - ruby-version: head
+            os: macos-latest
+            experimental: true
 
     name: Unit testing with Ruby ${{ matrix.ruby-version }} on ${{ matrix.os }}
     steps:

--- a/.github/workflows/windows-test.yaml
+++ b/.github/workflows/windows-test.yaml
@@ -18,9 +18,9 @@ jobs:
           - windows-latest
         experimental: [false]
         include:
-          - ruby-version: '3.0.2'
+          - ruby-version: '3.0.3'
             os: windows-latest
-            experimental: true
+            experimental: false
             # On Ruby 3.0, we need to use fiddle 1.0.8 or later to retrieve correct
             # error code. In addition, we have to specify the path of fiddle by RUBYLIB
             # because RubyInstaller loads Ruby's bundled fiddle before initializing gem.
@@ -28,7 +28,7 @@ jobs:
             # * https://github.com/ruby/fiddle/issues/72
             # * https://bugs.ruby-lang.org/issues/17813
             # * https://github.com/oneclick/rubyinstaller2/blob/8225034c22152d8195bc0aabc42a956c79d6c712/lib/ruby_installer/build/dll_directory.rb
-            ruby-lib-opt: RUBYLIB=%RUNNER_TOOL_CACHE%/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/fiddle-1.0.8/lib
+            ruby-lib-opt: RUBYLIB=%RUNNER_TOOL_CACHE%/Ruby/3.0.3/x64/lib/ruby/gems/3.0.0/gems/fiddle-1.1.0/lib
 
     name: Unit testing with Ruby ${{ matrix.ruby-version }} on ${{ matrix.os }}
     steps:
@@ -37,9 +37,9 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-      - name: Add Fiddle 1.0.8
-        if: ${{ matrix.ruby-version == '3.0.2' }}
-        run: gem install fiddle --version 1.0.8
+      - name: Add Fiddle 1.1.0
+        if: ${{ matrix.ruby-version == '3.0.3' }}
+        run: gem install fiddle --version 1.1.0
       - name: Install dependencies
         run: ridk exec bundle install
       - name: Run tests


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
Tweak CI on GitHub Actions:
* Add Ruby 3.1 for GNU/Linux and macOS
  *  For windows, we have several known issues on RubyInstaller 3.1 so that we don't yet add for now: #3585
* Use latest RubyInstaller 3.0 & Fiddle

**Docs Changes**:
none

**Release Note**: 
none
