### PR TITLE
Handle YAML configuration format on configuration file

### DIFF
--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -126,6 +126,14 @@ op.on('--without-source', "invoke a fluentd without input plugins", TrueClass) {
   opts[:without_source] = b
 }
 
+op.on('--config-file-type VALU', 'file type of fluentd. yaml or yml') { |s|
+  if (s == 'yaml') || (s == 'yml')
+    opts[:config_file_type] = s.to_sym
+  else
+    usage '--config-file-type accepts yaml or yml'
+  end
+}
+
 op.on('--use-v1-config', "Use v1 configuration format (default)", TrueClass) {|b|
   opts[:use_v1_config] = b
 }

--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -126,11 +126,13 @@ op.on('--without-source', "invoke a fluentd without input plugins", TrueClass) {
   opts[:without_source] = b
 }
 
-op.on('--guess-config-file-type VALU', 'guessing file type of fluentd configuration. yaml or yml') { |s|
+op.on('--config-file-type VALU', 'guessing file type of fluentd configuration. yaml/yml or guess') { |s|
   if (s == 'yaml') || (s == 'yml')
-    opts[:guess_config_file_type] = s.to_sym
+    opts[:config_file_type] = s.to_sym
+  elsif (s == 'guess')
+    opts[:config_file_type] = s.to_sym
   else
-    usage '--guess-config-file-type accepts yaml or yml'
+    usage '--config-file-type accepts yaml/yml or guess'
   end
 }
 

--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -126,16 +126,12 @@ op.on('--without-source', "invoke a fluentd without input plugins", TrueClass) {
   opts[:without_source] = b
 }
 
-op.on('--config-file-type VALU', 'file type of fluentd. yaml or yml') { |s|
+op.on('--guess-config-file-type VALU', 'guessing file type of fluentd configuration. yaml or yml') { |s|
   if (s == 'yaml') || (s == 'yml')
-    opts[:config_file_type] = s.to_sym
+    opts[:guess_config_file_type] = s.to_sym
   else
-    usage '--config-file-type accepts yaml or yml'
+    usage '--guess-config-file-type accepts yaml or yml'
   end
-}
-
-op.on('--guess-config-file-type', "Guess config file type that is yaml or not (default)", TrueClass) {|b|
-  opts[:guess_config_file_type] = b
 }
 
 op.on('--use-v1-config', "Use v1 configuration format (default)", TrueClass) {|b|

--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -134,6 +134,10 @@ op.on('--config-file-type VALU', 'file type of fluentd. yaml or yml') { |s|
   end
 }
 
+op.on('--guess-config-file-type', "Guess config file type that is yaml or not (default)", TrueClass) {|b|
+  opts[:guess_config_file_type] = b
+}
+
 op.on('--use-v1-config', "Use v1 configuration format (default)", TrueClass) {|b|
   opts[:use_v1_config] = b
 }

--- a/lib/fluent/config.rb
+++ b/lib/fluent/config.rb
@@ -26,8 +26,15 @@ module Fluent
     # @param additional_config [String] config which is added to last of config body
     # @param use_v1_config [Bool] config is formatted with v1 or not
     # @return [Fluent::Config]
-    def self.build(config_path:, encoding: 'utf-8', additional_config: nil, use_v1_config: true, type: nil)
-      if type == :yaml
+    def self.build(config_path:, encoding: 'utf-8', additional_config: nil, use_v1_config: true, type: nil, guess_type: nil)
+      if guess_type
+        config_fext = File.extname(config_path.dup)
+        if config_fext == '.yaml' || config_fext == '.yml'
+          type = :yaml
+        end
+      end
+
+      if type == :yaml || type == :yml
         return Fluent::Config::YamlParser.parse(config_path)
       end
 

--- a/lib/fluent/config.rb
+++ b/lib/fluent/config.rb
@@ -17,6 +17,7 @@
 require 'fluent/config/error'
 require 'fluent/config/element'
 require 'fluent/configurable'
+require 'fluent/config/yaml_parser'
 
 module Fluent
   module Config
@@ -25,7 +26,11 @@ module Fluent
     # @param additional_config [String] config which is added to last of config body
     # @param use_v1_config [Bool] config is formatted with v1 or not
     # @return [Fluent::Config]
-    def self.build(config_path:, encoding: 'utf-8', additional_config: nil, use_v1_config: true)
+    def self.build(config_path:, encoding: 'utf-8', additional_config: nil, use_v1_config: true, type: nil)
+      if type == :yaml
+        return Fluent::Config::YamlParser.parse(config_path)
+      end
+
       config_fname = File.basename(config_path)
       config_basedir = File.dirname(config_path)
       config_data = File.open(config_path, "r:#{encoding}:utf-8") do |f|
@@ -36,6 +41,7 @@ module Fluent
         end
         s
       end
+
       Fluent::Config.parse(config_data, config_fname, config_basedir, use_v1_config)
     end
 

--- a/lib/fluent/config.rb
+++ b/lib/fluent/config.rb
@@ -28,7 +28,7 @@ module Fluent
     # @return [Fluent::Config]
     def self.build(config_path:, encoding: 'utf-8', additional_config: nil, use_v1_config: true, type: nil, guess_type: nil)
       if guess_type
-        config_file_ext = File.extname(config_path.dup)
+        config_file_ext = File.extname(config_path)
         if config_file_ext == '.yaml' || config_file_ext == '.yml'
           type = :yaml
         end

--- a/lib/fluent/config.rb
+++ b/lib/fluent/config.rb
@@ -27,9 +27,11 @@ module Fluent
     # @param use_v1_config [Bool] config is formatted with v1 or not
     # @return [Fluent::Config]
     def self.build(config_path:, encoding: 'utf-8', additional_config: nil, use_v1_config: true, type: nil)
-      config_file_ext = File.extname(config_path)
-      if config_file_ext == '.yaml' || config_file_ext == '.yml'
-        type = :yaml
+      if type == :guess
+        config_file_ext = File.extname(config_path)
+        if config_file_ext == '.yaml' || config_file_ext == '.yml'
+          type = :yaml
+        end
       end
 
       if type == :yaml || type == :yml

--- a/lib/fluent/config.rb
+++ b/lib/fluent/config.rb
@@ -26,12 +26,10 @@ module Fluent
     # @param additional_config [String] config which is added to last of config body
     # @param use_v1_config [Bool] config is formatted with v1 or not
     # @return [Fluent::Config]
-    def self.build(config_path:, encoding: 'utf-8', additional_config: nil, use_v1_config: true, type: nil, guess_type: nil)
-      if guess_type
-        config_file_ext = File.extname(config_path)
-        if config_file_ext == '.yaml' || config_file_ext == '.yml'
-          type = :yaml
-        end
+    def self.build(config_path:, encoding: 'utf-8', additional_config: nil, use_v1_config: true, type: nil)
+      config_file_ext = File.extname(config_path)
+      if config_file_ext == '.yaml' || config_file_ext == '.yml'
+        type = :yaml
       end
 
       if type == :yaml || type == :yml

--- a/lib/fluent/config.rb
+++ b/lib/fluent/config.rb
@@ -28,8 +28,8 @@ module Fluent
     # @return [Fluent::Config]
     def self.build(config_path:, encoding: 'utf-8', additional_config: nil, use_v1_config: true, type: nil, guess_type: nil)
       if guess_type
-        config_fext = File.extname(config_path.dup)
-        if config_fext == '.yaml' || config_fext == '.yml'
+        config_file_ext = File.extname(config_path.dup)
+        if config_file_ext == '.yaml' || config_file_ext == '.yml'
           type = :yaml
         end
       end

--- a/lib/fluent/config/yaml_parser.rb
+++ b/lib/fluent/config/yaml_parser.rb
@@ -1,0 +1,44 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'fluent/config/yaml_parser/loader'
+require 'fluent/config/yaml_parser/parser'
+require 'pathname'
+
+module Fluent
+  module Config
+    module YamlParser
+      def self.parse(path)
+        context = Kernel.binding
+
+        unless context.respond_to?(:use_nil)
+          context.define_singleton_method(:use_nil) do
+            raise Fluent::SetNil
+          end
+        end
+
+        unless context.respond_to?(:use_default)
+          context.define_singleton_method(:use_default) do
+            raise Fluent::SetDefault
+          end
+        end
+
+        s = Fluent::Config::YamlParser::Loader.new(context).load(Pathname.new(path))
+        Fluent::Config::YamlParser::Parser.new(s).build.to_element
+      end
+    end
+  end
+end

--- a/lib/fluent/config/yaml_parser.rb
+++ b/lib/fluent/config/yaml_parser.rb
@@ -36,6 +36,18 @@ module Fluent
           end
         end
 
+        unless context.respond_to?(:hostname)
+          context.define_singleton_method(:hostname) do
+            Socket.gethostname
+          end
+        end
+
+        unless context.respond_to?(:worker_id)
+          context.define_singleton_method(:worker_id) do
+            ENV['SERVERENGINE_WORKER_ID'] || ''
+          end
+        end
+
         s = Fluent::Config::YamlParser::Loader.new(context).load(Pathname.new(path))
         Fluent::Config::YamlParser::Parser.new(s).build.to_element
       end

--- a/lib/fluent/config/yaml_parser/fluent_value.rb
+++ b/lib/fluent/config/yaml_parser/fluent_value.rb
@@ -1,0 +1,47 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+module Fluent
+  module Config
+    module YamlParser
+      module FluentValue
+        JsonValue = Struct.new(:val) do
+          def to_s
+            val.to_json
+          end
+
+          def to_element
+            to_s
+          end
+        end
+
+        StringValue = Struct.new(:val, :context) do
+          def to_s
+            context.instance_eval("\"#{val}\"")
+          rescue Fluent::SetNil => _
+            ''
+          rescue Fluent::SetDefault => _
+            ':default'
+          end
+
+          def to_element
+            to_s
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fluent/config/yaml_parser/loader.rb
+++ b/lib/fluent/config/yaml_parser/loader.rb
@@ -1,0 +1,91 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'psych'
+require 'json'
+require 'fluent/config/error'
+require 'fluent/config/yaml_parser/fluent_value'
+
+# Based on https://github.com/eagletmt/hako/blob/34cdde06fe8f3aeafd794be830180c3cedfbb4dc/lib/hako/yaml_loader.rb
+
+module Fluent
+  module Config
+    module YamlParser
+      class Loader
+        INCLUDE_TAG = 'tag:include'.freeze
+        FLUENT_JSON_TAG = 'tag:fluent/json'.freeze
+        FLUENT_STR_TAG = 'tag:fluent/s'.freeze
+        SHOVEL = '<<'.freeze
+
+        def initialize(context = Kernel.binding)
+          @context = context
+          @current_path = nil
+        end
+
+        # @param [String] path
+        # @return [Hash]
+        def load(path)
+          class_loader = Psych::ClassLoader.new
+          scanner = Psych::ScalarScanner.new(class_loader)
+
+          visitor = Visitor.new(scanner, class_loader)
+
+          visitor._register_domain(INCLUDE_TAG) do |_, val|
+            load(path.parent.join(val))
+          end
+
+          visitor._register_domain(FLUENT_JSON_TAG) do |_, val|
+            Fluent::Config::YamlParser::FluentValue::JsonValue.new(val)
+          end
+
+          visitor._register_domain(FLUENT_STR_TAG) do |_, val|
+            Fluent::Config::YamlParser::FluentValue::StringValue.new(val, @context)
+          end
+
+          path.open do |f|
+            visitor.accept(Psych.parse(f))
+          end
+        end
+
+        class Visitor < Psych::Visitors::ToRuby
+          def initialize(scanner, class_loader)
+            super(scanner, class_loader)
+          end
+
+          def _register_domain(name, &block)
+            @domain_types.merge!({ name => [name, block] })
+          end
+
+          def revive_hash(hash, o)
+            super(hash, o).tap do |r|
+              if r[SHOVEL].is_a?(Hash)
+                h2 = {}
+                r.each do |k, v|
+                  if k == SHOVEL
+                    h2.merge!(v)
+                  else
+                    h2[k] = v
+                  end
+                end
+                r.replace(h2)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fluent/config/yaml_parser/parser.rb
+++ b/lib/fluent/config/yaml_parser/parser.rb
@@ -59,6 +59,8 @@ module Fluent
             if (wc = c.delete('worker'))
               sb.add_section(worker_build(wc, indent: indent))
             end
+
+            included_sections_build(c, sb, indent: indent)
           end
 
           sb
@@ -92,6 +94,25 @@ module Fluent
           config = config.dup
           tag = config.delete('$tag')
           section_build('match', config, indent: indent, arg: tag)
+        end
+
+        def included_sections_build(config, section_builder, indent: 0)
+          config.each_entry do |e|
+            k = e.keys.first
+            cc = e.delete(k)
+            case k
+            when 'label'
+              section_builder.add_section(label_build(cc, indent: indent))
+            when 'worker'
+              section_builder.add_section(worker_build(cc, indent: indent))
+            when 'source'
+              section_builder.add_section(source_build(cc, indent: indent))
+            when 'filter'
+              section_builder.add_section(filter_build(cc, indent: indent))
+            when 'match'
+              section_builder.add_section(match_build(cc, indent: indent))
+            end
+          end
         end
 
         def section_build(name, config, indent: 0, arg: nil)

--- a/lib/fluent/config/yaml_parser/parser.rb
+++ b/lib/fluent/config/yaml_parser/parser.rb
@@ -134,6 +134,10 @@ module Fluent
             sb.add_line('@label', v)
           end
 
+          if (v = config.delete('$id'))
+            sb.add_line('@id', v)
+          end
+
           config.each do |key, val|
             if val.is_a?(Array)
               val.each do |v|

--- a/lib/fluent/config/yaml_parser/parser.rb
+++ b/lib/fluent/config/yaml_parser/parser.rb
@@ -87,13 +87,21 @@ module Fluent
         def filter_build(config, indent: 0)
           config = config.dup
           tag = config.delete('$tag')
-          section_build('filter', config, indent: indent, arg: tag)
+          if tag.is_a?(Array)
+            section_build('filter', config, indent: indent, arg: tag&.join(','))
+          else
+            section_build('filter', config, indent: indent, arg: tag)
+          end
         end
 
         def match_build(config, indent: 0)
           config = config.dup
           tag = config.delete('$tag')
-          section_build('match', config, indent: indent, arg: tag)
+          if tag.is_a?(Array)
+            section_build('match', config, indent: indent, arg: tag&.join(','))
+          else
+            section_build('match', config, indent: indent, arg: tag)
+          end
         end
 
         def included_sections_build(config, section_builder, indent: 0)

--- a/lib/fluent/config/yaml_parser/parser.rb
+++ b/lib/fluent/config/yaml_parser/parser.rb
@@ -112,7 +112,14 @@ module Fluent
               end
             elsif val.is_a?(Hash)
               harg = val.delete('$arg')
-              sb.add_section(section_build(key, val, indent: indent + @base_indent, arg: harg))
+              if harg.is_a?(Array)
+                # To prevent to generate invalid configuration for arg.
+                # "arg" should be String object and concatenated by ","
+                # when two or more objects are specified there.
+                sb.add_section(section_build(key, val, indent: indent + @base_indent, arg: harg&.join(',')))
+              else
+                sb.add_section(section_build(key, val, indent: indent + @base_indent, arg: harg))
+              end
             else
               sb.add_line(key, val)
             end

--- a/lib/fluent/config/yaml_parser/parser.rb
+++ b/lib/fluent/config/yaml_parser/parser.rb
@@ -1,0 +1,126 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'fluent/config/yaml_parser/section_builder'
+
+module Fluent
+  module Config
+    module YamlParser
+      class Parser
+        def initialize(config, indent: 2)
+          @base_indent = indent
+          @config = config
+        end
+
+        def build
+          s = @config['system'] && system_config_build(@config['system'])
+          c = @config['config'] && config_build(@config['config'], root: true)
+          RootBuilder.new(s, c)
+        end
+
+        private
+
+        def system_config_build(config)
+          section_build('system', config)
+        end
+
+        def config_build(config, indent: 0, root: false)
+          sb = SectionBodyBuilder.new(indent, root: root)
+          config.each do |c|
+            if (lc = c.delete('label'))
+              sb.add_section(label_build(lc, indent: indent))
+            end
+
+            if (sc = c.delete('source'))
+              sb.add_section(source_build(sc, indent: indent))
+            end
+
+            if (fc = c.delete('filter'))
+              sb.add_section(filter_build(fc, indent: indent))
+            end
+
+            if (mc = c.delete('match'))
+              sb.add_section(match_build(mc, indent: indent))
+            end
+
+            if (wc = c.delete('worker'))
+              sb.add_section(worker_build(wc, indent: indent))
+            end
+          end
+
+          sb
+        end
+
+        def label_build(config, indent: 0)
+          config = config.dup
+          name = config.delete('$name')
+          c = config.delete('config')
+          SectionBuilder.new('label', config_build(c, indent: indent + @base_indent), indent, name)
+        end
+
+        def worker_build(config, indent: 0)
+          config = config.dup
+          num = config.delete('$arg')
+          c = config.delete('config')
+          SectionBuilder.new('worker', config_build(c, indent: indent + @base_indent), indent, num)
+        end
+
+        def source_build(config, indent: 0)
+          section_build('source', config, indent: indent)
+        end
+
+        def filter_build(config, indent: 0)
+          config = config.dup
+          tag = config.delete('$tag')
+          section_build('filter', config, indent: indent, arg: tag)
+        end
+
+        def match_build(config, indent: 0)
+          config = config.dup
+          tag = config.delete('$tag')
+          section_build('match', config, indent: indent, arg: tag)
+        end
+
+        def section_build(name, config, indent: 0, arg: nil)
+          sb = SectionBodyBuilder.new(indent + @base_indent)
+
+          if (v = config.delete('$type'))
+            sb.add_line('@type', v)
+          end
+
+          if (v = config.delete('$label'))
+            sb.add_line('@label', v)
+          end
+
+          config.each do |key, val|
+            if val.is_a?(Array)
+              val.each do |v|
+                sb.add_section(section_build(key, v, indent: indent + @base_indent))
+              end
+            elsif val.is_a?(Hash)
+              harg = val.delete('$arg')
+              sb.add_section(section_build(key, val, indent: indent + @base_indent, arg: harg))
+            else
+              sb.add_line(key, val)
+            end
+          end
+
+          SectionBuilder.new(name, sb, indent, arg)
+        end
+      end
+    end
+  end
+end

--- a/lib/fluent/config/yaml_parser/section_builder.rb
+++ b/lib/fluent/config/yaml_parser/section_builder.rb
@@ -1,0 +1,107 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+module Fluent
+  module Config
+    module YamlParser
+      SectionBuilder = Struct.new(:name, :body, :indent_size, :arg) do
+        def to_s
+          indent = ' ' * indent_size
+
+          if arg && !arg.to_s.empty?
+            "#{indent}<#{name} #{arg}>\n#{body}\n#{indent}</#{name}>"
+          else
+            "#{indent}<#{name}>\n#{body}\n#{indent}</#{name}>"
+          end
+        end
+
+        def to_element
+          elem = body.to_element
+          elem.name = name
+          elem.arg = arg.to_s if arg
+          elem.v1_config = true
+          elem
+        end
+      end
+
+      class RootBuilder
+        def initialize(system, conf)
+          @system = system
+          @conf = conf
+        end
+
+        attr_reader :system, :conf
+
+        def to_element
+          Fluent::Config::Element.new('ROOT', '', {}, [@system, @conf].compact.map(&:to_element).flatten)
+        end
+
+        def to_s
+          s = StringIO.new(+'')
+          s.puts(@system.to_s) if @system
+          s.puts(@conf.to_s) if @conf
+
+          s.string
+        end
+      end
+
+      class SectionBodyBuilder
+        Row = Struct.new(:key, :value, :indent) do
+          def to_s
+            "#{indent}#{key} #{value}"
+          end
+        end
+
+        def initialize(indent, root: false)
+          @indent = ' ' * indent
+          @bodies = []
+          @root = root
+        end
+
+        def add_line(k, v)
+          @bodies << Row.new(k, v, @indent)
+        end
+
+        def add_section(section)
+          @bodies << section
+        end
+
+        def to_element
+          if @root
+            return @bodies.map(&:to_element)
+          end
+
+          not_section, section = @bodies.partition { |e| e.is_a?(Row) }
+          r = {}
+          not_section.each do |e|
+            v = e.value
+            r[e.key] = v.respond_to?(:to_element) ? v.to_element : v
+          end
+
+          if @root
+            section.map(&:to_element)
+          else
+            Fluent::Config::Element.new('', '', r, section.map(&:to_element))
+          end
+        end
+
+        def to_s
+          @bodies.map(&:to_s).join("\n")
+        end
+      end
+    end
+  end
+end

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -621,7 +621,10 @@ module Fluent
         @conf = Fluent::Config.build(config_path: @config_path,
                                      encoding: @conf_encoding ? @conf_encoding : 'utf-8',
                                      additional_config: @inline_config ? @inline_config : nil,
-                                     use_v1_config: !!@use_v1_config)
+                                     use_v1_config: !!@use_v1_config,
+                                     type: @config_file_type,
+                                     guess_type: @guess_config_file_type,
+                                    )
         @system_config = build_system_config(@conf)
         if @system_config.log
           @log_rotate_age ||= @system_config.log.rotate_age

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -581,7 +581,7 @@ module Fluent
         signame: nil,
         conf_encoding: 'utf-8',
         disable_shared_socket: nil,
-        guess_config_file_type: nil,
+        config_file_type: :guess,
       }
     end
 
@@ -594,7 +594,7 @@ module Fluent
     end
 
     def initialize(opt)
-      @guess_config_file_type = opt[:guess_config_file_type]
+      @config_file_type = opt[:config_file_type]
       @daemonize = opt[:daemonize]
       @standalone_worker= opt[:standalone_worker]
       @config_path = opt[:config_path]
@@ -621,7 +621,7 @@ module Fluent
                                      encoding: @conf_encoding ? @conf_encoding : 'utf-8',
                                      additional_config: @inline_config ? @inline_config : nil,
                                      use_v1_config: !!@use_v1_config,
-                                     type: @guess_config_file_type,
+                                     type: @config_file_type,
                                     )
         @system_config = build_system_config(@conf)
         if @system_config.log
