### PR TITLE
Add missing dependency to base64

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("tzinfo-data", ["~> 1.0"])
   gem.add_runtime_dependency("strptime", [">= 0.2.4", "< 1.0.0"])
   gem.add_runtime_dependency("webrick", ["~> 1.4"])
+  gem.add_runtime_dependency("base64", ["~> 0.1"])
 
   # build gem for a certain platform. see also Rakefile
   fake_platform = ENV['GEM_BUILD_FAKE_PLATFORM'].to_s


### PR DESCRIPTION

**Which issue(s) this PR fixes**: 

Fixes #

**What this PR does / why we need it**: 

Since ruby 3.4.0, base64 is changed to non-default gems. It need to be installed explicitly now.
(service discovery and out forward plugin use it)

At least base64 >= 0.1.0 should be installed.

FYI:

* ruby 3.0.0 (base64 0.1.0)
* ruby 3.0.6 (base64 0.1.0)
* ruby 3.1.4 (base64 0.1.1)
* ruby 3.2.3 (base64 0.1.1)
* ruby 3.3.0 (base64 0.2.0)

It seems that ruby-2.7.8 bundles base64 0.1.0 equivalent version.

e.g. It fixes the following LoadError.

 warning: base64 was loaded from the standard library, but is not part
 of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or
 gemspec.
 /home/runner/.rubies/ruby-head/lib/ruby/3.4.0+0/bundled_gems.rb:74:in
 'Kernel.require': cannot load such file -- base64 (LoadError)

**Docs Changes**:

N/A

**Release Note**: 

N/A
