### PR TITLE
Fix wrong calculation of max retry timeout for exponential backoff

### DIFF
--- a/lib/fluent/plugin_helper/retry_state.rb
+++ b/lib/fluent/plugin_helper/retry_state.rb
@@ -159,7 +159,7 @@ module Fluent
         def calc_max_retry_timeout(max_steps)
           result = 0
           max_steps.times { |i|
-            result += calc_interval(i)
+            result += calc_interval(i + 1)
           }
           result
         end

--- a/test/plugin_helper/test_retry_state.rb
+++ b/test/plugin_helper/test_retry_state.rb
@@ -413,7 +413,7 @@ class RetryStateHelperTest < Test::Unit::TestCase
     override_current_time(s, dummy_current_time)
 
     timeout = 0
-    5.times { |i| timeout += 1.0 * (2 ** (i - 1)) }
+    5.times { |i| timeout += 1.0 * (2 ** i) }
 
     assert_equal dummy_current_time, s.current_time
     assert_equal (dummy_current_time + 100), s.timeout_at


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #3609

**What this PR does / why we need it**: 
Calculation of max retry timeout for exponential backoff is wrong, 
exponents should be started with 0, not -1.

**Docs Changes**:
none

**Release Note**: 
Same with the title.