@@ -753,7 +753,7 @@ module Fluent
         encoding: @conf_encoding,
         additional_config: @inline_config,
         use_v1_config: @use_v1_config,
-        type: @guess_config_file_type,
+        type: @config_file_type,
       )
       @system_config = build_system_config(@conf)
 
@@ -939,7 +939,7 @@ module Fluent
             encoding: @conf_encoding,
             additional_config: @inline_config,
             use_v1_config: @use_v1_config,
-            type: @guess_config_file_type,
+            type: @config_file_type,
           )
 
           Fluent::VariableStore.try_to_reset do

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -580,7 +580,8 @@ module Fluent
         standalone_worker: false,
         signame: nil,
         conf_encoding: 'utf-8',
-        disable_shared_socket: nil
+        disable_shared_socket: nil,
+        guess_config_file_type: true,
       }
     end
 
@@ -594,6 +595,7 @@ module Fluent
 
     def initialize(opt)
       @config_file_type = opt[:config_file_type]
+      @guess_config_file_type = opt[:guess_config_file_type]
       @daemonize = opt[:daemonize]
       @standalone_worker= opt[:standalone_worker]
       @config_path = opt[:config_path]
@@ -751,6 +753,7 @@ module Fluent
         additional_config: @inline_config,
         use_v1_config: @use_v1_config,
         type: @config_file_type,
