### PR TITLE
Fix failure to launch Fluentd on Windows with log rotation but not specifying the log path in the command line

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -697,7 +697,7 @@ module Fluent
       actual_log_path = @log_path
 
       # We need to prepare a unique path for each worker since Windows locks files.
-      if Fluent.windows? && rotate
+      if Fluent.windows? && rotate && @log_path && @log_path != "-"
         actual_log_path = Fluent::Log.per_process_path(@log_path, process_type, worker_id)
       end
 

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -621,6 +621,19 @@ class SupervisorTest < ::Test::Unit::TestCase
       assert_equal 10, $log.out.instance_variable_get(:@shift_size)
     end
 
+    def test_can_start_with_rotate_but_no_log_path
+      config_path = "#{@tmp_dir}/empty.conf"
+      write_config config_path, ""
+
+      sv = Fluent::Supervisor.new(
+        config_path: config_path,
+        log_rotate_age: 5,
+      )
+      sv.__send__(:setup_global_logger)
+
+      assert_true $log.stdout?
+    end
+
     sub_test_case "system log rotation" do
       def parse_text(text)
         basepath = File.expand_path(File.dirname(__FILE__) + '/../../')


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #4187

**What this PR does / why we need it**: 
Fix a bug of f8b73a571954b4a7cfb137cb521edeb370f3f0b5 (#4091).

Before that fix, Fluentd can start if rotation is enabled but the log file path is not specified.
After that fix, the logger setup starts to fail on Windows.

This fix solves it.

**Docs Changes**:
Not needed.

**Release Note**: 
Same as the title.
