### PR TITLE
CHANGELOG.md: Fix one wrong link in 1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -443,7 +443,7 @@ We recommend to upgrade Fluentd to v1.14.2 or use patched version of
 ### New feature
 
 * in_tail: Add `follow_inode` to support log rotation with wild card
-  https://github.com/fluent/fluentd/pull/2992
+  https://github.com/fluent/fluentd/pull/3182
 * in_tail: Handle linux capability
   https://github.com/fluent/fluentd/pull/3155
   https://github.com/fluent/fluentd/pull/3162


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 
There was a wrong link in CHANGELOG.
This PR fixes it.

**Docs Changes**:
None.

**Release Note**: 
None.
