### PR TITLE
Apply v1.16.4 to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # v1.16
 
+## Release v1.16.4 - 2024/03/14
+
+### Bug Fix
+
+* Fix to avoid processing discarded chunks in write_step_by_step.
+  It fixes not to raise pile of IOError when many `chunk
+  bytes limit exceeds` errors are occurred.
+  https://github.com/fluent/fluentd/pull/4342
+* in_tail: Fix tail watchers in `rotate_wait` state not being managed.
+  https://github.com/fluent/fluentd/pull/4334
+
+### Misc
+
+* buffer: Avoid unnecessary log processing. It will improve performance.
+  https://github.com/fluent/fluentd/pull/4331
+
 ## Release v1.16.3 - 2023/11/14
 
 ### Bug Fix

--- a/lib/fluent/version.rb
+++ b/lib/fluent/version.rb
@@ -16,6 +16,6 @@
 
 module Fluent
 
-  VERSION = '1.16.2'
+  VERSION = '1.16.4'
 
 end


### PR DESCRIPTION
* Version
* CHANGELOG

When releasing v1.16.3, we forgot to apply the version to the master.
So, the version on the master is still v1.16.2.
Currently, the master is the same minor version as the LTS branch v1.16, so we should update it along with the LTS branch, until releasing v1.17 on the master.
