### PR TITLE
Test `in_tcp`: Fix undesirable way to assert logs

### DIFF
--- a/test/plugin/test_in_tcp.rb
+++ b/test/plugin/test_in_tcp.rb
@@ -218,16 +218,14 @@ class TcpInputTest < Test::Unit::TestCase
           </client>
         </security>
       !)
-      d.run(shutdown: false, expect_records: 1, timeout: 2) do
+      d.run(expect_records: 1, timeout: 2) do
         create_tcp_socket('127.0.0.1', @port) do |sock|
           sock.send("hello\n", 0)
         end
       end
 
-      assert_equal 1, d.instance.log.logs.count { |l| l =~ /anonymous client/ }
+      assert_equal 1, d.logs.count { |l| l =~ /anonymous client/ }
       assert_equal 0, d.events.size
-    ensure
-      d.instance_shutdown if d&.instance
     end
   end
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
* Partially fixes #4136

**What this PR does / why we need it**: 
We should use `Driver::logs` so that we don't have to use `shutdown: false`.

**Docs Changes**:
Not needed.

**Release Note**: 
Not needed (or the same as the title).
