### PR TITLE
Proposing a new Fluentd maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,3 +10,4 @@
 - [Fujimoto Seiji](https://github.com/fujimots), [ClearCode](https://www.clear-code.com/)
 - [Takuro Ashie](https://github.com/ashie), [ClearCode](https://www.clear-code.com/)
 - [Kentaro Hayashi](https://github.com/kenhys), [ClearCode](https://www.clear-code.com/)
+- [Daijiro Fukuda](https://github.com/daipom), [ClearCode](https://www.clear-code.com/)


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

N/A

**What this PR does / why we need it**: 

According to our [governance policy](https://github.com/fluent/fluentd/blob/master/GOVERNANCE.md), we need to vote for changing maintainership.

As @daipom contributing to fluentd a lot, so I'll propose @daipom as a new maintainer.

Currently, there are following organizations:

* @sonots (ZOZO)
* @cosmo0920 , @edsiper (Calyptia)
* @toru-takahashi (Treasure Data)
* @ashie, @kenhys (ClearCode)

And individual developers.

* @okkez
* @repeatedly 
* @tagomoris 
* @fujimotos

(We need to also update affilicated compaty information in MAINTAINERS.md later)

Thus, the total number of organization is 8 and satisfying the majority of 2/3 must be  not less than  6.

So every organization need to show :+1: or :-1:

**Docs Changes**:

N/A

**Release Note**: 


N/A