### PR TITLE
TEST: Don't use SIGTERM on Windows

### DIFF
--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -72,6 +72,11 @@ class TestFluentdCommand < ::Test::Unit::TestCase
   end
 
   def process_kill(pid)
+    if Fluent.windows?
+      Process.kill(:KILL, pid) rescue nil
+      return
+    end
+
     begin
       Process.kill(:TERM, pid) rescue nil
       Timeout.timeout(10){ sleep 0.1 while process_exist?(pid) }


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 
On Windows, unnecessary timeout always occurred in `TestFluentdCommand`.
This fix reduces the test time to 210s from 520s on my environment:

* Widows 10 Home
* Ruby 3.2
* CPU: core i7
* RAM: 16GB

**Docs Changes**:
Not needed.

**Release Note**: 
Not needed.
