### PR TITLE
buffer: add log for time periods of restored chunks which may be broken

### DIFF
--- a/lib/fluent/plugin/buf_file.rb
+++ b/lib/fluent/plugin/buf_file.rb
@@ -188,7 +188,7 @@ module Fluent
         # The time priods of each chunk are helpful to check the data.
         if exist_broken_file
           log.info "Since a broken chunk file was found, it is possible that other files remaining at the time of resuming were also broken. Here is the list of the files."
-          (stage.values + queue).map { |chunk|
+          (stage.values + queue).each { |chunk|
             log.info "  #{chunk.path}:", :created_at => chunk.created_at, :modified_at => chunk.modified_at
           }
         end

--- a/lib/fluent/plugin/buf_file.rb
+++ b/lib/fluent/plugin/buf_file.rb
@@ -139,6 +139,7 @@ module Fluent
       def resume
         stage = {}
         queue = []
+        exist_broken_file = false
 
         patterns = [@path]
         patterns.unshift @additional_resume_path if @additional_resume_path
@@ -158,6 +159,7 @@ module Fluent
           begin
             chunk = Fluent::Plugin::Buffer::FileChunk.new(m, path, mode, compress: @compress) # file chunk resumes contents of metadata
           rescue Fluent::Plugin::Buffer::FileChunk::FileChunkError => e
+            exist_broken_file = true
             handle_broken_files(path, mode, e)
             next
           end
@@ -181,6 +183,15 @@ module Fluent
         end
 
         queue.sort_by!{ |chunk| chunk.modified_at }
+
+        # If one of the files is corrupted, other files may also be corrupted and be undetected.
+        # The time priods of each chunk are helpful to check the data.
+        if exist_broken_file
+          log.info "Since a broken chunk file was found, it is possible that other files remaining at the time of resuming were also broken. Here is the list of the files."
+          (stage.values + queue).map { |chunk|
+            log.info "  #{chunk.path}:", :created_at => chunk.created_at, :modified_at => chunk.modified_at
+          }
+        end
 
         return stage, queue
       end

--- a/lib/fluent/plugin/buf_file_single.rb
+++ b/lib/fluent/plugin/buf_file_single.rb
@@ -199,7 +199,7 @@ module Fluent
         # The time priods of each chunk are helpful to check the data.
         if exist_broken_file
           log.info "Since a broken chunk file was found, it is possible that other files remaining at the time of resuming were also broken. Here is the list of the files."
-          (stage.values + queue).map { |chunk|
+          (stage.values + queue).each { |chunk|
             log.info "  #{chunk.path}:", :created_at => chunk.created_at, :modified_at => chunk.modified_at
           }
         end

--- a/lib/fluent/plugin/buf_file_single.rb
+++ b/lib/fluent/plugin/buf_file_single.rb
@@ -160,6 +160,7 @@ module Fluent
       def resume
         stage = {}
         queue = []
+        exist_broken_file = false
 
         patterns = [@path]
         patterns.unshift @additional_resume_path if @additional_resume_path
@@ -179,6 +180,7 @@ module Fluent
             chunk = Fluent::Plugin::Buffer::FileSingleChunk.new(m, path, mode, @key_in_path, compress: @compress)
             chunk.restore_size(@chunk_format) if @calc_num_records
           rescue Fluent::Plugin::Buffer::FileSingleChunk::FileChunkError => e
+            exist_broken_file = true
             handle_broken_files(path, mode, e)
             next
           end
@@ -192,6 +194,15 @@ module Fluent
         end
 
         queue.sort_by!(&:modified_at)
+
+        # If one of the files is corrupted, other files may also be corrupted and be undetected.
+        # The time priods of each chunk are helpful to check the data.
+        if exist_broken_file
+          log.info "Since a broken chunk file was found, it is possible that other files remaining at the time of resuming were also broken. Here is the list of the files."
+          (stage.values + queue).map { |chunk|
+            log.info "  #{chunk.path}:", :created_at => chunk.created_at, :modified_at => chunk.modified_at
+          }
+        end
 
         return stage, queue
       end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Partial fix for #3970

**What this PR does / why we need it**: 
Add logs of possible time periods of buffer corruption during buffer resumimg.
When one of the remaining chunk files is broken at the resuming, this logs `created_at` and `modified_at` of other files undetected.

```
Since a broken chunk file was found, it is possible that other files remaining at the time of resuming were also broken. Here is the list of the files.
  /path/buffer.bxxxx.log: created_at=2023-01-26 18:08:16 +0900 modified_at=2023-01-26 18:08:17 +0900
  /path/buffer.qxxxx.log: created_at=2023-01-26 18:08:16 +0900 modified_at=2023-01-26 18:08:17 +0900
  {...}
```

Fluentd can detect the corruption when the meta-data is broken, but can't when the chunk file is broken.
So if one corruption is detected, we should assume that other files may also be broken.
This allows us to know other possible time periods of corruption.

**Docs Changes**:
Not needed.

**Release Note**: 
Add logs for time period of restored buffer possibly broken.

**How to Reproduce**

* Prepare a config:

```xml
<source>
  @type sample
  tag test.a
</source>

<source>
  @type sample
  tag test.b
</source>

<source>
  @type sample
  tag test.c
</source>

<match test.**>
  @type file
  path /test/fluentd/log/${tag}/%Y%m%d/fluentd.log
  append true
  add_path_suffix false
  <buffer time,tag>
    @type file
    path /test/fluentd/buffer
    timekey 24h
    flush_mode interval
    flush_interval 10s
    overflow_action drop_oldest_chunk
  </buffer>
</match>
```

* Start the fluentd, and you can get 3 chunk files.
* Stop the fluentd so that the 3 files remain.
* Break the one of meta data:

```console
$ head -c 89 /dev/zero > buffer.b5f32716d72fc5d71592aa89c5865fd48.log.meta
```

* Restart the fluentd, and you can see the following logs:

```
[info]: #0 fluent/log.rb:330:info: starting fluentd worker pid=920781 ppid=920761 worker=0
[debug]: #0 fluent/log.rb:309:debug: restoring buffer file: path = /test/fluentd/buffer/buffer.b5f32716d7292f8138b36fd759abf7207.log
[debug]: #0 fluent/log.rb:309:debug: restoring buffer file: path = /test/fluentd/buffer/buffer.b5f32716d72fc5d71592aa89c5865fd48.log
[error]: #0 fluent/log.rb:372:error: found broken chunk file during resume. Deleted corresponding files: path="/test/fluentd/buffer/buffer.b5f32716d72fc5d71592aa89c5865fd48.log" mode=:staged err_msg="staged meta file is broken. no implicit conversion of Symbol into Integer"
[debug]: #0 fluent/log.rb:309:debug: restoring buffer file: path = /test/fluentd/buffer/buffer.b5f32716d734618fef772d3ae48fd577a.log
[info]: #0 fluent/log.rb:330:info: Since a broken chunk file was found, it is possible that other files remaining at the time of resuming were also broken. Here is the list of the files.
[info]: #0 fluent/log.rb:330:info:   /test/fluentd/buffer/buffer.b5f32716d7292f8138b36fd759abf7207.log: created_at=2023-01-26 18:08:16 +0900 modified_at=2023-01-26 18:08:17 +0900
[info]: #0 fluent/log.rb:330:info:   /test/fluentd/buffer/buffer.b5f32716d734618fef772d3ae48fd577a.log: created_at=2023-01-26 18:08:16 +0900 modified_at=2023-01-26 18:08:17 +0900
[debug]: #0 fluent/log.rb:309:debug: buffer started instance=3000 stage_size=216 queue_size=0
[info]: #0 fluent/log.rb:330:info: fluentd worker is now running worker=0
```

* This allows us to know other possible time periods of corruption.
