### PR TITLE
github: migrate to GitHub Actions v3

### DIFF
--- a/.github/workflows/linux-test.yaml
+++ b/.github/workflows/linux-test.yaml
@@ -23,7 +23,7 @@ jobs:
 
     name: Unit testing with Ruby ${{ matrix.ruby-version }} on ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/macos-test.yaml
+++ b/.github/workflows/macos-test.yaml
@@ -23,7 +23,7 @@ jobs:
 
     name: Unit testing with Ruby ${{ matrix.ruby-version }} on ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/windows-test.yaml
+++ b/.github/workflows/windows-test.yaml
@@ -35,7 +35,7 @@ jobs:
 
     name: Unit testing with Ruby ${{ matrix.ruby-version }} on ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

N/A

**What this PR does / why we need it**: 

v2 actions are now deprecated because of upgrading Node version from 12 to 16 on GitHub infrastructure.

See
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

**Docs Changes**:

No need to change 

**Release Note**: 

N/A
