### PR TITLE
buffer: warning message for restoring buffer with flush_at_shutdown

### DIFF
--- a/lib/fluent/plugin/buf_file.rb
+++ b/lib/fluent/plugin/buf_file.rb
@@ -145,7 +145,11 @@ module Fluent
         Dir.glob(escaped_patterns(patterns)) do |path|
           next unless File.file?(path)
 
-          log.debug { "restoring buffer file: path = #{path}" }
+          if owner.respond_to?(:buffer_config) && owner.buffer_config&.flush_at_shutdown
+            log.warn { "restoring buffer file: path = #{path}" }
+          else
+            log.debug { "restoring buffer file: path = #{path}" }
+          end
 
           m = new_metadata() # this metadata will be overwritten by resuming .meta file content
                              # so it should not added into @metadata_list for now

--- a/lib/fluent/plugin/buf_file.rb
+++ b/lib/fluent/plugin/buf_file.rb
@@ -146,6 +146,8 @@ module Fluent
           next unless File.file?(path)
 
           if owner.respond_to?(:buffer_config) && owner.buffer_config&.flush_at_shutdown
+            # When `flush_at_shutdown` is `true`, the remaining chunk files during resuming are possibly broken
+            # since there may be a power failure or similar failure.
             log.warn { "restoring buffer file: path = #{path}" }
           else
             log.debug { "restoring buffer file: path = #{path}" }

--- a/lib/fluent/plugin/buf_file_single.rb
+++ b/lib/fluent/plugin/buf_file_single.rb
@@ -167,6 +167,8 @@ module Fluent
           next unless File.file?(path)
 
           if owner.respond_to?(:buffer_config) && owner.buffer_config&.flush_at_shutdown
+            # When `flush_at_shutdown` is `true`, the remaining chunk files during resuming are possibly broken
+            # since there may be a power failure or similar failure.
             log.warn { "restoring buffer file: path = #{path}" }
           else
             log.debug { "restoring buffer file: path = #{path}" }

--- a/lib/fluent/plugin/buf_file_single.rb
+++ b/lib/fluent/plugin/buf_file_single.rb
@@ -166,7 +166,11 @@ module Fluent
         Dir.glob(escaped_patterns(patterns)) do |path|
           next unless File.file?(path)
 
-          log.debug { "restoring buffer file: path = #{path}" }
+          if owner.respond_to?(:buffer_config) && owner.buffer_config&.flush_at_shutdown
+            log.warn { "restoring buffer file: path = #{path}" }
+          else
+            log.debug { "restoring buffer file: path = #{path}" }
+          end
 
           m = new_metadata() # this metadata will be updated in FileSingleChunk.new
           mode = Fluent::Plugin::Buffer::FileSingleChunk.assume_chunk_state(path)


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Partial fix for #3970

**What this PR does / why we need it**: 
When `flush_at_shutdown` is `true`, the remaining chunk files during resuming are possibly broken since there may be a power failure or similar failure.

Without this log, even if we notice that we have received corrupted data on the destination server, we can not know which chunks may have been corrupted.

**Docs Changes**:
Not needed.

**Release Note**: 
Add warning messages for restoring buffer with `flush_at_shutdown true`.
