### PR TITLE
Apply modifications in pipeline to the records being passed to `@ERROR` label

### DIFF
--- a/test/test_event_router.rb
+++ b/test/test_event_router.rb
@@ -328,7 +328,7 @@ class EventRouterTest < ::Test::Unit::TestCase
       end
 
       test 'can pass records modified by filters to handle_emits_error' do
-        filter = Class.new(FluentTestFilter) { |x|
+        filter = Class.new(FluentTestFilter) {
           def filter_stream(_tag, es); end
         }.new
         event_router.add_rule('test', filter)


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #3465

**What this PR does / why we need it**: 
When an error occurs in the output process in a pipeline,
the modifications made by the filter process should be applied to the records
that are passed to `@ERROR` label.

**Docs Changes**:
None.

**Release Note**: 
Same with the title.

I have confirmed all success of `bundle exec rake test` in my environment, Ubunty 20.04.3, Ruby 2.7.0.

I have confirmed `@Error` label outputs the records including the modifications made by `record_transformer` as follows.

**Config**

```conf
<source>
  @type forward
  @id forward_input
</source>

<filter debug.**>
  @type record_transformer
  <record>
    newfield "new value"
  </record>
</filter>

<match debug.**>
  @type stdout
  @id stdout_output
  <buffer>
    @type memory
    total_limit_size 128
  </buffer>
</match>

<label @ERROR>
  <match debug.**>
    @type file
    path "{output_filepath}"
  </match>
</label>
```

**Operation**

1. Run `echo '{"hoge":"fuga"}' | fluent-cat debug.hoge` about 3 or 4 times and generate BufferOverflowError as follows.

```log
2022-02-14 17:40:05 +0900 [warn]: #0 [stdout_output] failed to write data into buffer by buffer overflow action=:throw_exception
2022-02-14 17:40:05 +0900 [warn]: #0 send an error event stream to @ERROR: error_class=Fluent::Plugin::Buffer::BufferOverflowError error="buffer space has too many data" location="/home/daipom/work/fluentd/fluentd/lib/fluent/plugin/buffer.rb:327:in `write'" tag="debug.hoge"
```

2. Confirm records being outputted by `@ERROR` label.

```log
2022-02-14T17:40:05+09:00	debug.hoge	{"hoge":"fuga","newfield":"new value"}
2022-02-14T17:40:06+09:00	debug.hoge	{"hoge":"fuga","newfield":"new value"}
2022-02-14T17:40:21+09:00	debug.hoge	{"hoge":"fuga","newfield":"new value"}
2022-02-14T17:40:21+09:00	debug.hoge	{"hoge":"fuga","newfield":"new value"}
```