### PR TITLE
test_in_tail: Fix unstable tests

### DIFF
--- a/.github/workflows/linux-test.yaml
+++ b/.github/workflows/linux-test.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['3.1', '3.0', '2.7', '2.6']
+        ruby-version: ['3.1', '3.0', '2.7']
         os: [ubuntu-latest]
         experimental: [false]
         include:

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -998,7 +998,7 @@ class TailInputTest < Test::Unit::TestCase
       assert_equal({"message" => "test8"}, events[3][2])
     end
 
-    def sub_test_rotate_file(config = nil, expect_emits: nil, expect_records: nil, timeout: nil)
+    def sub_test_rotate_file(config = nil, expect_emits: nil, expect_records: nil, timeout: 5)
       file = Fluent::FileWrapper.open("#{TMP_DIR}/tail.txt", "wb")
       file.puts "test1"
       file.puts "test2"
@@ -1016,7 +1016,7 @@ class TailInputTest < Test::Unit::TestCase
         if Fluent.windows?
           file.close
           FileUtils.mv("#{TMP_DIR}/tail.txt", "#{TMP_DIR}/tail2.txt", force: true)
-          file = File.open("#{TMP_DIR}/tail.txt", "ab")
+          file = Fluent::FileWrapper.open("#{TMP_DIR}/tail2.txt", "ab")
         else
           FileUtils.mv("#{TMP_DIR}/tail.txt", "#{TMP_DIR}/tail2.txt")
         end

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -31,60 +31,11 @@ class TailInputTest < Test::Unit::TestCase
       return
     end
 
-    if Fluent.windows?
-      Dir.glob("*", base: path).each do |name|
-        begin
-          cleanup_file(File.join(path, name))
-        rescue
-          # expect test driver block release already owned file handle.
-        end
-      end
-    else
-      begin
-        FileUtils.rm_f(path, secure:true)
-      rescue ArgumentError
-        FileUtils.rm_f(path) # For Ruby 2.6 or before.
-      end
-      if File.exist?(path)
-        FileUtils.remove_entry_secure(path, true)
-      end
-    end
-    FileUtils.mkdir_p(path)
+    FileUtils.remove_entry_secure(path, true)
   end
 
   def cleanup_file(path)
-    if Fluent.windows?
-      # On Windows, when the file or directory is removed and created
-      # frequently, there is a case that creating file or directory will
-      # fail. This situation is caused by pending file or directory
-      # deletion which is mentioned on win32 API document [1]
-      # As a workaround, execute rename and remove method.
-      #
-      # [1] https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea#files
-      #
-      file = File.join(Dir.tmpdir, SecureRandom.hex(10))
-      begin
-        FileUtils.mv(path, file)
-        FileUtils.rm_rf(file, secure: true)
-      rescue ArgumentError
-        FileUtils.rm_rf(file) # For Ruby 2.6 or before.
-      end
-      if File.exist?(file)
-        # ensure files are closed for Windows, on which deleted files
-        # are still visible from filesystem
-        GC.start(full_mark: true, immediate_mark: true, immediate_sweep: true)
-        FileUtils.remove_entry_secure(file, true)
-      end
-    else
-      begin
-        FileUtils.rm_f(path, secure: true)
-      rescue ArgumentError
-        FileUtils.rm_f(path) # For Ruby 2.6 or before.
-      end
-      if File.exist?(path)
-        FileUtils.remove_entry_secure(path, true)
-      end
-    end
+    FileUtils.remove_entry_secure(path, true)
   end
 
   def create_target_info(path)

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -985,6 +985,7 @@ class TailInputTest < Test::Unit::TestCase
 
       d = create_driver(config)
       d.run(expect_emits: expect_emits, expect_records: expect_records, timeout: timeout) do
+        sleep(0.1) while d.instance.instance_variable_get(:@startup)
         size = d.emit_count
         file.puts "test3"
         file.puts "test4"

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -920,11 +920,8 @@ class TailInputTest < Test::Unit::TestCase
     def test_rotate_file(data)
       config = data
       events = sub_test_rotate_file(config, expect_emits: 2)
