### PR TITLE
Update Webrick

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("tzinfo", [">= 1.0", "< 3.0"])
   gem.add_runtime_dependency("tzinfo-data", ["~> 1.0"])
   gem.add_runtime_dependency("strptime", [">= 0.2.4", "< 1.0.0"])
-  gem.add_runtime_dependency("webrick", [">= 1.4.2", "< 1.8.0"])
+  gem.add_runtime_dependency("webrick", ["~> 1.4"])
 
   # build gem for a certain platform. see also Rakefile
   fake_platform = ENV['GEM_BUILD_FAKE_PLATFORM'].to_s


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #4060

**What this PR does / why we need it**: 
This PR allows us to use the latest `Webrick` v1.8.

https://github.com/ruby/webrick/releases

Without this fix,  plugins using the latest version of `Webrick` tries to bundle the Fluentd v1.12.1.

* https://github.com/fluent-plugins-nursery/fluent-plugin-utmpx/issues/6

**Docs Changes**:
Not needed.

**Release Note**: 
Not needed.
