### PR TITLE
Added --umask command line parameter

### DIFF
--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -81,6 +81,11 @@ op.on('--group GROUP', "change group") {|s|
   opts[:chgroup] = s
 }
 
+opts[:chumask] = 0
+op.on('--umask UMASK', "change umask") {|s|
+  opts[:chumask] = s
+}
+
 op.on('-o', '--log PATH', "log file path") {|s|
   opts[:log_path] = s
 }

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -397,6 +397,7 @@ module Fluent
       log_path = params['log_path']
       chuser = params['chuser']
       chgroup = params['chgroup']
+      chumask = params['chumask']
       log_rotate_age = params['log_rotate_age']
       log_rotate_size = params['log_rotate_size']
 
@@ -436,7 +437,7 @@ module Fluent
         logger_initializer: logger_initializer,
         chuser: chuser,
         chgroup: chgroup,
-        chumask: 0,
+        chumask: chumask,
         suppress_repeated_stacktrace: suppress_repeated_stacktrace,
         ignore_repeated_log_interval: ignore_repeated_log_interval,
         ignore_same_log_interval: ignore_same_log_interval,
@@ -603,6 +604,7 @@ module Fluent
       @plugin_dirs = opt[:plugin_dirs]
       @chgroup = opt[:chgroup]
       @chuser = opt[:chuser]
+      @chumask = opt[:chumask]
 
       @log_rotate_age = opt[:log_rotate_age]
       @log_rotate_size = opt[:log_rotate_size]
@@ -709,7 +711,7 @@ module Fluent
         create_socket_manager if @standalone_worker
         if @standalone_worker
           ServerEngine::Privilege.change(@chuser, @chgroup)
-          File.umask(0)
+          File.umask(@chumask.to_i(8))
         end
         MessagePackFactory.init(enable_time_support: @system_config.enable_msgpack_time_support)
         Fluent::Engine.init(@system_config)


### PR DESCRIPTION
Signed-off-by: Sergey Yedrikov <syedriko@redhat.com>

**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 
I needed to control permissions on files and directories fluentd creates on disk, to make them accessible only to the user running fluentd:
```
sh-4.4# find /var/lib/fluentd -ls
100978405      0 drwxr-xr-x   5  root     root           53 Feb  4 04:52 /var/lib/fluentd
157295736      0 drwx------   2  root     root           59 Feb  4 05:01 /var/lib/fluentd/pos
157295739     12 -rw-------   1  root     root        11117 Feb  4 05:02 /var/lib/fluentd/pos/es-containers.log.pos
157295855      4 -rw-------   1  root     root          137 Feb  4 05:01 /var/lib/fluentd/pos/journal_pos.json
 48242762      0 drwxr-xr-x   2  root     root          115 Feb  4 05:02 /var/lib/fluentd/default
 48257477      8 -rw-------   1  root     root         5156 Feb  4 05:02 /var/lib/fluentd/default/buffer.b5d72a27e600fe3fec22c832f88f14303.log
 48257478      4 -rw-------   1  root     root          203 Feb  4 05:02 /var/lib/fluentd/default/buffer.b5d72a27e600fe3fec22c832f88f14303.log.meta
 50664000      0 drwxr-xr-x   2  root     root            6 Feb  4 04:52 /var/lib/fluentd/retry_default
sh-4.4# 
```
Setting the appropriate umask looked like an elegant solution. However, I found it impossible to control the umask of fluentd when it runs with --no-supervisor, as fluentd overrides the umask set in the parent shell.

**Docs Changes**:
--umask UMASK           change umask
needs to be added to https://docs.fluentd.org/deployment/command-line-option

**Release Note**: 
