### PR TITLE
Add keep alive to tcp plugin

### DIFF
--- a/test/plugin/test_in_tcp.rb
+++ b/test/plugin/test_in_tcp.rb
@@ -156,6 +156,14 @@ class TcpInputTest < Test::Unit::TestCase
     assert_equal hostname, event[2]['host']
   end
 
+  test "test_send_keepalive_packet_can_be_enabled" do
+    addr = "127.0.0.1"
+    d = create_driver(base_config + %!
+      send_keepalive_packet true
+    !)
+    assert_true d.instance.send_keepalive_packet
+  end
+  
   test 'source_address_key' do
     d = create_driver(base_config + %!
       format none

--- a/test/plugin/test_in_tcp.rb
+++ b/test/plugin/test_in_tcp.rb
@@ -156,14 +156,14 @@ class TcpInputTest < Test::Unit::TestCase
     assert_equal hostname, event[2]['host']
   end
 
-  test "test_send_keepalive_packet_can_be_enabled" do
-    addr = "127.0.0.1"
+  test "send_keepalive_packet_can_be_enabled" do
     d = create_driver(base_config + %!
+      format none
       send_keepalive_packet true
     !)
     assert_true d.instance.send_keepalive_packet
   end
-  
+
   test 'source_address_key' do
     d = create_driver(base_config + %!
       format none


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
[Fixes #3960 ](https://github.com/fluent/fluentd/issues/3960)

**What this PR does / why we need it**: 
TCP keepalive should be supported by in_tcp to avoid dead connection, as same as in_forward

**Docs Changes**:
send_keepalive_packet should be added to https://docs.fluentd.org/input/tcp
**Release Note**: 
Same with the title