### PR TITLE
Improve handling of SIGCONT after SIGTERM

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -190,6 +190,12 @@ module Fluent
         $log.debug 'fluentd supervisor process got SIGUSR2'
         supervisor_sigusr2_handler
       end
+
+      term_handler = trap :TERM do
+        # After SIGTERM, disable the sigdump file by ignoring SIGCONT.
+        trap(:CONT, nil)
+        term_handler.call
+      end
     end
 
     if Fluent.windows?
@@ -922,6 +928,9 @@ module Fluent
       end
 
       trap :TERM do
+        # After SIGTERM, disable the sigdump file by ignoring SIGCONT.
+        trap(:CONT, nil)
+
         $log.debug "fluentd main process get SIGTERM"
         unless @finished
           @finished = true

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -194,7 +194,7 @@ module Fluent
       term_handler = trap :TERM do
         # After SIGTERM, disable the sigdump file by ignoring SIGCONT.
         trap(:CONT, nil)
-        term_handler.call
+        term_handler.call if term_handler.is_a?(Proc)
       end
     end
 

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -324,25 +324,21 @@ class SupervisorTest < ::Test::Unit::TestCase
     File.delete(@sigdump_path) if File.exist?(@sigdump_path)
   end
 
-  # TODO Sending SIGTERM terminates the test itself.
-  # I think we have to figure out a good way.
-  # def test_term_cont_in_supervisor_signal_handler
-  #   omit "Windows cannot handle signals" if Fluent.windows?
-  #
-  #   server = DummyServer.new
-  #   server.install_supervisor_signal_handlers
-  #   begin
-  #     Process.kill :TERM, $$
-  #     Process.kill :CONT, $$
-  #   rescue
-  #   end
-  #
-  #   sleep 1
-  #
-  #   assert_not File.exist?(@sigdump_path)
-  # ensure
-  #   File.delete(@sigdump_path) if File.exist?(@sigdump_path)
-  # end
+  def test_term_cont_in_supervisor_signal_handler
+    omit "Windows cannot handle signals" if Fluent.windows?
+
+    server = DummyServer.new
+    server.install_supervisor_signal_handlers
+    begin
+      Process.kill :TERM, $$
+      Process.kill :CONT, $$
+    rescue
+    end
+
+    assert_false File.exist?(@sigdump_path)
+  ensure
+    File.delete(@sigdump_path) if File.exist?(@sigdump_path)
+  end
 
   def test_windows_shutdown_event
     omit "Only for Windows platform" unless Fluent.windows?

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -214,7 +214,7 @@ class SupervisorTest < ::Test::Unit::TestCase
     $log.out.reset if $log && $log.out && $log.out.respond_to?(:reset)
   end
 
-  def test_cont_in_main_processsignal_handlers
+  def test_cont_in_main_process_signal_handlers
     omit "Windows cannot handle signals" if Fluent.windows?
 
     opts = Fluent::Supervisor.default_options
@@ -233,7 +233,7 @@ class SupervisorTest < ::Test::Unit::TestCase
     File.delete(@sigdump_path) if File.exist?(@sigdump_path)
   end
 
-  def test_term_cont_in_main_processsignal_handlers
+  def test_term_cont_in_main_process_signal_handlers
     omit "Windows cannot handle signals" if Fluent.windows?
 
     create_debug_dummy_logger


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**:

<!--
Fixes #3932
-->

Ideas for #3932 fixes.

**What this PR does / why we need it**:

After SIGTERM, disable SIGCONT handler.
This will prevent sigdump files from being generated.

**Docs Changes**:

**Release Note**: