### PR TITLE
in_tail: prevent wrongly unwatching with follow_inodes

### DIFF
--- a/lib/fluent/plugin/in_tail/position_file.rb
+++ b/lib/fluent/plugin/in_tail/position_file.rb
@@ -53,10 +53,16 @@ module Fluent::Plugin
         }
       end
 
+      def unwatch_removed_targets(existing_targets)
+        @map.reject { |key, entry|
+          existing_targets.key?(key)
+        }.each_key { |key|
+          unwatch_key(key)
+        }
+      end
+
       def unwatch(target_info)
-        if (entry = @map.delete(@follow_inodes ? target_info.ino : target_info.path))
-          entry.update_pos(UNWATCHED_POSITION)
-        end
+        unwatch_key(@follow_inodes ? target_info.ino : target_info.path)
       end
 
       def load(existing_targets = nil)
@@ -117,6 +123,12 @@ module Fluent::Plugin
       end
 
       private
+
+      def unwatch_key(key)
+        if (entry = @map.delete(key))
+          entry.update_pos(UNWATCHED_POSITION)
+        end
+      end
 
       def compact(existing_targets = nil)
         @file_mutex.synchronize do

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -2704,22 +2704,14 @@ class TailInputTest < Test::Unit::TestCase
 
       assert_equal(
         {
-          # TODO: This is BUG!! We need to fix it and replace this with the next.
-          record_values: ["file1 log1", "file1 log1", "file1 log2", "file1 log2", "file2 log1", "file2 log2"],
-          # record_values: ["file1 log1", "file1 log2", "file2 log1", "file2 log2"],
+          record_values: ["file1 log1", "file1 log2", "file2 log1", "file2 log2"],
           tail_watcher_paths: ["#{@tmp_dir}/tail.txt", "#{@tmp_dir}/tail.txt", "#{@tmp_dir}/tail.txt1"],
           tail_watcher_inodes: [inode_0, inode_1, inode_0],
           tail_watcher_io_handler_opened_statuses: [false, false, false],
-          # TODO: This is BUG!! We need to fix it and replace this with the next.
           position_entries: [
-            ["#{@tmp_dir}/tail.txt", "ffffffffffffffff", inode_0],
+            ["#{@tmp_dir}/tail.txt", "0000000000000016", inode_0],
             ["#{@tmp_dir}/tail.txt", "0000000000000016", inode_1],
-            ["#{@tmp_dir}/tail.txt1", "0000000000000016", inode_0],
           ],
-          # position_entries: [
-          #   ["#{@tmp_dir}/tail.txt", "ffffffffffffffff", inode_0],
-          #   ["#{@tmp_dir}/tail.txt", "0000000000000016", inode_1],
-          # ],
         },
         {
           record_values: record_values,
@@ -2802,7 +2794,8 @@ class TailInputTest < Test::Unit::TestCase
           tail_watcher_inodes: [inode_0, inode_1, inode_0],
           tail_watcher_io_handler_opened_statuses: [false, false, false],
           position_entries: [
-            ["#{@tmp_dir}/tail.txt", "ffffffffffffffff", inode_0],
+            # The recorded path is old, but it is no problem. The path is not used when using follow_inodes.
+            ["#{@tmp_dir}/tail.txt", "0000000000000016", inode_0],
             ["#{@tmp_dir}/tail.txt", "0000000000000016", inode_1],
           ],
         },
@@ -2861,8 +2854,9 @@ class TailInputTest < Test::Unit::TestCase
         #     This overwrites `@tails["tail.txt"]`
         d.instance.refresh_watchers
 
-        # `watch_timer` calls `TailWatcher::on_notify`, and then `update_watcher` updates the TailWatcher:
+        # `watch_timer` calls `TailWatcher::on_notify`, and then `update_watcher` trys to update the TailWatcher:
         #     TailWatcher(path: "tail.txt", inode: inode_0) => TailWatcher(path: "tail.txt", inode: inode_1)
+        # However, it is already added in `refresh_watcher`, so `update_watcher` doesn't create the new TailWatcher.
         # The old TailWathcer is detached here since `rotate_wait` is just `1s`.
         sleep 3
 
@@ -2886,22 +2880,15 @@ class TailInputTest < Test::Unit::TestCase
 
       assert_equal(
         {
-          # TODO: This is BUG!! We need to fix it and replace this with the next.
-          record_values: ["file1 log1", "file1 log1", "file1 log2", "file1 log2", "file2 log1", "file2 log2"],
-          # record_values: ["file1 log1", "file1 log2", "file2 log1", "file2 log2"],
+          record_values: ["file1 log1", "file1 log2", "file2 log1", "file2 log2"],
           tail_watcher_paths: ["#{@tmp_dir}/tail.txt", "#{@tmp_dir}/tail.txt", "#{@tmp_dir}/tail.txt1"],
           tail_watcher_inodes: [inode_0, inode_1, inode_0],
           tail_watcher_io_handler_opened_statuses: [false, false, false],
-          # TODO: This is BUG!! We need to fix it and replace this with the next.
           position_entries: [
-            ["#{@tmp_dir}/tail.txt", "ffffffffffffffff", inode_0],
+            # The recorded path is old, but it is no problem. The path is not used when using follow_inodes.
+            ["#{@tmp_dir}/tail.txt", "0000000000000016", inode_0],
             ["#{@tmp_dir}/tail.txt", "0000000000000016", inode_1],
-            ["#{@tmp_dir}/tail.txt1", "0000000000000016", inode_0],
           ],
-          # position_entries: [
-          #   ["#{@tmp_dir}/tail.txt", "ffffffffffffffff", inode_0],
-          #   ["#{@tmp_dir}/tail.txt", "0000000000000016", inode_1],
-          # ],
         },
         {
           record_values: record_values,


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
* Following up to #4208
* Another idea of #4221

**What this PR does / why we need it**: 
We must not unwatch targets that still exist.
If unwatching an existing target, it causes log duplication.

This problem exists from v1.13.3 (the following fix).

* #3466

This can occur when enabling `follow_inodes`.

In the existing implementation, `update_watcher` needs to unwatch the old TailWatcher since `refresh_watcher` can't unwatch it when `update_watcher` is called first (when rotation happens).
It is because `update_watcher` discards the old TailWatcher and `refresh_watcher` can't recognize the old inode is disappeared.

https://github.com/fluent/fluentd/blob/e12069351a431b30bd84996d60ff9c4a7e78adce/lib/fluent/plugin/in_tail.rb#L504-L507

However, it can wrongly unwatch an existing inode because the old inode may still exist.
(See the diff of test cases.)

Thus, we need a new mechanism to unwatch targets correctly.

This fix is based on the idea that we should unwatch based on directly on PositionFile's data.

**Docs Changes**:
No need.

**Release Note**: 
Same as the title.

**How to Reproduce**

Config:

```xml
<source>
  @type tail
  tag test
  path /test/fluentd/input4/test.log*
  pos_file /test/fluentd/pos/pos
  read_from_head true
  follow_inodes true
  refresh_interval 15s
  enable_stat_watcher false
  <parse>
    @type none
  </parse>
</source>

<match test.**>
  @type stdout
</match>
```

* note about `enable_stat_watcher`
  * `enable_stat_watcher false` is for making sure to detect rotation.
    * I think this is problematic too... If stat_watcher notifies too quickly before the new current file is created, [TailWatcher sets `nil` to it's `rotate_handler`](https://github.com/fluent/fluentd/blob/77d7229f75a15b1d817cebb43044bbeaf6f24eb8/lib/fluent/plugin/in_tail.rb#L874).  This causes some problems. (I will create an issue or PR about this later.)
    * This may have prevented this problem from occurring in a real environment. If `in_tail` can't detect the rotation of the current file because of this, then this problem does not occur. The focus is on whether the rotation of the current file can be detected when `enable_stat_watcher` is enabled. If not, then this can occur only when disabling `enable_stat_watcher`.

Files:

```console
$ ls /test/fluentd/input4
test.log

$ cat /test/fluentd/input4/test.log
foooooaaa
Barrrrraaa
```

Script to rotate:

```sh
mv /test/fluentd/input4/test.log /test/fluentd/input4/test.log.1
echo "aaa" > /test/fluentd/input4/test.log
```

Run:

* Run Fluentd
* Run the script to rotate

Result:

```
2023-06-29 09:55:07 +0900 [info]: #0 starting fluentd worker pid=686256 ppid=686236 worker=0
2023-06-29 09:55:07 +0900 [info]: #0 following tail of /test/fluentd/input4/test.log
2023-06-29 09:55:07.232909021 +0900 test: {"message":"foooooaaa"}
2023-06-29 09:55:07.232911541 +0900 test: {"message":"Barrrrraaa"}
2023-06-29 09:55:07 +0900 [info]: #0 fluentd worker is now running worker=0
2023-06-29 09:55:12 +0900 [info]: #0 detected rotation of /test/fluentd/input4/test.log; waiting 5 seconds
2023-06-29 09:55:12 +0900 [info]: #0 following tail of /test/fluentd/input4/test.log
2023-06-29 09:55:12.234238467 +0900 test: {"message":"aaa"}
2023-06-29 09:55:22 +0900 [info]: #0 following tail of /test/fluentd/input4/test.log.1
2023-06-29 09:55:22.234924294 +0900 test: {"message":"foooooaaa"}
2023-06-29 09:55:22.234935622 +0900 test: {"message":"Barrrrraaa"}
```

* The old rotated file was read in duplicate.
* This occurs if detach is done before `refresh_watcher`.
  * It is because detach of `update_watcher` wrongly unwatches the existing inode.