### PR TITLE
Implements AWS SigV4 for the HTTP output plugin. 

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -29,6 +29,9 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("tzinfo-data", ["~> 1.0"])
   gem.add_runtime_dependency("strptime", [">= 0.2.4", "< 1.0.0"])
   gem.add_runtime_dependency("webrick", ["~> 1.4"])
+  gem.add_runtime_dependency("aws-sigv4", ["~> 1.8"])
+  gem.add_runtime_dependency("aws-sdk-sts", ["~> 1.11"])
+  gem.add_runtime_dependency("rexml", ["~> 3.2"])
 
   # gems that aren't default gems as of Ruby 3.4
   gem.add_runtime_dependency("base64", ["~> 0.2"])

--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -29,9 +29,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("tzinfo-data", ["~> 1.0"])
   gem.add_runtime_dependency("strptime", [">= 0.2.4", "< 1.0.0"])
   gem.add_runtime_dependency("webrick", ["~> 1.4"])
-  gem.add_runtime_dependency("aws-sigv4", ["~> 1.8"])
-  gem.add_runtime_dependency("aws-sdk-sts", ["~> 1.11"])
-  gem.add_runtime_dependency("rexml", ["~> 3.2"])
 
   # gems that aren't default gems as of Ruby 3.4
   gem.add_runtime_dependency("base64", ["~> 0.2"])
@@ -59,4 +56,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("oj", [">= 2.14", "< 4"])
   gem.add_development_dependency("async", "~> 1.23")
   gem.add_development_dependency("async-http", ">= 0.50.0")
+  gem.add_development_dependency("aws-sigv4", ["~> 1.8"])
+  gem.add_development_dependency("aws-sdk-core", ["~> 3.191"])
+  gem.add_development_dependency("rexml", ["~> 3.2"])
 end

--- a/lib/fluent/plugin/out_http.rb
+++ b/lib/fluent/plugin/out_http.rb
@@ -263,7 +263,6 @@ module Fluent::Plugin
         end
       end
       req['Content-Type'] = @content_type
-      req['Host'] = uri.host
     end
 
     def set_auth(req, uri)

--- a/test/plugin/test_out_http.rb
+++ b/test/plugin/test_out_http.rb
@@ -432,7 +432,6 @@ class HTTPOutputTest < Test::Unit::TestCase
       assert_equal 'application/x-ndjson', result.content_type
       assert_equal test_events, result.data
       assert_not_empty result.headers
-      assert_equal '127.0.0.1', result.headers['host']
       assert_not_nil result.headers['authorization']
       assert_match /AWS4-HMAC-SHA256 Credential=[a-zA-Z0-9]*\/\d+\/my-region-1\/someservice\/aws4_request/, result.headers['authorization']
       assert_match /SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-security-token/, result.headers['authorization']
@@ -470,7 +469,6 @@ class HTTPOutputTest < Test::Unit::TestCase
       assert_equal 'application/x-ndjson', result.content_type
       assert_equal test_events, result.data
       assert_not_empty result.headers
-      assert_equal '127.0.0.1', result.headers['host']
       assert_not_nil result.headers['authorization']
       assert_match /AWS4-HMAC-SHA256 Credential=[a-zA-Z0-9]*\/\d+\/my-region-1\/someservice\/aws4_request/, result.headers['authorization']
       assert_match /SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-security-token/, result.headers['authorization']

--- a/test/plugin/test_out_http.rb
+++ b/test/plugin/test_out_http.rb
@@ -7,6 +7,7 @@ require 'webrick/https'
 require 'net/http'
 require 'uri'
 require 'json'
+require 'aws-sdk-core'
 
 # WEBrick's ProcHandler doesn't handle PUT by default
 module WEBrick::HTTPServlet
@@ -387,6 +388,99 @@ class HTTPOutputTest < Test::Unit::TestCase
       assert_match(/got unrecoverable error/, d.instance.log.out.logs.join)
 
       d.instance_shutdown
