### PR TITLE
Make `TestFluentdCommand` tests stable on Windows

### DIFF
--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -126,6 +126,8 @@ class TestFluentdCommand < ::Test::Unit::TestCase
     end
   end
 
+  # ATTENTION: This stops taking logs when all `pattern_list` match or timeout,
+  # so `patterns_not_match` can test only logs up to that point.
   def assert_log_matches(cmdline, *pattern_list, patterns_not_match: [], timeout: 10, env: {})
     matched = false
     matched_wrongly = false
@@ -1186,6 +1188,8 @@ CONF
     end
   end
 
+  # TODO: `patterns_not_match` can test only logs up to `pattern_list`,
+  # so we need to fix some meaningless `patterns_not_match` conditions.
   sub_test_case 'log_level by command line option' do
     test 'info' do
       conf = ""

--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -128,7 +128,7 @@ class TestFluentdCommand < ::Test::Unit::TestCase
 
   # ATTENTION: This stops taking logs when all `pattern_list` match or timeout,
   # so `patterns_not_match` can test only logs up to that point.
-  def assert_log_matches(cmdline, *pattern_list, patterns_not_match: [], timeout: 10, env: {})
+  def assert_log_matches(cmdline, *pattern_list, patterns_not_match: [], timeout: 20, env: {})
     matched = false
     matched_wrongly = false
     assert_error_msg = ""
@@ -209,7 +209,7 @@ class TestFluentdCommand < ::Test::Unit::TestCase
     assert matched && !matched_wrongly, assert_error_msg
   end
 
-  def assert_fluentd_fails_to_start(cmdline, *pattern_list, timeout: 10)
+  def assert_fluentd_fails_to_start(cmdline, *pattern_list, timeout: 20)
     # empty_list.all?{ ... } is always true
     matched = false
     running = false


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #4095

**What this PR does / why we need it**: 
Make`TestFluentdCommand` tests stable on Windows.
(Please see #4095 for details.)

**Docs Changes**:
Not needed.

**Release Note**: 
Not needed.
