### PR TITLE
Adapt Console::Logger to Fluent::Log

### DIFF
--- a/lib/fluent/log/console_adapter.rb
+++ b/lib/fluent/log/console_adapter.rb
@@ -59,7 +59,7 @@ module Fluent
         @io.seek(0)
         @io.truncate(0)
         super
-        @logger.send(severity, @io.string.chomp)
+        @logger.send(level, @io.string.chomp)
       end
     end
   end

--- a/lib/fluent/log/console_adapter.rb
+++ b/lib/fluent/log/console_adapter.rb
@@ -35,6 +35,16 @@ module Fluent
 
       def initialize(logger)
         @logger = logger
+        # When `verbose` is `true`, following items will be added as a prefix or
+        # suffix of the subject:
+        #   * Severity
+        #   * Object ID
+        #   * PID
+        #   * Time
+        # Severity and Time are added by Fluentd::Log too so they are redundant.
+        # PID is the worker's PID so it's also redundant.
+        # Object ID will be too verbose in usual cases.
+        # So set it as `false` here to suppress redundant items.
         super(StringIO.new, verbose: false)
       end
 

--- a/lib/fluent/log/console_adapter.rb
+++ b/lib/fluent/log/console_adapter.rb
@@ -20,7 +20,14 @@ module Fluent
   class Log
     class ConsoleAdapter < Console::Terminal::Logger
       def self.wrap(logger)
-        Console::Logger.new(ConsoleAdapter.new(logger))
+        _, level = Console::Logger::LEVELS.find { |key, value|
+          if logger.level <= 0
+            key == :debug
+          else
+            value == logger.level - 1
+          end
+        }
+        Console::Logger.new(ConsoleAdapter.new(logger), level: level)
       end
 
       def initialize(logger)

--- a/lib/fluent/log/console_adapter.rb
+++ b/lib/fluent/log/console_adapter.rb
@@ -1,0 +1,62 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'console/serialized/logger'
+
+module Fluent
+  class Log
+    class ConsoleAdapter < Console::Serialized::Logger
+      def self.wrap(logger)
+        Console::Logger.new(ConsoleAdapter.new(logger))
+      end
+
+      def initialize(logger)
+        @logger = logger
+        super(@logger)
+      end
+
+      def call(subject = nil, *arguments, severity: 'info', **options, &block)
+        if LEVEL_TEXT.include?(severity.to_s)
+          level = severity
+        else
+          @logger.warn "Unknown severity: #{severity}"
+          level = 'warn'
+        end
+
+        args = arguments.dup
+        args.unshift("#{subject}") if subject
+
+        if block_given?
+          if block.arity.zero?
+            args << yield
+          else
+            buffer = StringIO.new
+            yield buffer
+            args << buffer.string
+          end
+        end
+
+        exception = find_exception(args)
+        args.delete(exception) if exception
+
+        @logger.send(severity, args.join(" "))
+        if exception && @logger.respond_to?("#{level}_backtrace")
+          @logger.send("#{level}_backtrace", exception)
+        end
+      end
+    end
+  end
+end

--- a/lib/fluent/log/console_adapter.rb
+++ b/lib/fluent/log/console_adapter.rb
@@ -20,12 +20,12 @@ module Fluent
   class Log
     class ConsoleAdapter < Console::Terminal::Logger
       def self.wrap(logger)
-        Console::Logger.new(ConsoleAdapter.new(StringIO.new, logger))
+        Console::Logger.new(ConsoleAdapter.new(logger))
       end
 
-      def initialize(io, logger)
+      def initialize(logger)
         @logger = logger
-        super(io, verbose: false)
+        super(StringIO.new, verbose: false)
       end
 
       def call(subject = nil, *arguments, name: nil, severity: 'info', **options, &block)

--- a/lib/fluent/log/console_adapter.rb
+++ b/lib/fluent/log/console_adapter.rb
@@ -14,7 +14,7 @@
 #    limitations under the License.
 #
 
