### PR TITLE
Fix broken argument `unpacker` of `ChunkMessagePackEventStreamer.each`

### DIFF
--- a/lib/fluent/event.rb
+++ b/lib/fluent/event.rb
@@ -308,11 +308,15 @@ module Fluent
   end
 
   module ChunkMessagePackEventStreamer
-    # chunk.extend(ChunkEventStreamer)
+    # chunk.extend(ChunkMessagePackEventStreamer)
     #  => chunk.each{|time, record| ... }
     def each(unpacker: nil, &block)
+      # Note: If need to use `unpacker`, then implement it,
+      # e.g., `unpacker.feed_each(io.read, &block)` (Not tested)
+      raise NotImplementedError, "'unpacker' argument is not implemented." if unpacker
+
       open do |io|
-        (unpacker || Fluent::MessagePackFactory.msgpack_unpacker(io)).each(&block)
+        Fluent::MessagePackFactory.msgpack_unpacker(io).each(&block)
       end
       nil
     end

--- a/test/plugin/test_buffer_chunk.rb
+++ b/test/plugin/test_buffer_chunk.rb
@@ -57,6 +57,17 @@ class BufferChunkTest < Test::Unit::TestCase
       assert chunk.respond_to?(:msgpack_each)
     end
 
+    test 'unpacker arg is not implemented for ChunkMessagePackEventStreamer' do
+      meta = Object.new
+      chunk = Fluent::Plugin::Buffer::Chunk.new(meta)
+      chunk.extend Fluent::ChunkMessagePackEventStreamer
+
+      unpacker = Fluent::MessagePackFactory.thread_local_msgpack_unpacker
+
+      assert_raise(NotImplementedError){ chunk.each(unpacker: unpacker) }
+      assert_raise(NotImplementedError){ chunk.msgpack_each(unpacker: unpacker) }
+    end
+
     test 'some methods raise ArgumentError with an option of `compressed: :gzip` and without extending Compressble`' do
       meta = Object.new
       chunk = Fluent::Plugin::Buffer::Chunk.new(meta)


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None.

**What this PR does / why we need it**: 
The argument `unpacker` of [ChunkMessagePackEventStreamer.each](https://github.com/fluent/fluentd/blob/v1.16.1/lib/fluent/event.rb#L313) seems to have been added in order to match the feature with `EventStream` at

* #2559

However, that previous implementation at that point does not work as expected.
It has never caused any issues just because the argument was not used at all.

When `unpacker` is passed, the following will be executed.

```ruby
unpacker.each($block)
```

This just iterates the internal buffer of the unpacker without reading `io` of the chunk.
Thus it seems to me that this doesn't work as expected.

Note: It could be implemented so that this argument is used, but given that it has not been used so far, there is little need for it.

**Docs Changes**:
Not needed since it is an internal fix.

**Release Note**: 
Same as the title.
