### PR TITLE
SocketManager: Use new feature to select path automatically

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("msgpack", [">= 1.3.1", "< 2.0.0"])
   gem.add_runtime_dependency("yajl-ruby", ["~> 1.0"])
   gem.add_runtime_dependency("cool.io", [">= 1.4.5", "< 2.0.0"])
-  gem.add_runtime_dependency("serverengine", [">= 2.3.0", "< 3.0.0"])
+  gem.add_runtime_dependency("serverengine", [">= 2.3.2", "< 3.0.0"])
   gem.add_runtime_dependency("http_parser.rb", [">= 0.5.1", "< 0.9.0"])
   gem.add_runtime_dependency("sigdump", ["~> 0.2.2"])
   gem.add_runtime_dependency("tzinfo", [">= 1.0", "< 3.0"])

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -66,9 +66,8 @@ module Fluent
       if config[:disable_shared_socket]
         $log.info "shared socket for multiple workers is disabled"
       else
-        socket_manager_path = ServerEngine::SocketManager::Server.generate_path
-        ServerEngine::SocketManager::Server.open(socket_manager_path)
-        ENV['SERVERENGINE_SOCKETMANAGER_PATH'] = socket_manager_path.to_s
+        server = ServerEngine::SocketManager::Server.open
+        ENV['SERVERENGINE_SOCKETMANAGER_PATH'] = server.path.to_s
       end
     end
 
@@ -801,9 +800,8 @@ module Fluent
     private
 
     def create_socket_manager
-      socket_manager_path = ServerEngine::SocketManager::Server.generate_path
-      ServerEngine::SocketManager::Server.open(socket_manager_path)
-      ENV['SERVERENGINE_SOCKETMANAGER_PATH'] = socket_manager_path.to_s
+      server = ServerEngine::SocketManager::Server.open
+      ENV['SERVERENGINE_SOCKETMANAGER_PATH'] = server.path.to_s
     end
 
     def show_plugin_config

--- a/lib/fluent/test/driver/base.rb
+++ b/lib/fluent/test/driver/base.rb
@@ -16,6 +16,7 @@
 
 require 'fluent/config'
 require 'fluent/config/element'
+require 'fluent/env'
 require 'fluent/log'
 require 'fluent/clock'
 
@@ -102,11 +103,16 @@ module Fluent
 
         def instance_start
           if @instance.respond_to?(:server_wait_until_start)
-            @socket_manager_path = ServerEngine::SocketManager::Server.generate_path
-            if @socket_manager_path.is_a?(String) && File.exist?(@socket_manager_path)
-              FileUtils.rm_f @socket_manager_path
+            if Fluent.windows?
+              @socket_manager_server = ServerEngine::SocketManager::Server.open
+              @socket_manager_path = @socket_manager_server.path
+            else
+              @socket_manager_path = ServerEngine::SocketManager::Server.generate_path
+              if @socket_manager_path.is_a?(String) && File.exist?(@socket_manager_path)
+                FileUtils.rm_f @socket_manager_path
+              end
+              @socket_manager_server = ServerEngine::SocketManager::Server.open(@socket_manager_path)
             end
-            @socket_manager_server = ServerEngine::SocketManager::Server.open(@socket_manager_path)
             ENV['SERVERENGINE_SOCKETMANAGER_PATH'] = @socket_manager_path.to_s
           end
 

--- a/lib/fluent/test/startup_shutdown.rb
+++ b/lib/fluent/test/startup_shutdown.rb
@@ -21,9 +21,8 @@ module Fluent
   module Test
     module StartupShutdown
       def startup
-        socket_manager_path = ServerEngine::SocketManager::Server.generate_path
-        @server = ServerEngine::SocketManager::Server.open(socket_manager_path)
-        ENV['SERVERENGINE_SOCKETMANAGER_PATH'] = socket_manager_path.to_s
+        @server = ServerEngine::SocketManager::Server.open
+        ENV['SERVERENGINE_SOCKETMANAGER_PATH'] = @server.path.to_s
       end
 
       def shutdown
@@ -31,15 +30,14 @@ module Fluent
       end
 
       def self.setup
-        @socket_manager_path = ServerEngine::SocketManager::Server.generate_path
-        @server = ServerEngine::SocketManager::Server.open(@socket_manager_path)
-        ENV['SERVERENGINE_SOCKETMANAGER_PATH'] = @socket_manager_path.to_s
+        @server = ServerEngine::SocketManager::Server.open
+        ENV['SERVERENGINE_SOCKETMANAGER_PATH'] = @server.path.to_s
       end
 
       def self.teardown
         @server.close
-        # on Windows, socket_manager_path is a TCP port number
-        FileUtils.rm_f @socket_manager_path unless Fluent.windows?
+        # on Windows, the path is a TCP port number
+        FileUtils.rm_f @server.path unless Fluent.windows?
       end
     end
   end

--- a/test/plugin/test_in_http.rb
+++ b/test/plugin/test_in_http.rb
@@ -7,9 +7,8 @@ require 'timecop'
 class HttpInputTest < Test::Unit::TestCase
   class << self
     def startup
-      socket_manager_path = ServerEngine::SocketManager::Server.generate_path
-      @server = ServerEngine::SocketManager::Server.open(socket_manager_path)
-      ENV['SERVERENGINE_SOCKETMANAGER_PATH'] = socket_manager_path.to_s
+      @server = ServerEngine::SocketManager::Server.open
+      ENV['SERVERENGINE_SOCKETMANAGER_PATH'] = @server.path.to_s
     end
 
     def shutdown

--- a/test/plugin_helper/test_server.rb
+++ b/test/plugin_helper/test_server.rb
@@ -16,11 +16,16 @@ class ServerPluginHelperTest < Test::Unit::TestCase
 
   setup do
     @port = unused_port
-    @socket_manager_path = ServerEngine::SocketManager::Server.generate_path
-    if @socket_manager_path.is_a?(String) && File.exist?(@socket_manager_path)
-      FileUtils.rm_f @socket_manager_path
+    if Fluent.windows?
+      @socket_manager_server = ServerEngine::SocketManager::Server.open
+      @socket_manager_path = @socket_manager_server.path
+    else
+      @socket_manager_path = ServerEngine::SocketManager::Server.generate_path
+      if @socket_manager_path.is_a?(String) && File.exist?(@socket_manager_path)
+        FileUtils.rm_f @socket_manager_path
+      end
+      @socket_manager_server = ServerEngine::SocketManager::Server.open(@socket_manager_path)
     end
-    @socket_manager_server = ServerEngine::SocketManager::Server.open(@socket_manager_path)
     ENV['SERVERENGINE_SOCKETMANAGER_PATH'] = @socket_manager_path.to_s
 
     @d = Dummy.new


### PR DESCRIPTION
Use ServerEngine's new feature:

https://github.com/treasure-data/serverengine/pull/143

On Windows, this prevents SocketManager from wrongly selecting an unavailable port, such as a port in excluded port range.

**Which issue(s) this PR fixes**: 
Fixes https://github.com/treasure-data/serverengine/issues/140
(Sorry, I made the issue in ServerEngine, and not made it here.)

**What this PR does / why we need it**: 
On Windows, `ServerEngine::SocketManager::generate_path` sometimes generates an unavailable port.
This makes Fluentd fail to start.

To fix this, I made the fix for ServerEngine:

* https://github.com/treasure-data/serverengine/pull/143

This is a fix on Fluentd's side.

**Docs Changes**:
Not needed.

**Release Note**: 
Fix bug that Fluentd sometimes tries to use an unavailable port and fails to start on Windows.