-require 'console/serialized/logger'
+require 'console/terminal/logger'
 
 module Fluent
   class Log

--- a/lib/fluent/log/console_adapter.rb
+++ b/lib/fluent/log/console_adapter.rb
@@ -43,6 +43,7 @@ module Fluent
           level = 'warn'
         end
 
+        @io.seek(0)
         @io.truncate(0)
         super
         @logger.send(severity, @io.string.chomp)

--- a/lib/fluent/log/console_adapter.rb
+++ b/lib/fluent/log/console_adapter.rb
@@ -18,6 +18,9 @@ require 'console/serialized/logger'
 
 module Fluent
   class Log
+    # Async gem which is used by http_server helper switched logger mechanism to
+    # Console gem which isn't complatible with Ruby's standard Logger (since
+    # v1.17). This class adapts it to Fluentd's logger mechanism.
     class ConsoleAdapter < Console::Terminal::Logger
       def self.wrap(logger)
         _, level = Console::Logger::LEVELS.find { |key, value|

--- a/lib/fluent/plugin_helper/http_server/server.rb
+++ b/lib/fluent/plugin_helper/http_server/server.rb
@@ -21,6 +21,7 @@ require 'async/http/endpoint'
 require 'fluent/plugin_helper/http_server/app'
 require 'fluent/plugin_helper/http_server/router'
 require 'fluent/plugin_helper/http_server/methods'
+require 'fluent/log/console_adapter'
 
 module Fluent
   module PluginHelper
@@ -38,7 +39,7 @@ module Fluent
           scheme = tls_context ? 'https' : 'http'
           @uri = URI("#{scheme}://#{@addr}:#{@port}").to_s
           @router = Router.new(default_app)
-          @reactor = Async::Reactor.new(nil, logger: @logger)
+          @reactor = Async::Reactor.new(nil, logger: Fluent::Log::ConsoleAdapter.wrap(@logger))
 
           opts = if tls_context
                    { ssl_context: tls_context }

--- a/test/log/test_console_adapter.rb
+++ b/test/log/test_console_adapter.rb
@@ -13,7 +13,6 @@ class ConsoleAdapterTest < Test::Unit::TestCase
     @logger = ServerEngine::DaemonLogger.new(@logdev)
     @fluent_log = Fluent::Log.new(@logger)
     @console_logger = Fluent::Log::ConsoleAdapter.wrap(@fluent_log)
-    @console_logger.level = :debug
   end
 
   def teardown
@@ -23,6 +22,20 @@ class ConsoleAdapterTest < Test::Unit::TestCase
   def test_expected_log_levels
     assert_equal({debug: 0, info: 1, warn: 2, error: 3, fatal: 4},
                  Console::Logger::LEVELS)
+  end
+
+  data(trace: [Fluent::Log::LEVEL_TRACE, :debug],
+       debug: [Fluent::Log::LEVEL_DEBUG, :debug],
+       info: [Fluent::Log::LEVEL_INFO, :info],
+       warn: [Fluent::Log::LEVEL_WARN, :warn],
+       error: [Fluent::Log::LEVEL_ERROR, :error],
+       fatal: [Fluent::Log::LEVEL_FATAL, :fatal])
+  def test_reflect_log_level(data)
+    level, expected = data
+    @fluent_log.level = level
+    console_logger = Fluent::Log::ConsoleAdapter.wrap(@fluent_log)
+    assert_equal(Console::Logger::LEVELS[expected],
+                 console_logger.level)
   end
 
   data(debug: :debug,

--- a/test/log/test_console_adapter.rb
+++ b/test/log/test_console_adapter.rb
@@ -31,8 +31,8 @@ class ConsoleAdapterTest < Test::Unit::TestCase
        error: :error,
        fatal: :fatal)
   def test_one_message(level)
-    @console_logger.send(level, "message1")
-    assert_equal(["#{@timestamp_str} [#{level}]: message1\n"],
+    @console_logger.send(level, "subject")
+    assert_equal(["#{@timestamp_str} [#{level}]:   0.0s: subject\n"],
                  @logdev.logs)
   end
 
@@ -42,8 +42,11 @@ class ConsoleAdapterTest < Test::Unit::TestCase
        error: :error,
        fatal: :fatal)
   def test_block(level)
-    @console_logger.send(level) { "block message" }
-    assert_equal(["#{@timestamp_str} [#{level}]: block message\n"],
+    @console_logger.send(level, "subject") { "block message" }
+    assert_equal([
+                   "#{@timestamp_str} [#{level}]:   0.0s: subject\n" +
+                   "      | block message\n"
+                 ],
                  @logdev.logs)
   end
 end

--- a/test/log/test_console_adapter.rb
+++ b/test/log/test_console_adapter.rb
@@ -1,0 +1,33 @@
+require_relative '../helper'
+
+require 'fluent/log'
+require 'fluent/log/console_adapter'
+
+class ConsoleAdapterTest < Test::Unit::TestCase
+  def setup
+    @timestamp = Time.parse("2023-01-01 15:32:41 +0000")
+    @timestamp_str = @timestamp.strftime("%Y-%m-%d %H:%M:%S %z")
+    Timecop.freeze(@timestamp)
+
+    @logdev = Fluent::Test::DummyLogDevice.new
+    @logger = ServerEngine::DaemonLogger.new(@logdev)
+    @fluent_log = Fluent::Log.new(@logger)
+    @console_logger = Fluent::Log::ConsoleAdapter.wrap(@fluent_log)
+    @console_logger.level = :debug
+  end
+
+  def teardown
+    Timecop.return
+  end
+
+  data(debug: :debug,
+       info: :info,
+       warn: :warn,
+       error: :error,
+       fatal: :fatal)
+  def test_one_message(level)
+    @console_logger.send(level, "message1")
+    assert_equal(["#{@timestamp_str} [#{level}]: message1\n"],
+                 @logdev.logs)
+  end
+end

--- a/test/log/test_console_adapter.rb
+++ b/test/log/test_console_adapter.rb
@@ -92,4 +92,19 @@ class ConsoleAdapterTest < Test::Unit::TestCase
                  ],
                  @logdev.logs)
   end
