### PR TITLE
test_in_tail: Reduce information of test_unwatched_files_should_be_removed

### DIFF
--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -1615,11 +1615,11 @@ class TailInputTest < Test::Unit::TestCase
       assert_equal(
         {
           files: [],
-          tails: {}
+          tails: []
         },
         {
           files: Dir.glob("#{@tmp_dir}/*.txt"),
-          tails: d.instance.instance_variable_get(:@tails)
+          tails: d.instance.instance_variable_get(:@tails).keys
         }
       )
     ensure


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
Follow up for #3784

Showing whole `@tails` seems too heavy on CI environment:

```
2022-06-14T07:17:55.0456030Z Error: test_unwatched_files_should_be_removed(TailInputTest::path): SystemStackError: stack level too deep
2022-06-14T07:17:55.2289960Z /Users/runner/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/2.7.0/pp.rb:179:in `bind_call'
2022-06-14T07:17:55.2290470Z /Users/runner/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/2.7.0/pp.rb:179:in `object_address_group'
2022-06-14T07:17:55.2291380Z /Users/runner/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/2.7.0/pp.rb:241:in `pp_object'
...
2022-06-14T07:17:55.5055170Z /Users/runner/work/fluentd/fluentd/test/plugin/test_in_tail.rb:1615:in `test_unwatched_files_should_be_removed'
2022-06-14T07:17:55.5055350Z      1612:       waiting(20) { sleep 0.1 until Dir.glob("#{@tmp_dir}/*.txt").size == 0 } # Ensure file is deleted on Windows
2022-06-14T07:17:55.5055520Z      1613:       waiting(5) { sleep 0.1 until d.instance.instance_variable_get(:@tails).keys.size <= 0 }
2022-06-14T07:17:55.5055590Z      1614:
2022-06-14T07:17:55.5055670Z   => 1615:       assert_equal(
2022-06-14T07:17:55.5055730Z      1616:         {
2022-06-14T07:17:55.5055810Z      1617:           files: [],
2022-06-14T07:17:55.5055880Z      1618:           tails: {}
```

**Docs Changes**:

**Release Note**: 
