### PR TITLE
test_in_tail: Relax limit of duration for group watch tests

### DIFF
--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -2589,7 +2589,7 @@ class TailInputTest < Test::Unit::TestCase
         ## since no logs are left to be read
         ## Hence, d.record_count = prev_count
         tail_watcher_interval = 1.0 # hard coded value in in_tail
-        safety_ratio = 1.02
+        safety_ratio = 1.2
         jitter = tail_watcher_interval * safety_ratio
         sleep(1.0 + jitter)
         assert_equal(0, d.record_count - prev_count)
@@ -2622,7 +2622,7 @@ class TailInputTest < Test::Unit::TestCase
       d.run(timeout: 15) do
         sleep_interval = 0.1
         tail_watcher_interval = 1.0 # hard coded value in in_tail
-        safety_ratio = 1.02
+        safety_ratio = 1.2
         lower_jitter = sleep_interval * safety_ratio
         upper_jitter = (tail_watcher_interval + sleep_interval) * safety_ratio
         lower_interval = rate_period - lower_jitter


### PR DESCRIPTION

Signed-off-by: Takuro Ashie <ashie@clear-code.com>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Follow up for #3535

**What this PR does / why we need it**: 
The previous value seems too tight for poor environment such as ARM arch.

**Docs Changes**:
None

**Release Note**: 
None