+
+  data(debug: :debug,
+       info: :info,
+       warn: :warn,
+       error: :error,
+       fatal: :fatal)
+  def test_multiple_entries(level)
+    @console_logger.send(level, "subject1")
+    @console_logger.send(level, "line2")
+    assert_equal([
+                   "#{@timestamp_str} [#{level}]:   0.0s: subject1\n",
+                   "#{@timestamp_str} [#{level}]:   0.0s: line2\n"
+                 ],
+                 @logdev.logs)
+  end
 end

--- a/test/log/test_console_adapter.rb
+++ b/test/log/test_console_adapter.rb
@@ -20,6 +20,11 @@ class ConsoleAdapterTest < Test::Unit::TestCase
     Timecop.return
   end
 
+  def test_expected_log_levels
+    assert_equal({debug: 0, info: 1, warn: 2, error: 3, fatal: 4},
+                 Console::Logger::LEVELS)
+  end
+
   data(debug: :debug,
        info: :info,
        warn: :warn,
@@ -28,6 +33,17 @@ class ConsoleAdapterTest < Test::Unit::TestCase
   def test_one_message(level)
     @console_logger.send(level, "message1")
     assert_equal(["#{@timestamp_str} [#{level}]: message1\n"],
+                 @logdev.logs)
+  end
+
+  data(debug: :debug,
+       info: :info,
+       warn: :warn,
+       error: :error,
+       fatal: :fatal)
+  def test_block(level)
+    @console_logger.send(level) { "block message" }
+    assert_equal(["#{@timestamp_str} [#{level}]: block message\n"],
                  @logdev.logs)
   end
 end

--- a/test/log/test_console_adapter.rb
+++ b/test/log/test_console_adapter.rb
@@ -30,9 +30,39 @@ class ConsoleAdapterTest < Test::Unit::TestCase
        warn: :warn,
        error: :error,
        fatal: :fatal)
