### PR TITLE
in_tail: Show more information on skipping update_watcher

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -498,7 +498,8 @@ module Fluent::Plugin
         pe_inode = pe.read_inode
         target_info_from_position_entry = TargetInfo.new(path, pe_inode)
         unless pe_inode == @pf[target_info_from_position_entry].read_inode
-          log.debug "Skip update_watcher because watcher has been already updated by other inotify event"
+          log.warn "Skip update_watcher because watcher has been already updated by other inotify event",
+                   path: path, inode: pe.read_inode, inode_in_pos_file: @pf[target_info_from_position_entry].read_inode
           return
         end
       end


### PR DESCRIPTION

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 
In #3614 some users reported that in_tail rarely stops tailing. It seems
it's caused when skipping update_watcher due to unexpected duplicate
pos_file entries. The root cause is unknown yet. To investigate it, show
more infomation when it happens. Ideally it should't happen so that log
level "warn" is desired for it (I can't reproduce this issue yet).

**Docs Changes**:
None

**Release Note**: 
Same with the title