### PR TITLE
Use driver for formatter tests

### DIFF
--- a/test/test_formatter.rb
+++ b/test/test_formatter.rb
@@ -13,10 +13,6 @@ module FormatterTest
     {'message' => 'awesome', 'greeting' => 'hello'}
   end
 
-  def config_element_in_params(params)
-    config_element('test', '', params)
-  end
-
   class BaseFormatterTest < ::Test::Unit::TestCase
     include FormatterTest
 
@@ -134,12 +130,12 @@ module FormatterTest
     include FormatterTest
 
     def setup
-      @formatter = TextFormatter::MessagePackFormatter.new
+      @formatter = Fluent::Test::FormatterTestDriver.new(TextFormatter::MessagePackFormatter)
       @time = Engine.now
     end
 
     def test_format
-      @formatter.configure(config_element())
+      @formatter.configure({})
       formatted = @formatter.format(tag, @time, record)
 
       assert_equal(record.to_msgpack, formatted)
@@ -150,7 +146,7 @@ module FormatterTest
     include FormatterTest
 
     def setup
-      @formatter = TextFormatter::LabeledTSVFormatter.new
+      @formatter = Fluent::Test::FormatterTestDriver.new(TextFormatter::LabeledTSVFormatter)
       @time = Engine.now
       @newline = if Fluent.windows?
                    "\r\n"
@@ -160,30 +156,30 @@ module FormatterTest
     end
 
     def test_config_params
-      assert_equal "\t", @formatter.delimiter
-      assert_equal  ":", @formatter.label_delimiter
+      assert_equal "\t", @formatter.instance.delimiter
+      assert_equal  ":", @formatter.instance.label_delimiter
 
-      @formatter.configure(config_element_in_params(
+      @formatter.configure(
         'delimiter'       => ',',
         'label_delimiter' => '=',
-      ))
+      )
 
-      assert_equal ",", @formatter.delimiter
-      assert_equal "=", @formatter.label_delimiter
+      assert_equal ",", @formatter.instance.delimiter
+      assert_equal "=", @formatter.instance.label_delimiter
     end
 
     def test_format
-      @formatter.configure(config_element())
+      @formatter.configure({})
       formatted = @formatter.format(tag, @time, record)
 
       assert_equal("message:awesome\tgreeting:hello#{@newline}", formatted)
     end
 
     def test_format_with_customized_delimiters
-      @formatter.configure(config_element_in_params(
+      @formatter.configure(
         'delimiter'       => ',',
         'label_delimiter' => '=',
-      ))
+      )
       formatted = @formatter.format(tag, @time, record)
 
       assert_equal("message=awesome,greeting=hello#{@newline}", formatted)
@@ -194,26 +190,26 @@ module FormatterTest
     end
 
     def test_format_suppresses_tab
-      @formatter.configure(config_element())
+      @formatter.configure({})
       formatted = @formatter.format(tag, @time, record_with_tab)
 
       assert_equal("message:awe some\tgreeting:hello #{@newline}", formatted)
     end
 
     def test_format_suppresses_tab_custom_replacement
-      @formatter.configure(config_element_in_params(
+      @formatter.configure(
         'replacement'      => 'X',
-      ))
+      )
       formatted = @formatter.format(tag, @time, record_with_tab)
 
       assert_equal("message:aweXsome\tgreeting:helloX#{@newline}", formatted)
     end
 
     def test_format_suppresses_custom_delimiter
-      @formatter.configure(config_element_in_params(
+      @formatter.configure(
         'delimiter'       => 'w',
         'label_delimiter' => '=',
-      ))
+      )
       formatted = @formatter.format(tag, @time, record)
 
       assert_equal("message=a esomewgreeting=hello#{@newline}", formatted)
@@ -224,14 +220,14 @@ module FormatterTest
     include FormatterTest
 
     def setup
-      @formatter = TextFormatter::CsvFormatter.new
+      @formatter = Fluent::Test::FormatterTestDriver.new(TextFormatter::CsvFormatter)
       @time = Engine.now
     end
 
     def test_config_params
-      assert_equal ',', @formatter.delimiter
-      assert_equal true, @formatter.force_quotes
-      assert_nil @formatter.fields
+      assert_equal ',', @formatter.instance.delimiter
+      assert_equal true, @formatter.instance.force_quotes
+      assert_nil @formatter.instance.fields
     end
 
     data(
@@ -240,13 +236,13 @@ module FormatterTest
       'pipe' => ['|', '|'])
     def test_config_params_with_customized_delimiters(data)
       expected, target = data
