### PR TITLE
out_http: Add option to reuse connections

### DIFF
--- a/lib/fluent/plugin/out_http.rb
+++ b/lib/fluent/plugin/out_http.rb
@@ -340,15 +340,11 @@ module Fluent::Plugin
       @cache[id].conn.request(req)
     end
 
-    def make_request(uri, req)
+    def make_request(uri, req, &block)
       if @proxy_uri
-        Net::HTTP.start(uri.host, uri.port, @proxy_uri.host, @proxy_uri.port, @proxy_uri.user, @proxy_uri.password, @http_opt) { |http|
-          http.request(req)
-        }
+        Net::HTTP.start(uri.host, uri.port, @proxy_uri.host, @proxy_uri.port, @proxy_uri.user, @proxy_uri.password, @http_opt, &block)
       else
-        Net::HTTP.start(uri.host, uri.port, @http_opt) { |http|
-          http.request(req)
-        }
+        Net::HTTP.start(uri.host, uri.port, @http_opt, &block)
       end
     end
 
@@ -356,7 +352,7 @@ module Fluent::Plugin
       res = if @reuse_connections
               make_request_cached(uri, req)
             else
-              make_request(uri, req)
+              make_request(uri, req) { |http| http.request(req) }
             end
 
       if res.is_a?(Net::HTTPSuccess)

--- a/lib/fluent/plugin/out_http.rb
+++ b/lib/fluent/plugin/out_http.rb
@@ -109,23 +109,23 @@ module Fluent::Plugin
       @proxy_uri = nil
       @formatter = nil
 
-      @Cache = []
-      @CacheIdMutex = Mutex.new
-      @CacheEntry = Struct.new(:uri, :conn)
+      @cache = []
+      @cache_id_mutex = Mutex.new
+      @cache_entry = Struct.new(:uri, :conn)
     end
 
     def close
       super
 
       # Close all open connections
-      @Cache.each {|entry| entry.conn.finish if entry.conn&.started? }
+      @cache.each {|entry| entry.conn.finish if entry.conn&.started? }
     end
 
     def configure(conf)
       super
 
-      @Cache = Array.new(actual_flush_thread_count, @CacheEntry.new("", nil)) if @reuse_connections
-      @CacheId = 0
+      @cache = Array.new(actual_flush_thread_count, @cache_entry.new("", nil)) if @reuse_connections
+      @cache_id = 0
 
       if @retryable_response_codes.nil?
         log.warn('Status code 503 is going to be removed from default `retryable_response_codes` from fluentd v2. Please add it by yourself if you wish')
@@ -321,23 +321,23 @@ module Fluent::Plugin
     def make_request_cached(uri, req)
       id = Thread.current.thread_variable_get(plugin_id)
       if id.nil?
-        @CacheIdMutex.synchronize {
-          id = @CacheId
-          @CacheId += 1
+        @cache_id_mutex.synchronize {
+          id = @cache_id
+          @cache_id += 1
         }
         Thread.current.thread_variable_set(plugin_id, id)
       end
       uri_str = uri.to_s
-      if @Cache[id].uri != uri_str
-        @Cache[id].conn.finish if @Cache[id].conn&.started?
+      if @cache[id].uri != uri_str
+        @cache[id].conn.finish if @cache[id].conn&.started?
         http =  if @proxy_uri
                   Net::HTTP.start(uri.host, uri.port, @proxy_uri.host, @proxy_uri.port, @proxy_uri.user, @proxy_uri.password, @http_opt)
                 else
                   Net::HTTP.start(uri.host, uri.port, @http_opt)
                 end
-        @Cache[id] = @CacheEntry.new(uri_str, http)
+        @cache[id] = @cache_entry.new(uri_str, http)
       end
-      @Cache[id].conn.request(req)
+      @cache[id].conn.request(req)
     end
 
     def make_request(uri, req)


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
N/A

**What this PR does / why we need it**: 
The HTTP output plugin recreates a connection for every HTTP request. In combination with TLS and high network latencies, this can result in very poor performance. This PR adds an option to reuse connections. 

The implementation caches one connection per flush thread. The cache is part of the HTTP plugin instance and is implemented as an array. When a thread creates its first request, it gets assigned a slot (id) in this array and the id is stored in a thread local variable. Since this slot is exclusively used by a single thread, no synchronization is required. If the endpoint changes at runtime, the old connection will be closed and replaced by a new connection to the new endpoint. During shutdown, all open connections are finished in the `close` method. 

This implementation works very well for a static endpoint. If the endpoint changes frequently, there will be little benefit. However, it can be assumed that most users use a static endpoint.

**Benchmark**
I tested the throughput with two Fluentd instances on a single machine. One instance acting as sender and the other as receiver.  Even though the connection creation was very fast, because both instances were located on the same machine and TLS was not enabled, activating connection reuse doubled the throughput. 

Sender configuration:
```
<source>
  @type sample
  sample {"hello":"world"}
  tag sample
  rate 5000
</source>

<match **>
  @type http

  endpoint http://localhost:9000
  open_timeout 2
  reuse_connections true
  <format>
    @type json
  </format>
  <buffer>
    flush_interval 10s
    chunk_limit_records 1
    flush_thread_count 32
  </buffer>
</match>
```

Receiver configuration:
```
<system>
  workers 1
</system>

<source>
  @type http
  port 9000
  bind 0.0.0.0
  body_size_limit 32m
  keepalive_timeout 10s
</source>

<match **>
  @type flowcounter_simple
  unit second
</match>
```

**Docs Changes**:

**Release Note**: 
out_http: Add option to reuse connections