### PR TITLE
add json minify utility

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("tzinfo-data", ["~> 1.0"])
   gem.add_runtime_dependency("strptime", [">= 0.2.4", "< 1.0.0"])
   gem.add_runtime_dependency("webrick", [">= 1.4.2", "< 1.8.0"])
+  gem.add_runtime_dependency("json-minify")
 
   # build gem for a certain platform. see also Rakefile
   fake_platform = ENV['GEM_BUILD_FAKE_PLATFORM'].to_s


### PR DESCRIPTION
Hello, So i have an issue on my infra. My infra does not accept multiline json, so i need to remove the /n from the messages sent. As such i though of adding a json minifier to the code, but i am currently not able to test it yet. Ence i need your HELP!!!

I can successfully(?) create the fluentd gem under pck/fluentd-1.14.6
```
gem build
WARNING:  open-ended dependency on bundler (>= 0) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on async-http (>= 0.50.0, development) is not recommended
  if async-http is semantically versioned, use:
    add_development_dependency 'async-http', '~> 0.50', '>= 0.50.0'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: fluentd
  Version: 1.14.6
  File: fluentd-1.14.6.gem
```

 but when creating the Docker image the dependencies are missing

``` Dockerfile
# From https://github.com/fluent/fluentd-docker-image/blob/master/v1.14/alpine/Dockerfile
# AUTOMATICALLY GENERATED
# DO NOT EDIT THIS FILE DIRECTLY, USE /Dockerfile.template.erb

FROM alpine:3.13
LABEL maintainer "Fluentd developers <fluentd@googlegroups.com>"
LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.14.6"

RUN mkdir pkg
COPY pkg/fluentd-1.14.6.gem pkg/fluentd-1.14.6.gem

# Do not split this into multiple RUN!
# Docker creates a layer for every RUN-Statement
# therefore an 'apk delete' has no effect
RUN apk update \
 && apk add --no-cache \
        ca-certificates \
        ruby ruby-irb ruby-etc ruby-webrick \
        tini \
 && apk add --no-cache --virtual .build-deps \
        build-base linux-headers \
        ruby-dev gnupg \
 && echo 'gem: --no-document' >> /etc/gemrc \
 && gem install oj -v 3.10.18 \
 && gem install json -v 2.4.1 \
 && gem install async-http -v 0.54.0 \
 && gem install ext_monitor -v 0.1.2 \
 && gem install json-minify \
 && gem install strptime \
 && gem install --local pkg/fluentd-1.14.6.gem \
 && gem install bigdecimal -v 1.4.4 \
 && apk del .build-deps \
 && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem /usr/lib/ruby/gems/2.*/gems/fluentd-*/test

RUN addgroup -S fluent && adduser -S -G fluent fluent \
    # for log storage (maybe shared with host)
    && mkdir -p /fluentd/log \
    # configuration/plugins path (default: copied from .)
    && mkdir -p /fluentd/etc /fluentd/plugins \
    && chown -R fluent /fluentd && chgrp -R fluent /fluentd


COPY fluent.conf /fluentd/etc/
COPY entrypoint.sh /bin/


ENV FLUENTD_CONF="fluent.conf"

ENV LD_PRELOAD=""
EXPOSE 24224 5140

USER fluent
ENTRYPOINT ["tini",  "--", "/bin/entrypoint.sh"]
CMD ["fluentd"]
```

And then trying to build with `docker build . --tag foo.bar.com/myrepo/fluentd:mod` I have the following error:
```
[...]
12 gems installed
Building native extensions. This could take a while...
Successfully installed ext_monitor-0.1.2
1 gem installed
Successfully installed json-minify-0.0.3
1 gem installed
Building native extensions. This could take a while...
Successfully installed strptime-0.2.5
1 gem installed
ERROR:  Could not find a valid gem 'tzinfo-data' (~> 1.0) (required by 'pkg/fluentd-1.14.6.gem' (>= 0)) in any repository
The command '/bin/sh -c apk update  && apk add --no-cache         ca-certificates         ruby ruby-irb ruby-etc ruby-webrick         tini  && apk add --no-cache --virtual .build-deps         build-base linux-headers         ruby-dev gnupg  && echo 'gem: --no-document' >> /etc/gemrc  && gem install oj -v 3.10.18  && gem install json -v 2.4.1  && gem install async-http -v 0.54.0  && gem install ext_monitor -v 0.1.2  && gem install json-minify  && gem install strptime  && gem install --local pkg/fluentd-1.14.6.gem  && gem install bigdecimal -v 1.4.4  && apk del .build-deps  && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem /usr/lib/ruby/gems/2.*/gems/fluentd-*/test' returned a non-zero code: 2
```

How can I test this? How can i create an image with the required gem dependencies. I think i need to update
with `bundle update` so that the vendors/ dir gets populated? but that is returning an error too!:

```
bundle update
The gemspec at /afs/cern.ch/user/d/dtomasgu/ws/fluentd/fluentd/fluentd.gemspec is not valid. Please fix this gemspec.
The validation error was 'metadata['homepage_uri'] has invalid link: "TODO: Put your gem's website or public repo URL here."'
```

Although grepping for this shows nothing...
`git grep 'TODO: Put your gem'```

Can you help??? I never used ruby and this is bogling my mind. I am also available in slack `@Diogo Guerra `
Please help! Thank you!