-      @formatter.configure(config_element_in_params('delimiter' => target, 'fields' => 'a,b,c'))
-      assert_equal expected, @formatter.delimiter
-      assert_equal ['a', 'b', 'c'], @formatter.fields
+      @formatter.configure('delimiter' => target, 'fields' => 'a,b,c')
+      assert_equal expected, @formatter.instance.delimiter
+      assert_equal ['a', 'b', 'c'], @formatter.instance.fields
     end
 
     def test_format
-      @formatter.configure(config_element_in_params('fields' => 'message,message2'))
+      @formatter.configure('fields' => 'message,message2')
       formatted = @formatter.format(tag, @time, {
         'message' => 'awesome',
         'message2' => 'awesome2'
@@ -255,10 +251,10 @@ module FormatterTest
     end
 
     def test_format_with_customized_delimiters
-      @formatter.configure(config_element_in_params(
+      @formatter.configure(
         'fields' => 'message,message2',
         'delimiter' => '\t'
-      ))
+      )
       formatted = @formatter.format(tag, @time, {
         'message' => 'awesome',
         'message2' => 'awesome2'
@@ -267,10 +263,10 @@ module FormatterTest
     end
 
     def test_format_with_non_quote
-      @formatter.configure(config_element_in_params(
+      @formatter.configure(
         'fields' => 'message,message2',
         'force_quotes' => 'false'
-      ))
+      )
       formatted = @formatter.format(tag, @time, {
         'message' => 'awesome',
         'message2' => 'awesome2'
@@ -290,9 +286,9 @@ module FormatterTest
         'message3' => 'awesome3'
       })
     def test_format_with_empty_fields(data)
-      @formatter.configure(config_element_in_params(
+      @formatter.configure(
         'fields' => 'message,message2,message3'
-      ))
+      )
       formatted = @formatter.format(tag, @time, data)
       assert_equal("\"awesome\",\"\",\"awesome3\"\n", formatted)
     end
@@ -302,8 +298,8 @@ module FormatterTest
       'white_space' => 'one , two , three',
       'blank' => 'one,,two,three')
     def test_config_params_with_fields(data)
-      @formatter.configure(config_element_in_params('fields' => data))
-      assert_equal %w(one two three), @formatter.fields
+      @formatter.configure('fields' => data)
+      assert_equal %w(one two three), @formatter.instance.fields
     end
   end
 
@@ -317,32 +313,35 @@ module FormatterTest
                  end
     end
 
+    def create_driver(klass_or_str)
+      Fluent::Test::FormatterTestDriver.new(klass_or_str)
+    end
 
     def test_config_params
-      formatter = TextFormatter::SingleValueFormatter.new
-      assert_equal "message", formatter.message_key
+      formatter = create_driver(TextFormatter::SingleValueFormatter)
+      assert_equal "message", formatter.instance.message_key
 
-      formatter.configure(config_element_in_params('message_key' => 'foobar'))
-      assert_equal "foobar", formatter.message_key
+      formatter.configure('message_key' => 'foobar')
+      assert_equal "foobar", formatter.instance.message_key
     end
 
     def test_format
-      formatter = Fluent::Plugin.new_formatter('single_value')
-      formatter.configure(config_element())
+      formatter = create_driver('single_value')
+      formatter.configure({})
       formatted = formatter.format('tag', Engine.now, {'message' => 'awesome'})
       assert_equal("awesome#{@newline}", formatted)
     end
 
     def test_format_without_newline
-      formatter = Fluent::Plugin.new_formatter('single_value')
-      formatter.configure(config_element_in_params('add_newline' => 'false'))
+      formatter = create_driver('single_value')
+      formatter.configure('add_newline' => 'false')
       formatted = formatter.format('tag', Engine.now, {'message' => 'awesome'})
       assert_equal("awesome", formatted)
     end
 
     def test_format_with_message_key
-      formatter = TextFormatter::SingleValueFormatter.new
-      formatter.configure(config_element_in_params('message_key' => 'foobar'))
+      formatter = create_driver(TextFormatter::SingleValueFormatter)
+      formatter.configure('message_key' => 'foobar')
       formatted = formatter.format('tag', Engine.now, {'foobar' => 'foo'})
 
       assert_equal("foo#{@newline}", formatted)


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None. This is the following fix to

* #4074 

**What this PR does / why we need it**: 
* #4074

In this PR, some tests passing `Hash` directly to `Fluent::Plugin::Base::configure()` are fixed so that passing `Fluent::Config::Element`.

However, a part of those tests should use the test-driver, and then we can passing `Hash` to the driver safely.

**Docs Changes**:
None.

**Release Note**: 
None.