+        guess_type: @guess_config_file_type,
       )
       @system_config = build_system_config(@conf)
 
@@ -936,6 +939,8 @@ module Fluent
             encoding: @conf_encoding,
             additional_config: @inline_config,
             use_v1_config: @use_v1_config,
+            type: @config_file_type,
+            guess_type: @guess_config_file_type,
           )
 
           Fluent::VariableStore.try_to_reset do

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -581,7 +581,7 @@ module Fluent
         signame: nil,
         conf_encoding: 'utf-8',
         disable_shared_socket: nil,
-        guess_config_file_type: true,
+        guess_config_file_type: nil,
       }
     end
 
@@ -594,7 +594,6 @@ module Fluent
     end
 
     def initialize(opt)
-      @config_file_type = opt[:config_file_type]
       @guess_config_file_type = opt[:guess_config_file_type]
       @daemonize = opt[:daemonize]
       @standalone_worker= opt[:standalone_worker]
@@ -622,8 +621,7 @@ module Fluent
                                      encoding: @conf_encoding ? @conf_encoding : 'utf-8',
                                      additional_config: @inline_config ? @inline_config : nil,
                                      use_v1_config: !!@use_v1_config,
-                                     type: @config_file_type,
-                                     guess_type: @guess_config_file_type,
+                                     type: @guess_config_file_type,
                                     )
         @system_config = build_system_config(@conf)
         if @system_config.log
