### PR TITLE
Drop win32-api gem

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -34,12 +34,9 @@ Gem::Specification.new do |gem|
   fake_platform = ENV['GEM_BUILD_FAKE_PLATFORM'].to_s
   gem.platform = fake_platform unless fake_platform.empty?
   if /mswin|mingw/ =~ fake_platform || (/mswin|mingw/ =~ RUBY_PLATFORM && fake_platform.empty?)
-    gem.add_runtime_dependency("win32-api", [">= 1.10", "< 2.0.0"])
     gem.add_runtime_dependency("win32-service", ["~> 2.3.0"])
     gem.add_runtime_dependency("win32-ipc", ["~> 0.7.0"])
     gem.add_runtime_dependency("win32-event", ["~> 0.6.3"])
-    gem.add_runtime_dependency("windows-api", ["~> 0.4.5"])
-    gem.add_runtime_dependency("windows-pr", ["~> 1.2.6"])
     gem.add_runtime_dependency("certstore_c", ["~> 0.1.7"])
   end
 

--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -189,9 +189,6 @@ op.on('--disable-shared-socket', "Don't open shared socket for multiple workers"
 }
 
 if Fluent.windows?
-  require 'windows/library'
-  include Windows::Library
-
   opts.merge!(
     :winsvc_name => 'fluentdwinsvc',
     :winsvc_display_name => 'Fluentd Windows Service',
@@ -292,9 +289,7 @@ if winsvcinstmode = opts[:regwinsvc]
   case winsvcinstmode
   when 'i'
     binary_path = File.join(File.dirname(__FILE__), "..")
-    ruby_path = "\0" * 256
-    GetModuleFileName.call(0,ruby_path,256)
-    ruby_path = ruby_path.rstrip.gsub(/\\/, '/')
+    ruby_path = ServerEngine.ruby_bin_path
     start_type = Service::DEMAND_START
     if opts[:regwinsvcautostart]
       start_type = Service::AUTO_START

--- a/lib/fluent/plugin/file_wrapper.rb
+++ b/lib/fluent/plugin/file_wrapper.rb
@@ -14,6 +14,8 @@
 #    limitations under the License.
 #
 
+require 'fluent/win32api'
+
 module Fluent
   module FileWrapper
     def self.open(path, mode='r')
@@ -33,25 +35,6 @@ module Fluent
       f.close
       s
     end
-  end
-
-  module Win32API
-    require 'fiddle/import'
-    require 'fiddle/types'
-    extend Fiddle::Importer
-
-    if RUBY_PLATFORM.split('-')[-1] == "ucrt"
-      MSVCRT_DLL = 'ucrtbase.dll'
-    else
-      MSVCRT_DLL = 'msvcrt.dll'
-    end
-
-    dlload MSVCRT_DLL, "kernel32.dll"
-    include Fiddle::Win32Types
-
-    extern "intptr_t _get_osfhandle(int)"
-    extern "BOOL GetFileInformationByHandle(HANDLE, void *)"
-    extern "BOOL GetFileInformationByHandleEx(HANDLE, int, void *, DWORD)"
   end
 
   class WindowsFile

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -32,12 +32,6 @@ require 'fluent/variable_store'
 require 'serverengine'
 
 if Fluent.windows?
-  require 'windows/library'
-  require 'windows/synchronize'
-  require 'windows/system_info'
-  include Windows::Library
-  include Windows::Synchronize
-  include Windows::SystemInfo
   require 'win32/ipc'
   require 'win32/event'
 end
@@ -235,7 +229,8 @@ module Fluent
         end
         begin
           loop do
-            ipc_idx = ipc.wait_any(events.map {|e| e[:win32_event]}, Windows::Synchronize::INFINITE)
+            infinite = 0xFFFFFFFF
+            ipc_idx = ipc.wait_any(events.map {|e| e[:win32_event]}, infinite)
             event_idx = ipc_idx - 1
 
             if event_idx >= 0 && event_idx < events.length

--- a/lib/fluent/win32api.rb
+++ b/lib/fluent/win32api.rb
@@ -1,0 +1,38 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'fluent/env'
+
+module Fluent
+  module Win32API
+    require 'fiddle/import'
+    require 'fiddle/types'
+    extend Fiddle::Importer
+
+    if RUBY_PLATFORM.split('-')[-1] == "ucrt"
+      MSVCRT_DLL = 'ucrtbase.dll'
+    else
+      MSVCRT_DLL = 'msvcrt.dll'
+    end
+
+    dlload MSVCRT_DLL, "kernel32.dll"
+    include Fiddle::Win32Types
+
+    extern "intptr_t _get_osfhandle(int)"
+    extern "BOOL GetFileInformationByHandle(HANDLE, void *)"
+    extern "BOOL GetFileInformationByHandleEx(HANDLE, int, void *, DWORD)"
+  end if Fluent.windows?
+end

--- a/lib/fluent/winsvc.rb
+++ b/lib/fluent/winsvc.rb
@@ -17,14 +17,10 @@
 begin
 
   require 'optparse'
-  require 'windows/debug'
-  require 'Windows/Library'
   require 'win32/daemon'
   require 'win32/event'
 
   include Win32
-  include Windows::Library
-  include Windows::Debug
 
   op = OptionParser.new
   opts = {service_name: nil}
@@ -37,16 +33,14 @@ begin
   end 
 
   def read_fluentdopt(service_name)
-    require 'win32/Registry'
+    require 'win32/registry'
     Win32::Registry::HKEY_LOCAL_MACHINE.open("SYSTEM\\CurrentControlSet\\Services\\#{service_name}") do |reg|
       reg.read("fluentdopt")[1] rescue ""
     end
   end
 
   def service_main_start(service_name)
-    ruby_path = 0.chr * 260
-    GetModuleFileName.call(0, ruby_path,260)
-    ruby_path = ruby_path.rstrip.gsub(/\\/, '/')
+    ruby_path = ServerEngine.ruby_bin_path
     rubybin_dir = ruby_path[0, ruby_path.rindex("/")]
     opt = read_fluentdopt(service_name)
     Process.spawn("\"#{rubybin_dir}/ruby.exe\" \"#{rubybin_dir}/fluentd\" #{opt} -x #{service_name}")

--- a/test/plugin/test_file_wrapper.rb
+++ b/test/plugin/test_file_wrapper.rb
@@ -2,11 +2,6 @@ require_relative '../helper'
 require 'fluent/plugin/file_wrapper'
 
 class FileWrapperTest < Test::Unit::TestCase
-  require 'windows/file'
-  require 'windows/error'
-  include Windows::File
-  include Windows::Error
-
   TMP_DIR = File.dirname(__FILE__) + "/../tmp/file_wrapper#{ENV['TEST_ENV_NUMBER']}"
 
   def setup


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
None (Found in #3844)

**What this PR does / why we need it**: 
Recently we fail to load win32-api on Ruby 3.2-dev:
https://github.com/fluent/fluentd/runs/7660210030?check_suite_focus=true

```
  D:/rubyinstaller-head-x64/lib/ruby/gems/3.2.0+2/gems/windows-api-0.4.5/lib/windows/api.rb:335:in `initialize': uninitialized constant Win32::API (NameError)
        @api = Win32::API.new(func, proto, rtype, dll)
                    ^^^^^
          from D:/rubyinstaller-head-x64/lib/ruby/gems/3.2.0+2/gems/windows-pr-1.2.6/lib/windows/msvcrt/string.rb:12:in `new'
```

but Fluentd doesn't seem depend on win32-api so much.
Using Fiddle is enough instead. It's time to drop win32-api gem.

**Docs Changes**:
None.

**Release Note**: 
Same with the title.