### PR TITLE
in_tail: Fix unhandled exception due to NFS race conditions

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -1097,6 +1097,9 @@ module Fluent::Plugin
                   end
                 rescue EOFError
                   @eof = true
+                rescue Errno::ESTALE
+                  @log.info "remote file was deleted during read", path: path
+                  @eof = true
                 end
               end
 


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 

N/A

**What this PR does / why we need it**: 

```
While we're reading from a remote file on NFS, the same file can
be concurrently deleted by another user. POSIX defines a special
error code (ESTALE) specifically for that case.

Sadly Fluentd just loudly crashes on such cases:

    2022-01-01 00:00:00 [error]: Stale file handler @ io_getpartial

This teaches Fluentd to treat ESTALE same as EOF.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>
```

**Docs Changes**:

N/A

**Release Note**: 

in_tail: Fix unhandled exception due to NFS race conditions