### PR TITLE
Fix value of `system_config.workers` at `run_configure`

### DIFF
--- a/lib/fluent/plugin/base.rb
+++ b/lib/fluent/plugin/base.rb
@@ -52,13 +52,13 @@ module Fluent
         @_fluentd_worker_id
       end
 
-      # @param conf [Fluent::Config::Element, Hash] configuration
       def configure(conf)
-        if conf.is_a?(Fluent::Config::Element)
-          if (Fluent::Engine.supervisor_mode && !conf.target_worker_ids.empty?) || conf.for_this_worker?
-            system_config_override(workers: conf.target_worker_ids.size)
-          end
+        raise ArgumentError, "BUG: type of conf must be Fluent::Config::Element, but #{conf.class} is passed." unless conf.is_a?(Fluent::Config::Element)
+
+        if (Fluent::Engine.supervisor_mode && !conf.target_worker_ids.empty?) || conf.for_this_worker?
+          system_config_override(workers: conf.target_worker_ids.size)
         end
+
         super(conf, system_config.strict_config_value)
         @_state ||= State.new(false, false, false, false, false, false, false, false, false)
         @_state.configure = true

--- a/lib/fluent/plugin/base.rb
+++ b/lib/fluent/plugin/base.rb
@@ -55,7 +55,7 @@ module Fluent
       def configure(conf)
         raise ArgumentError, "BUG: type of conf must be Fluent::Config::Element, but #{conf.class} is passed." unless conf.is_a?(Fluent::Config::Element)
 
-        if (Fluent::Engine.supervisor_mode && !conf.target_worker_ids.empty?) || conf.for_this_worker?
+        if conf.for_this_worker? || (Fluent::Engine.supervisor_mode && !conf.for_every_workers?)
           system_config_override(workers: conf.target_worker_ids.size)
         end
 

--- a/lib/fluent/plugin/base.rb
+++ b/lib/fluent/plugin/base.rb
@@ -52,14 +52,12 @@ module Fluent
         @_fluentd_worker_id
       end
 
+      # @param conf [Fluent::Config::Element, Hash] configuration
       def configure(conf)
-        if Fluent::Engine.supervisor_mode || (conf.respond_to?(:for_this_worker?) && conf.for_this_worker?)
-          workers = if conf.target_worker_ids && !conf.target_worker_ids.empty?
-                      conf.target_worker_ids.size
-                    else
-                      1
-                    end
-          system_config_override(workers: workers)
+        if conf.is_a?(Fluent::Config::Element)
+          if (Fluent::Engine.supervisor_mode && !conf.target_worker_ids.empty?) || conf.for_this_worker?
+            system_config_override(workers: conf.target_worker_ids.size)
+          end
         end
         super(conf, system_config.strict_config_value)
         @_state ||= State.new(false, false, false, false, false, false, false, false, false)

--- a/test/plugin/test_base.rb
+++ b/test/plugin/test_base.rb
@@ -146,4 +146,148 @@ class BaseTest < Test::Unit::TestCase
       end
     end
   end
