### PR TITLE
config: yaml_parser: Handle $log_level element for special case

### DIFF
--- a/lib/fluent/config/yaml_parser/parser.rb
+++ b/lib/fluent/config/yaml_parser/parser.rb
@@ -138,6 +138,10 @@ module Fluent
             sb.add_line('@id', v)
           end
 
+          if (v = config.delete('$log_level'))
+            sb.add_line('@log_level', v)
+          end
+
           config.each do |key, val|
             if val.is_a?(Array)
               val.each do |v|

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -167,6 +167,7 @@ class ConfigTest < Test::Unit::TestCase
             tag: tag.dummy
         - source:
             $type: tcp
+            $log_level: info
             tag: tag.tcp
             parse:
               $arg:
@@ -176,6 +177,7 @@ class ConfigTest < Test::Unit::TestCase
         - match:
             $tag: tag.*
             $type: stdout
+            $log_level: debug
             buffer:
               $type: memory
               flush_interval: 1s
@@ -208,10 +210,12 @@ class ConfigTest < Test::Unit::TestCase
           'tag.dummy',
           'tcp',
           'tag.tcp',
+          'info',
           'none',
           'why.parse.section.doesnot.have.arg,huh',
           'stdout',
           'tag.*',
+          'debug',
           'null',
           '**',
           '@FLUENT_LOG',
@@ -224,10 +228,12 @@ class ConfigTest < Test::Unit::TestCase
           dummy_source_conf['tag'],
           tcp_source_conf['@type'],
           tcp_source_conf['tag'],
+          tcp_source_conf['@log_level'],
           parse_tcp_conf['@type'],
           parse_tcp_conf.arg,
           match_conf['@type'],
           match_conf.arg,
+          match_conf['@log_level'],
           fluent_log_conf['@type'],
           fluent_log_conf.arg,
           label_conf.arg,


### PR DESCRIPTION



<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 

Closes https://github.com/fluent/fluentd/issues/4463.

**What this PR does / why we need it**: 

This is because `@log_level` is invalid for YAML.
Instead, we should interpret $log_level as `@log_level` on YAML parser.

**Docs Changes**:

Needed. Will handle on it.

**Release Note**: 

Same as title.