-  def test_one_message(level)
+  def test_string_subject(level)
     @console_logger.send(level, "subject")
     assert_equal(["#{@timestamp_str} [#{level}]:   0.0s: subject\n"],
+                 @logdev.logs)
+  end
+
+  data(debug: :debug,
+       info: :info,
+       warn: :warn,
+       error: :error,
+       fatal: :fatal)
+  def test_args(level)
+    @console_logger.send(level, "subject", 1, 2, 3)
+    assert_equal([
+                   "#{@timestamp_str} [#{level}]:   0.0s: subject\n" +
+                   "      | 1\n" +
+                   "      | 2\n" +
+                   "      | 3\n"
+                 ],
+                 @logdev.logs)
+  end
+
+  data(debug: :debug,
+       info: :info,
+       warn: :warn,
+       error: :error,
+       fatal: :fatal)
+  def test_options(level)
+    @console_logger.send(level, "subject", kwarg1: "opt1", kwarg2: "opt2")
+    assert_equal([
+                   "#{@timestamp_str} [#{level}]:   0.0s: subject\n" +
+                   "      | {\"kwarg1\":\"opt1\",\"kwarg2\":\"opt2\"}\n"
+                 ],
                  @logdev.logs)
   end
 

--- a/test/plugin_helper/test_http_server_helper.rb
+++ b/test/plugin_helper/test_http_server_helper.rb
@@ -127,7 +127,7 @@ class HttpHelperTest < Test::Unit::TestCase
     end
 
     client = Async::HTTP::Client.new(Async::HTTP::Endpoint.parse("https://#{addr}:#{port}", ssl_context: context))
-    reactor = Async::Reactor.new(nil, logger: NULL_LOGGER)
+    reactor = Async::Reactor.new(nil, logger: Fluent::Log::ConsoleAdapter.wrap(NULL_LOGGER))
 
     resp = nil
     error = nil


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
N/A