@@ -755,8 +753,7 @@ module Fluent
         encoding: @conf_encoding,
         additional_config: @inline_config,
         use_v1_config: @use_v1_config,
-        type: @config_file_type,
-        guess_type: @guess_config_file_type,
+        type: @guess_config_file_type,
       )
       @system_config = build_system_config(@conf)
 
@@ -942,8 +939,7 @@ module Fluent
             encoding: @conf_encoding,
             additional_config: @inline_config,
             use_v1_config: @use_v1_config,
-            type: @config_file_type,
-            guess_type: @guess_config_file_type,
+            type: @guess_config_file_type,
           )
 
           Fluent::VariableStore.try_to_reset do

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -593,6 +593,7 @@ module Fluent
     end
 
     def initialize(opt)
+      @config_file_type = opt[:config_file_type]
       @daemonize = opt[:daemonize]
       @standalone_worker= opt[:standalone_worker]
       @config_path = opt[:config_path]
@@ -744,7 +745,13 @@ module Fluent
         $log.warn('the value "-" for `inline_config` is deprecated. See https://github.com/fluent/fluentd/issues/2711')
         @inline_config = STDIN.read
       end
-      @conf = Fluent::Config.build(config_path: @config_path, encoding: @conf_encoding, additional_config: @inline_config, use_v1_config: @use_v1_config)
+      @conf = Fluent::Config.build(
+        config_path: @config_path,
+        encoding: @conf_encoding,
+        additional_config: @inline_config,
+        use_v1_config: @use_v1_config,
+        type: @config_file_type,
+      )
       @system_config = build_system_config(@conf)
 
       @log.level = @system_config.log_level

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -202,26 +202,39 @@ class ConfigTest < Test::Unit::TestCase
       fluent_log_conf = label_conf.elements.first
       fluent_log_buffer_conf = fluent_log_conf.elements.first
 
