### PR TITLE
in_tail: Manage tail watchers that are `rorate_wait` state too

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -594,8 +594,6 @@ module Fluent::Plugin
         target_info = TargetInfo.new(tw.path, ino)
         @pf.unwatch(target_info)
       end
-
-      @tails_rotate_wait.delete(tw)
     end
 
     def throttling_is_enabled?(tw)
@@ -622,6 +620,7 @@ module Fluent::Plugin
           elapsed = Fluent::Clock.now - start_time_to_wait
           if tw.eof? && elapsed >= @rotate_wait
             timer.detach
+            @tails_rotate_wait.delete(tw)
             detach_watcher(tw, ino)
           end
         end
@@ -629,6 +628,7 @@ module Fluent::Plugin
       else
         # when the throttling feature isn't enabled, just wait @rotate_wait
         timer = timer_execute(:in_tail_close_watcher, @rotate_wait, repeat: false) do
+          @tails_rotate_wait.delete(tw)
           detach_watcher(tw, ino)
         end
         @tails_rotate_wait[tw] = { ino: ino, timer: timer }

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -52,6 +52,7 @@ module Fluent::Plugin
       super
       @paths = []
       @tails = {}
+      @tails_rotate_wait = {}
       @pf_file = nil
       @pf = nil
       @ignore_list = []
@@ -267,6 +268,9 @@ module Fluent::Plugin
       @shutdown_start_time = Fluent::Clock.now
       # during shutdown phase, don't close io. It should be done in close after all threads are stopped. See close.
       stop_watchers(existence_path, immediate: true, remove_watcher: false)
+      @tails_rotate_wait.keys.each do |tw|
+        detach_watcher(tw, @tails_rotate_wait[tw][:ino])
+      end
       @pf_file.close if @pf_file
 
       super
@@ -590,6 +594,8 @@ module Fluent::Plugin
         target_info = TargetInfo.new(tw.path, ino)
         @pf.unwatch(target_info)
       end
+
+      @tails_rotate_wait.delete(tw)
     end
 
     def throttling_is_enabled?(tw)
@@ -604,7 +610,11 @@ module Fluent::Plugin
       if @open_on_every_update
         # Detach now because it's already closed, waiting it doesn't make sense.
         detach_watcher(tw, ino)
-      elsif throttling_is_enabled?(tw)
+      end
+
+      return if @tails_rotate_wait[tw]
+
+      if throttling_is_enabled?(tw)
         # When the throttling feature is enabled, it might not reach EOF yet.
         # Should ensure to read all contents before closing it, with keeping throttling.
         start_time_to_wait = Fluent::Clock.now
@@ -615,11 +625,13 @@ module Fluent::Plugin
             detach_watcher(tw, ino)
           end
         end
+        @tails_rotate_wait[tw] = { ino: ino, timer: timer }
       else
         # when the throttling feature isn't enabled, just wait @rotate_wait
-        timer_execute(:in_tail_close_watcher, @rotate_wait, repeat: false) do
+        timer = timer_execute(:in_tail_close_watcher, @rotate_wait, repeat: false) do
           detach_watcher(tw, ino)
         end
+        @tails_rotate_wait[tw] = { ino: ino, timer: timer }
       end
     end
 

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -578,10 +578,6 @@ module Fluent::Plugin
       detach_watcher_after_rotate_wait(tail_watcher, pe.read_inode)
     end
 
