### PR TITLE
plugin metrics: fix a typo about emit_count

### DIFF
--- a/lib/fluent/plugin/bare_output.rb
+++ b/lib/fluent/plugin/bare_output.rb
@@ -70,7 +70,7 @@ module Fluent
         super
 
         @num_errors_metrics = metrics_create(namespace: "fluentd", subsystem: "bare_output", name: "num_errors", help_text: "Number of count num errors")
-        @emit_count_metrics = metrics_create(namespace: "fluentd", subsystem: "bare_output", name: "emit_records", help_text: "Number of count emits")
+        @emit_count_metrics = metrics_create(namespace: "fluentd", subsystem: "bare_output", name: "emit_count", help_text: "Number of count emits")
         @emit_records_metrics = metrics_create(namespace: "fluentd", subsystem: "bare_output", name: "emit_records", help_text: "Number of emit records")
         @emit_size_metrics =  metrics_create(namespace: "fluentd", subsystem: "bare_output", name: "emit_size", help_text: "Total size of emit events")
         @enable_size_metrics = !!system_config.enable_size_metrics


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

Fixes #3628 


**What this PR does / why we need it**: 

When implementing metrics plugin mechanism, it should be
named as `emit_count` instead of `emit_records`.

See
https://github.com/fluent/fluentd/commit/4a0335a43a131f5f8a428f7deff98c3942e6cf4e

**Docs Changes**:

N/A

**Release Note**: 

N/A
