### PR TITLE
Suppress warning using different secondary for out_secondary_file

### DIFF
--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -426,7 +426,9 @@ module Fluent
           end
           @secondary.acts_as_secondary(self)
           @secondary.configure(secondary_conf)
-          if (self.class != @secondary.class) && (@custom_format || @secondary.implement?(:custom_format))
+          if (@secondary.class != SecondaryFileOutput) &&
+             (self.class != @secondary.class) &&
+             (@custom_format || @secondary.implement?(:custom_format))
             log.warn "Use different plugin for secondary. Check the plugin works with primary like secondary_file", primary: self.class.to_s, secondary: @secondary.class.to_s
           end
         else


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None.

**What this PR does / why we need it**: 
Fluentd outputs the following warning message even when we use `out_secondary_file` for the secondary.

```
2023-03-09 14:50:10 +0900 [warn]: #0 Use different plugin for secondary. Check the plugin works with primary like secondary_file primary="Fluent::Plugin::FileOutput" secondary="Fluent::Plugin::SecondaryFileOutput"
```

Example config:

```xml
<source>
  @type sample
  tag test.hoge
  sample {"message": "hoge"}
</source>

<match test.**>
  @type file
  path /test/fluentd/log/${tag}/fluentd.log
  <format>
    @type single_value
  </format>
  <buffer tag>
    @type file
    path /test/fluentd/buffer
    flush_mode interval
    flush_interval 10s
  </buffer>
  <secondary>
    @type secondary_file
    directory /test/fluentd/error/
  </secondary>
</match>
```

This warning is meaningless when we use `out_secondary_file` for the secondary.

This PR suppresses it.

**Docs Changes**:
Not needed.

**Release Note**: 
Same as the title.
