### PR TITLE
Update sigdump to 0.2.5

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("cool.io", [">= 1.4.5", "< 2.0.0"])
   gem.add_runtime_dependency("serverengine", [">= 2.3.2", "< 3.0.0"])
   gem.add_runtime_dependency("http_parser.rb", [">= 0.5.1", "< 0.9.0"])
-  gem.add_runtime_dependency("sigdump", ["~> 0.2.2"])
+  gem.add_runtime_dependency("sigdump", ["~> 0.2.5"])
   gem.add_runtime_dependency("tzinfo", [">= 1.0", "< 3.0"])
   gem.add_runtime_dependency("tzinfo-data", ["~> 1.0"])
   gem.add_runtime_dependency("strptime", [">= 0.2.4", "< 1.0.0"])


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None.

**What this PR does / why we need it**: 
In 0.2.5, the bug of wrong value of `hash pairs` and `array elements` fixed.

That version will be installed without this fix, but I think we should explicitly update the version.
(Is it correct?)

We can confirm it as follows on non-Windows. (On Windows, we can use `fluent-ctl`.)

```console
$ sudo kill -CONT {pid}
$ less /tmp/sigdump-{pid}.log
```

Before: Too small Array and Hash sizes

```
...
   Array 61 elements
    Hash 8 pairs
```

After: Correct size

```
...
   Array 41,555 elements
    Hash 15,752 pairs
```

**Docs Changes**:
No need.

**Release Note**: 
Fix wrong Object Array and Hash sizes of SIGDUMP.

**ETC**:
Should we merge this into v1.16 too?
