### PR TITLE
Guard launching duplicated fluentd with same configuration

### DIFF
--- a/lib/fluent/process.rb
+++ b/lib/fluent/process.rb
@@ -15,8 +15,32 @@
 #
 
 require 'fluent/compat/detach_process_mixin'
+require 'fluent/env'
 
 module Fluent
   DetachProcessMixin = Fluent::Compat::DetachProcessMixin
   DetachMultiProcessMixin = Fluent::Compat::DetachMultiProcessMixin
+
+  class ProcessDetector
+    def self.running_fluentd_conf
+      # Detect if same configuration is used
+      unless Fluent.windows?
+        IO.popen(["/usr/bin/ps", "-e", "-o", "uid,pid,ppid,cmd"]) do |_io|
+          _io.readlines.each do |line|
+            uid, pid, ppid, cmd = line.split(' ', 4)
+            # skip self and supervisor process
+            next if Process.pid == pid.to_i or Process.pid == ppid.to_i
+            if cmd and cmd.chomp.include?("fluentd") and ppid.to_i == 1
+              # under systemd control
+              File.open("/proc/#{pid.to_i}/environ") do |file|
+                conf = file.read.split("\u0000").select { |entry| entry.include?("FLUENT_CONF") }
+                return conf.first.split('=').last unless conf.empty?
+              end
+            end
+          end
+        end
+      end
+      return nil
+    end
+  end
 end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

Fixes https://github.com/fluent/fluent-package-builder/issues/611

**What this PR does / why we need it**: 

**This is just a PoC PR.**

Before:

  If you launch multiple Fluentd instance with same
  configuration file, it causes a disaster with inconsistency
  processed buffer or pos file.

After:

  Detect fluentd service's main process and fetch FLUENT_CONF.
  if configuration is same as spawned process, abort it.

  It can block the following conditions are met:

  * fluentd is launched via systemd (fluent-package) configuration file is specified via FLUENT_CONF.
  * manually try to launch fluentd  with same configuration file as fluentd user with -c option.

  Thus running fluentd service and manually try to launch normal
  user case can't be detected.

NOTE: Windows is out of scope in this PR.

**Docs Changes**:

N/A

**Release Note**: 

N/A