### PR TITLE
Plugin template: Remove unnecessary code

### DIFF
--- a/templates/new_gem/test/helper.rb.erb
+++ b/templates/new_gem/test/helper.rb.erb
@@ -1,4 +1,3 @@
-$LOAD_PATH.unshift(File.expand_path("../../", __FILE__))
 require "test-unit"
 require "fluent/test"
 require "fluent/test/driver/<%= type %>"


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None

**What this PR does / why we need it**: 
This code in `test/helper.rb` is unnecessary, so we should remove it.

```rb
$LOAD_PATH.unshift(File.expand_path("../../", __FILE__))
```

`File.expand_path("../../", __FILE__)` returns the repository's top directory path.
So, this enables using relative paths from the top for `require`, such as `require test/helper`.

However, we don't use this.
We use the following and use the relative paths from `test/` or `lib/`.

https://github.com/fluent/fluentd/blob/37858d36563222d71adde291d539b3ef514aff9b/templates/new_gem/Rakefile#L6-L7

https://github.com/fluent/fluentd/blob/37858d36563222d71adde291d539b3ef514aff9b/templates/new_gem/test/plugin/test_input.rb.erb#L1-L2

So I think it's unnecessary as template content.

**Docs Changes**:
* https://github.com/fluent/fluentd-docs-gitbook/pull/449

**Release Note**: 
Same as the title.
