### PR TITLE
test_in_tail: Call missing Timecop.return at teardown

### DIFF
--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -21,6 +21,7 @@ class TailInputTest < Test::Unit::TestCase
     super
     cleanup_directory(TMP_DIR)
     Fluent::Engine.stop
+    Timecop.return
   end
 
   def cleanup_directory(path)


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 
Without it, test duration report is broken:
```
Finished in -15177316.118847948 seconds.
```

**Docs Changes**:
None

**Release Note**: 
None
