### PR TITLE
winsvc: require serverengine

### DIFF
--- a/lib/fluent/winsvc.rb
+++ b/lib/fluent/winsvc.rb
@@ -19,6 +19,8 @@ begin
   require 'optparse'
   require 'win32/daemon'
   require 'win32/event'
+  require 'win32/registry'
+  require 'serverengine'
 
   include Win32
 
@@ -33,7 +35,6 @@ begin
   end 
 
   def read_fluentdopt(service_name)
-    require 'win32/registry'
     Win32::Registry::HKEY_LOCAL_MACHINE.open("SYSTEM\\CurrentControlSet\\Services\\#{service_name}") do |reg|
       reg.read("fluentdopt")[1] rescue ""
     end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Follow up for #3849

**What this PR does / why we need it**: 
In #3849, getting ruby's path was replaced with
`ServerEngine.ruby_bin_path` but `require 'serverengine'` was missing.
As a result it fails to launch fluentd service.

**Docs Changes**:
None

**Release Note**: 
None (Same with #3849)