### PR TITLE
in_tail: Add a missing nil check for rotated_tw in update_watcher

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -511,7 +511,7 @@ module Fluent::Plugin
         if new_position_entry.read_inode == 0
           # When follow_inodes is true, it's not cleaned up by refresh_watcher.
           # So it should be unwatched here explicitly.
-          rotated_tw.unwatched = true
+          rotated_tw.unwatched = true if rotated_tw
           @tails[path] = setup_watcher(target_info, new_position_entry)
           @tails[path].on_notify
         end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #3752

**What this PR does / why we need it**: 
The tail watcher for the path might by already removed from `@tails` by refresh_watchers.
Without this fix in_tail might crash on file rotation.

**Docs Changes**:
None

**Release Note**: 
in_tail: Fix a possible crash on file rotation when `follow_inodes true`
