### PR TITLE
Fix warnings on runnings tests

### DIFF
--- a/lib/fluent/command/ctl.rb
+++ b/lib/fluent/command/ctl.rb
@@ -146,7 +146,7 @@ module Fluent
         event = Win32::Event.open("#{prefix}#{suffix}")
         event.set
         event.close
-      rescue Errno::ENOENT => e
+      rescue Errno::ENOENT
         puts "Error: Cannot find the fluentd process with the event name: \"#{prefix}\""
       end
     end

--- a/lib/fluent/config/literal_parser.rb
+++ b/lib/fluent/config/literal_parser.rb
@@ -191,9 +191,9 @@ worker_id = ENV['SERVERENGINE_WORKER_ID'] || ''
 EOM
         begin
           @eval_context.instance_eval(code)
-        rescue SetNil => e
+        rescue SetNil
           nil
-        rescue SetDefault => e
+        rescue SetDefault
           :default
         end
       end

--- a/lib/fluent/plugin/file_wrapper.rb
+++ b/lib/fluent/plugin/file_wrapper.rb
@@ -106,7 +106,7 @@ module Fluent
       @mode = mode
 
 
-      access, creationdisposition, seektoend = case mode.delete('b')
+      access, creationdisposition, _seektoend = case mode.delete('b')
       when "r" ; [FILE_GENERIC_READ                     , OPEN_EXISTING, false]
       when "r+"; [FILE_GENERIC_READ | FILE_GENERIC_WRITE, OPEN_ALWAYS  , false]
       when "w" ; [FILE_GENERIC_WRITE                    , CREATE_ALWAYS, false]

--- a/lib/fluent/plugin/parser_syslog.rb
+++ b/lib/fluent/plugin/parser_syslog.rb
@@ -484,7 +484,7 @@ module Fluent
 
         time = begin
                  @time_parser_rfc5424.parse(time_str)
-               rescue Fluent::TimeParser::TimeParseError => e
+               rescue Fluent::TimeParser::TimeParseError
                  @time_parser_rfc5424_without_subseconds.parse(time_str)
                end
         record['time'] = time_str if @keep_time_key

--- a/test/command/test_ctl.rb
+++ b/test/command/test_ctl.rb
@@ -7,7 +7,6 @@ require 'fluent/command/ctl'
 
 class TestFluentdCtl < ::Test::Unit::TestCase
   def assert_win32_event(event_name, command, pid_or_svcname)
-    command, event_suffix = data
     event = Win32::Event.new(event_name)
     ipc = Win32::Ipc.new(event.handle)
     ret = Win32::Ipc::TIMEOUT

--- a/test/config/test_system_config.rb
+++ b/test/config/test_system_config.rb
@@ -174,7 +174,6 @@ module Fluent::Config
             </log>
           </system>
         EOS
-        s = FakeSupervisor.new
         sc = Fluent::SystemConfig.new(conf)
         assert_equal(3, sc.log.rotate_age)
       end

--- a/test/config/test_types.rb
+++ b/test/config/test_types.rb
@@ -190,7 +190,7 @@ class TestConfigTypes < ::Test::Unit::TestCase
     data("val" => [:val, 'val'],
          "v" => [:v, 'v'],
          "value" => [:value, 'value'])
-    test 'enum' do |(expected, val, list)|
+    test 'enum' do |(expected, val)|
       assert_equal expected, Config::ENUM_TYPE.call(val, {list: [:val, :value, :v]})
     end
 

--- a/test/plugin/in_tail/test_io_handler.rb
+++ b/test/plugin/in_tail/test_io_handler.rb
@@ -107,6 +107,7 @@ class IntailIOHandlerTest < Test::Unit::TestCase
       end
 
       r.on_notify
+      assert_equal text.bytesize, update_pos
       assert_equal 8, returned_lines[0].size
     end
 
@@ -133,6 +134,7 @@ class IntailIOHandlerTest < Test::Unit::TestCase
       end
 
       r.on_notify
+      assert_equal text.bytesize, update_pos
       assert_equal 5, returned_lines[0].size
       assert_equal 3, returned_lines[1].size
     end

--- a/test/plugin/in_tail/test_position_file.rb
+++ b/test/plugin/in_tail/test_position_file.rb
@@ -40,10 +40,6 @@ class IntailPositionFileTest < Test::Unit::TestCase
 
   test '.load' do
     write_data(@file, TEST_CONTENT)
-    paths = {
-      "valid_path" => Fluent::Plugin::TailInput::TargetInfo.new("valid_path", 1),
-      "inode23bit" => Fluent::Plugin::TailInput::TargetInfo.new("inode23bit", 2),
-    }
     Fluent::Plugin::TailInput::PositionFile.load(@file, false, TEST_CONTENT_PATHS, **{logger: $log})
 
     @file.seek(0)
