### PR TITLE
Add sigdump func to fluent-ctl

### DIFF
--- a/lib/fluent/command/ctl.rb
+++ b/lib/fluent/command/ctl.rb
@@ -45,7 +45,7 @@ module Fluent
         restart: 128,
         flush: 129,
         reload: SERVICE_CONTROL_PARAMCHANGE,
-        # dump: 130? TODO support svc control
+        dump: 130,
       }
     else
       COMMAND_MAP = {

--- a/lib/fluent/command/ctl.rb
+++ b/lib/fluent/command/ctl.rb
@@ -36,6 +36,7 @@ module Fluent
         restart: "HUP",
         flush: "USR1",
         reload: "USR2",
+        dump: "CONT",
       }
       WINSVC_CONTROL_CODE_MAP = {
         shutdown: SERVICE_CONTROL_STOP,
@@ -44,6 +45,7 @@ module Fluent
         restart: 128,
         flush: 129,
         reload: SERVICE_CONTROL_PARAMCHANGE,
+        # dump: 130? TODO support svc control
       }
     else
       COMMAND_MAP = {
@@ -51,6 +53,7 @@ module Fluent
         restart: :HUP,
         flush: :USR1,
         reload: :USR2,
+        dump: "CONT",
       }
     end
 

--- a/lib/fluent/command/ctl.rb
+++ b/lib/fluent/command/ctl.rb
@@ -53,7 +53,7 @@ module Fluent
         restart: :HUP,
         flush: :USR1,
         reload: :USR2,
-        dump: "CONT",
+        dump: :CONT,
       }
     end
 

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -268,7 +268,7 @@ module Fluent
             end
           end
         ensure
-          events.each { |event| event.close }
+          events.each { |event| event[:win32_event].close }
         end
       end
     end

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -106,6 +106,11 @@ module Fluent
         end
         nil
       }
+      @rpc_server.mount_proc('/api/processes.dump') { |req, res|
+        $log.debug "fluentd RPC got /api/processes.dump request"
+        supervisor_sigcont_handler
+        nil
+      }
       @rpc_server.mount_proc('/api/plugins.flushBuffers') { |req, res|
         $log.debug "fluentd RPC got /api/plugins.flushBuffers request"
         if Fluent.windows?

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -321,6 +321,18 @@ module Fluent
     def supervisor_sigcont_handler
       if Fluent.windows?
         $log.info "dump file. [pid:#{Process.pid}]"
+
+        # Sigdump outputs under `/tmp` dir without `SIGDUMP_PATH` specified
+        # but `/tmp` dir may not exist on Windows by default.
+        # Since this function is mainly for Windows, this case should be saved.
+        # (Don't want to couple tightly with the Sigdump library but want to save this case especially.)
+        unless ENV['SIGDUMP_PATH']
+          dump_dir = '/tmp'
+          unless Dir.exist?(dump_dir)
+            FileUtils.mkdir_p(dump_dir, mode: Fluent::DEFAULT_DIR_PERMISSION)
+          end
+        end
+
         require 'sigdump'
         Sigdump.dump
       else

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -326,7 +326,13 @@ module Fluent
       # but for backward compatibility, this handler is currently for a Windows-only.
       raise "[BUG] This function is for Windows ONLY." unless Fluent.windows?
 
-      FluentSigdump.dump_windows
+      Thread.new do
+        begin
+          FluentSigdump.dump_windows
+        rescue => e
+          $log.error "failed to dump: #{e}"
+        end
+      end
 
       send_signal_to_workers(:CONT)
     rescue => e
@@ -988,9 +994,13 @@ module Fluent
     end
 
     def dump
-      FluentSigdump.dump_windows
-    rescue => e
-      $log.error("failed to dump: #{e}")
+      Thread.new do
+        begin
+          FluentSigdump.dump_windows
+        rescue => e
+          $log.error("failed to dump: #{e}")
+        end
+      end
     end
 
     def logging_with_console_output

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -107,16 +107,6 @@ module Fluent
         end
         nil
       }
