### PR TITLE
Windows: Fix a bug that the wrong log file is reopened with log ratote setting when flushing or graceful reloading

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -563,12 +563,8 @@ module Fluent
           if @log_rotate_age || @log_rotate_size
             # We need to prepare a unique path for each worker since
             # Windows locks files.
-            if Fluent.windows?
-                path = LoggerInitializer.per_process_path(@path, process_type, worker_id)
-            else
-                path = @path
-            end
-            @logdev = Fluent::LogDeviceIO.new(path, shift_age: @log_rotate_age, shift_size: @log_rotate_size)
+            @path = LoggerInitializer.per_process_path(@path, process_type, worker_id) if Fluent.windows?
+            @logdev = Fluent::LogDeviceIO.new(@path, shift_age: @log_rotate_age, shift_size: @log_rotate_size)
           else
             @logdev = File.open(@path, "a")
           end
@@ -591,7 +587,7 @@ module Fluent
         $log = Fluent::Log.new(logger, @opts)
         $log.enable_color(false) if @path
         $log.enable_debug if @level <= Fluent::Log::LEVEL_DEBUG
-        $log.info "init #{process_type} logger", path: path, rotate_age: @log_rotate_age, rotate_size: @log_rotate_size
+        $log.info "init #{process_type} logger", path: @path, rotate_age: @log_rotate_age, rotate_size: @log_rotate_size
       end
 
       def stdout?

--- a/test/test_logger_initializer.rb
+++ b/test/test_logger_initializer.rb
@@ -7,13 +7,13 @@ class LoggerInitializerTest < ::Test::Unit::TestCase
   def setup
     @stored_global_logger = $log
     Dir.mktmpdir do |tmp_dir|
-      begin
-        @tmp_dir = Pathname(tmp_dir)
-        yield
-      ensure
-        $log = @stored_global_logger
-      end
+      @tmp_dir = Pathname(tmp_dir)
+      yield
     end
+  end
+
+  def teardown
+    $log = @stored_global_logger
   end
 
   test 'when path is given' do

--- a/test/test_logger_initializer.rb
+++ b/test/test_logger_initializer.rb
@@ -22,6 +22,7 @@ class LoggerInitializerTest < ::Test::Unit::TestCase
     assert_nothing_raised do
       logger.init(:supervisor, 0)
     end
+    $log.out.close
 
     assert_true File.exist?(TMP_DIR)
   end
@@ -38,8 +39,9 @@ class LoggerInitializerTest < ::Test::Unit::TestCase
     assert_nothing_raised do
       logger.init(:supervisor, 0)
     end
-
     logger.apply_options(log_dir_perm: 0o777)
+    $log.out.close
+
     assert_true File.exist?(TMP_DIR)
     assert_equal 0o777, (File.stat(TMP_DIR).mode & 0xFFF)
   end

--- a/test/test_logger_initializer.rb
+++ b/test/test_logger_initializer.rb
@@ -1,42 +1,40 @@
 require_relative 'helper'
 require 'fluent/supervisor'
 require 'fileutils'
+require 'pathname'
 
 class LoggerInitializerTest < ::Test::Unit::TestCase
-  TMP_DIR = File.expand_path(File.dirname(__FILE__) + "/tmp/logger_initializer#{ENV['TEST_ENV_NUMBER']}")
-
-  setup do
-    FileUtils.rm_rf(TMP_DIR) rescue nil
+  def setup
     @stored_global_logger = $log
-  end
-
-  teardown do
-    $log = @stored_global_logger
+    Dir.mktmpdir do |tmp_dir|
+      begin
+        @tmp_dir = Pathname(tmp_dir)
+        yield
+      ensure
+        $log = @stored_global_logger
+      end
+    end
   end
 
   test 'when path is given' do
-    assert { not File.exist?(TMP_DIR) }
-
-    path = File.join(TMP_DIR, 'fluent_with_path.log')
-    logger = Fluent::Supervisor::LoggerInitializer.new(path, Fluent::Log::LEVEL_DEBUG, nil, nil, {})
-    mock.proxy(File).chmod(0o777, TMP_DIR).never
+    path = @tmp_dir + 'log' + 'fluent_with_path.log'
+    logger = Fluent::Supervisor::LoggerInitializer.new(path.to_s, Fluent::Log::LEVEL_DEBUG, nil, nil, {})
+    mock.proxy(File).chmod(0o777, path.parent.to_s).never
 
     assert_nothing_raised do
       logger.init(:supervisor, 0)
     end
     $log.out.close
 