-      assert_equal(4, events.length)
-      assert_equal({"message" => "test3"}, events[0][2])
-      assert_equal({"message" => "test4"}, events[1][2])
-      assert_equal({"message" => "test5"}, events[2][2])
-      assert_equal({"message" => "test6"}, events[3][2])
+      assert_equal(3.upto(6).collect { |i| {"message" => "test#{i}"} },
+                   events.collect { |event| event[2] })
     end
 
     data(flat: CONFIG_READ_FROM_HEAD + SINGLE_LINE_CONFIG,
@@ -932,13 +929,8 @@ class TailInputTest < Test::Unit::TestCase
     def test_rotate_file_with_read_from_head(data)
       config = data
       events = sub_test_rotate_file(config, expect_records: 6)
-      assert_equal(6, events.length)
-      assert_equal({"message" => "test1"}, events[0][2])
-      assert_equal({"message" => "test2"}, events[1][2])
-      assert_equal({"message" => "test3"}, events[2][2])
-      assert_equal({"message" => "test4"}, events[3][2])
-      assert_equal({"message" => "test5"}, events[4][2])
-      assert_equal({"message" => "test6"}, events[5][2])
+      assert_equal(1.upto(6).collect { |i| {"message" => "test#{i}"} },
+                   events.collect { |event| event[2] })
     end
 
     data(flat: CONFIG_OPEN_ON_EVERY_UPDATE + CONFIG_READ_FROM_HEAD + SINGLE_LINE_CONFIG,
@@ -946,13 +938,8 @@ class TailInputTest < Test::Unit::TestCase
     def test_rotate_file_with_open_on_every_update(data)
       config = data
       events = sub_test_rotate_file(config, expect_records: 6)
-      assert_equal(6, events.length)
-      assert_equal({"message" => "test1"}, events[0][2])
-      assert_equal({"message" => "test2"}, events[1][2])
-      assert_equal({"message" => "test3"}, events[2][2])
-      assert_equal({"message" => "test4"}, events[3][2])
-      assert_equal({"message" => "test5"}, events[4][2])
-      assert_equal({"message" => "test6"}, events[5][2])
+      assert_equal(1.upto(6).collect { |i| {"message" => "test#{i}"} },
+                   events.collect { |event| event[2] })
     end
 
     data(flat: SINGLE_LINE_CONFIG,
@@ -973,13 +960,8 @@ class TailInputTest < Test::Unit::TestCase
       }
       # This test sometimes fails and it shows a potential bug of in_tail
       # https://github.com/fluent/fluentd/issues/1434
-      assert_equal(6, events.length)
-      assert_equal({"message" => "test3"}, events[0][2])
-      assert_equal({"message" => "test4"}, events[1][2])
-      assert_equal({"message" => "test7"}, events[2][2])
-      assert_equal({"message" => "test8"}, events[3][2])
-      assert_equal({"message" => "test5"}, events[4][2])
-      assert_equal({"message" => "test6"}, events[5][2])
+      assert_equal([3, 4, 7, 8, 5, 6].collect { |i| {"message" => "test#{i}"} },
+                   events.collect { |event| event[2] })
     end
 
     data(flat: SINGLE_LINE_CONFIG,
@@ -991,11 +973,8 @@ class TailInputTest < Test::Unit::TestCase
         rotated_file.puts "test8"
         rotated_file.flush
       }
-      assert_equal(4, events.length)
-      assert_equal({"message" => "test3"}, events[0][2])
-      assert_equal({"message" => "test4"}, events[1][2])
-      assert_equal({"message" => "test7"}, events[2][2])
-      assert_equal({"message" => "test8"}, events[3][2])
+      assert_equal([3, 4, 7, 8].collect { |i| {"message" => "test#{i}"} },
+                   events.collect { |event| event[2] })
     end
 
     def sub_test_rotate_file(config = nil, expect_emits: nil, expect_records: nil, timeout: 5)

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -1011,8 +1011,6 @@ class TailInputTest < Test::Unit::TestCase
   end
 
   def test_truncate_file
-    omit "Permission denied error happen on Windows. Need fix" if Fluent.windows?
-
     config = SINGLE_LINE_CONFIG
     File.open("#{@tmp_dir}/tail.txt", "wb") {|f|
       f.puts "test1"
@@ -1028,7 +1026,13 @@ class TailInputTest < Test::Unit::TestCase
         f.flush
       }
       waiting(2) { sleep 0.1 until d.events.length == 2 }
-      File.truncate("#{@tmp_dir}/tail.txt", 6)
+      if Fluent.windows?
+        Fluent::FileWrapper.open("#{@tmp_dir}/tail.txt", "wb") { |f|
+          f.puts("test1");
+        }
+      else
+        File.truncate("#{@tmp_dir}/tail.txt", 6)
+      end
     end
 
     expected = {
@@ -1047,8 +1051,6 @@ class TailInputTest < Test::Unit::TestCase
   end
 
   def test_move_truncate_move_back
-    omit "Permission denied error happen on Windows. Need fix" if Fluent.windows?
-
     config = SINGLE_LINE_CONFIG
     File.open("#{@tmp_dir}/tail.txt", "wb") {|f|
       f.puts "test1"
@@ -1064,7 +1066,13 @@ class TailInputTest < Test::Unit::TestCase
         FileUtils.mv("#{@tmp_dir}/tail.txt", "#{@tmp_dir}/tail2.txt")
       end
       sleep(1)
-      File.truncate("#{@tmp_dir}/tail2.txt", 6)
+      if Fluent.windows?
+        Fluent::FileWrapper.open("#{@tmp_dir}/tail2.txt", "wb") { |f|
+          f.puts("test1");
+        }
+      else
+        File.truncate("#{@tmp_dir}/tail2.txt", 6)
+      end
       sleep(1)
       if Fluent.windows?
         FileUtils.mv("#{@tmp_dir}/tail2.txt", "#{@tmp_dir}/tail.txt", force: true)


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 
* 3fbcc1119a5b16dc193c5c189bdde0cb49af3c2c: The rotation tests are wrong on Windows. `sub_test_rotate_file` should pass a rotated file to the block, not a new file.
  In addition, it should be opened by `Fluent::FileWrapper` to avoid locking.
* 90ad37db6e1eacefbeecdddebfdd5153500ebdfb, bcba06fe5e6a66d0eda7c14df47545229de5fe2d: Create a new empty directory with a random path on each tests to avoid locking files by Windows OS.
* a065d02de25fffa037569b748fd628f4449ee8c1: Simplify deleting temp directory. The previous hacky way is no longer needed since we always create a new directory for now.
  In addition, the previous implementations has some bugs, for example `FileUtils.rm_f` doesn't have `secure` option even though the latest Ruby (v3.1), probably it intend `FileUtils.rm_r`.
* 4f3b7f370ee69d8916c6b60fd279a3e894837122: Drop CI for Ruby 2.6
* e041b618fd9527b964c8546e80ffe1f39d57050f: Fix some omitted tests on Windows

**Docs Changes**:
None

**Release Note**: 
Same with the title.