### PR TITLE
Fix NameError of `SecondaryFileOutput` when setting secondary other than `out_secondary_file`

### DIFF
--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -426,7 +426,7 @@ module Fluent
           end
           @secondary.acts_as_secondary(self)
           @secondary.configure(secondary_conf)
-          if (@secondary.class != SecondaryFileOutput) &&
+          if (@secondary.class.to_s != "Fluent::Plugin::SecondaryFileOutput") &&
              (self.class != @secondary.class) &&
              (@custom_format || @secondary.implement?(:custom_format))
             log.warn "Use different plugin for secondary. Check the plugin works with primary like secondary_file", primary: self.class.to_s, secondary: @secondary.class.to_s


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None.

Fix bug of 3a796cd93c21190e46cd0ac108e1265e482f07a3

* #4087

**What this PR does / why we need it**: 

In Fluentd v1.16.0, the following setting causes NameError and Fluentd to fail to start.

```xml
<match test.**>
  @type stdout
  <buffer>
    @type memory
  </buffer>
  <secondary>
    @type file
    path /tmp/backup/
  </secondary>
</match>
```

Error

```console
$ bundle exec fluentd -c .\fluent\fluent.conf
2023-04-03 18:49:11 +0900 [info]: init supervisor logger path=nil rotate_age=nil rotate_size=nil
2023-04-03 18:49:11 +0900 [info]: parsing config file is succeeded path=".\\fluent\\fluent.conf"
2023-04-03 18:49:11 +0900 [info]: gem 'fluentd' version '1.16.0'
C:/Users/reang/Documents/work/fluentd/fluentd/lib/fluent/plugin/output.rb:429:in `configure': uninitialized constant Fluent::Plugin::Output::SecondaryFileOutput (NameError)

          if (@secondary.class != SecondaryFileOutput) &&
                                  ^^^^^^^^^^^^^^^^^^^
        from C:/Users/reang/Documents/work/fluentd/fluentd/lib/fluent/plugin_helper/formatter.rb:83:in `configure'
        from C:/Users/reang/Documents/work/fluentd/fluentd/lib/fluent/plugin_helper/inject.rb:104:in `configure'
        from C:/Users/reang/Documents/work/fluentd/fluentd/lib/fluent/plugin/out_stdout.rb:52:in `configure'
        from C:/Users/reang/Documents/work/fluentd/fluentd/lib/fluent/plugin.rb:187:in `configure'
        from C:/Users/reang/Documents/work/fluentd/fluentd/lib/fluent/agent.rb:132:in `add_match'
        from C:/Users/reang/Documents/work/fluentd/fluentd/lib/fluent/agent.rb:74:in `block in configure'
        from C:/Users/reang/Documents/work/fluentd/fluentd/lib/fluent/agent.rb:64:in `each'
        from C:/Users/reang/Documents/work/fluentd/fluentd/lib/fluent/agent.rb:64:in `configure'
        from C:/Users/reang/Documents/work/fluentd/fluentd/lib/fluent/root_agent.rb:149:in `configure'
        from C:/Users/reang/Documents/work/fluentd/fluentd/lib/fluent/engine.rb:105:in `configure'
        from C:/Users/reang/Documents/work/fluentd/fluentd/lib/fluent/engine.rb:80:in `run_configure'
        from C:/Users/reang/Documents/work/fluentd/fluentd/lib/fluent/supervisor.rb:571:in `run_supervisor'
        from C:/Users/reang/Documents/work/fluentd/fluentd/lib/fluent/command/fluentd.rb:352:in `<top (required)>'
        from <internal:C:/Ruby32-x64/lib/ruby/site_ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
        from <internal:C:/Ruby32-x64/lib/ruby/site_ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
        from C:/Users/reang/Documents/work/fluentd/fluentd/bin/fluentd:15:in `<top (required)>'
        from C:/Ruby32-x64/lib/ruby/gems/3.2.0/bin/fluentd:25:in `load'
        from C:/Ruby32-x64/lib/ruby/gems/3.2.0/bin/fluentd:25:in `<main>'
```

This PR fixes this bug.

In #4087, I could not notice this error since this error would not occur if `out_secondary_file` is set once before such a setting.
I'm sorry for my careless mistake.

**Docs Changes**:
Not needed.

**Release Note**: 
Same as the title.