@@ -146,11 +142,6 @@ class IntailPositionFileTest < Test::Unit::TestCase
   sub_test_case '#load' do
     test 'compact invalid and convert 32 bit inode value' do
       write_data(@file, TEST_CONTENT)
-      invalid_path = "invalidpath100000000000000000000000000000000"
-      paths = TEST_CONTENT_PATHS.merge({
-        invalid_path => Fluent::Plugin::TailInput::TargetInfo.new(invalid_path, 0),
-        "unwatched" => Fluent::Plugin::TailInput::TargetInfo.new("unwatched", 0),
-      })
       Fluent::Plugin::TailInput::PositionFile.load(@file, false, TEST_CONTENT_PATHS, **{logger: $log})
 
       @file.seek(0)

--- a/test/plugin/test_in_syslog.rb
+++ b/test/plugin/test_in_syslog.rb
@@ -497,7 +497,7 @@ EOS
 
   def test_send_keepalive_packet_can_not_be_enabled_for_udp
     assert_raise(Fluent::ConfigError) do
-      d = create_driver(ipv4_config + %[
+      create_driver(ipv4_config + %[
         send_keepalive_packet true
       ])
     end

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -152,13 +152,13 @@ class TailInputTest < Test::Unit::TestCase
   sub_test_case "configure" do
     test "plain single line" do
       d = create_driver
-      assert_equal ["#{TMP_DIR}/tail.txt"], d.instance.paths
-      assert_equal "t1", d.instance.tag
-      assert_equal 2, d.instance.rotate_wait
-      assert_equal "#{TMP_DIR}/tail.pos", d.instance.pos_file
-      assert_equal 1000, d.instance.read_lines_limit
-      assert_equal -1, d.instance.read_bytes_limit_per_second
-      assert_equal false, d.instance.ignore_repeated_permission_error
+      assert_equal(["#{TMP_DIR}/tail.txt"], d.instance.paths)
+      assert_equal("t1", d.instance.tag)
+      assert_equal(2, d.instance.rotate_wait)
+      assert_equal("#{TMP_DIR}/tail.pos", d.instance.pos_file)
+      assert_equal(1000, d.instance.read_lines_limit)
+      assert_equal(-1, d.instance.read_bytes_limit_per_second)
+      assert_equal(false, d.instance.ignore_repeated_permission_error)
       assert_nothing_raised do
         d.instance.have_read_capability?
       end
@@ -175,13 +175,13 @@ class TailInputTest < Test::Unit::TestCase
     test "multi paths with path_delimiter" do
       c = config_element("ROOT", "", { "path" => "tail.txt|test2|tmp,dev", "tag" => "t1", "path_delimiter" => "|" })
       d = create_driver(c + PARSE_SINGLE_LINE_CONFIG, false)
-      assert_equal ["tail.txt", "test2", "tmp,dev"], d.instance.paths
+      assert_equal(["tail.txt", "test2", "tmp,dev"], d.instance.paths)
     end
 
     test "multi paths with same path configured twice" do
       c = config_element("ROOT", "", { "path" => "test1.txt,test2.txt,test1.txt", "tag" => "t1", "path_delimiter" => "," })
       d = create_driver(c + PARSE_SINGLE_LINE_CONFIG, false)
-      assert_equal ["test2.txt","test1.txt"].sort, d.instance.paths.sort
+      assert_equal(["test2.txt","test1.txt"].sort, d.instance.paths.sort)
     end
 
     test "multi paths with invaid path_delimiter" do
@@ -223,7 +223,7 @@ class TailInputTest < Test::Unit::TestCase
       test "valid" do
         conf = SINGLE_LINE_CONFIG + config_element("", "", { "encoding" => "utf-8" })
         d = create_driver(conf)
-        assert_equal Encoding::UTF_8, d.instance.encoding
+        assert_equal(Encoding::UTF_8, d.instance.encoding)
       end
 
       test "invalid" do
@@ -1150,7 +1150,7 @@ class TailInputTest < Test::Unit::TestCase
       config = data + config_element("", "", { "multiline_flush_interval" => "2s" })
       d = create_driver(config)
 
-      assert_equal 2, d.instance.multiline_flush_interval
+      assert_equal(2, d.instance.multiline_flush_interval)
 
       d.run(expect_emits: 1) do
         File.open("#{TMP_DIR}/tail.txt", "ab") { |f|
@@ -1375,13 +1375,13 @@ class TailInputTest < Test::Unit::TestCase
       plugin = create_driver(EX_CONFIG, false).instance
       flexstub(Time) do |timeclass|
         timeclass.should_receive(:now).with_no_args.and_return(Time.new(2010, 1, 2, 3, 4, 5))
-        assert_equal ex_paths, plugin.expand_paths.values.sort_by { |path_ino| path_ino.path }
+        assert_equal(ex_paths, plugin.expand_paths.values.sort_by { |path_ino| path_ino.path })
       end
 
       # Test exclusion
       exclude_config = EX_CONFIG + config_element("", "", { "exclude_path" => %Q(["#{ex_paths.last.path}"]) })
       plugin = create_driver(exclude_config, false).instance
-      assert_equal ex_paths - [ex_paths.last], plugin.expand_paths.values.sort_by { |path_ino| path_ino.path }
+      assert_equal(ex_paths - [ex_paths.last], plugin.expand_paths.values.sort_by { |path_ino| path_ino.path })
     end
 
     def test_expand_paths_with_duplicate_configuration
@@ -1392,7 +1392,7 @@ class TailInputTest < Test::Unit::TestCase
       duplicate_config = EX_CONFIG.dup
       duplicate_config["path"]="test/plugin/data/log/**/*.log, test/plugin/data/log/**/*.log"
       plugin = create_driver(EX_CONFIG, false).instance
-      assert_equal expanded_paths, plugin.expand_paths.values.sort_by { |path_ino| path_ino.path }
+      assert_equal(expanded_paths, plugin.expand_paths.values.sort_by { |path_ino| path_ino.path })
     end
 
     def test_expand_paths_with_timezone
@@ -1414,8 +1414,8 @@ class TailInputTest < Test::Unit::TestCase
             # env : 2010-01-01 19:04:05 (UTC), tail path : 2010-01-02 03:04:05 (Asia/Taipei)
             timeclass.should_receive(:now).with_no_args.and_return(Time.new(2010, 1, 1, 19, 4, 5))
 
-            assert_equal ex_paths, plugin.expand_paths.values.sort_by { |path_ino| path_ino.path }
-            assert_equal ex_paths - [ex_paths.first], exclude_plugin.expand_paths.values.sort_by { |path_ino| path_ino.path }
+            assert_equal(ex_paths, plugin.expand_paths.values.sort_by { |path_ino| path_ino.path })
+            assert_equal(ex_paths - [ex_paths.first], exclude_plugin.expand_paths.values.sort_by { |path_ino| path_ino.path })
           end
         end
       end
@@ -1437,7 +1437,7 @@ class TailInputTest < Test::Unit::TestCase
       })
 
       plugin = create_driver(config, false).instance
-      assert_equal expected_files, plugin.expand_paths.values.sort_by { |path_ino| path_ino.path }
+      assert_equal(expected_files, plugin.expand_paths.values.sort_by { |path_ino| path_ino.path })
     end
 
     def test_unwatched_files_should_be_removed
@@ -1459,7 +1459,7 @@ class TailInputTest < Test::Unit::TestCase
       waiting(20) { sleep 0.1 until Dir.glob("#{TMP_DIR}/*.txt").size == 0 } # Ensure file is deleted on Windows
       waiting(5) { sleep 0.1 until d.instance.instance_variable_get(:@tails).keys.size <= 0 }
 
-      assert_equal 0, d.instance.instance_variable_get(:@tails).keys.size
+      assert_equal(0, d.instance.instance_variable_get(:@tails).keys.size)
 
       d.instance_shutdown
     end
@@ -1511,8 +1511,8 @@ class TailInputTest < Test::Unit::TestCase
                             "rotate_wait" => "2s"
                        }) + PARSE_SINGLE_LINE_CONFIG, false)
 
