### PR TITLE
Add comments to `linger_timeout` behavior about Windows

### DIFF
--- a/lib/fluent/plugin_helper/server.rb
+++ b/lib/fluent/plugin_helper/server.rb
@@ -267,7 +267,9 @@ module Fluent
           ### Socket Params ###
 
           # SO_LINGER 0 to send RST rather than FIN to avoid lots of connections sitting in TIME_WAIT at src.
-          # Set positive value if needing to send FIN on closing.
+          # Set positive value if needing to send FIN on closing on non-Windows.
+          # (On Windows, Fluentd can send FIN with zero `linger_timeout` since Fluentd doesn't set 0 to SO_LINGER on Windows.
+          # See `socket_option.rb`.)
           # NOTE:
             # Socket-options can be specified from each plugin as needed, so most of them is not defined here for now.
             # This is because there is no positive reason to do so.


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None.

**What this PR does / why we need it**: 
This fix comments about #3644.
There was a lack of consideration regarding the default behavior on Windows.

**Docs Changes**:
https://github.com/fluent/fluentd-docs-gitbook/pull/398

**Release Note**: 
None