### PR TITLE
Fix for rotate_age where Fluentd passes as Symbol

### DIFF
--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -62,7 +62,7 @@ module Fluent
       config_param :time_format, :string, default: '%Y-%m-%d %H:%M:%S %z'
       config_param :rotate_age, default: nil do |v|
         if Fluent::Log::LOG_ROTATE_AGE.include?(v)
-          v.to_s
+          v.to_s 
         else
           begin
             Integer(v)

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -62,7 +62,7 @@ module Fluent
       config_param :time_format, :string, default: '%Y-%m-%d %H:%M:%S %z'
       config_param :rotate_age, default: nil do |v|
         if Fluent::Log::LOG_ROTATE_AGE.include?(v)
-          v.to_sym
+          v.to_s
         else
           begin
             Integer(v)

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -62,7 +62,7 @@ module Fluent
       config_param :time_format, :string, default: '%Y-%m-%d %H:%M:%S %z'
       config_param :rotate_age, default: nil do |v|
         if Fluent::Log::LOG_ROTATE_AGE.include?(v)
-          v 
+          v
         else
           begin
             Integer(v)

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -62,7 +62,7 @@ module Fluent
       config_param :time_format, :string, default: '%Y-%m-%d %H:%M:%S %z'
       config_param :rotate_age, default: nil do |v|
         if Fluent::Log::LOG_ROTATE_AGE.include?(v)
-          v.to_s 
+          v 
         else
           begin
             Integer(v)

--- a/test/config/test_system_config.rb
+++ b/test/config/test_system_config.rb
@@ -160,7 +160,7 @@ module Fluent::Config
           </system>
         EOS
         sc = Fluent::SystemConfig.new(conf)
-        assert_equal(age.to_s, sc.log.rotate_age)
+        assert_equal(age, sc.log.rotate_age)
       end
 
       test "numeric number for rotate age" do

--- a/test/config/test_system_config.rb
+++ b/test/config/test_system_config.rb
@@ -151,7 +151,7 @@ module Fluent::Config
       data('daily' => "daily",
            'weekly' => 'weekly',
            'monthly' => 'monthly')
-      test "symbols for rotate_age" do |age|
+      test "strings for rotate_age" do |age|
         conf = parse_text(<<-EOS)
           <system>
             <log>
@@ -160,7 +160,7 @@ module Fluent::Config
           </system>
         EOS
         sc = Fluent::SystemConfig.new(conf)
-        assert_equal(age.to_sym, sc.log.rotate_age)
+        assert_equal(age.to_s, sc.log.rotate_age)
       end
 
       test "numeric number for rotate age" do


### PR DESCRIPTION
Fix for rotate_age where Fluentd passes as Symbol while Ruby Logger expects String

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #4227

**What this PR does / why we need it**: 

**Docs Changes**:

**Release Note**: 
