### PR TITLE
Switch to GitHub Discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Ask a Question
-    url: https://discuss.fluentd.org/
-    about: I have questions about Fluentd and plugins. Please ask and answer questions at https://discuss.fluentd.org/.
+    url: https://github.com/fluent/fluentd/discussions
+    about: I have questions about Fluentd and plugins. Please ask and answer questions at https://github.com/fluent/fluentd/discussions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ We'd love your contribution. Here are the guidelines!
 
 RESOURCES of [Official site](https://www.fluentd.org/) and [Fluentd documentation](https://docs.fluentd.org/) may help you.
 
-If you have further questions about Fluentd and plugins, please direct these to [Community Forum](https://discuss.fluentd.org/).
+If you have further questions about Fluentd and plugins, please direct these to [Community Forum](https://github.com/fluent/fluentd/discussions).
 Don't use Github issue for asking questions. Here are examples:
 
 - I installed xxx plugin but it doesn't work. Why?

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You can run specified test via `TEST` environment variable:
 - Website: https://www.fluentd.org/
 - Documentation: https://docs.fluentd.org/
 - Project repository: https://github.com/fluent
-- Discussion: https://discuss.fluentd.org/
+- Discussion: https://github.com/fluent/fluentd/discussions
 - Slack / Community: https://slack.fluentd.org
 - Newsletters: https://www.fluentd.org/newsletter
 - Author: [Sadayuki Furuhashi](https://github.com/frsyuki)


### PR DESCRIPTION

**Which issue(s) this PR fixes**: 

Fixes #

**What this PR does / why we need it**: 

Discuss.fluentd.org will not work as expected with
limitation of infrastructure itself and human resources,
it may be better transition from discuss.fluentd.org to GitHub
Discussions.

**Docs Changes**:

NOTE: fluent/fluentd-docs-gitbook has a link to it in issue template.

**Release Note**: 
