### PR TITLE
Refactor logger initialization

### DIFF
--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -154,7 +154,7 @@ module Fluent
 
     attr_reader :format
     attr_reader :time_format
-    attr_accessor :log_event_enabled, :ignore_repeated_log_interval, :ignore_same_log_interval
+    attr_accessor :log_event_enabled, :ignore_repeated_log_interval, :ignore_same_log_interval, :suppress_repeated_stacktrace
     attr_accessor :out
     attr_accessor :level
     attr_accessor :optional_header, :optional_attrs

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -436,14 +436,6 @@ module Fluent
         return params['pre_conf']
       end
 
-      log_level = params['log_level']
-
-      chuser = params['chuser']
-      chgroup = params['chgroup']
-      chumask = params['chumask']
-
-      command_sender = Fluent.windows? ? "pipe" : "signal"
-
       # ServerEngine's "daemonize" option is boolean, and path of pid file is brought by "pid_path"
       pid_path = params['daemonize']
       daemonize = !!params['daemonize']
@@ -461,11 +453,11 @@ module Fluent
         root_dir: params['root_dir'],
         logger: $log,
         log: $log.out,
-        log_level: log_level,
+        log_level: params['log_level'],
         logger_initializer: params['logger_initializer'],
-        chuser: chuser,
-        chgroup: chgroup,
-        chumask: chumask,
+        chuser: params['chuser'],
+        chgroup: params['chgroup'],
+        chumask: params['chumask'],
         daemonize: daemonize,
         rpc_endpoint: params['rpc_endpoint'],
         counter_server: params['counter_server'],
@@ -476,7 +468,7 @@ module Fluent
                                  WorkerModule.name,
                                  path,
                                  JSON.dump(params)],
-        command_sender: command_sender,
+        command_sender: Fluent.windows? ? "pipe" : "signal",
         fluentd_conf: params['fluentd_conf'],
         conf_encoding: params['conf_encoding'],
         inline_config: params['inline_config'],

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -424,6 +424,10 @@ module Fluent
   end
 
   class Supervisor
+    # For ServerEngine's `reload_config`.
+    # This is called only at the initilization of the supervisor process,
+    # since Fluentd overwrites all related SIGNAL(HUP,USR1,USR2) and have own
+    # reloading feature.
     def self.load_config(path, params = {})
       pre_loadtime = 0
       pre_loadtime = params['pre_loadtime'].to_i if params['pre_loadtime']


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
I found this problem during fixing:

* https://github.com/fluent/fluentd/issues/4037#issuecomment-1427366287

This fix should be done before fixing this issue.

**What this PR does / why we need it**: 
In the supervisor process, Fluentd initializes the logger twice, at `Supervisor::configure()` and `Supervisor.load_config()`.

`Supervisor.load_config()` is called in ServerEngine's reloading function, but Fluentd doesn't use the function even when `SIGHUP` or `SIGUSR2`.
So I can't see the reason for initializing the logger in that callback.

This also fixes a problem that `ignore_same_log_interval` is not passed to the `Supervisor.load_config()` and that option is not reflected to the logger of the supervisor process.

**Docs Changes**:
Not needed.

**Release Note**: 
* Fix bug that `ignore_same_log_interval` option is not reflected in the supervisor process.
* Fix bug that `suppress_repeated_stacktrace` from SystemConfig is not reflected in the worker processes.

We should consider the release note with

* #4064