+
+  sub_test_case 'system_config.workers value after configure' do
+    sub_test_case 'with <system> workers 3 </system>' do
+      setup do
+        system_config = Fluent::SystemConfig.new
+        system_config.workers = 3
+        stub(Fluent::Engine).system_config { system_config }
+      end
+
+      sub_test_case 'supervisor_mode is true' do
+        setup do
+          stub(Fluent::Engine).supervisor_mode { true }
+          stub(Fluent::Engine).worker_id { -1 }
+        end
+
+        test 'without <worker> directive' do
+          conf = config_element()
+          conf.set_target_worker_ids([])
+          @p.configure(conf)
+          assert{ @p.system_config.workers == 3 }
+        end
+
+        test 'with <worker 0>' do
+          conf = config_element()
+          conf.set_target_worker_ids([0])
+          @p.configure(conf)
+          assert{ @p.system_config.workers == 1 }
+        end
+
+        test 'with <worker 0-1>' do
+          conf = config_element()
+          conf.set_target_worker_ids([0, 1])
+          @p.configure(conf)
+          assert{ @p.system_config.workers == 2 }
+        end
+
+        test 'with <worker 0-2>' do
+          conf = config_element()
+          conf.set_target_worker_ids([0, 1, 2])
+          @p.configure(conf)
+          assert{ @p.system_config.workers == 3 }
+        end
+
+        test '`conf` is `Hash`' do
+          @p.configure({})
+          assert{ @p.system_config.workers == 3 }
+        end
+      end
+
+      sub_test_case 'supervisor_mode is false' do
+        setup do
+          stub(Fluent::Engine).supervisor_mode { false }
+          stub(Fluent::Engine).worker_id { 0 }
+        end
+
+        test 'without <worker> directive' do
+          conf = config_element()
+          conf.set_target_worker_ids([])
+          @p.configure(conf)
+          assert{ @p.system_config.workers == 3 }
+        end
+
+        test 'with <worker 0>' do
+          conf = config_element()
+          conf.set_target_worker_ids([0])
+          @p.configure(conf)
+          assert{ @p.system_config.workers == 1 }
+        end
+
+        test 'with <worker 0-1>' do
+          conf = config_element()
+          conf.set_target_worker_ids([0, 1])
+          @p.configure(conf)
+          assert{ @p.system_config.workers == 2 }
+        end
+
+        test 'with <worker 0-2>' do
+          conf = config_element()
+          conf.set_target_worker_ids([0, 1, 2])
+          @p.configure(conf)
+          assert{ @p.system_config.workers == 3 }
+        end
+
+        test '`conf` is `Hash`' do
+          @p.configure({})
+          assert{ @p.system_config.workers == 3 }
+        end
+      end
+    end
+
+    sub_test_case 'without <system> directive' do
+      sub_test_case 'supervisor_mode is true' do
+        setup do
+          stub(Fluent::Engine).supervisor_mode { true }
+          stub(Fluent::Engine).worker_id { -1 }
+        end
+
+        test 'without <worker> directive' do
+          conf = config_element()
+          conf.set_target_worker_ids([])
+          @p.configure(conf)
+          assert{ @p.system_config.workers == 1 }
+        end
+
+        test 'with <worker 0>' do
+          conf = config_element()
+          conf.set_target_worker_ids([0])
+          @p.configure(conf)
+          assert{ @p.system_config.workers == 1 }
+        end
+
+        test '`conf` is `Hash`' do
+          @p.configure({})
+          assert{ @p.system_config.workers == 1 }
+        end
+      end
+
+      sub_test_case 'supervisor_mode is false' do
+        setup do
+          stub(Fluent::Engine).supervisor_mode { false }
+          stub(Fluent::Engine).worker_id { 0 }
+        end
+
+        test 'without <worker> directive' do
+          conf = config_element()
+          conf.set_target_worker_ids([])
+          @p.configure(conf)
+          assert{ @p.system_config.workers == 1 }
+        end
+
+        test 'with <worker 0>' do
+          conf = config_element()
+          conf.set_target_worker_ids([0])
+          @p.configure(conf)
+          assert{ @p.system_config.workers == 1 }
+        end
+
+        test '`conf` is `Hash`' do
+          @p.configure({})
+          assert{ @p.system_config.workers == 1 }
+        end
+      end
+    end
+  end
 end

--- a/test/plugin/test_base.rb
+++ b/test/plugin/test_base.rb
@@ -147,6 +147,12 @@ class BaseTest < Test::Unit::TestCase
     end
   end
 
+  test '`ArgumentError` when `conf` is not `Fluent::Config::Element`' do
+    assert_raise ArgumentError.new('BUG: type of conf must be Fluent::Config::Element, but Hash is passed.') do
+      @p.configure({})
+    end
+  end
+
   sub_test_case 'system_config.workers value after configure' do
     sub_test_case 'with <system> workers 3 </system>' do
       setup do
