### PR TITLE
Add a new system config 'enable_jit'

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -1104,6 +1104,11 @@ module Fluent
         fluentd_spawn_cmd << '-Eascii-8bit:ascii-8bit'
       end
 
+      if @system_config.enable_jit
+        $log.info "enable Ruby JIT for workers (--jit)"
+        fluentd_spawn_cmd << '--jit'
+      end
+
       # Adding `-h` so that it can avoid ruby's command blocking
       # e.g. `ruby -Eascii-8bit:ascii-8bit` will block. but `ruby -Eascii-8bit:ascii-8bit -h` won't.
       _, e, s = Open3.capture3(*fluentd_spawn_cmd, "-h")

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -28,7 +28,7 @@ module Fluent
       :without_source, :rpc_endpoint, :enable_get_dump, :process_name,
       :file_permission, :dir_permission, :counter_server, :counter_client,
       :strict_config_value, :enable_msgpack_time_support, :disable_shared_socket,
-      :metrics, :enable_input_metrics, :enable_size_metrics
+      :metrics, :enable_input_metrics, :enable_size_metrics, :enable_jit
     ]
 
     config_param :workers,   :integer, default: 1
@@ -50,6 +50,7 @@ module Fluent
     config_param :disable_shared_socket, :bool, default: nil
     config_param :enable_input_metrics, :bool, default: nil
     config_param :enable_size_metrics, :bool, default: nil
+    config_param :enable_jit, :bool, default: false
     config_param :file_permission, default: nil do |v|
       v.to_i(8)
     end

--- a/test/config/test_system_config.rb
+++ b/test/config/test_system_config.rb
@@ -84,6 +84,7 @@ module Fluent::Config
       assert_nil(sc.enable_input_metrics)
       assert_nil(sc.enable_size_metrics)
       assert_nil(sc.enable_msgpack_time_support)
+      assert(!sc.enable_jit)
       assert_equal(:text, sc.log.format)
       assert_equal('%Y-%m-%d %H:%M:%S %z', sc.log.time_format)
     end
@@ -102,6 +103,7 @@ module Fluent::Config
       'enable_msgpack_time_support' => ['enable_msgpack_time_support', true],
       'enable_input_metrics' => ['enable_input_metrics', true],
       'enable_size_metrics' => ['enable_size_metrics', true],
+      'enable_jit' => ['enable_jit', true],
     )
     test "accepts parameters" do |(k, v)|
       conf = parse_text(<<-EOS)


### PR DESCRIPTION


<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 

N/A

**What this PR does / why we need it**: 

This adds a new option to enable Ruby JIT in worker processes.

Here is an example configuration:

```xml
<system>
  workers 3
  enable_jit true
</system>
```


The exact JIT strategy (in particular, mjit or yjit) will be chosen
by Ruby as it sees fit. See the following ticket for details:

https://bugs.ruby-lang.org/issues/18349

**Docs Changes**:

https://github.com/fluent/fluentd-docs-gitbook/pull/422

**Release Note**: 

Add a new system configuration `enable_jit`