### PR TITLE
Fix a test failure on ruby 3.2.0dev (2022-10-20)

### DIFF
--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -523,7 +523,7 @@ CONF
 
       assert_fluentd_fails_to_start(
         create_cmdline(conf_path, "-p", File.dirname(plugin_path)),
-        "in_buggy.rb:5: syntax error, unexpected end-of-input, expecting"
+        "in_buggy.rb:5: syntax error, unexpected end-of-input"
       )
     end
   end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
N/A

**What this PR does / why we need it**: 
A test fails on latest Ruby-3.2dev.

The expected error massage pattern was

```
in_buggy.rb:5: syntax error, unexpected end-of-input, expecting
```

but the actual error message on Ruby 3.2 is

```
in_buggy.rb:5: syntax error, unexpected end-of-input (SyntaxError)
```

**Docs Changes**:
N/A

**Release Note**: 
N/A