### PR TITLE
out_forward: fix error  of ack handling confict on stopping with `require_ack_response` enabled

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -521,7 +521,7 @@ module Fluent::Plugin
         when AckHandler::Result::SUCCESS
           commit_write(chunk_id)
         when AckHandler::Result::FAILED
-          node.disable! if node
+          node&.disable!
           rollback_write(chunk_id, update_retry: false) if chunk_id
         when AckHandler::Result::CHUNKID_UNMATCHED
           rollback_write(chunk_id, update_retry: false)

--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -521,8 +521,8 @@ module Fluent::Plugin
         when AckHandler::Result::SUCCESS
           commit_write(chunk_id)
         when AckHandler::Result::FAILED
-          node.disable!
-          rollback_write(chunk_id, update_retry: false)
+          node.disable! if node
+          rollback_write(chunk_id, update_retry: false) if chunk_id
         when AckHandler::Result::CHUNKID_UNMATCHED
           rollback_write(chunk_id, update_retry: false)
         else

--- a/lib/fluent/plugin/out_forward/ack_handler.rb
+++ b/lib/fluent/plugin/out_forward/ack_handler.rb
@@ -123,7 +123,7 @@ module Fluent::Plugin
         info = find(sock)
 
         if info.nil?
-          # The info can be deleted during by another thread during `sock.recv()` and `find()`.
+          # The info can be deleted by another thread during `sock.recv()` and `find()`.
           # This is OK since another thread has completed to process the ack, so we can skip this.
           # Note: exclusion mechanism about `collect_response()` may need to be considered.
           @log.debug "could not find the ack info. this ack may be processed by another thread."

--- a/test/plugin/out_forward/test_ack_handler.rb
+++ b/test/plugin/out_forward/test_ack_handler.rb
@@ -111,7 +111,7 @@ class AckHandlerTest < Test::Unit::TestCase
     r, w = IO.pipe
     begin
       w.write(chunk_id)
-      stub(r).recv(anything) { |_|
+      stub(r).recv { |_|
         sleep(1) # To ensure that multiple threads select the socket before closing.
         raise IOError, 'stream closed in another thread' if r.closed?
         MessagePack.pack({ 'ack' => Base64.encode64('chunk_id 111') })

--- a/test/plugin/out_forward/test_ack_handler.rb
+++ b/test/plugin/out_forward/test_ack_handler.rb
@@ -98,4 +98,43 @@ class AckHandlerTest < Test::Unit::TestCase
       w.close rescue nil
     end
   end
+
+  # ForwardOutput uses AckHandler in multiple threads, so we need to assume this case.
+  # If exclusive control for this case is implemented, this test may not be necessary.
+  test 'raises no error when another thread closes a socket' do
+    ack_handler = Fluent::Plugin::ForwardOutput::AckHandler.new(timeout: 10, log: $log, read_length: 100)
+
+    node = flexmock('node', host: '127.0.0.1', port: '1000') # for log
+    chunk_id = 'chunk_id 111'
+    ack = ack_handler.create_ack(chunk_id, node)
+
+    r, w = IO.pipe
+    begin
+      w.write(chunk_id)
+      stub(r).recv(anything) { |_|
+        sleep(1) # To ensure that multiple threads select the socket before closing.
+        raise IOError, 'stream closed in another thread' if r.closed?
+        MessagePack.pack({ 'ack' => Base64.encode64('chunk_id 111') })
+      }
+      ack.enqueue(r)
+
+      threads = []
+      2.times do
+        threads << Thread.new do
+          ack_handler.collect_response(1) do |cid, n, s, ret|
+            s&.close
+          end
+        end
+      end
+
+      assert_true threads.map{ |t| t.join(10) }.all?
+      assert_false(
+        $log.out.logs.any? { |log| log.include?('[error]') },
+        $log.out.logs.select{ |log| log.include?('[error]') }.join('\n')
+      )
+    ensure
+      r.close rescue nil
+      w.close rescue nil
+    end
+  end
 end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #3962

**What this PR does / why we need it**: 
`out_forward` has a thread always checking the ack and closing the socket.

* https://github.com/fluent/fluentd/blob/e89092ce1132a933c12bb23fe8c9323c07ca81f5/lib/fluent/plugin/out_forward.rb#L512

When stopping Fluentd, some other threads try to do it at the same time.

* https://github.com/fluent/fluentd/blob/e89092ce1132a933c12bb23fe8c9323c07ca81f5/lib/fluent/plugin/out_forward.rb#L347
* https://github.com/fluent/fluentd/blob/e89092ce1132a933c12bb23fe8c9323c07ca81f5/lib/fluent/plugin/out_forward.rb#L376

This somtimes causes errors.
Although these errors are harmless (at least as far as I can confirm), we should fix this.

This fixes 2 points.

1. Suppress the error log.
    * When another thread closes the socket, there is no need to output an error log.
1. Fix an unhandled error of `ForwardOutput::ach_check()`.
    * Consideration of the possibility that [args of the block function of `AckHandler::collect_response()`](https://github.com/fluent/fluentd/blob/e89092ce1132a933c12bb23fe8c9323c07ca81f5/lib/fluent/plugin/out_forward.rb#L517) can be nil was lacking from before.

The logs will change as follows.

* before:

```
[info]: #0 fluent/log.rb:330:info: shutting down output plugin type=:forward plugin_id="object:ba4"
[info]: #0 fluent/log.rb:330:info: delayed_commit_timeout is overwritten by ack_response_timeout
[error]: #0 fluent/log.rb:372:error: unexpected error while receiving ack message error_class=IOError error="stream closed in another thread"
[error]: #0 fluent/log.rb:372:error: unexpected error while receiving ack error_class=NoMethodError error="undefined method `disable!' for nil:NilClass"
[info]: fluent/log.rb:330:info: Worker 0 finished with status 0
```

* after

```
[info]: #0 fluent/log.rb:330:info: shutting down output plugin type=:forward plugin_id="object:ba4"
[info]: #0 fluent/log.rb:330:info: delayed_commit_timeout is overwritten by ack_response_timeout
[info]: #0 fluent/log.rb:330:info: socket closed while receiving ack response
[info]: fluent/log.rb:330:info: Worker 0 finished with status 0
```

**Docs Changes**:
Not needed.

**Release Note**: 
Same with the title.
