### PR TITLE
out_file:add warn message for symlink_path-setting

### DIFF
--- a/lib/fluent/plugin/out_file.rb
+++ b/lib/fluent/plugin/out_file.rb
@@ -172,15 +172,14 @@ module Fluent::Plugin
           log.warn "symlink_path is unavailable on Windows platform. disabled."
           @symlink_path = nil
         else
-          #add check if symlink_path has a tag placeholder.
-            placeholder_validators(:symlink_path, @symlink_path).reject{|v| v.type == :time }.each do |v|
+          placeholder_validators(:symlink_path, @symlink_path).reject{ |v| v.type == :time }.each do |v|
             begin
               v.validate!
+            rescue Fluent::ConfigError => e
+              log.warn "#{e}. This means multiple chunks are competing for a single symlink_path, so some logs may not be taken from the symlink."
             end
-          rescue Fluent::ConfigError => e
-            log.warn "#{e}. This means multiple chunks are competing for a single symlink_path, so some logs may not be taken from the symlink."
           end
-          
+
           @buffer.extend SymlinkBufferMixin
           @buffer.symlink_path = @symlink_path
           @buffer.output_plugin_for_symlink = self

--- a/lib/fluent/plugin/out_file.rb
+++ b/lib/fluent/plugin/out_file.rb
@@ -172,6 +172,15 @@ module Fluent::Plugin
           log.warn "symlink_path is unavailable on Windows platform. disabled."
           @symlink_path = nil
         else
+          #add check if symlink_path has a tag placeholder.
+            placeholder_validators(:symlink_path, @symlink_path).reject{|v| v.type == :time }.each do |v|
+            begin
+              v.validate!
+            end
+          rescue Fluent::ConfigError => e
+            log.warn "#{e}. This means multiple chunks are competing for a single symlink_path, so some logs may not be taken from the symlink."
+          end
+          
           @buffer.extend SymlinkBufferMixin
           @buffer.symlink_path = @symlink_path
           @buffer.output_plugin_for_symlink = self

--- a/test/plugin/test_out_file.rb
+++ b/test/plugin/test_out_file.rb
@@ -130,7 +130,7 @@ class FileOutputTest < Test::Unit::TestCase
           'path' => "#{TMP_DIR}/${tag}/${type}/conf_test.%Y%m%d.%H%M.log",
           'add_path_suffix' => 'false',
           'append' => "true",
-          'symlink_path' => "#{TMP_DIR}/conf_test.current.log",
+          'symlink_path' => "#{TMP_DIR}/${tag}/conf_test.current.log",
           'compress' => 'gzip',
           'recompress' => 'true',
         }, [
@@ -181,6 +181,25 @@ class FileOutputTest < Test::Unit::TestCase
       ])
       assert_nothing_raised do
         Fluent::Test::Driver::Output.new(Fluent::Plugin::NullOutput).configure(conf)
+      end
+    end
+
+    test 'symlink path has not tag placeholder or key placeholder' do
+      conf = config_element('match', '**', {
+          'path' => "#{TMP_DIR}/${tag}/${key1}/${key2}/conf_test.%Y%m%d.%H%M.log",
+          'symlink_path' => "#{TMP_DIR}/conf_test.current.log",
+        }, [
+          config_element('buffer', 'time,tag,key1,key2', {
+              '@type' => 'file',
+              'timekey' => '1d',
+              'path' => "#{TMP_DIR}/buf_conf_test",
+          }),
+      ])
+      assert_nothing_raised do
+        d = create_driver(conf)
+        assert do
+          d.logs.count { |log| log.include?("symlink_path:") } == 2
+        end
       end
     end
   end

--- a/test/plugin/test_out_file.rb
+++ b/test/plugin/test_out_file.rb
@@ -184,7 +184,8 @@ class FileOutputTest < Test::Unit::TestCase
       end
     end
 
-    test 'symlink path has not tag placeholder or key placeholder' do
+    test 'warning for symlink_path not including correct placeholders corresponding to chunk keys' do
+      omit "Windows doesn't support symlink" if Fluent.windows?
       conf = config_element('match', '**', {
           'path' => "#{TMP_DIR}/${tag}/${key1}/${key2}/conf_test.%Y%m%d.%H%M.log",
           'symlink_path' => "#{TMP_DIR}/conf_test.current.log",
@@ -198,7 +199,7 @@ class FileOutputTest < Test::Unit::TestCase
       assert_nothing_raised do
         d = create_driver(conf)
         assert do
-          d.logs.count { |log| log.include?("symlink_path:") } == 2
+          d.logs.count { |log| log.include?("multiple chunks are competing for a single symlink_path") } == 2
         end
       end
     end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
* Partially fixes #4490

**What this PR does / why we need it**: 
According to the issue https://github.com/fluent/fluentd/issues/4490 , if a `tag` or `keys` is set in the chunk key and those placeholders do not exist in the `symlink_path`, multiple chunks to compete for the same symlink and some logs can't be taken from it.
Since this is unintended behavior, I think it is necessary to inform the user that this is a bad setting by the warn message.

If a `tag` or `keys` is set in the chunk key and those placeholders do not exist in the `symlink_path`, the following warning log is displayed.

Ex:
```
<source>
  @type sample
  sample {"message":"hoge","key1":"A","key2":"B"}
  tag test.hoge
</source>

<source>
  @type sample
  sample {"message":"fuga","key1":"A","key2":"B"}
  tag test.fuga
</source>

<match test.**>
  @type file
  path /tmp/test/${tag}/${key1}/${key2}
 symlink_path /tmp/test/link
  append true

  <buffer time,tag,key1,key2>
    @type file
    path /tmp/test/buffer/tag
    timekey 60 
    timekey_wait 3
  </buffer>
</match>
```
```
[warn]: #0 Parameter 'symlink_path: /tmp/test/link' doesn't have tag placeholder. This means multiple chunks are competing for a single symlink_path, so some logs may not be taken from the symlink.
[warn]: #0 Parameter 'symlink_path: /tmp/test/link' doesn't have enough placeholders for keys key1,key2. This means multiple chunks are competing for a single symlink_path, so some logs may not be taken from the symlink.
```

**Docs Changes**:
None (may be necessary)

**Release Note**: 
Same with the title