-    # TailWatcher#close is called by another thread at shutdown phase.
-    # It causes 'can't modify string; temporarily locked' error in IOHandler
-    # so adding close_io argument to avoid this problem.
-    # At shutdown, IOHandler's io will be released automatically after detached the event loop
     def detach_watcher(tw, ino, close_io = true)
       if @follow_inodes && tw.ino != ino
         log.warn("detach_watcher could be detaching an unexpected tail_watcher with a different ino.",

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -269,7 +269,7 @@ module Fluent::Plugin
       # during shutdown phase, don't close io. It should be done in close after all threads are stopped. See close.
       stop_watchers(existence_path, immediate: true, remove_watcher: false)
       @tails_rotate_wait.keys.each do |tw|
-        detach_watcher(tw, @tails_rotate_wait[tw][:ino])
+        detach_watcher(tw, @tails_rotate_wait[tw][:ino], false)
       end
       @pf_file.close if @pf_file
 
@@ -279,6 +279,7 @@ module Fluent::Plugin
     def close
       super
       # close file handles after all threads stopped (in #close of thread plugin helper)
+      # It may be because we need to wait IOHanlder.ready_to_shutdown()
       close_watcher_handles
     end
 
@@ -519,6 +520,9 @@ module Fluent::Plugin
         if tw
           tw.close
         end
+      end
+      @tails_rotate_wait.keys.each do |tw|
+        tw.close
       end
     end
 

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -3049,13 +3049,13 @@ class TailInputTest < Test::Unit::TestCase
       d.run(expect_records: 6, timeout: 15) do
         Fluent::FileWrapper.open("#{@tmp_dir}/tail.txt0", "ab") {|f| f.puts "file1 log2"}
 
-        sleep 1
+        sleep 1.5 # Need to be larger than 1s (the interval of watch_timer)
 
         FileUtils.move("#{@tmp_dir}/tail.txt0", "#{@tmp_dir}/tail.txt" + "1")
         Fluent::FileWrapper.open("#{@tmp_dir}/tail.txt0", "wb") {|f| f.puts "file2 log1"}
         Fluent::FileWrapper.open("#{@tmp_dir}/tail.txt0", "ab") {|f| f.puts "file2 log2"}
 
-        sleep 1
+        sleep 1.5 # Need to be larger than 1s (the interval of watch_timer)
 
         # Rotate again (Old TailWatcher waiting rotate_wait also calls update_watcher)
         [1, 0].each do |i|
@@ -3233,13 +3233,13 @@ class TailInputTest < Test::Unit::TestCase
       d.run(expect_records: 6, timeout: 15) do
         Fluent::FileWrapper.open("#{@tmp_dir}/tail.txt0", "ab") {|f| f.puts "file1 log2"}
 
-        sleep 1
+        sleep 1.5 # Need to be larger than 1s (the interval of watch_timer)
 
         FileUtils.move("#{@tmp_dir}/tail.txt0", "#{@tmp_dir}/tail.txt" + "1")
         Fluent::FileWrapper.open("#{@tmp_dir}/tail.txt0", "wb") {|f| f.puts "file2 log1"}
         Fluent::FileWrapper.open("#{@tmp_dir}/tail.txt0", "ab") {|f| f.puts "file2 log2"}
 
-        sleep 1
+        sleep 1.5 # Need to be larger than 1s (the interval of watch_timer)
 
         # Rotate again (Old TailWatcher waiting rotate_wait also calls update_watcher)
         [1, 0].each do |i|

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -3084,9 +3084,6 @@ class TailInputTest < Test::Unit::TestCase
         sleep 3
 
         Fluent::FileWrapper.open("#{@tmp_dir}/tail.txt0", "ab") {|f| f.puts "file3 log2"}
-
-        # Wait `rotate_wait` for file2 to make sure to close all IO handlers
-        sleep 3
       end
 
       inode_0 = tail_watchers[0]&.ino


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
N/A (Follow up for https://github.com/fluent/fluentd/pull/4327#issuecomment-1774330298)

**What this PR does / why we need it**: 
After a tail watcher transitions to `rotate_wait` state, the `rotate_wait` timer is no longer managed by in_tail, it might cause unexpected behaviour. e.g.)

* It's never unwatched when shutdown occurs before `rotate_wait` passed.
* Needless `rotate_wait` timers are executed when it detects more rotations.

This patch fixes such unexpected behaviour.

**Docs Changes**:
N/A

**Release Note**: 
