### PR TITLE
Add support for concurrent append in out_file

### DIFF
--- a/lib/fluent/plugin/out_file.rb
+++ b/lib/fluent/plugin/out_file.rb
@@ -217,7 +217,13 @@ module Fluent::Plugin
                end
 
       if @append
-        writer.call(path, chunk)
+        if @need_lock
+          acquire_worker_lock(path) do
+            writer.call(path, chunk)
+          end
+        else
+          writer.call(path, chunk)
+        end
       else
         find_filepath_available(path, with_lock: @need_lock) do |actual_path|
           writer.call(actual_path, chunk)

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -50,6 +50,9 @@ module Fluent
       @rpc_server = nil
       @counter = nil
 
+      @fluentd_lockdir = Dir.mktmpdir("fluentd-lock-")
+      ENV['FLUENTD_LOCKDIR'] = @fluentd_lockdir
+
       if config[:rpc_endpoint]
         @rpc_endpoint = config[:rpc_endpoint]
         @enable_get_dump = config[:enable_get_dump]
@@ -79,7 +82,13 @@ module Fluent
       stop_windows_event_thread if Fluent.windows?
       stop_rpc_server if @rpc_endpoint
       stop_counter_server if @counter
+      cleanup_lockdir
       Fluent::Supervisor.cleanup_resources
+    end
+
+    def cleanup_lockdir
+      FileUtils.rm(Dir.glob(File.join(@fluentd_lockdir, "fluentd-*.lock")))
+      FileUtils.rmdir(@fluentd_lockdir)
     end
 
     def run_rpc_server


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #3805

**What this PR does / why we need it**: 

The basic problem is that Fluentd can run a plugin in multiple workers,
but there is no mechanism that allows workers to coordinate each other.

For this reason, plugins are often suffers race condition issues on multi-worker
mode (e.g. #3805, https://github.com/fluent/fluent-plugin-s3/issues/391).

This can be simply resolvable by implementing a inter-worker lock.
Here is how I implemented it:

 * ServerModule prepares a lockfile directory and share that directory
   path with its workers (through ENV).
    
 * Now, Workers can define critical sessions by creating a lockfile
   in that directory.
    
 * The actual lock was held by flock, so it's automatically freed by
   OS even when Worker gets killed in the middle of critical session.

WIth this merged, we will be able to run `out_file` without race
conditions among workers.

**Docs Changes**:

Required

**Release Note**: 
