### PR TITLE
in_exec: fix a file descriptor leaks

### DIFF
--- a/lib/fluent/plugin/in_exec.rb
+++ b/lib/fluent/plugin/in_exec.rb
@@ -95,6 +95,7 @@ module Fluent::Plugin
       else
         @parser.parse(io.read, &method(:on_record))
       end
+      io.close if io.eof?
     end
 
     def on_record(time, record)

--- a/test/plugin/test_in_exec.rb
+++ b/test/plugin/test_in_exec.rb
@@ -258,4 +258,14 @@ EOC
       assert_match(/LoadError/, event[2]['message'])
     end
   end
+
+  test 'ensure not leaking file descriptor' do
+    omit "/proc/PID is not available on Windows" if Fluent.windows?
+    d = create_driver JSON_CONFIG_COMPAT
+    before_fd_count = Dir.glob("/proc/#{$$}/fd/*").length
+    d.run(expect_records: 10, timeout: 10)
+    after_fd_count =  Dir.glob("/proc/#{$$}/fd/*").length
+
+    assert{ before_fd_count == after_fd_count }
+  end
 end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

Follow up #3627

**What this PR does / why we need it**: 

Every calling command from in_exec plugin, it causes
a file descriptor leak.

If interval is short enough or running Fluentd in long term,
it will reaches the limit of file descriptor - "too many open files".

In this commit, ensure to close IO object when it reaches EOF.

**Docs Changes**:

N/A

**Release Note**: 

N/A