-      assert_equal 'dummy', dummy_source_conf['@type']
-      assert_equal 'tag.dummy', dummy_source_conf['tag']
-
-      assert_equal 'tcp', tcp_source_conf['@type']
-      assert_equal 'tag.tcp', tcp_source_conf['tag']
-
-      assert_equal 'none', parse_tcp_conf['@type']
-      assert_equal 'why.parse.section.doesnot.have.arg,huh', parse_tcp_conf.arg
-
-      assert_equal 'stdout', match_conf['@type']
-      assert_equal 'tag.*', match_conf.arg
-
-      assert_equal 'null', fluent_log_conf['@type']
-      assert_equal '**', fluent_log_conf.arg
-
-      assert_equal '@FLUENT_LOG', label_conf.arg
-
-      assert_equal 'memory', fluent_log_buffer_conf['@type']
-      assert_equal 'interval', fluent_log_buffer_conf['flush_mode']
-      assert_equal '1s', fluent_log_buffer_conf['flush_interval']
+      assert_equal(
+        [
+          'dummy',
+          'tag.dummy',
+          'tcp',
+          'tag.tcp',
+          'none',
+          'why.parse.section.doesnot.have.arg,huh',
+          'stdout',
+          'tag.*',
+          'null',
+          '**',
+          '@FLUENT_LOG',
+          'memory',
+          'interval',
+          '1s',
+        ],
+        [
+          dummy_source_conf['@type'],
+          dummy_source_conf['tag'],
+          tcp_source_conf['@type'],
+          tcp_source_conf['tag'],
+          parse_tcp_conf['@type'],
+          parse_tcp_conf.arg,
+          match_conf['@type'],
+          match_conf.arg,
+          fluent_log_conf['@type'],
+          fluent_log_conf.arg,
+          label_conf.arg,
+          fluent_log_buffer_conf['@type'],
+          fluent_log_buffer_conf['flush_mode'],
+          fluent_log_buffer_conf['flush_interval'],
+        ])
     end
 
     def test_check_not_fetchd

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -90,6 +90,71 @@ class SupervisorTest < ::Test::Unit::TestCase
     assert_equal 2, counter_client.timeout
   end
 
