### PR TITLE
Remove meaningless oj options

### DIFF
--- a/lib/fluent/oj_options.rb
+++ b/lib/fluent/oj_options.rb
@@ -4,7 +4,6 @@ module Fluent
   class OjOptions
     OPTIONS = {
       'bigdecimal_load': :symbol,
-      'max_nesting': :integer,
       'mode': :symbol,
       'use_to_json': :bool
     }

--- a/lib/fluent/oj_options.rb
+++ b/lib/fluent/oj_options.rb
@@ -11,7 +11,7 @@ module Fluent
 
     ALLOWED_VALUES = {
       'bigdecimal_load': %i[bigdecimal float auto],
-      'mode': %i[strict null compat json rails object custom]
+      'mode': %i[strict null compat json rails custom]
     }
 
     DEFAULTS = {


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
N/A

**What this PR does / why we need it**: 
Although some oj options become configurable by #3315, we've noticed that some of them are meaningless or unsecure.

* `FLUENT_OJ_OPTION_MODE=object`
  * It's unsecure, it allows executing arbitrary Ruby code.
* `FLUENT_OJ_OPTION_MAX_NESTING`
  * It doesn't take effect, `Oj.default_options` doesn't support `max_nesting`
  * https://github.com/fluent/fluentd/issues/3311#issuecomment-923741031

**Docs Changes**:
~~Needed~~ It's not described in the document yet.

**Release Note**: 
Same with the title