+    end
+  end
+
+
+  sub_test_case 'aws sigv4 auth' do
+    setup do
+      @@fake_aws_credentials = Aws::Credentials.new(
+        'fakeaccess',
+        'fakesecret',
+        'fake session token'
+      )
+    end
+
+    def server_port
+      19883
+    end
+
+    def test_aws_sigv4_sts_role_arn
+      stub(Aws::AssumeRoleCredentials).new do |credentials_provider|
+        stub(credentials_provider).credentials {
+          @@fake_aws_credentials
+        }
+        credentials_provider
+      end
+
+      d = create_driver(config + %[
+          <auth>
+            method aws_sigv4
+            aws_service someservice
+            aws_region my-region-1
+            aws_role_arn arn:aws:iam::123456789012:role/MyRole
+          </auth>
+        ])
+      d.run(default_tag: 'test.http') do
+        test_events.each { |event|
+          d.feed(event)
+        }
+      end
+
+      result = @@result
+      assert_equal 'POST', result.method
+      assert_equal 'application/x-ndjson', result.content_type
+      assert_equal test_events, result.data
+      assert_not_empty result.headers
+      assert_equal '127.0.0.1', result.headers['host']
+      assert_not_nil result.headers['authorization']
+      assert_match /AWS4-HMAC-SHA256 Credential=[a-zA-Z0-9]*\/\d+\/my-region-1\/someservice\/aws4_request/, result.headers['authorization']
+      assert_match /SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-security-token/, result.headers['authorization']
+      assert_equal @@fake_aws_credentials.session_token, result.headers['x-amz-security-token']
+      assert_not_nil result.headers['x-amz-content-sha256']
+      assert_not_empty result.headers['x-amz-content-sha256']
+      assert_not_nil result.headers['x-amz-security-token']
+      assert_not_empty result.headers['x-amz-security-token']
+      assert_not_nil result.headers['x-amz-date']
+      assert_not_empty result.headers['x-amz-date']
+    end
+
+    def test_aws_sigv4_no_role
+      stub(Aws::CredentialProviderChain).new do |provider_chain|
+        stub(provider_chain).resolve {
+          @@fake_aws_credentials
+        }
+        provider_chain
+      end
+      d = create_driver(config + %[
+          <auth>
+            method aws_sigv4
+            aws_service someservice
+            aws_region my-region-1
+          </auth>
+        ])
+      d.run(default_tag: 'test.http') do
+        test_events.each { |event|
+          d.feed(event)
+        }
+      end
+
+      result = @@result
+      assert_equal 'POST', result.method
+      assert_equal 'application/x-ndjson', result.content_type
+      assert_equal test_events, result.data
+      assert_not_empty result.headers
+      assert_equal '127.0.0.1', result.headers['host']
+      assert_not_nil result.headers['authorization']
+      assert_match /AWS4-HMAC-SHA256 Credential=[a-zA-Z0-9]*\/\d+\/my-region-1\/someservice\/aws4_request/, result.headers['authorization']
+      assert_match /SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-security-token/, result.headers['authorization']
+      assert_equal @@fake_aws_credentials.session_token, result.headers['x-amz-security-token']
+      assert_not_nil result.headers['x-amz-content-sha256']
+      assert_not_empty result.headers['x-amz-content-sha256']
+      assert_not_nil result.headers['x-amz-security-token']
+      assert_not_empty result.headers['x-amz-security-token']
+      assert_not_nil result.headers['x-amz-date']
+      assert_not_empty result.headers['x-amz-date']
     end
   end
 


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #4444

**What this PR does / why we need it**: 

This PR adds a new authentication method to the HTTP output plugin for AWS sigV4. We need it so that customers can use Fluentd to send data to Amazon OpenSearch Ingestion which supports the Fluentd output plugin, but requires SigV4 authentication.

**Docs Changes**:

* `aws_sigv4` - When this option is specified, Fluentd will sign requests using AWS Signature Version 4.

* `aws_service` - The AWS service to authenticate against
* `aws_region` - The AWS region to use when authenticating
* `aws_role_arn` - The AWS role ARN to assume when authenticating

You can optionally specify an `aws_role_arn`. If you provide it, Fluentd will assume that AWS role and send requests signing from that role. Otherwise, Fluentd will use the credentials found by the [credential provider chain](https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/setup-config.html) as defined in the AWS documentation.

**Release Note**: 

The http output plugin supports AWS Signature Version 4 authentication.