+  sub_test_case "yaml config" do
+    def parse_yaml(yaml)
+      context = Kernel.binding
+
+      config = nil
+      Tempfile.open do |file|
+        file.puts(yaml)
+        file.flush
+        s = Fluent::Config::YamlParser::Loader.new(context).load(Pathname.new(file))
+        config = Fluent::Config::YamlParser::Parser.new(s).build.to_element
+      end
+      config
+    end
+
+    def test_system_config
+      opts = Fluent::Supervisor.default_options
+      sv = Fluent::Supervisor.new(opts)
+      conf_data = <<-EOC
+      system:
+        rpc_endpoint: 127.0.0.1:24445
+        suppress_repeated_stacktrace: true
+        suppress_config_dump: true
+        without_source: true
+        enable_get_dump: true
+        process_name: "process_name"
+        log_level: info
+        root_dir: !fluent/s "#{TMP_ROOT_DIR}"
+        log:
+          format: json
+          time_format: "%Y"
+        counter_server:
+          bind: 127.0.0.1
+          port: 24321
+          scope: server1
+          backup_path: /tmp/backup
+        counter_client:
+          host: 127.0.0.1
+          port: 24321
+          timeout: 2
+      EOC
+      conf = parse_yaml(conf_data)
+      sys_conf = sv.__send__(:build_system_config, conf)
+
+      assert_equal '127.0.0.1:24445', sys_conf.rpc_endpoint
+      assert_equal true, sys_conf.suppress_repeated_stacktrace
+      assert_equal true, sys_conf.suppress_config_dump
+      assert_equal true, sys_conf.without_source
+      assert_equal true, sys_conf.enable_get_dump
+      assert_equal "process_name", sys_conf.process_name
+      assert_equal 2, sys_conf.log_level
+      assert_equal TMP_ROOT_DIR, sys_conf.root_dir
+      assert_equal :json, sys_conf.log.format
+      assert_equal '%Y', sys_conf.log.time_format
+      counter_server = sys_conf.counter_server
+      assert_equal '127.0.0.1', counter_server.bind
+      assert_equal 24321, counter_server.port
+      assert_equal 'server1', counter_server.scope
+      assert_equal '/tmp/backup', counter_server.backup_path
+      counter_client = sys_conf.counter_client
+      assert_equal '127.0.0.1', counter_client.host
+      assert_equal 24321, counter_client.port
+      assert_equal 2, counter_client.timeout
+    end
+  end
+
   def test_main_process_signal_handlers
     omit "Windows cannot handle signals" if Fluent.windows?
 