**What this PR does / why we need it**: 
The log mechanism of [Async](https://github.com/socketry/async) gem was changed as of [async-1.17](https://github.com/socketry/async/releases/tag/v1.17.0). Async gem is used in [http_server helper](https://docs.fluentd.org/plugin-helper-overview/api-plugin-helper-http_server) of Fluentd. From async-1.17 it uses `Console::Logger` of [Console](https://github.com/socketry/console) gem which isn't compatible with Ruby's standard Logger. So we need to adapt it to our logger mechanism to output Async's log correctly.

For example sometimes following error is occurred on CI without this patch:
https://github.com/fluent/fluentd/pull/3842#discussion_r942080998
```
2022-07-01T01:29:37.2657850Z 	from /Users/runner/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/async-1.30.3/lib/async/task.rb:242:in `fail!'
2022-07-01T01:29:37.2658430Z Failure: test: with insecure in transport section(HttpHelperTest::Create a HTTP server::create a HTTPS server::#http_server_create_https_server)
2022-07-01T01:29:37.2694380Z 	from /Users/runner/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/async-1.30.3/lib/async/task.rb:267:in `rescue in block in make_fiber'
2022-07-01T01:29:37.2694980Z /Users/runner/work/fluentd/fluentd/test/plugin_helper/test_http_server_helper.rb:296:in `block (5 levels) in <class:HttpHelperTest>'
2022-07-01T01:29:37.2786170Z 	from /Users/runner/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/async-1.30.3/lib/async/task.rb:264:in `block in make_fiber'
2022-07-01T01:29:37.2786710Z      293:             assert_equal('200', resp.code)
2022-07-01T01:29:37.2820540Z /Users/runner/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/async-io-1.33.0/lib/async/io/generic.rb:216:in `accept_nonblock': SSL_accept returned=1 errno=0 state=error: tlsv1 alert unknown ca (OpenSSL::SSL::SSLError)
2022-07-01T01:29:37.2821140Z      294:             assert_equal('hello get', resp.body)
2022-07-01T01:29:37.2823720Z 	from /Users/runner/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/async-io-1.33.0/lib/async/io/generic.rb:216:in `async_send'
2022-07-01T01:29:37.2824260Z      295: 
2022-07-01T01:29:37.2826690Z 	from /Users/runner/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/async-io-1.33.0/lib/async/io/generic.rb:62:in `block in wrap_blocking_method'
2022-07-01T01:29:37.2827090Z   => 296:             assert_raise OpenSSL::SSL::SSLError do
2022-07-01T01:29:37.2828630Z 	from /Users/runner/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/async-io-1.33.0/lib/async/io/ssl_socket.rb:143:in `block in accept'
2022-07-01T01:29:37.2830080Z      297:               secure_get("https://127.0.0.1:#{@port}/example/hello")
2022-07-01T01:29:37.2903090Z 	from /Users/runner/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/async-1.30.3/lib/async/task.rb:261:in `block in make_fiber'
2022-07-01T01:29:37.2903440Z      298:             end
2022-07-01T01:29:37.2974280Z      299:           end
2022-07-01T01:29:37.2980450Z /Users/runner/work/fluentd/fluentd/test/plugin_helper/test_http_server_helper.rb:36:in `on_driver'
2022-07-01T01:29:37.2983740Z /Users/runner/work/fluentd/fluentd/test/plugin_helper/test_http_server_helper.rb:66:in `on_driver_transport'
2022-07-01T01:29:37.2984210Z /Users/runner/work/fluentd/fluentd/test/plugin_helper/test_http_server_helper.rb:286:in `block (4 levels) in <class:HttpHelperTest>'
2022-07-01T01:29:37.2984460Z 
2022-07-01T01:29:37.2987480Z <OpenSSL::SSL::SSLError> expected but was
2022-07-01T01:29:37.2989170Z <ArgumentError(<wrong number of arguments (given 3, expected 0..1)>)
2022-07-01T01:29:37.2989610Z /Users/runner/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/2.7.0/logger.rb:536:in `warn'
2022-07-01T01:29:37.2990540Z /Users/runner/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/async-1.30.3/lib/async/task.rb:242:in `fail!'
2022-07-01T01:29:37.2991210Z /Users/runner/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/async-1.30.3/lib/async/task.rb:267:in `rescue in block in make_fiber'
2022-07-01T01:29:37.2992000Z /Users/runner/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/async-1.30.3/lib/async/task.rb:264:in `block in make_fiber'
2022-07-01T01:29:37.2992290Z >
2022-07-01T01:29:37.2992390Z 
2022-07-01T01:29:37.2992450Z diff:
2022-07-01T01:29:37.2992690Z ? Op   enSSL::SSL::SSLError                                                      
2022-07-01T01:29:37.2992980Z ? Argum  t                 (<wrong number of arguments (given 3, expected 0..1)>)
2022-07-01T01:29:37.2993260Z ? ??  ?????????????                 ++++++++++++++++++++++++++++++++++++++++++++++++++++++
2022-07-01T01:29:37.2993530Z + /Users/runner/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/2.7.0/logger.rb:536:in `warn'
2022-07-01T01:29:37.2994060Z + /Users/runner/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/async-1.30.3/lib/async/task.rb:242:in `fail!'
2022-07-01T01:29:37.2994730Z + /Users/runner/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/async-1.30.3/lib/async/task.rb:267:in `rescue in block in make_fiber'
2022-07-01T01:29:37.2995800Z + /Users/runner/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/async-1.30.3/lib/async/task.rb:264:in `block in make_fiber'
```

**Docs Changes**:
N/A

**Release Note**: 
* http_server helper, in_monitor_agent: Fix a crash when outputting Async gem's log