### PR TITLE
child_process: Plug file descriptor leak

### DIFF
--- a/lib/fluent/plugin_helper/child_process.rb
+++ b/lib/fluent/plugin_helper/child_process.rb
@@ -346,6 +346,9 @@ module Fluent
           if cb
             cb.call(process_info.exit_status) rescue nil
           end
+          process_info.readio&.close rescue nil
+          process_info.writeio&.close rescue nil
+          process_info.stderrio&.close rescue nil
         end
         thread[:_fluentd_plugin_helper_child_process_running] = true
         thread[:_fluentd_plugin_helper_child_process_pid] = pid


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #3627

**What this PR does / why we need it**: 
Pipes for child processes aren't closed explicitly after exiting child processes.
It might causes leave  too many file descriptors opened on certain condition.

**Docs Changes**:
none

**Release Note**: 
Same with the title.