### PR TITLE
in_tail: Fix warning log about overwriting entry with follow_inodes

### DIFF
--- a/lib/fluent/plugin/in_tail/position_file.rb
+++ b/lib/fluent/plugin/in_tail/position_file.rb
@@ -145,13 +145,11 @@ module Fluent::Plugin
           if pos == UNWATCHED_POSITION
             @logger.debug "Remove unwatched line from pos_file: #{line}" if @logger
           else
-            if entries.include?(path)
-              @logger.warn("#{path} already exists. use latest one: deleted #{entries[path]}") if @logger
-            end
-
             if @follow_inodes
+              @logger&.warn("#{path} (inode: #{ino}) already exists. use latest one: deleted #{entries[ino]}") if entries.include?(ino)
               entries[ino] = Entry.new(path, pos, ino, file_pos + path.bytesize + 1)
             else
+              @logger&.warn("#{path} already exists. use latest one: deleted #{entries[path]}") if entries.include?(path)
               entries[path] = Entry.new(path, pos, ino, file_pos + path.bytesize + 1)
             end
             file_pos += line.size


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None.

**What this PR does / why we need it**: 
This fixes the following warning message:

```
... already exists. use latest one: deleted ...
```

Even when `follow_inodes` was enabled, this message was displayed based on the path.
This PR fixes it.

In addition, this PR slightly fixed this message when `follow_inodes` is enabled.

```
... (inode: ...) already exists. use latest one: deleted ...
```

**Docs Changes**:
No need because this fixes only the log message.

**Release Note**: 
Same as the title.