@@ -545,6 +610,31 @@ class SupervisorTest < ::Test::Unit::TestCase
         file.flush
         opts = Fluent::Supervisor.default_options.merge(
           log_path: "#{TMP_DIR}/test.log", config_path: file.path
+        )
+        sv = Fluent::Supervisor.new(opts)
+
+        log = sv.instance_variable_get(:@log)
+        log.init(:standalone, 0)
+        logger = $log.instance_variable_get(:@logger)
+
+        assert_equal([3, 300],
+                     [logger.instance_variable_get(:@rotate_age),
+                      logger.instance_variable_get(:@rotate_size)])
+      end
+    end
+
+    def test_override_default_log_rotate_with_yaml_config
+      Tempfile.open do |file|
+        config = <<-EOS
+          system:
+            log:
+              rotate_age: 3
+              rotate_size: 300
+        EOS
+        file.puts(config)
+        file.flush
+        opts = Fluent::Supervisor.default_options.merge(
+          log_path: "#{TMP_DIR}/test.log", config_path: file.path, config_file_type: :yaml,
         )
         sv = Fluent::Supervisor.new(opts)
 

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -634,7 +634,7 @@ class SupervisorTest < ::Test::Unit::TestCase
         file.puts(config)
         file.flush
         opts = Fluent::Supervisor.default_options.merge(
-          log_path: "#{TMP_DIR}/test.log", config_path: file.path, guess_config_file_type: :yaml,
+          log_path: "#{TMP_DIR}/test.log", config_path: file.path, config_file_type: :yaml,
         )
         sv = Fluent::Supervisor.new(opts)
 

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -133,25 +133,47 @@ class SupervisorTest < ::Test::Unit::TestCase
       conf = parse_yaml(conf_data)
       sys_conf = sv.__send__(:build_system_config, conf)
 
