### PR TITLE
Drop unused @_plugin_id_configured from all own-able plugins

### DIFF
--- a/lib/fluent/plugin/owned_by_mixin.rb
+++ b/lib/fluent/plugin/owned_by_mixin.rb
@@ -21,7 +21,6 @@ module Fluent
         @_owner = plugin
 
         @_plugin_id = plugin.plugin_id
-        @_plugin_id_configured = plugin.plugin_id_configured?
 
         @log = plugin.log
       end

--- a/test/plugin/test_owned_by.rb
+++ b/test/plugin/test_owned_by.rb
@@ -26,7 +26,6 @@ class OwnedByMixinTest < Test::Unit::TestCase
 
       assert_equal parent.object_id, child.owner.object_id
 
-      assert child.instance_eval{ @_plugin_id_configured }
       assert_equal 'my_parent_id', child.instance_eval{ @_plugin_id }
 
       assert_equal Fluent::Log::LEVEL_TRACE, child.log.level

--- a/test/plugin/test_storage.rb
+++ b/test/plugin/test_storage.rb
@@ -68,7 +68,6 @@ class StorageTest < Test::Unit::TestCase
 
       assert_equal 'mytest', s.owner.system_config.process_name
       assert_equal '1', s.instance_eval{ @_plugin_id }
-      assert_equal true, s.instance_eval{ @_plugin_id_configured }
     end
 
     test 'does NOT have features for high-performance/high-consistent storages' do


### PR DESCRIPTION
This variable is unused since b32781d0f03e7984f3b4eeec63f7310fa340b562.