### PR TITLE
Refactor Superviser.load_config()

### DIFF
--- a/lib/fluent/daemon.rb
+++ b/lib/fluent/daemon.rb
@@ -9,7 +9,5 @@ require 'fluent/supervisor'
 
 server_module = Fluent.const_get(ARGV[0])
 worker_module = Fluent.const_get(ARGV[1])
-# it doesn't call ARGV in block because when reloading config, params will be initialized and then it can't use previous config.
-config_path = ARGV[2]
-params = JSON.parse(ARGV[3])
-ServerEngine::Daemon.run_server(server_module, worker_module) { Fluent::Supervisor.load_config(config_path, params) }
+params = JSON.parse(ARGV[2])
+ServerEngine::Daemon.run_server(server_module, worker_module) { Fluent::Supervisor.serverengine_config(params) }

--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -203,7 +203,6 @@ module Fluent
     end
 
     def reopen!
-      # do nothing in @logger.reopen! because it's already reopened in Supervisor.load_config
       @logger.reopen! if @logger
       nil
     end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
This PR is the following to

* #4065 

**What this PR does / why we need it**: 
It does not load the config anymore since

* #2709

So it should simply return the config for `ServerEngine`.

**Docs Changes**:
Not needed.

**Release Note**: 
Not needed. (This fixes only internal specifications)
