### PR TITLE
Raise minimum required ruby version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Fluentd: Open-Source Log Collector
 
 ### Prerequisites
 
-- Ruby 2.4 or later
+- Ruby 2.7 or later
 - git
 
 `git` should be in `PATH`. On Windows, you can use `Github for Windows` and `GitShell` for easy setup.

--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.license = "Apache-2.0"
 
-  gem.required_ruby_version = '>= 2.4'
+  gem.required_ruby_version = '>= 2.7'
 
   gem.add_runtime_dependency("bundler")
   gem.add_runtime_dependency("msgpack", [">= 1.3.1", "< 2.0.0"])


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

N/A

**What this PR does / why we need it**: 

The service discovery plugin helper use Array#prepend, it means that the ruby version must be 2.5 or later precisely.

   fluentd.work/lib/fluent/plugin_helper/service_discovery.rb:71:in
   `service_discovery_configure': undefined method `prepend' for
   []:Array (NoMethodError) from
   /work/fluent/fluentd/fluentd.work/lib/fluent/plugin/out_

**Docs Changes**:

https://github.com/fluent/fluentd-docs-gitbook/pull/471

**Release Note**: 

N/A
