### PR TITLE
Fix "unable to rotate log files on Windows" bug

### DIFF
--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -345,17 +345,6 @@ end
 exit 0 if early_exit
 
 if opts[:supervise]
-  if Fluent.windows?
-    if opts[:log_path] && opts[:log_path] != "-"
-      if opts[:log_rotate_age] || opts[:log_rotate_size]
-        require 'pathname'
-
-        log_path = Pathname(opts[:log_path]).sub_ext("-supervisor#{Pathname(opts[:log_path]).extname}").to_s
-        opts[:log_path] = log_path
-      end
-    end
-  end
-
   supervisor = Fluent::Supervisor.new(opts)
   supervisor.configure(supervisor: true)
   supervisor.run_supervisor(dry_run: opts[:dry_run])

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -773,6 +773,14 @@ class SupervisorTest < ::Test::Unit::TestCase
     end
   end
 
+  def test_per_process_path
+    path = Fluent::Supervisor::LoggerInitializer.per_process_path("C:/tmp/test.log", :supervisor, 0)
+    assert_equal(path, "C:/tmp/test-supervisor-0.log")
+
+    path = Fluent::Supervisor::LoggerInitializer.per_process_path("C:/tmp/test.log", :worker, 1)
+    assert_equal(path, "C:/tmp/test-1.log")
+  end
+
   def create_debug_dummy_logger
     dl_opts = {}
     dl_opts[:log_level] = ServerEngine::DaemonLogger::DEBUG


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

Fixes #3921

**What this PR does / why we need it**: 

```
Suppose we set up the log rotation on Windows as follows:

    <system>
      <log>
        rotate_age 5
      </log>
    </sytem>

Currently this does not work, because the supervisor and worker will
share the same log path, and they won't coordinate with each other.

This makes it sure that each process has a log file for themselves
on Windows.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>
```

**Docs Changes**:

N/A

**Release Note**: 

Fix log initializer to correctly create per-process files on Windows