-    assert { File.exist?(TMP_DIR) }
+    assert { path.parent.exist? }
   end
 
   test 'apply_options with log_dir_perm' do
     omit "NTFS doesn't support UNIX like permissions" if Fluent.windows?
 
-    assert { not File.exist?(TMP_DIR) }
-
-    path = File.join(TMP_DIR, 'fluent_with_path.log')
-    logger = Fluent::Supervisor::LoggerInitializer.new(path, Fluent::Log::LEVEL_DEBUG, nil, nil, {})
-    mock.proxy(File).chmod(0o777, TMP_DIR).once
+    path = @tmp_dir + 'log' + 'fluent_with_path.log'
+    logger = Fluent::Supervisor::LoggerInitializer.new(path.to_s, Fluent::Log::LEVEL_DEBUG, nil, nil, {})
+    mock.proxy(File).chmod(0o777, path.parent.to_s).once
 
     assert_nothing_raised do
       logger.init(:supervisor, 0)
@@ -44,15 +42,13 @@ class LoggerInitializerTest < ::Test::Unit::TestCase
     logger.apply_options(log_dir_perm: 0o777)
     $log.out.close
 
-    assert { File.exist?(TMP_DIR) }
-    assert_equal 0o777, (File.stat(TMP_DIR).mode & 0xFFF)
+    assert { path.parent.exist? }
+    assert_equal 0o777, (File.stat(path.parent).mode & 0xFFF)
   end
 
   test 'rotate' do
-    assert { not File.exist?(TMP_DIR) }
-
-    path = File.join(TMP_DIR, 'fluent.log')
-    logger = Fluent::Supervisor::LoggerInitializer.new(path, Fluent::Log::LEVEL_DEBUG, nil, nil, {}, log_rotate_age: 5, log_rotate_size: 500)
+    path = @tmp_dir + 'log' + 'fluent.log'
+    logger = Fluent::Supervisor::LoggerInitializer.new(path.to_s, Fluent::Log::LEVEL_DEBUG, nil, nil, {}, log_rotate_age: 5, log_rotate_size: 500)
     logger.init(:supervisor, 0)
     begin
       10.times.each do
@@ -62,14 +58,12 @@ class LoggerInitializerTest < ::Test::Unit::TestCase
       $log.out.close
     end
 
-    assert { Dir.entries(TMP_DIR).size > 3 } # [".", "..", "logfile.log", ...]
+    assert { path.parent.entries.size > 3 } # [".", "..", "logfile.log", ...]
   end
 
   test 'rotate to max age' do
-    assert { not File.exist?(TMP_DIR) }
-
-    path = File.join(TMP_DIR, 'fluent.log')
-    logger = Fluent::Supervisor::LoggerInitializer.new(path, Fluent::Log::LEVEL_DEBUG, nil, nil, {}, log_rotate_age: 5, log_rotate_size: 500)
+    path = @tmp_dir + 'log' + 'fluent.log'
+    logger = Fluent::Supervisor::LoggerInitializer.new(path.to_s, Fluent::Log::LEVEL_DEBUG, nil, nil, {}, log_rotate_age: 5, log_rotate_size: 500)
     logger.init(:supervisor, 0)
     begin
       100.times.each do
@@ -79,35 +73,31 @@ class LoggerInitializerTest < ::Test::Unit::TestCase
       $log.out.close
     end
 
-    assert { Dir.entries(TMP_DIR).size == 7 } # [".", "..", "logfile.log", ...]
+    assert { path.parent.entries.size == 7 } # [".", "..", "logfile.log", ...]
   end
 
   test 'files for each process with rotate on Windows' do
     omit "Only for Windows." unless Fluent.windows?
 
-    assert { not File.exist?(TMP_DIR) }
-
-    path = File.join(TMP_DIR, 'fluent.log')
-    logger = Fluent::Supervisor::LoggerInitializer.new(path, Fluent::Log::LEVEL_DEBUG, nil, nil, {}, log_rotate_age: 5)
+    path = @tmp_dir + 'log' + 'fluent.log'
+    logger = Fluent::Supervisor::LoggerInitializer.new(path.to_s, Fluent::Log::LEVEL_DEBUG, nil, nil, {}, log_rotate_age: 5)
     logger.init(:supervisor, 0)
     $log.out.close
 
