### PR TITLE
in_tail: Check detaching inode when follow_inodes

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -524,9 +524,8 @@ module Fluent::Plugin
     # At shutdown, IOHandler's io will be released automatically after detached the event loop
     def detach_watcher(tw, ino, close_io = true)
       if @follow_inodes && tw.ino != ino
-        log.warn("Skip detach_watcher because this is not the expected watcher to be detached",
-                  path: tw.path, current_ino: tw.ino, expect_ino_to_close: ino)
-        return
+        log.warn("detach_watcher could be detaching an unexpected tail_watcher with a different ino.",
+                  path: tw.path, actual_ino_in_tw: tw.ino, expect_ino_to_close: ino)
       end
       tw.watchers.each do |watcher|
         event_loop_detach(watcher)

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -523,6 +523,11 @@ module Fluent::Plugin
     # so adding close_io argument to avoid this problem.
     # At shutdown, IOHandler's io will be released automatically after detached the event loop
     def detach_watcher(tw, ino, close_io = true)
+      if @follow_inodes && tw.ino != ino
+        log.warn("Skip detach_watcher because this is not the expected watcher to be detached",
+                  path: tw.path, current_ino: tw.ino, expect_ino_to_close: ino)
+        return
+      end
       tw.watchers.each do |watcher|
         event_loop_detach(watcher)
       end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #4190 

**What this PR does / why we need it**:
~~Add validation to make sure detach_watcher is detaching expected watcher. This can avoid unexpectedly detach new watcher created for new log file and lead to log stuck transiently.~~

Add log to check that detaching inode is the same as the detaching TailWatcher's inode when enabling `follow_inodes`.
 
Note: If they do not match, canceling the detach (by adding `return`) may prevent an incorrect detach.
Since #4208 will prevent an incorrect detach, we will only add the warning log in this PR for now.

**Docs Changes**:
N/A

**Release Note**: 
~~Fix transient log stuck in in_tail when log file rotated and follow_inodes is enabled~~
Same as the title.