### PR TITLE
out_file: Avoid performing multi-worker check in configure()

### DIFF
--- a/lib/fluent/plugin/out_file.rb
+++ b/lib/fluent/plugin/out_file.rb
@@ -188,10 +188,6 @@ module Fluent::Plugin
         condition = Gem::Dependency.new('', [">= 2.7.0", "< 3.1.0"])
         @need_ruby_on_macos_workaround = true if condition.match?('', RUBY_VERSION)
       end
-
-      if @need_lock && @append && @fluentd_lock_dir.nil?
-        raise Fluent::InvalidLockDirectory, "must set FLUENTD_LOCK_DIR on multi-worker append mode"
-      end
     end
 
     def multi_workers_ready?


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #3941

**What this PR does / why we need it**: 

    
    
    The check did not work well with `<worker 0-N>` directive for
    the following reasons:
    
     * When Fluentd starts up, supervisor performs sanity check on
       configuration by creating actual instances of plugins.
    
     * This check precedes SeverModule, which prepares various assets
       for workers (lockdir, RPC endpoints and shared sockets etc.)
    
     * Fluent::Plugin::Base dynamically overrides `system_config.workers`
       during start-up, and leaves the value > 1 only when `<worker 0-N>`
       directive is used.
    
    Fix this issue by avoiding faulty sanity check in `configure()`.
    
    Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>


**Docs Changes**:

N/A

**Release Note**: 

out_file: Fix the multi-worker check with `<worker 0-N>` directive