-    logger = Fluent::Supervisor::LoggerInitializer.new(path, Fluent::Log::LEVEL_DEBUG, nil, nil, {}, log_rotate_age: 5)
+    logger = Fluent::Supervisor::LoggerInitializer.new(path.to_s, Fluent::Log::LEVEL_DEBUG, nil, nil, {}, log_rotate_age: 5)
     logger.init(:worker0, 0)
     $log.out.close
 
-    logger = Fluent::Supervisor::LoggerInitializer.new(path, Fluent::Log::LEVEL_DEBUG, nil, nil, {}, log_rotate_age: 5)
+    logger = Fluent::Supervisor::LoggerInitializer.new(path.to_s, Fluent::Log::LEVEL_DEBUG, nil, nil, {}, log_rotate_age: 5)
     logger.init(:workers, 1)
     $log.out.close
 
-    assert { Dir.entries(TMP_DIR).size == 5 } # [".", "..", "logfile.log", ...]
+    assert { path.parent.entries.size == 5 } # [".", "..", "logfile.log", ...]
   end
 
   test 'reopen!' do
-    assert { not File.exist?(TMP_DIR) }
-
-    path = File.join(TMP_DIR, 'fluent.log')
-    logger = Fluent::Supervisor::LoggerInitializer.new(path, Fluent::Log::LEVEL_DEBUG, nil, nil, {})
+    path = @tmp_dir + 'log' + 'fluent.log'
+    logger = Fluent::Supervisor::LoggerInitializer.new(path.to_s, Fluent::Log::LEVEL_DEBUG, nil, nil, {})
     logger.init(:supervisor, 0)
     message = "This is test message."
     $log.info message
@@ -115,18 +105,16 @@ class LoggerInitializerTest < ::Test::Unit::TestCase
     $log.info message
     $log.out.close
 
-    assert { File.read(path).lines.select{ |line| line.include?(message) }.size == 2 }
+    assert { path.read.lines.select{ |line| line.include?(message) }.size == 2 }
   end
 
   test 'reopen! with rotate reopens the same file' do
-    assert { not File.exist?(TMP_DIR) }
-
-    path = File.join(TMP_DIR, 'fluent.log')
-    logger = Fluent::Supervisor::LoggerInitializer.new(path, Fluent::Log::LEVEL_DEBUG, nil, nil, {}, log_rotate_age: 5)
+    path = @tmp_dir + 'log' + 'fluent.log'
+    logger = Fluent::Supervisor::LoggerInitializer.new(path.to_s, Fluent::Log::LEVEL_DEBUG, nil, nil, {}, log_rotate_age: 5)
     logger.init(:supervisor, 0)
     logger.reopen!
     $log.out.close
 
-    assert { Dir.entries(TMP_DIR).size == 3 } # [".", "..", "logfile.log", ...]
+    assert { path.parent.entries.size == 3 } # [".", "..", "logfile.log", ...]
   end
 end

--- a/test/test_logger_initializer.rb
+++ b/test/test_logger_initializer.rb
@@ -18,7 +18,6 @@ class LoggerInitializerTest < ::Test::Unit::TestCase
     assert { not File.exist?(TMP_DIR) }
 
     path = File.join(TMP_DIR, 'fluent_with_path.log')
-    assert_false File.exist?(TMP_DIR)
     logger = Fluent::Supervisor::LoggerInitializer.new(path, Fluent::Log::LEVEL_DEBUG, nil, nil, {})
     mock.proxy(File).chmod(0o777, TMP_DIR).never
 

--- a/test/test_logger_initializer.rb
+++ b/test/test_logger_initializer.rb
@@ -5,11 +5,8 @@ require 'fileutils'
 class LoggerInitializerTest < ::Test::Unit::TestCase
   TMP_DIR = File.expand_path(File.dirname(__FILE__) + "/tmp/logger_initializer#{ENV['TEST_ENV_NUMBER']}")
 
-  teardown do
-    begin
-      FileUtils.rm_rf(TMP_DIR)
-    rescue => _
-    end
+  setup do
+    FileUtils.rm_rf(TMP_DIR) rescue nil
   end
 
   test 'when path is given' do

--- a/test/test_logger_initializer.rb
+++ b/test/test_logger_initializer.rb
@@ -7,6 +7,11 @@ class LoggerInitializerTest < ::Test::Unit::TestCase
 
   setup do
     FileUtils.rm_rf(TMP_DIR) rescue nil
+    @stored_global_logger = $log
+  end
+
+  teardown do
+    $log = @stored_global_logger
   end
 
   test 'when path is given' do

