### PR TITLE
Clean up after unit tests

### DIFF
--- a/lib/fluent/test/driver/base.rb
+++ b/lib/fluent/test/driver/base.rb
@@ -173,7 +173,7 @@ module Fluent
 
           if @socket_manager_server
             @socket_manager_server.close
-            if @socket_manager_server.is_a?(String) && File.exist?(@socket_manager_path)
+            if @socket_manager_path.is_a?(String) && File.exist?(@socket_manager_path)
               FileUtils.rm_f @socket_manager_path
             end
           end

--- a/test/plugin/test_in_tcp.rb
+++ b/test/plugin/test_in_tcp.rb
@@ -226,8 +226,8 @@ class TcpInputTest < Test::Unit::TestCase
 
       assert_equal 1, d.instance.log.logs.count { |l| l =~ /anonymous client/ }
       assert_equal 0, d.events.size
-
-      d.instance_shutdown
+    ensure
+      d.instance_shutdown if d&.instance
     end
   end
 

--- a/test/plugin/test_in_tcp.rb
+++ b/test/plugin/test_in_tcp.rb
@@ -226,6 +226,8 @@ class TcpInputTest < Test::Unit::TestCase
 
       assert_equal 1, d.instance.log.logs.count { |l| l =~ /anonymous client/ }
       assert_equal 0, d.events.size
+
+      d.instance_shutdown
     end
   end
 

--- a/test/plugin/test_out_http.rb
+++ b/test/plugin/test_out_http.rb
@@ -378,6 +378,7 @@ class HTTPOutputTest < Test::Unit::TestCase
           password hello?
         </auth>
       ])
+      d.instance.system_config_override(root_dir: TMP_DIR) # Backup files are generated in TMP_DIR.
       d.run(default_tag: 'test.http', shutdown: false) do
         test_events.each { |event|
           d.feed(event)

--- a/test/plugin/test_output.rb
+++ b/test/plugin/test_output.rb
@@ -803,7 +803,10 @@ class OutputTest < Test::Unit::TestCase
     end
 
     test 'output plugin will call #try_write for plugin supports delayed commit only to flush buffer chunks' do
+      tmp_dir = File.join(__dir__, '../tmp/test_output')
+
       i = create_output(:delayed)
+      i.system_config_override(root_dir: tmp_dir) # Backup files are generated in `tmp_dir`.
       try_write_called = false
       i.register(:try_write){|chunk| try_write_called = true; commit_write(chunk.unique_id) }
 
@@ -820,6 +823,8 @@ class OutputTest < Test::Unit::TestCase
       assert try_write_called
 
       i.stop; i.before_shutdown; i.shutdown; i.after_shutdown; i.close; i.terminate
+    ensure
+      FileUtils.rm_rf(tmp_dir)
     end
 
     test '#prefer_delayed_commit (returns false) decides delayed commit is disabled if both are implemented' do
@@ -849,7 +854,10 @@ class OutputTest < Test::Unit::TestCase
     end
 
     test '#prefer_delayed_commit (returns true) decides delayed commit is enabled if both are implemented' do
+      tmp_dir = File.join(__dir__, '../tmp/test_output')
+
       i = create_output(:full)
+      i.system_config_override(root_dir: tmp_dir) # Backup files are generated in `tmp_dir`.
       write_called = false
       try_write_called = false
       i.register(:write){ |chunk| write_called = true }
@@ -872,6 +880,8 @@ class OutputTest < Test::Unit::TestCase
       assert try_write_called
 
       i.stop; i.before_shutdown; i.shutdown; i.after_shutdown; i.close; i.terminate
+    ensure
+      FileUtils.rm_rf(tmp_dir)
     end
 
     test 'flush_interval is ignored when flush_mode is not interval' do

--- a/test/plugin_helper/test_server.rb
+++ b/test/plugin_helper/test_server.rb
@@ -37,7 +37,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     (@d.terminated? || @d.terminate) rescue nil
 
     @socket_manager_server.close
-    if @socket_manager_server.is_a?(String) && File.exist?(@socket_manager_path)
+    if @socket_manager_path.is_a?(String) && File.exist?(@socket_manager_path)
       FileUtils.rm_f @socket_manager_path
     end
   end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 

Fixes #4048

**What this PR does / why we need it**: 

After unit testing, clean up in /tmp.

(If you cannot terminate with SIGTERM and terminate with SIGKILL, some files cannot be cleaned up. https://github.com/fluent/fluentd/pull/4050#issuecomment-1427932016 https://github.com/fluent/fluentd/pull/4050#issuecomment-1430665345)

**Docs Changes**:

None

**Release Note**: 

None