### PR TITLE
test_out_forward: Fix a failed test on Ruby 3.2 on Windows

### DIFF
--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -1331,26 +1331,22 @@ EOL
         d = create_driver(output_conf)
         d.instance_start
 
-        begin
-          chunk = Fluent::Plugin::Buffer::MemoryChunk.new(Fluent::Plugin::Buffer::Metadata.new(nil, nil, nil))
-          mock.proxy(d.instance).socket_create_tcp(TARGET_HOST, @target_port,
-                                                   linger_timeout: anything,
-                                                   send_timeout: anything,
-                                                   recv_timeout: anything,
-                                                   connect_timeout: anything) { |sock|
-            mock(sock).close.once; sock
-          }.twice
+        chunk = Fluent::Plugin::Buffer::MemoryChunk.new(Fluent::Plugin::Buffer::Metadata.new(nil, nil, nil))
+        mock.proxy(d.instance).socket_create_tcp(TARGET_HOST, @target_port,
+                                                 linger_timeout: anything,
+                                                 send_timeout: anything,
+                                                 recv_timeout: anything,
+                                                 connect_timeout: anything) { |sock|
+          mock(sock).close.once; sock
+        }.twice
 
-          target_input_driver.run(timeout: 15) do
-            d.run(shutdown: false) do
-              node = d.instance.nodes.first
-              2.times do
-                node.send_data('test', chunk) rescue nil
-              end
+        target_input_driver.run(timeout: 15) do
+          d.run do
+            node = d.instance.nodes.first
+            2.times do
+              node.send_data('test', chunk) rescue nil
             end
           end
-        ensure
-          d.instance_shutdown
         end
       end
     end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #3885

**What this PR does / why we need it**: 
Fluent::Test::Driver::Base#instance_shutdown causes rase on Ruby 3.2 on Windows. I'm not sure the detailed mechanism of this issue but exiting the test driver normally doesn't cause it.

```
2022-09-15T04:02:03.9921391Z #<Thread:0x000001ddefc90b20@event_loop D:/a/fluentd/fluentd/lib/fluent/plugin_helper/thread.rb:70 run> terminated with exception (report_on_exception is true):
2022-09-15T04:02:03.9948504Z D:/rubyinstaller-head-x64/lib/ruby/gems/3.2.0+2/gems/cool.io-1.7.1/lib/cool.io/io.rb:35:in `attach': expected loop to be an instance of Coolio::Loop, not nil (ArgumentError)
2022-09-15T04:02:03.9948899Z
2022-09-15T04:02:03.9949030Z       @_read_watcher.attach(loop)
2022-09-15T04:02:03.9949263Z                             ^^^^
2022-09-15T04:02:03.9949760Z 	 from D:/rubyinstaller-head-x64/lib/ruby/gems/3.2.0+2/gems/cool.io-1.7.1/lib/cool.io/io.rb:35:in `attach'
2022-09-15T04:02:03.9950342Z 	 from D:/rubyinstaller-head-x64/lib/ruby/gems/3.2.0+2/gems/cool.io-1.7.1/lib/cool.io/socket.rb:39:in `attach'
2022-09-15T04:02:03.9950654Z 	 from (eval):7:in `attach'
2022-09-15T04:02:03.9951144Z 	 from D:/rubyinstaller-head-x64/lib/ruby/gems/3.2.0+2/gems/cool.io-1.7.1/lib/cool.io/server.rb:40:in `on_connection'
2022-09-15T04:02:03.9951733Z 	 from D:/rubyinstaller-head-x64/lib/ruby/gems/3.2.0+2/gems/cool.io-1.7.1/lib/cool.io/listener.rb:65:in `on_readable'
2022-09-15T04:02:03.9952292Z 	 from D:/rubyinstaller-head-x64/lib/ruby/gems/3.2.0+2/gems/cool.io-1.7.1/lib/cool.io/loop.rb:88:in `run_once'
2022-09-15T04:02:03.9952792Z 	 from D:/rubyinstaller-head-x64/lib/ruby/gems/3.2.0+2/gems/cool.io-1.7.1/lib/cool.io/loop.rb:88:in `run'
2022-09-15T04:02:03.9953233Z 	 from D:/a/fluentd/fluentd/lib/fluent/plugin_helper/event_loop.rb:93:in `block in start'
2022-09-15T04:02:03.9953646Z 	 from D:/a/fluentd/fluentd/lib/fluent/plugin_helper/thread.rb:78:in `block in thread_create'
2022-09-15T04:02:04.9796436Z Started
2022-09-15T04:02:04.9796980Z E
2022-09-15T04:02:04.9797374Z ===============================================================================
2022-09-15T04:02:04.9803849Z Error: test: Create connection per send_data(ForwardOutputTest::keepalive::with require_ack_response): ArgumentError: expected loop to be an instance of Coolio::Loop, not nil
2022-09-15T04:02:04.9805379Z D:/rubyinstaller-head-x64/lib/ruby/gems/3.2.0+2/gems/cool.io-1.7.1/lib/cool.io/io.rb:35:in `attach'
2022-09-15T04:02:04.9806300Z D:/rubyinstaller-head-x64/lib/ruby/gems/3.2.0+2/gems/cool.io-1.7.1/lib/cool.io/io.rb:35:in `attach'
2022-09-15T04:02:04.9807276Z D:/rubyinstaller-head-x64/lib/ruby/gems/3.2.0+2/gems/cool.io-1.7.1/lib/cool.io/socket.rb:39:in `attach'
2022-09-15T04:02:04.9807673Z (eval):7:in `attach'
2022-09-15T04:02:04.9808146Z D:/rubyinstaller-head-x64/lib/ruby/gems/3.2.0+2/gems/cool.io-1.7.1/lib/cool.io/server.rb:40:in `on_connection'
2022-09-15T04:02:04.9808662Z D:/rubyinstaller-head-x64/lib/ruby/gems/3.2.0+2/gems/cool.io-1.7.1/lib/cool.io/listener.rb:65:in `on_readable'
2022-09-15T04:02:04.9809222Z D:/rubyinstaller-head-x64/lib/ruby/gems/3.2.0+2/gems/cool.io-1.7.1/lib/cool.io/loop.rb:88:in `run_once'
2022-09-15T04:02:04.9809774Z D:/rubyinstaller-head-x64/lib/ruby/gems/3.2.0+2/gems/cool.io-1.7.1/lib/cool.io/loop.rb:88:in `run'
2022-09-15T04:02:04.9810202Z D:/a/fluentd/fluentd/lib/fluent/plugin_helper/event_loop.rb:93:in `block in start'
2022-09-15T04:02:04.9810573Z D:/a/fluentd/fluentd/lib/fluent/plugin_helper/thread.rb:78:in `block in thread_create'
2022-09-15T04:02:04.9810931Z ===============================================================================
```

**Docs Changes**:
N/A

**Release Note**: 
N/A