### PR TITLE
v1.16: keep console v1.24

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("tzinfo-data", ["~> 1.0"])
   gem.add_runtime_dependency("strptime", [">= 0.2.4", "< 1.0.0"])
   gem.add_runtime_dependency("webrick", ["~> 1.4"])
+  gem.add_runtime_dependency("console", ["< 1.25.0"])
 
   # build gem for a certain platform. see also Rakefile
   fake_platform = ENV['GEM_BUILD_FAKE_PLATFORM'].to_s


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
* Fixes #4487 for v1.16 branch

**What this PR does / why we need it**: 
console gem v1.25 causes LoadError because it has changed some namepaths (#4487).
v1.25 has been supported on the master branch at #4492, but on v1.16, we should keep v1.24 to prioritize stability.

**Docs Changes**:
Not needed.

**Release Note**: 
Not needed since there is no specification change.