### PR TITLE
CI: Reduce log level on Windows

### DIFF
--- a/.github/workflows/windows-test.yaml
+++ b/.github/workflows/windows-test.yaml
@@ -46,4 +46,4 @@ jobs:
       - name: Install dependencies
         run: ridk exec bundle install
       - name: Run tests
-        run: bundle exec rake test TESTOPTS=-v ${{ matrix.ruby-lib-opt }}
+        run: bundle exec rake test ${{ matrix.ruby-lib-opt }}


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 
For some reason, the log level is Debug only on Windows.
This makes it harder to find failing tests.

**Docs Changes**:
Not needed.

**Release Note**: 
Not needed.