-      assert_equal '127.0.0.1:24445', sys_conf.rpc_endpoint
-      assert_equal true, sys_conf.suppress_repeated_stacktrace
-      assert_equal true, sys_conf.suppress_config_dump
-      assert_equal true, sys_conf.without_source
-      assert_equal true, sys_conf.enable_get_dump
-      assert_equal "process_name", sys_conf.process_name
-      assert_equal 2, sys_conf.log_level
-      assert_equal TMP_ROOT_DIR, sys_conf.root_dir
-      assert_equal :json, sys_conf.log.format
-      assert_equal '%Y', sys_conf.log.time_format
-      counter_server = sys_conf.counter_server
-      assert_equal '127.0.0.1', counter_server.bind
-      assert_equal 24321, counter_server.port
-      assert_equal 'server1', counter_server.scope
-      assert_equal '/tmp/backup', counter_server.backup_path
-      counter_client = sys_conf.counter_client
-      assert_equal '127.0.0.1', counter_client.host
-      assert_equal 24321, counter_client.port
-      assert_equal 2, counter_client.timeout
+    counter_client = sys_conf.counter_client
+    counter_server = sys_conf.counter_server
+    assert_equal(
+      [
+        '127.0.0.1:24445',
+        true,
+        true,
+        true,
+        true,
+        "process_name",
+        2,
+        TMP_ROOT_DIR,
+        :json,
+        '%Y',
+        '127.0.0.1',
+        24321,
+        'server1',
+        '/tmp/backup',
+        '127.0.0.1',
+        24321,
+        2,
+      ],
+      [
+        sys_conf.rpc_endpoint,
+        sys_conf.suppress_repeated_stacktrace,
+        sys_conf.suppress_config_dump,
+        sys_conf.without_source,
+        sys_conf.enable_get_dump,
+        sys_conf.process_name,
+        sys_conf.log_level,
+        sys_conf.root_dir,
+        sys_conf.log.format,
+        sys_conf.log.time_format,
+        counter_server.bind,
+        counter_server.port,
+        counter_server.scope,
+        counter_server.backup_path,
+        counter_client.host,
+        counter_client.port,
+        counter_client.timeout,
+      ])
     end
   end
 

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -634,7 +634,7 @@ class SupervisorTest < ::Test::Unit::TestCase
         file.puts(config)
         file.flush
         opts = Fluent::Supervisor.default_options.merge(
-          log_path: "#{TMP_DIR}/test.log", config_path: file.path, config_file_type: :yaml,
+          log_path: "#{TMP_DIR}/test.log", config_path: file.path, guess_config_file_type: :yaml,
         )
         sv = Fluent::Supervisor.new(opts)
 


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes https://github.com/fluent/fluentd/issues/554
Revised #2818

**What this PR does / why we need it**: 

Recently, fluent-bit supports YAML configuration in https://github.com/fluent/fluent-bit/pull/4621.

Now, it is reasonable to handle YAML configuration format on Fluentd, too.
This is because YAML config format is more kubernetes friendly and machine friendly.
It's time to discuss to support YAML configuration format again.
 
**Docs Changes**:
https://github.com/fluent/fluentd-docs-gitbook/pull/402

**Release Note**: 

Same as title