### PR TITLE
out_forward: Fix to update timeout of cached sockets

### DIFF
--- a/lib/fluent/plugin/out_forward/socket_cache.rb
+++ b/lib/fluent/plugin/out_forward/socket_cache.rb
@@ -50,6 +50,7 @@ module Fluent::Plugin
       def checkin(sock)
         @mutex.synchronize do
           if (s = @inflight_sockets.delete(sock))
+            s.timeout = timeout
             @available_sockets[s.key] << s
           else
             @log.debug("there is no socket #{sock}")
@@ -122,6 +123,7 @@ module Fluent::Plugin
         t = Time.now
         if (s = @available_sockets[key].find { |sock| !expired_socket?(sock, time: t) })
           @inflight_sockets[s.sock] = @available_sockets[key].delete(s)
+          s.timeout = timeout
           s
         else
           nil

--- a/test/plugin/out_forward/test_socket_cache.rb
+++ b/test/plugin/out_forward/test_socket_cache.rb
@@ -138,7 +138,7 @@ class SocketCacheTest < Test::Unit::TestCase
       c.checkin(sock)
 
       # wait timeout
-      Timecop.freeze(Time.parse('2016-04-13 14:20:00 +0900'))
+      Timecop.freeze(Time.parse('2016-04-13 14:00:11 +0900'))
       c.checkout_or('key') { sock2 }
 
       assert_equal(1, c.instance_variable_get(:@inflight_sockets).size)

--- a/test/plugin/out_forward/test_socket_cache.rb
+++ b/test/plugin/out_forward/test_socket_cache.rb
@@ -145,5 +145,26 @@ class SocketCacheTest < Test::Unit::TestCase
       assert_equal(1, c.instance_variable_get(:@inflight_sockets).size)
       assert_equal(sock2, c.instance_variable_get(:@inflight_sockets).values.first.sock)
     end
+
+    test 'should not purge just after checkin and purge after timeout' do
+      Timecop.freeze(Time.parse('2016-04-13 14:00:00 +0900'))
+
+      c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
+      sock = dont_allow(mock!).close
+      stub(sock).inspect
+      c.checkout_or('key') { sock }
+
+      Timecop.freeze(Time.parse('2016-04-13 14:00:11 +0900'))
+      c.checkin(sock)
+
+      assert_equal(1, c.instance_variable_get(:@available_sockets).size)
+      c.purge_obsolete_socks
+      assert_equal(1, c.instance_variable_get(:@available_sockets).size)
+
+      Timecop.freeze(Time.parse('2016-04-13 14:00:22 +0900'))
+      assert_equal(1, c.instance_variable_get(:@available_sockets).size)
+      c.purge_obsolete_socks
+      assert_equal(0, c.instance_variable_get(:@available_sockets).size)
+    end
   end
 end

--- a/test/plugin/out_forward/test_socket_cache.rb
+++ b/test/plugin/out_forward/test_socket_cache.rb
@@ -110,6 +110,10 @@ class SocketCacheTest < Test::Unit::TestCase
   end
 
   sub_test_case 'purge_obsolete_socks' do
+    def teardown
+      Timecop.return
+    end
+
     test 'delete key in inactive_socks' do
       c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
       sock = mock!.close { 'closed' }.subject


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None.

**What this PR does / why we need it**: 
In `SocketCache`, timeout of sockets are set only on creating them and
never be updated. So that cached sockets (`@available_sockets`) are
always closed after `keepalive_timeout` is passed from its creation,
even if it was used within `keepalive_timeout` seconds.

**Docs Changes**:
Not needed.

**Release Note**: 
Same with the title
