### PR TITLE
remove unnecessary self-assignment

### DIFF
--- a/lib/fluent/fluent_log_event_router.rb
+++ b/lib/fluent/fluent_log_event_router.rb
@@ -47,8 +47,6 @@ module Fluent
         # it's not suppressed in default event router for non-log-event events
         log_event_router.suppress_missing_match!
 
-        log_event_router = log_event_router
-
         unmatched_tags = Fluent::Log.event_tags.select { |t| !log_event_router.match?(t) }
         unless unmatched_tags.empty?
           $log.warn "match for some tags of log events are not defined in @FLUENT_LOG label (to be ignored)", tags: unmatched_tags


### PR DESCRIPTION
Previously this code was assigning instance variable like

    @log_event_router = log_event_router

later, during the refactoring of Fluent Engine it was changed to

    log_event_router = log_event_router

which can be now removed. For reference please review changeset at 3a3aee0227b621b61d1d7f258147f7ff661316e0