@@ -188,11 +194,6 @@ class BaseTest < Test::Unit::TestCase
           @p.configure(conf)
           assert{ @p.system_config.workers == 3 }
         end
-
-        test '`conf` is `Hash`' do
-          @p.configure({})
-          assert{ @p.system_config.workers == 3 }
-        end
       end
 
       sub_test_case 'supervisor_mode is false' do
@@ -228,11 +229,6 @@ class BaseTest < Test::Unit::TestCase
           @p.configure(conf)
           assert{ @p.system_config.workers == 3 }
         end
-
-        test '`conf` is `Hash`' do
-          @p.configure({})
-          assert{ @p.system_config.workers == 3 }
-        end
       end
     end
 
@@ -256,11 +252,6 @@ class BaseTest < Test::Unit::TestCase
           @p.configure(conf)
           assert{ @p.system_config.workers == 1 }
         end
-
-        test '`conf` is `Hash`' do
-          @p.configure({})
-          assert{ @p.system_config.workers == 1 }
-        end
       end
 
       sub_test_case 'supervisor_mode is false' do
@@ -280,11 +271,6 @@ class BaseTest < Test::Unit::TestCase
           conf = config_element()
           conf.set_target_worker_ids([0])
           @p.configure(conf)
-          assert{ @p.system_config.workers == 1 }
-        end
-
-        test '`conf` is `Hash`' do
-          @p.configure({})
           assert{ @p.system_config.workers == 1 }
         end
       end

--- a/test/plugin/test_base.rb
+++ b/test/plugin/test_base.rb
@@ -154,6 +154,18 @@ class BaseTest < Test::Unit::TestCase
   end
 
   sub_test_case 'system_config.workers value after configure' do
+    def assert_system_config_workers_value(data)
+      conf = config_element()
+      conf.set_target_worker_ids(data[:target_worker_ids])
+      @p.configure(conf)
+      assert{ @p.system_config.workers == data[:expected] }
+    end
+
+    def stub_supervisor_mode
+      stub(Fluent::Engine).supervisor_mode { true }
+      stub(Fluent::Engine).worker_id { -1 }
+    end
+
     sub_test_case 'with <system> workers 3 </system>' do
       setup do
         system_config = Fluent::SystemConfig.new
@@ -161,118 +173,74 @@ class BaseTest < Test::Unit::TestCase
         stub(Fluent::Engine).system_config { system_config }
       end
 
-      sub_test_case 'supervisor_mode is true' do
-        setup do
-          stub(Fluent::Engine).supervisor_mode { true }
-          stub(Fluent::Engine).worker_id { -1 }
-        end
+      data(
+        'without <worker> directive',
+        {
+          target_worker_ids: [],
+          expected: 3
+        },
+        keep: true
+      )
+      data(
+        'with <worker 0>',
+        {
+          target_worker_ids: [0],
+          expected: 1
+        },
+        keep: true
+      )
+      data(
+        'with <worker 0-1>',
+        {
+          target_worker_ids: [0, 1],
+          expected: 2
+        },
+        keep: true
+      )
+      data(
+        'with <worker 0-2>',
+        {
+          target_worker_ids: [0, 1, 2],
+          expected: 3
+        },
+        keep: true
+      )
 
-        test 'without <worker> directive' do
-          conf = config_element()
-          conf.set_target_worker_ids([])
-          @p.configure(conf)
-          assert{ @p.system_config.workers == 3 }
-        end
-
-        test 'with <worker 0>' do
-          conf = config_element()
-          conf.set_target_worker_ids([0])
-          @p.configure(conf)
-          assert{ @p.system_config.workers == 1 }
-        end
-
-        test 'with <worker 0-1>' do
-          conf = config_element()
-          conf.set_target_worker_ids([0, 1])
-          @p.configure(conf)
-          assert{ @p.system_config.workers == 2 }
-        end
-
-        test 'with <worker 0-2>' do
-          conf = config_element()
-          conf.set_target_worker_ids([0, 1, 2])
-          @p.configure(conf)
-          assert{ @p.system_config.workers == 3 }
-        end
+      test 'system_config.workers value after configure' do
+        assert_system_config_workers_value(data)
       end
 