-      @rpc_server.mount_proc('/api/processes.dump') { |req, res|
-        $log.debug "fluentd RPC got /api/processes.dump request"
-        if Fluent.windows?
-          supervisor_dump_handler_for_windows
-        else
-          Process.kill :CONT, $$
-          send_signal_to_workers(:CONT)
-        end
-        nil
-      }
       @rpc_server.mount_proc('/api/plugins.flushBuffers') { |req, res|
         $log.debug "fluentd RPC got /api/plugins.flushBuffers request"
         if Fluent.windows?

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -110,7 +110,7 @@ module Fluent
       @rpc_server.mount_proc('/api/processes.dump') { |req, res|
         $log.debug "fluentd RPC got /api/processes.dump request"
         if Fluent.windows?
-          supervisor_sigcont_handler
+          supervisor_dump_handler
         else
           Process.kill :CONT, $$
         end
@@ -199,7 +199,7 @@ module Fluent
 
       trap :CONT do
         $log.debug 'fluentd supervisor process got CONT'
-        supervisor_sigcont_handler
+        supervisor_dump_handler
       end
     end
 
@@ -267,7 +267,7 @@ module Fluent
             when :usr2
               supervisor_sigusr2_handler
             when :cont
-              supervisor_sigcont_handler
+              supervisor_dump_handler
             when :stop_event_thread
               break
             end
@@ -323,7 +323,7 @@ module Fluent
       $log.error "Failed to reload config file: #{e}"
     end
 
-    def supervisor_sigcont_handler
+    def supervisor_dump_handler
       if Fluent.windows?
         FluentSigdump.dump_windows
       else

--- a/lib/fluent/winsvc.rb
+++ b/lib/fluent/winsvc.rb
@@ -84,6 +84,8 @@ begin
         set_event("#{@service_name}_HUP")
       when 129
         set_event("#{@service_name}_USR1")
+      when 130
+        set_event("#{@service_name}_CONT")
       end
     end
 

--- a/test/plugin/test_in_object_space.rb
+++ b/test/plugin/test_in_object_space.rb
@@ -17,13 +17,19 @@ class ObjectSpaceInputTest < Test::Unit::TestCase
   end
 
   class FailObject
-    def self.class
-      raise "error"
-    end
   end
 
   def setup
     Fluent::Test.setup
+    # Overriding this behavior in the global scope will have an unexpected influence on other tests.
+    # So this should be overridden here and be removed in `teardown`.
+    def FailObject.class
+      raise "FailObject error for tests in ObjectSpaceInputTest."
+    end
+  end
+
+  def teardown
+    FailObject.singleton_class.remove_method(:class)
   end
 
   TESTCONFIG = %[

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -226,27 +226,34 @@ class SupervisorTest < ::Test::Unit::TestCase
   def test_supervisor_event_dump_windows
     omit "Only for Windows, alternative to UNIX signals" unless Fluent.windows?
 
-    ENV['SIGDUMP_PATH'] = TMP_DIR + "/sigdump.log"
-
     server = DummyServer.new
     def server.config
       {:signame => "TestFluentdEvent"}
     end
     server.install_windows_event_handler
-    begin
-      sleep 0.1 # Wait for starting windows event thread
-      event = Win32::Event.open("TestFluentdEvent_CONT")
-      event.set
-      event.close
-      sleep 1.0 # Wait for dumping
-    ensure
-      server.stop_windows_event_thread
-    end
 
-    result_filepaths = Dir.glob("#{TMP_DIR}/*")
-    assert {result_filepaths.length > 0}
-  ensure
-    ENV.delete('SIGDUMP_PATH')
+    assert_rr do
+      # Have to use mock because `Sigdump.dump` seems to be somehow incompatible with RR.
+      # The `mock(server).restart(true) { nil }` line in `test_rpc_server_windows` cause the next error.
+      # Failure: test_supervisor_event_dump_windows(SupervisorTest):
+      #   class()
+      #   Called 0 times.
+      #   Expected 1 times.
+      # .../Ruby26-x64/lib/ruby/gems/2.6.0/gems/sigdump-0.2.4/lib/sigdump.rb:74:in `block in dump_object_count'
+      #     73: ObjectSpace.each_object {|o|
+      #     74:   c = o.class <-- HERE!
+      mock(Sigdump).dump(anything)
+
+      begin
+        sleep 0.1 # Wait for starting windows event thread
+        event = Win32::Event.open("TestFluentdEvent_CONT")
+        event.set
+        event.close
+        sleep 1.0 # Wait for dumping
+      ensure
+        server.stop_windows_event_thread
+      end
+    end
   end
 
   data(:ipv4 => ["0.0.0.0", "127.0.0.1", false],

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -213,6 +213,16 @@ class SupervisorTest < ::Test::Unit::TestCase
     $log.out.reset if $log && $log.out && $log.out.respond_to?(:reset)
   end
 
+  data("Normal", {raw_path: "C:\\Windows\\Temp\\sigdump.log", expected: "C:\\Windows\\Temp\\sigdump-#{$$}.log"})
+  data("UNIX style", {raw_path: "/Windows/Temp/sigdump.log", expected: "/Windows/Temp/sigdump-#{$$}.log"})
+  data("No extension", {raw_path: "C:\\Windows\\Temp\\sigdump", expected: "C:\\Windows\\Temp\\sigdump-#{$$}"})
+  data("Multi-extension", {raw_path: "C:\\Windows\\Temp\\sig.dump.bk", expected: "C:\\Windows\\Temp\\sig.dump-#{$$}.bk"})
+  def test_fluentsigdump_get_path_with_pid(data)
+    p data
+    path = Fluent::FluentSigdump.get_path_with_pid(data[:raw_path])
+    assert_equal(data[:expected], path)
+  end
+
   def test_supervisor_event_dump_windows
     omit "Only for Windows, alternative to UNIX signals" unless Fluent.windows?
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #3600

**What this PR does / why we need it**: 
Currently, [Sigdump](https://github.com/fluent/sigdump/) is available by sending the CONT signal, **without Windows**.
The main purpose of this PR is to make this function available for Windows too.

To do so, add the following features to `fluent-ctl` and rpc.

We can use the following methods to use Sigdump.

- command: `$ fluent-ctl dump {pid or svcname}`
- ~~http request to Fluentd: `/api/processes.dump`~~

**Windows**

- Fluentd outputs dump-files about the supervisor process and all worker processes to the system temp dir `C:\\Windows\\Temp`.
- We can specify `SIGDUMP_PATH` environment variable to change the path.
  - Automatically add each process-id to the path to avoid a writing conflict.

Examples of dump files on Windows.
```
C:\\Windows\\Temp\\fluentd-sigdump-{supervisor-pid}.log
C:\\Windows\\Temp\\fluentd-sigdump-{worker0-pid}.log
C:\\Windows\\Temp\\fluentd-sigdump-{worker1-pid}.log
...
```

Examples of specifying `SIGDUMP_PATH` by powershell on Windows.
```Powershell
$ $env:SIGDUMP_PATH="/sigdump/sigdump.log"

... [info]: fluent/log.rb:330:info: dump to /sigdump/sigdump-41544.log.
... [info]: #0 fluent/log.rb:330:info: dump to /sigdump/sigdump-21152.log.
... [info]: #1 fluent/log.rb:330:info: dump to /sigdump/sigdump-15656.log.
...
```

**UNIX-like**

- command: `$ fluent-ctl dump {pid}`
  - This is the same behavior as sending SIGCONT to the process as before. (Output the process's dump-file.)

- ~~http request to Fluentd: `/api/processes.dump`~~
  - ~~This is the same as Windows and outputs all processes' dump-files.~~
  - ~~However, we cannot use `SIGDUMP_PATH` to specify the path for this rpc command.~~
    - ~~Since each process-id is not added in this case and it causes a writing conflict.~~
    - ~~We need to fix [Sigdump library](https://github.com/fluent/sigdump).~~

**Docs Changes**:
https://github.com/fluent/fluentd-docs-gitbook/pull/397

**Release Note**: 
TODO