--- a/test/test_logger_initializer.rb
+++ b/test/test_logger_initializer.rb
@@ -15,8 +15,9 @@ class LoggerInitializerTest < ::Test::Unit::TestCase
   end
 
   test 'when path is given' do
-    path = File.join(TMP_DIR, 'fluent_with_path.log')
+    assert { not File.exist?(TMP_DIR) }
 
+    path = File.join(TMP_DIR, 'fluent_with_path.log')
     assert_false File.exist?(TMP_DIR)
     logger = Fluent::Supervisor::LoggerInitializer.new(path, Fluent::Log::LEVEL_DEBUG, nil, nil, {})
     mock.proxy(File).chmod(0o777, TMP_DIR).never
@@ -26,15 +27,15 @@ class LoggerInitializerTest < ::Test::Unit::TestCase
     end
     $log.out.close
 
-    assert_true File.exist?(TMP_DIR)
+    assert { File.exist?(TMP_DIR) }
   end
 
   test 'apply_options with log_dir_perm' do
     omit "NTFS doesn't support UNIX like permissions" if Fluent.windows?
 
-    path = File.join(TMP_DIR, 'fluent_with_path.log')
+    assert { not File.exist?(TMP_DIR) }
 
-    assert_false File.exist?(TMP_DIR)
+    path = File.join(TMP_DIR, 'fluent_with_path.log')
     logger = Fluent::Supervisor::LoggerInitializer.new(path, Fluent::Log::LEVEL_DEBUG, nil, nil, {})
     mock.proxy(File).chmod(0o777, TMP_DIR).once
 
@@ -44,7 +45,7 @@ class LoggerInitializerTest < ::Test::Unit::TestCase
     logger.apply_options(log_dir_perm: 0o777)
     $log.out.close
 
-    assert_true File.exist?(TMP_DIR)
+    assert { File.exist?(TMP_DIR) }
     assert_equal 0o777, (File.stat(TMP_DIR).mode & 0xFFF)
   end
 


### PR DESCRIPTION
When log rotation is enabled on Windows, the log path is separated for each process.
But, the new path value is not applied to the instance variable, so it breaks the following behavior, since #2663.

https://github.com/fluent/fluentd/blob/bf7498d6ff2805bfa517bbd6f7c17103c7d879d4/lib/fluent/supervisor.rb#L576-L580

https://github.com/fluent/fluentd/blob/bf7498d6ff2805bfa517bbd6f7c17103c7d879d4/lib/fluent/supervisor.rb#L601-L606

I can't assume that `File.chown` is used on Windows, but `reopen` must be fixed.
(`--user` and `--group` are not intended to be used on Windows, right? If so, I will add some comments to [the doc](https://docs.fluentd.org/deployment/command-line-option) and code.)

**Which issue(s) this PR fixes**: 
I found this problem during fixing:

* #4037

I thought this should be fixed in a separate PR, so I made this PR first.

**What this PR does / why we need it**: 
This bug breaks the function of reopening the log file with log rotation enabled on Windows, since

* #2663

We need this fix to fix this problem.

**How to Reproduce**

* Prepare config
```xml
<system>
  <log>
    rotate_age 5
    rotate_size 2000
  </log>
</system>

 <source>
   @type sample
   tag test
 </source>
 
 <match test.**>
   @type stdout
 </match>
```

* Run Fluentd
```console
$ bundle exec fluentd -c /test/fluent.conf -o /test/log/fluent.log
```

* We can find the log files
```
fluent-supervisor-0.log
fluent-0.log
fluent-0.log.0
...
```

* Flush([SIGUSR1](https://docs.fluentd.org/deployment/signals#sigusr1))
  * We can check the pid of the supervisor process in `fluent-supervisor-0.log`.
  * `starting fluentd-1.15.3 pid=4208 ruby="2.6.6"`
```console
$ fluent-ctl flush {pid of supervisor process}
```

* Then Fluentd reopens `fluent.log` for the worker process, although this should be `fluent-0.log`.

We can find a similar problem in graceful reloading([SIGUSR2](https://docs.fluentd.org/deployment/signals#sigusr2)), but this often causes an error in rotating supervisor log file.
This seems to have another bug, I would like to exclude this bug for now.

```console
$ fluent-ctl reload {pid of supervisor process} (another shell)
log shifting failed. Permission denied @ rb_file_s_rename - (.\fluent\log\fluent-supervisor-0.log, .\fluent\log\fluent-supervisor-0.log.0)
log writing failed. closed stream
```

**Docs Changes**:
Not needed.

**Release Note**: 
Same as the title.
