### PR TITLE
ci: do not show test detail immediately

### DIFF
--- a/.github/workflows/test-ruby-head.yml
+++ b/.github/workflows/test-ruby-head.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Install dependencies
         run: bundle install
       - name: Run tests
-        run: bundle exec rake test TESTOPTS=-v
+        run: bundle exec rake test TESTOPTS="-v --no-show-detail-immediately"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Install dependencies
         run: bundle install
       - name: Run tests
-        run: bundle exec rake test TESTOPTS=-v
+        run: bundle exec rake test TESTOPTS="-v --no-show-detail-immediately"


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

N/A

**What this PR does / why we need it**: 

TESTOPTS=-v shows running test and the result.
If something weird happen, it show error immediately.

As rake task executes many tests, so it may be better to delay showing test details later.

NOTE: --progress-style=fault-only helps you to focus on failure, but it is inconvenient when test case has stalled.

**Docs Changes**:

N/A

**Release Note**: 

N/A