-      assert_equal readable_paths, d.instance.expand_paths.length
-      assert_equal result, d.instance.have_read_capability?
+      assert_equal(readable_paths, d.instance.expand_paths.length)
+      assert_equal(result, d.instance.have_read_capability?)
     end
   end
 
@@ -1530,7 +1530,7 @@ class TailInputTest < Test::Unit::TestCase
     d = create_driver(config, false)
     d.run
     assert_path_exist("#{TMP_DIR}/pos")
-    assert_equal '755', File.stat("#{TMP_DIR}/pos").mode.to_s(8)[-3, 3]
+    assert_equal('755', File.stat("#{TMP_DIR}/pos").mode.to_s(8)[-3, 3])
   ensure
     cleanup_directory(TMP_DIR)
   end
@@ -1554,9 +1554,9 @@ class TailInputTest < Test::Unit::TestCase
 
     assert_path_exist("#{TMP_DIR}/pos")
     if Fluent.windows?
-      assert_equal '755', File.stat("#{TMP_DIR}/pos").mode.to_s(8)[-3, 3]
+      assert_equal('755', File.stat("#{TMP_DIR}/pos").mode.to_s(8)[-3, 3])
     else
-      assert_equal '744', File.stat("#{TMP_DIR}/pos").mode.to_s(8)[-3, 3]
+      assert_equal('744', File.stat("#{TMP_DIR}/pos").mode.to_s(8)[-3, 3])
     end
   ensure
     cleanup_directory(TMP_DIR)
