### PR TITLE
Fix problem that some system configs are not reflected

### DIFF
--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -158,15 +158,15 @@ op.on('--enable-size-metrics', "Enable plugin record size metrics on fluentd", T
 }
 
 op.on('-v', '--verbose', "increase verbose level (-v: debug, -vv: trace)", TrueClass) {|b|
-  if b
-    cmd_opts[:log_level] = [default_opts[:log_level] - 1, Fluent::Log::LEVEL_TRACE].max
-  end
+  return unless b
+  cur_level = cmd_opts.fetch(:log_level, default_opts[:log_level])
+  cmd_opts[:log_level] = [cur_level - 1, Fluent::Log::LEVEL_TRACE].max
 }
 
 op.on('-q', '--quiet', "decrease verbose level (-q: warn, -qq: error)", TrueClass) {|b|
-  if b
-    cmd_opts[:log_level] = [default_opts[:log_level] + 1, Fluent::Log::LEVEL_ERROR].min
-  end
+  return unless b
+  cur_level = cmd_opts.fetch(:log_level, default_opts[:log_level])
+  cmd_opts[:log_level] = [cur_level + 1, Fluent::Log::LEVEL_TRACE].max
 }
 
 op.on('--suppress-config-dump', "suppress config dumping when fluentd starts", TrueClass) {|b|

--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -26,26 +26,27 @@ $fluentdargv = Marshal.load(Marshal.dump(ARGV))
 op = OptionParser.new
 op.version = Fluent::VERSION
 
-opts = Fluent::Supervisor.default_options
+default_opts = Fluent::Supervisor.default_options
+cmd_opts = {}
 
 op.on('-s', "--setup [DIR=#{File.dirname(Fluent::DEFAULT_CONFIG_PATH)}]", "install sample configuration file to the directory") {|s|
-  opts[:setup_path] = s || File.dirname(Fluent::DEFAULT_CONFIG_PATH)
+  cmd_opts[:setup_path] = s || File.dirname(Fluent::DEFAULT_CONFIG_PATH)
 }
 
 op.on('-c', '--config PATH', "config file path (default: #{Fluent::DEFAULT_CONFIG_PATH})") {|s|
-  opts[:config_path] = s
+  cmd_opts[:config_path] = s
 }
 
 op.on('--dry-run', "Check fluentd setup is correct or not", TrueClass) {|b|
-  opts[:dry_run] = b
+  cmd_opts[:dry_run] = b
 }
 
 op.on('--show-plugin-config=PLUGIN', "[DEPRECATED] Show PLUGIN configuration and exit(ex: input:dummy)") {|plugin|
-  opts[:show_plugin_config] = plugin
+  cmd_opts[:show_plugin_config] = plugin
 }
 
 op.on('-p', '--plugin DIR', "add plugin directory") {|s|
-  opts[:plugin_dirs] << s
+  (cmd_opts[:plugin_dirs] ||= []) << s
 }
 
 op.on('-I PATH', "add library path") {|s|
@@ -53,48 +54,48 @@ op.on('-I PATH', "add library path") {|s|
 }
 
 op.on('-r NAME', "load library") {|s|
-  opts[:libs] << s
+  (cmd_opts[:libs] ||= []) << s
 }
 
 op.on('-d', '--daemon PIDFILE', "daemonize fluent process") {|s|
-  opts[:daemonize] = s
+  cmd_opts[:daemonize] = s
 }
 
 op.on('--under-supervisor', "run fluent worker under supervisor (this option is NOT for users)") {
-  opts[:supervise] = false
+  cmd_opts[:supervise] = false
 }
 
 op.on('--no-supervisor', "run fluent worker without supervisor") {
-  opts[:supervise] = false
-  opts[:standalone_worker] = true
+  cmd_opts[:supervise] = false
+  cmd_opts[:standalone_worker] = true
 }
 
 op.on('--workers NUM', "specify the number of workers under supervisor") { |i|
-  opts[:workers] = i.to_i
+  cmd_opts[:workers] = i.to_i
 }
 
 op.on('--user USER', "change user") {|s|
-  opts[:chuser] = s
+  cmd_opts[:chuser] = s
 }
 
 op.on('--group GROUP', "change group") {|s|
-  opts[:chgroup] = s
+  cmd_opts[:chgroup] = s
 }
 
 op.on('--umask UMASK', "change umask") {|s|
-  opts[:chumask] = s
+  cmd_opts[:chumask] = s
 }
 
 op.on('-o', '--log PATH', "log file path") {|s|
-  opts[:log_path] = s
+  cmd_opts[:log_path] = s
 }
 
 op.on('--log-rotate-age AGE', 'generations to keep rotated log files') {|age|
   if Fluent::Log::LOG_ROTATE_AGE.include?(age)
-    opts[:log_rotate_age] = age
+    cmd_opts[:log_rotate_age] = age
   else
     begin
-      opts[:log_rotate_age] = Integer(age)
+      cmd_opts[:log_rotate_age] = Integer(age)
     rescue TypeError, ArgumentError
       usage "log-rotate-age should be #{ROTATE_AGE.join(', ')} or a number"
     end
@@ -102,129 +103,129 @@ op.on('--log-rotate-age AGE', 'generations to keep rotated log files') {|age|
 }
 
 op.on('--log-rotate-size BYTES', 'sets the byte size to rotate log files') {|s|
-  opts[:log_rotate_size] = s.to_i
+  cmd_opts[:log_rotate_size] = s.to_i
 }
 
 op.on('--log-event-verbose', 'enable log events during process startup/shutdown') {|b|
-  opts[:log_event_verbose] = b
+  cmd_opts[:log_event_verbose] = b
 }
 
 op.on('-i', '--inline-config CONFIG_STRING', "inline config which is appended to the config file on-the-fly") {|s|
-  opts[:inline_config] = s
+  cmd_opts[:inline_config] = s
 }
 
 op.on('--emit-error-log-interval SECONDS', "suppress interval seconds of emit error logs") {|s|
-  opts[:suppress_interval] = s.to_i
+  cmd_opts[:suppress_interval] = s.to_i
 }
 
 op.on('--suppress-repeated-stacktrace [VALUE]', "suppress repeated stacktrace", TrueClass) {|b|
   b = true if b.nil?
-  opts[:suppress_repeated_stacktrace] = b
+  cmd_opts[:suppress_repeated_stacktrace] = b
 }
 
 op.on('--without-source', "invoke a fluentd without input plugins", TrueClass) {|b|
-  opts[:without_source] = b
+  cmd_opts[:without_source] = b
 }
 
 op.on('--config-file-type VALU', 'guessing file type of fluentd configuration. yaml/yml or guess') { |s|
   if (s == 'yaml') || (s == 'yml')
-    opts[:config_file_type] = s.to_sym
+    cmd_opts[:config_file_type] = s.to_sym
   elsif (s == 'guess')
-    opts[:config_file_type] = s.to_sym
+    cmd_opts[:config_file_type] = s.to_sym
   else
     usage '--config-file-type accepts yaml/yml or guess'
   end
 }
 
 op.on('--use-v1-config', "Use v1 configuration format (default)", TrueClass) {|b|
-  opts[:use_v1_config] = b
+  cmd_opts[:use_v1_config] = b
 }
 
 op.on('--use-v0-config', "Use v0 configuration format", TrueClass) {|b|
-  opts[:use_v1_config] = !b
+  cmd_opts[:use_v1_config] = !b
 }
 
 op.on('--strict-config-value', "Parse config values strictly", TrueClass) {|b|
-  opts[:strict_config_value] = b
+  cmd_opts[:strict_config_value] = b
 }
 
 op.on('--enable-input-metrics', "Enable input plugin metrics on fluentd", TrueClass) {|b|
-  opts[:enable_input_metrics] = b
+  cmd_opts[:enable_input_metrics] = b
 }
 
 op.on('--enable-size-metrics', "Enable plugin record size metrics on fluentd", TrueClass) {|b|
-  opts[:enable_size_metrics] = b
+  cmd_opts[:enable_size_metrics] = b
 }
 
 op.on('-v', '--verbose', "increase verbose level (-v: debug, -vv: trace)", TrueClass) {|b|
   if b
-    opts[:log_level] = [opts[:log_level] - 1, Fluent::Log::LEVEL_TRACE].max
+    cmd_opts[:log_level] = [default_opts[:log_level] - 1, Fluent::Log::LEVEL_TRACE].max
   end
 }
 
 op.on('-q', '--quiet', "decrease verbose level (-q: warn, -qq: error)", TrueClass) {|b|
   if b
-    opts[:log_level] = [opts[:log_level] + 1, Fluent::Log::LEVEL_ERROR].min
+    cmd_opts[:log_level] = [default_opts[:log_level] + 1, Fluent::Log::LEVEL_ERROR].min
   end
 }
 
 op.on('--suppress-config-dump', "suppress config dumping when fluentd starts", TrueClass) {|b|
-  opts[:suppress_config_dump] = b
+  cmd_opts[:suppress_config_dump] = b
 }
 
 op.on('-g', '--gemfile GEMFILE', "Gemfile path") {|s|
-  opts[:gemfile] = s
+  cmd_opts[:gemfile] = s
 }
 
 op.on('-G', '--gem-path GEM_INSTALL_PATH', "Gemfile install path (default: $(dirname $gemfile)/vendor/bundle)") {|s|
-  opts[:gem_install_path] = s
+  cmd_opts[:gem_install_path] = s
 }
 
 op.on('--conf-encoding ENCODING', "specify configuration file encoding") { |s|
-  opts[:conf_encoding] = s
+  cmd_opts[:conf_encoding] = s
 }
 
 op.on('--disable-shared-socket', "Don't open shared socket for multiple workers") { |b|
-  opts[:disable_shared_socket] = b
+  cmd_opts[:disable_shared_socket] = b
 }
 
 if Fluent.windows?
-  opts.merge!(
+  cmd_opts.merge!(
     :winsvc_name => 'fluentdwinsvc',
     :winsvc_display_name => 'Fluentd Windows Service',
     :winsvc_desc => 'Fluentd is an event collector system.',
   )
 
   op.on('-x', '--signame INTSIGNAME', "an object name which is used for Windows Service signal (Windows only)") {|s|
-    opts[:signame] = s
+    cmd_opts[:signame] = s
   }
 
   op.on('--reg-winsvc MODE', "install/uninstall as Windows Service. (i: install, u: uninstall) (Windows only)") {|s|
-    opts[:regwinsvc] = s
+    cmd_opts[:regwinsvc] = s
   }
 
   op.on('--[no-]reg-winsvc-auto-start', "Automatically start the Windows Service at boot. (only effective with '--reg-winsvc i') (Windows only)") {|s|
-    opts[:regwinsvcautostart] = s
+    cmd_opts[:regwinsvcautostart] = s
   }
 
   op.on('--[no-]reg-winsvc-delay-start', "Automatically start the Windows Service at boot with delay. (only effective with '--reg-winsvc i' and '--reg-winsvc-auto-start') (Windows only)") {|s|
-    opts[:regwinsvcdelaystart] = s
+    cmd_opts[:regwinsvcdelaystart] = s
   }
 
   op.on('--reg-winsvc-fluentdopt OPTION', "specify fluentd option parameters for Windows Service. (Windows only)") {|s|
-    opts[:fluentdopt] = s
+    cmd_opts[:fluentdopt] = s
   }
 
   op.on('--winsvc-name NAME', "The Windows Service name to run as (Windows only)") {|s|
-    opts[:winsvc_name] = s
+    cmd_opts[:winsvc_name] = s
   }
 
   op.on('--winsvc-display-name DISPLAY_NAME', "The Windows Service display name (Windows only)") {|s|
-    opts[:winsvc_display_name] = s
+    cmd_opts[:winsvc_display_name] = s
   }
 
   op.on('--winsvc-desc DESC', "The Windows Service description (Windows only)") {|s|
-    opts[:winsvc_desc] = s
+    cmd_opts[:winsvc_desc] = s
   }
 end
 
@@ -247,6 +248,7 @@ rescue
   usage $!.to_s
 end
 
+opts = default_opts.merge(cmd_opts)
 
 ##
 ## Bundler injection
@@ -345,7 +347,7 @@ end
 exit 0 if early_exit
 
 if opts[:supervise]
-  supervisor = Fluent::Supervisor.new(opts)
+  supervisor = Fluent::Supervisor.new(cmd_opts)
   supervisor.configure(supervisor: true)
   supervisor.run_supervisor(dry_run: opts[:dry_run])
 else
@@ -353,7 +355,7 @@ else
     puts "Error: multi workers is not supported with --no-supervisor"
     exit 2
   end
-  worker = Fluent::Supervisor.new(opts)
+  worker = Fluent::Supervisor.new(cmd_opts)
   worker.configure
 
   if opts[:daemonize] && opts[:standalone_worker]

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -1104,12 +1104,6 @@ module Fluent
       opt = {}
       Fluent::SystemConfig::SYSTEM_CONFIG_PARAMETERS.each do |param|
         if @cl_opt.key?(param) && !@cl_opt[param].nil?
-          if param == :log_level && @cl_opt[:log_level] == Fluent::Log::LEVEL_INFO
-            # info level can't be specified via command line option.
-            # log_level is info here, it is default value and <system>'s log_level should be applied if exists.
-            next
-          end
-
           opt[param] = @cl_opt[param]
         end
       end

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -656,7 +656,10 @@ module Fluent
       end
     end
 
-    def initialize(opt)
+    def initialize(cl_opt)
+      @cl_opt = cl_opt
+      opt = self.class.default_options.merge(cl_opt)
+
       @config_file_type = opt[:config_file_type]
       @daemonize = opt[:daemonize]
       @standalone_worker= opt[:standalone_worker]
@@ -676,7 +679,6 @@ module Fluent
       @log_rotate_size = opt[:log_rotate_size]
       @signame = opt[:signame]
 
-      @cl_opt = opt
       @conf = nil
       # parse configuration immediately to initialize logger in early stage
       if @config_path and File.exist?(@config_path)
@@ -1098,6 +1100,7 @@ module Fluent
 
     def build_system_config(conf)
       system_config = SystemConfig.create(conf, @cl_opt[:strict_config_value])
+      # Prefer the options explicitly specified in the command line
       opt = {}
       Fluent::SystemConfig::SYSTEM_CONFIG_PARAMETERS.each do |param|
         if @cl_opt.key?(param) && !@cl_opt[param].nil?

--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -1220,5 +1220,17 @@ CONF
                          "[error]",
                          patterns_not_match: ["[warn]"])
     end
+
+    test 'system config one should not be overwritten when cmd line one is not specified' do
+      conf = <<CONF
+<system>
+  log_level debug
+</system>
+CONF
+      conf_path = create_conf_file('debug.conf', conf)
+      assert File.exist?(conf_path)
+      assert_log_matches(create_cmdline(conf_path),
+                         "[debug]")
+    end
   end
 end

--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -1160,4 +1160,65 @@ CONF
                          "shared socket for multiple workers is disabled",)
     end
   end
+
+  sub_test_case 'log_level by command line option' do
+    test 'info' do
+      conf = ""
+      conf_path = create_conf_file('empty.conf', conf)
+      assert File.exist?(conf_path)
+      assert_log_matches(create_cmdline(conf_path),
+                         "[info]",
+                         patterns_not_match: ["[debug]"])
+    end
+
+    test 'debug' do
+      conf = ""
+      conf_path = create_conf_file('empty.conf', conf)
+      assert File.exist?(conf_path)
+      assert_log_matches(create_cmdline(conf_path, "-v"),
+                         "[debug]",
+                         patterns_not_match: ["[trace]"])
+    end
+
+    test 'trace' do
+      conf = <<CONF
+<source>
+  @type sample
+  tag test
+</source>
+CONF
+      conf_path = create_conf_file('sample.conf', conf)
+      assert File.exist?(conf_path)
+      assert_log_matches(create_cmdline(conf_path, "-vv"),
+                         "[trace]",)
+    end
+
+    test 'warn' do
+      conf = <<CONF
+<source>
+  @type sample
+  tag test
+</source>
+CONF
+      conf_path = create_conf_file('sample.conf', conf)
+      assert File.exist?(conf_path)
+      assert_log_matches(create_cmdline(conf_path, "-q"),
+                         "[warn]",
+                         patterns_not_match: ["[info]"])
+    end
+
+    test 'error' do
+      conf = <<CONF
+<source>
+  @type plugin_not_found
+  tag test
+</source>
+CONF
+      conf_path = create_conf_file('plugin_not_found.conf', conf)
+      assert File.exist?(conf_path)
+      assert_log_matches(create_cmdline(conf_path, "-qq"),
+                         "[error]",
+                         patterns_not_match: ["[warn]"])
+    end
+  end
 end

--- a/test/plugin/test_in_monitor_agent.rb
+++ b/test/plugin/test_in_monitor_agent.rb
@@ -355,14 +355,13 @@ EOC
 
     test "fluentd opts" do
       d = create_driver
-      opts = Fluent::Supervisor.default_options
 
       filepath = nil
       begin
         FileUtils.mkdir_p(CONFIG_DIR)
         filepath = File.expand_path('fluentd.conf', CONFIG_DIR)
         FileUtils.touch(filepath)
-        s = Fluent::Supervisor.new(opts.merge(config_path: filepath))
+        s = Fluent::Supervisor.new({config_path: filepath})
         s.configure
       ensure
         FileUtils.rm_r(CONFIG_DIR) rescue _
@@ -502,7 +501,7 @@ EOC
           v.puts(conf)
         end
 
-        @supervisor = Fluent::Supervisor.new(Fluent::Supervisor.default_options.merge(config_path: @filepath))
+        @supervisor = Fluent::Supervisor.new({config_path: @filepath})
         @supervisor.configure
       ensure
         FileUtils.rm_r(CONFIG_DIR) rescue _

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -52,12 +52,11 @@ class SupervisorTest < ::Test::Unit::TestCase
 
 
   def test_system_config
-    opts = Fluent::Supervisor.default_options
-    sv = Fluent::Supervisor.new(opts)
+    sv = Fluent::Supervisor.new({})
     conf_data = <<-EOC
 <system>
   rpc_endpoint 127.0.0.1:24445
-  suppress_repeated_stacktrace true
+  suppress_repeated_stacktrace false
   suppress_config_dump true
   without_source true
   enable_get_dump true
@@ -85,7 +84,7 @@ class SupervisorTest < ::Test::Unit::TestCase
     sys_conf = sv.__send__(:build_system_config, conf)
 
     assert_equal '127.0.0.1:24445', sys_conf.rpc_endpoint
-    assert_equal true, sys_conf.suppress_repeated_stacktrace
+    assert_equal false, sys_conf.suppress_repeated_stacktrace
     assert_equal true, sys_conf.suppress_config_dump
     assert_equal true, sys_conf.without_source
     assert_equal true, sys_conf.enable_get_dump
@@ -120,8 +119,7 @@ class SupervisorTest < ::Test::Unit::TestCase
     end
 
     def test_system_config
-      opts = Fluent::Supervisor.default_options
-      sv = Fluent::Supervisor.new(opts)
+      sv = Fluent::Supervisor.new({})
       conf_data = <<-EOC
       system:
         rpc_endpoint: 127.0.0.1:24445
@@ -197,8 +195,7 @@ class SupervisorTest < ::Test::Unit::TestCase
 
     create_info_dummy_logger
 
-    opts = Fluent::Supervisor.default_options
-    sv = Fluent::Supervisor.new(opts)
+    sv = Fluent::Supervisor.new({})
     sv.send(:install_main_process_signal_handlers)
 
     Process.kill :USR1, Process.pid
@@ -214,8 +211,7 @@ class SupervisorTest < ::Test::Unit::TestCase
   def test_cont_in_main_process_signal_handlers
     omit "Windows cannot handle signals" if Fluent.windows?
 
-    opts = Fluent::Supervisor.default_options
-    sv = Fluent::Supervisor.new(opts)
+    sv = Fluent::Supervisor.new({})
     sv.send(:install_main_process_signal_handlers)
 
     Process.kill :CONT, Process.pid
@@ -232,8 +228,7 @@ class SupervisorTest < ::Test::Unit::TestCase
 
     create_debug_dummy_logger
 
-    opts = Fluent::Supervisor.default_options
-    sv = Fluent::Supervisor.new(opts)
+    sv = Fluent::Supervisor.new({})
     sv.send(:install_main_process_signal_handlers)
 
     Process.kill :TERM, Process.pid
@@ -256,8 +251,7 @@ class SupervisorTest < ::Test::Unit::TestCase
 
     create_info_dummy_logger
 
-    opts = Fluent::Supervisor.default_options
-    sv = Fluent::Supervisor.new(opts)
+    sv = Fluent::Supervisor.new({})
     r, w = IO.pipe
     $stdin = r
     sv.send(:install_main_process_signal_handlers)
@@ -432,8 +426,7 @@ class SupervisorTest < ::Test::Unit::TestCase
 
     create_info_dummy_logger
 
-    opts = Fluent::Supervisor.default_options
-    sv = Fluent::Supervisor.new(opts)
+    sv = Fluent::Supervisor.new({})
     conf_data = <<-EOC
   <system>
     rpc_endpoint "#{bindaddr}:24447"
@@ -469,8 +462,7 @@ class SupervisorTest < ::Test::Unit::TestCase
   def test_invalid_rpc_endpoint(data)
     endpoint = data[0]
 
-    opts = Fluent::Supervisor.default_options
-    sv = Fluent::Supervisor.new(opts)
+    sv = Fluent::Supervisor.new({})
     conf_data = <<-EOC
   <system>
     rpc_endpoint "#{endpoint}"
@@ -498,8 +490,7 @@ class SupervisorTest < ::Test::Unit::TestCase
 
     create_info_dummy_logger
 
-    opts = Fluent::Supervisor.default_options
-    sv = Fluent::Supervisor.new(opts)
+    sv = Fluent::Supervisor.new({})
     conf_data = <<-EOC
   <system>
     rpc_endpoint "#{bindaddr}:24447"
@@ -698,8 +689,7 @@ class SupervisorTest < ::Test::Unit::TestCase
   end
 
   def test_logger
-    opts = Fluent::Supervisor.default_options
-    sv = Fluent::Supervisor.new(opts)
+    sv = Fluent::Supervisor.new({})
     log = sv.instance_variable_get(:@log)
     log.init(:standalone, 0)
     logger = $log.instance_variable_get(:@logger)
@@ -721,10 +711,7 @@ class SupervisorTest < ::Test::Unit::TestCase
     integer_age: 2,
   )
   def test_logger_with_rotate_age_and_rotate_size(rotate_age)
-    opts = Fluent::Supervisor.default_options.merge(
-      log_path: "#{@tmp_dir}/test", log_rotate_age: rotate_age, log_rotate_size: 10
-    )
-    sv = Fluent::Supervisor.new(opts)
+    sv = Fluent::Supervisor.new({log_path: "#{@tmp_dir}/test", log_rotate_age: rotate_age, log_rotate_size: 10})
     log = sv.instance_variable_get(:@log)
     log.init(:standalone, 0)
 
@@ -751,10 +738,7 @@ class SupervisorTest < ::Test::Unit::TestCase
         EOS
         file.puts(config)
         file.flush
-        opts = Fluent::Supervisor.default_options.merge(
-          log_path: "#{@tmp_dir}/test.log", config_path: file.path
-        )
-        sv = Fluent::Supervisor.new(opts)
+        sv = Fluent::Supervisor.new({log_path: "#{@tmp_dir}/test.log", config_path: file.path})
 
         log = sv.instance_variable_get(:@log)
         log.init(:standalone, 0)
@@ -776,10 +760,7 @@ class SupervisorTest < ::Test::Unit::TestCase
         EOS
         file.puts(config)
         file.flush
-        opts = Fluent::Supervisor.default_options.merge(
-          log_path: "#{@tmp_dir}/test.log", config_path: file.path, config_file_type: :yaml,
-        )
-        sv = Fluent::Supervisor.new(opts)
+        sv = Fluent::Supervisor.new({log_path: "#{@tmp_dir}/test.log", config_path: file.path, config_file_type: :yaml})
 
         log = sv.instance_variable_get(:@log)
         log.init(:standalone, 0)
@@ -795,9 +776,7 @@ class SupervisorTest < ::Test::Unit::TestCase
   def test_inline_config
     omit 'this feature is deprecated. see https://github.com/fluent/fluentd/issues/2711'
 
-    opts = Fluent::Supervisor.default_options
-    opts[:inline_config] = '-'
-    sv = Fluent::Supervisor.new(opts)
+    sv = Fluent::Supervisor.new({inline_config: '-'})
     assert_equal '-', sv.instance_variable_get(:@inline_config)
 
     inline_config = '<match *>\n@type stdout\n</match>'
@@ -810,8 +789,7 @@ class SupervisorTest < ::Test::Unit::TestCase
   end
 
   def test_log_level_affects
-    opts = Fluent::Supervisor.default_options
-    sv = Fluent::Supervisor.new(opts)
+    sv = Fluent::Supervisor.new({})
 
     c = Fluent::Config::Element.new('system', '', { 'log_level' => 'error' }, [])
     stub(Fluent::Config).build { config_element('ROOT', '', {}, [c]) }


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
I found this problem during fixing:

* #4037

I thought this should be fixed in a separate PR, so I made this PR first.

**What this PR does / why we need it**: 
Options explicitly specified in command line should be preferred to options specified in system config.

* https://github.com/fluent/fluentd/pull/1398
* https://github.com/fluent/fluentd/pull/2674

However, options that have a default value, such as `suppress_repeated_stacktrace`, are preferred even when they are not specified in the command line.

Because of this, the following setting is not reflected.

```xml
<system>
  suppress_repeated_stacktrace false
</system>
```

> Options explicitly specified in command line should be preferred to options specified in system config.

In order to realize this specification, we should pass only options that are explicitly specified in the command line to `Superviser.new()`.

**Docs Changes**:
Not needed.

**Release Note**: 
Same as the title.
