### PR TITLE
test_in_tail: Show more information of test_unwatched_files_should_be_removed

### DIFF
--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -1612,9 +1612,18 @@ class TailInputTest < Test::Unit::TestCase
       waiting(20) { sleep 0.1 until Dir.glob("#{@tmp_dir}/*.txt").size == 0 } # Ensure file is deleted on Windows
       waiting(5) { sleep 0.1 until d.instance.instance_variable_get(:@tails).keys.size <= 0 }
 
-      assert_equal(0, d.instance.instance_variable_get(:@tails).keys.size)
-
-      d.instance_shutdown
+      assert_equal(
+        {
+          files: [],
+          tails: {}
+        },
+        {
+          files: Dir.glob("#{@tmp_dir}/*.txt"),
+          tails: d.instance.instance_variable_get(:@tails)
+        }
+      )
+    ensure
+      d.instance_shutdown if d && d.instance
     end
 
     def count_timer_object


### PR DESCRIPTION
It's unstable on macOS but hard to debug due to less information:

https://github.com/fluent/fluentd/runs/6872721774?check_suite_focus=true
```
2022-06-14T02:25:40.1951760Z Failure: test_unwatched_files_should_be_removed(TailInputTest::path)
2022-06-14T02:25:40.1968250Z /Users/runner/work/fluentd/fluentd/test/plugin/test_in_tail.rb:1615:in `test_unwatched_files_should_be_removed'
2022-06-14T02:25:40.1968820Z      1612:       waiting(20) { sleep 0.1 until Dir.glob("#{@tmp_dir}/*.txt").size == 0 } # Ensure file is deleted on Windows
2022-06-14T02:25:40.1969220Z      1613:       waiting(5) { sleep 0.1 until d.instance.instance_variable_get(:@tails).keys.size <= 0 }
2022-06-14T02:25:40.1969500Z      1614:
2022-06-14T02:25:40.1969770Z   => 1615:       assert_equal(0, d.instance.instance_variable_get(:@tails).keys.size)
2022-06-14T02:25:40.1970010Z      1616:
2022-06-14T02:25:40.1970200Z      1617:       d.instance_shutdown
2022-06-14T02:25:40.1970500Z      1618:     end
2022-06-14T02:25:40.1970720Z <0> expected but was
2022-06-14T02:25:40.1970910Z <1>
```

Signed-off-by: Takuro Ashie <ashie@clear-code.com>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

**Docs Changes**:

**Release Note**: 