@@ -2246,7 +2246,7 @@ class TailInputTest < Test::Unit::TestCase
 
     Timecop.freeze(now) do
       plugin = create_driver(config, false).instance
-      assert_equal expected_files, plugin.expand_paths.values.sort_by { |path_ino| path_ino.path }
+      assert_equal(expected_files, plugin.expand_paths.values.sort_by { |path_ino| path_ino.path })
     end
   end
 
@@ -2259,7 +2259,7 @@ class TailInputTest < Test::Unit::TestCase
                             })
     d = create_driver(config)
     d.run(shutdown: false) {}
-    assert_equal 0, d.instance.instance_variable_get(:@tails).keys.size
+    assert_equal(0, d.instance.instance_variable_get(:@tails).keys.size)
     # detect a file at first execution of in_tail_refresh_watchers timer
     waiting(5) { sleep 0.1 until d.instance.instance_variable_get(:@tails).keys.size == 1 }
     d.instance_shutdown
@@ -2333,7 +2333,6 @@ class TailInputTest < Test::Unit::TestCase
   end
 
   def test_shutdown_timeout
-    path = "#{TMP_DIR}/tail.txt"
     File.open("#{TMP_DIR}/tail.txt", "wb") do |f|
       (1024 * 1024 * 5).times do
         f.puts "{\"test\":\"fizzbuzz\"}"

--- a/test/plugin/test_parser_syslog.rb
+++ b/test/plugin/test_parser_syslog.rb
@@ -644,7 +644,7 @@ class SyslogParserTest < ::Test::Unit::TestCase
 
   data('regexp' => :regexp, 'string' => :string)
   def test_parser_engine(engine)
-    d = @parser.configure({'parser_engine' => engine.to_s})
+    @parser.configure({'parser_engine' => engine.to_s})
     assert_equal(engine, @parser.instance.parser_engine)
   end
 end

--- a/test/plugin_helper/test_cert_option.rb
+++ b/test/plugin_helper/test_cert_option.rb
@@ -19,7 +19,7 @@ class CertOptionPluginHelperTest < Test::Unit::TestCase
   test 'raise an error for broken certificates_from_file file' do
     d = Dummy.new
     assert_raise Fluent::ConfigError do
-      certs = d.cert_option_certificates_from_file("test/plugin_helper/data/cert/empty.pem")
+      d.cert_option_certificates_from_file("test/plugin_helper/data/cert/empty.pem")
     end
   end
 end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 
Many warnings are shown on running unit tests.
It makes hard to find actual bugs.

```
/Users/aho/Projects/Fluentd/fluentd/lib/fluent/config/literal_parser.rb:194: warning: assigned but unused variable - e
/Users/aho/Projects/Fluentd/fluentd/lib/fluent/plugin/parser_syslog.rb:487: warning: assigned but unused variable - e
/Users/aho/Projects/Fluentd/fluentd/test/command/test_ctl.rb:10: warning: assigned but unused variable - event_suffix
/Users/aho/Projects/Fluentd/fluentd/lib/fluent/command/ctl.rb:149: warning: assigned but unused variable - e
/Users/aho/Projects/Fluentd/fluentd/test/config/test_types.rb:193: warning: assigned but unused variable - list
/Users/aho/Projects/Fluentd/fluentd/test/plugin/in_tail/test_io_handler.rb:93: warning: assigned but unused variable - update_pos
/Users/aho/Projects/Fluentd/fluentd/test/plugin/in_tail/test_io_handler.rb:119: warning: assigned but unused variable - update_pos
/Users/aho/Projects/Fluentd/fluentd/test/plugin/in_tail/test_position_file.rb:43: warning: assigned but unused variable - paths
/Users/aho/Projects/Fluentd/fluentd/test/plugin/in_tail/test_position_file.rb:150: warning: assigned but unused variable - paths
/Users/aho/Projects/Fluentd/fluentd/lib/fluent/plugin/file_wrapper.rb:109: warning: assigned but unused variable - seektoend
/Users/aho/Projects/Fluentd/fluentd/test/plugin/test_in_syslog.rb:500: warning: assigned but unused variable - d
/Users/aho/Projects/Fluentd/fluentd/test/plugin/test_in_tail.rb:160: warning: ambiguous first argument; put parentheses or a space even after `-' operator
/Users/aho/Projects/Fluentd/fluentd/test/plugin/test_in_tail.rb:2336: warning: assigned but unused variable - path
/Users/aho/Projects/Fluentd/fluentd/test/plugin/test_parser_syslog.rb:647: warning: assigned but unused variable - d
/Users/aho/Projects/Fluentd/fluentd/test/plugin_helper/test_cert_option.rb:22: warning: assigned but unused variable - certs
```

**Docs Changes**:
None

**Release Note**: 
None
