### PR TITLE
Buffer: Fix that `compress` setting causes unexpected error when receiving already compressed MessagePack

### DIFF
--- a/lib/fluent/event.rb
+++ b/lib/fluent/event.rb
@@ -294,7 +294,7 @@ module Fluent
       super
     end
 
-    def to_compressed_msgpack_stream(time_int: false)
+    def to_compressed_msgpack_stream(time_int: false, packer: nil)
       # time_int is always ignored because @data is always packed binary in this class
       @compressed_data
     end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
* Fixes #4146

**What this PR does / why we need it**: 
Fix that `compress` setting causes an unexpected error when receiving already compressed MessagePack.

When setting `compress gzip` of buffer, and it tries to process `CompressedMessagePackEventStream`, the following error occurs.

    [error]: xxx unexpected error on reading data
    host="xxx" port=xxx error_class=ArgumentError
    error="unknown keyword: :packer"

This is caused by the signature unmatching in c6c6c038c5cacab6fcb9aa89a714d9366ac4902e.

A possible use case is a two-stage transfer.

Forwarder1(out_forward) -> Forwarder2(in_forward, out_forward) -> Aggregator(in_forward)

In this case, Forwarder2 should process the data of `CompressedMessagePackEventStream` as is (i.e. without decompressing) and re-transfer the data to Aggregator.

**Docs Changes**:
Not needed.

**Release Note**: 
Same as the title.