### PR TITLE
log/console_adapter: support 'console' gem v1.25

### DIFF
--- a/lib/fluent/log/console_adapter.rb
+++ b/lib/fluent/log/console_adapter.rb
@@ -14,14 +14,16 @@
 #    limitations under the License.
 #
 
-require 'console/terminal/logger'
+require 'console'
 
 module Fluent
   class Log
     # Async gem which is used by http_server helper switched logger mechanism to
     # Console gem which isn't complatible with Ruby's standard Logger (since
     # v1.17). This class adapts it to Fluentd's logger mechanism.
-    class ConsoleAdapter < Console::Terminal::Logger
+    class ConsoleAdapter < Gem::Version.new(Console::VERSION) >= Gem::Version.new("1.25") ?
+      Console::Output::Terminal : Console::Terminal::Logger
+
       def self.wrap(logger)
         _, level = Console::Logger::LEVELS.find { |key, value|
           if logger.level <= 0


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
* Fixes #4487

**What this PR does / why we need it**: 
`Console::Terminal::Logger` class path has changed in `console` gem v1.25:

https://github.com/socketry/console/compare/v1.24.0...v1.25.0#diff-6e7355da8b6a8f794e74e462aebbe4b23f7752dab2a29967d17707eabb71ce12

This causes `LoadError` for `ConsoleAdapter`.
It means that `LoadError` occurs for `plugin_helper/http_server/server`, and Fluentd replaces the helper by `plugin_helper/http_server/compat/server`.
It also causes the CI failures.

This PR fixes these problems.
Please see #4487 for details.

Note: We can't stop considering the older versions because v1.25
requires Ruby v3.1 or older. 

Note: There is another issue about `console` gem v1.25:

* #4488

**Docs Changes**:
Not needed because this is a bug fix.

**Release Note**: 
HttpServer helper: Fixed a problem that some Fluentd logs were not being output.
