### PR TITLE
Make the default umask a string

### DIFF
--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -81,7 +81,6 @@ op.on('--group GROUP', "change group") {|s|
   opts[:chgroup] = s
 }
 
-opts[:chumask] = 0
 op.on('--umask UMASK', "change umask") {|s|
   opts[:chumask] = s
 }

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -566,6 +566,7 @@ module Fluent
         setup_path: nil,
         chuser: nil,
         chgroup: nil,
+        chumask: "0",
         root_dir: nil,
         suppress_interval: 0,
         suppress_repeated_stacktrace: true,


### PR DESCRIPTION
Signed-off-by: Sergey Yedrikov <syedriko@redhat.com>

This is a correction to a previous commit that added the --umask command line parameter.
The default umask needs to be a string, otherwise the following happens:

2022-03-16 05:14:45 +0000 [error]: unexpected error error_class=ArgumentError error="wrong number of arguments (given 1, expected 0)"
2022-03-16 05:14:45 +0000 [error]: /usr/local/share/gems/gems/fluentd-1.14.5/lib/fluent/supervisor.rb:714:in `to_i'

**Which issue(s) this PR fixes**: 
None