-      sub_test_case 'supervisor_mode is false' do
-        setup do
-          stub(Fluent::Engine).supervisor_mode { false }
-          stub(Fluent::Engine).worker_id { 0 }
-        end
-
-        test 'without <worker> directive' do
-          conf = config_element()
-          conf.set_target_worker_ids([])
-          @p.configure(conf)
-          assert{ @p.system_config.workers == 3 }
-        end
-
-        test 'with <worker 0>' do
-          conf = config_element()
-          conf.set_target_worker_ids([0])
-          @p.configure(conf)
-          assert{ @p.system_config.workers == 1 }
-        end
-
-        test 'with <worker 0-1>' do
-          conf = config_element()
-          conf.set_target_worker_ids([0, 1])
-          @p.configure(conf)
-          assert{ @p.system_config.workers == 2 }
-        end
-
-        test 'with <worker 0-2>' do
-          conf = config_element()
-          conf.set_target_worker_ids([0, 1, 2])
-          @p.configure(conf)
-          assert{ @p.system_config.workers == 3 }
-        end
+      test 'system_config.workers value after configure  with supervisor_mode' do
+        stub_supervisor_mode
+        assert_system_config_workers_value(data)
       end
     end
 
     sub_test_case 'without <system> directive' do
-      sub_test_case 'supervisor_mode is true' do
-        setup do
-          stub(Fluent::Engine).supervisor_mode { true }
-          stub(Fluent::Engine).worker_id { -1 }
-        end
+      data(
+        'without <worker> directive',
+        {
+          target_worker_ids: [],
+          expected: 1
+        },
+        keep: true
+      )
+      data(
+        'with <worker 0>',
+        {
+          target_worker_ids: [0],
+          expected: 1
+        },
+        keep: true
+      )
 
-        test 'without <worker> directive' do
-          conf = config_element()
-          conf.set_target_worker_ids([])
-          @p.configure(conf)
-          assert{ @p.system_config.workers == 1 }
-        end
-
-        test 'with <worker 0>' do
-          conf = config_element()
-          conf.set_target_worker_ids([0])
-          @p.configure(conf)
-          assert{ @p.system_config.workers == 1 }
-        end
+      test 'system_config.workers value after configure' do
+        assert_system_config_workers_value(data)
       end
 
-      sub_test_case 'supervisor_mode is false' do
-        setup do
-          stub(Fluent::Engine).supervisor_mode { false }
-          stub(Fluent::Engine).worker_id { 0 }
-        end
-
-        test 'without <worker> directive' do
-          conf = config_element()
-          conf.set_target_worker_ids([])
-          @p.configure(conf)
-          assert{ @p.system_config.workers == 1 }
-        end
-
-        test 'with <worker 0>' do
-          conf = config_element()
-          conf.set_target_worker_ids([0])
-          @p.configure(conf)
-          assert{ @p.system_config.workers == 1 }
-        end
+      test 'system_config.workers value after configure  with supervisor_mode' do
+        stub_supervisor_mode
+        assert_system_config_workers_value(data)
       end
     end
   end


### PR DESCRIPTION

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #4051

**What this PR does / why we need it**: 

Override `system_config` only if `conf.target_worker_ids.size >= 1`.

* If `<worker N>` or `<worker 0-N>` is not set, `conf.target_worker_ids` is empty.
* If `<system> workers N </system>` is not set, `system_config.workers` defaults to 1.

**Docs Changes**:

**Release Note**: 

* Fix value of `system_config.workers` at `run_configure`
* Change argument type of `Fluent::Plugin::Base::configure()` to `Fluent::Config::Element` only.
