### PR TITLE
Add new system-config to set interval to restart workers

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -493,7 +493,8 @@ module Fluent
         config_path: path,
         main_cmd: params['main_cmd'],
         signame: params['signame'],
-        disable_shared_socket: params['disable_shared_socket']
+        disable_shared_socket: params['disable_shared_socket'],
+        restart_worker_interval: params['restart_worker_interval'],
       }
       if daemonize
         se_config[:pid_path] = pid_path
@@ -867,7 +868,8 @@ module Fluent
         'counter_server' => @system_config.counter_server,
         'log_format' => @system_config.log.format,
         'log_time_format' => @system_config.log.time_format,
-        'disable_shared_socket' => @system_config.disable_shared_socket
+        'disable_shared_socket' => @system_config.disable_shared_socket,
+        'restart_worker_interval' => @system_config.restart_worker_interval,
       }
 
       se = ServerEngine.create(ServerModule, WorkerModule){

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -22,7 +22,7 @@ module Fluent
     include Configurable
 
     SYSTEM_CONFIG_PARAMETERS = [
-      :workers, :root_dir, :log_level,
+      :workers, :restart_worker_interval, :root_dir, :log_level,
       :suppress_repeated_stacktrace, :emit_error_log_interval, :suppress_config_dump,
       :log_event_verbose, :ignore_repeated_log_interval, :ignore_same_log_interval,
       :without_source, :rpc_endpoint, :enable_get_dump, :process_name,
@@ -32,6 +32,7 @@ module Fluent
     ]
 
     config_param :workers,   :integer, default: 1
+    config_param :restart_worker_interval, :time, default: 0
     config_param :root_dir,  :string, default: nil
     config_param :log_level, :enum, list: [:trace, :debug, :info, :warn, :error, :fatal], default: 'info'
     config_param :suppress_repeated_stacktrace, :bool, default: nil

--- a/test/config/test_system_config.rb
+++ b/test/config/test_system_config.rb
@@ -19,6 +19,7 @@ module Fluent::Config
       @system_config = nil
       @cl_opt = {
         wokers: nil,
+        restart_worker_interval: nil,
         root_dir: nil,
         log: FakeLoggerInitializer.new,
         log_level: Fluent::Log::LEVEL_INFO,
@@ -72,6 +73,7 @@ module Fluent::Config
       sc = Fluent::SystemConfig.new(conf)
       sc.overwrite_variables(**s.for_system_config)
       assert_equal(1, sc.workers)
+      assert_equal(0, sc.restart_worker_interval)
       assert_nil(sc.root_dir)
       assert_equal(Fluent::Log::LEVEL_INFO, sc.log_level)
       assert_nil(sc.suppress_repeated_stacktrace)
@@ -88,6 +90,7 @@ module Fluent::Config
 
     data(
       'workers' => ['workers', 3],
+      'restart_worker_interval' => ['restart_worker_interval', 60],
       'root_dir' => ['root_dir', File.join(TMP_DIR, 'root')],
       'log_level' => ['log_level', 'error'],
       'suppress_repeated_stacktrace' => ['suppress_repeated_stacktrace', true],


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #3749

**What this PR does / why we need it**: 
Add new option `restart_worker_interval` to system-config.
This enables workers to restart with an interval.

Please see #3749 for why this feature is necessary.

This needs the fix of ServerEngine: https://github.com/treasure-data/serverengine/pull/120

**Docs Changes**:
https://github.com/fluent/fluentd-docs-gitbook/pull/407

**Release Note**: 
Add `restart_worker_interval` parameter in `<system>` directive to set interval to restart workers that has stopped for some reason.

**Operation example**:

Config

```
<system>
  workers 3
  restart_worker_interval 1m
</system>
```

Operation

* Worker-A, B, C starts.
* Kill worker-A and worker-B at the same time (set this point as 0s-point).
* Kill worker-C at 15s-point.
* Worker-A and worker-B restart at 60s-point.
* Worker-C restarts at 75s-point.

**TODO**

* [x] Wait for the merge of https://github.com/treasure-data/serverengine/pull/120
* [x] Add some tests
* [x] Make the document's fix
