### PR TITLE
v1.16: keep console v1.23

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("tzinfo-data", ["~> 1.0"])
   gem.add_runtime_dependency("strptime", [">= 0.2.4", "< 1.0.0"])
   gem.add_runtime_dependency("webrick", ["~> 1.4"])
+  gem.add_runtime_dependency("console", ["< 1.24"])
 
   # build gem for a certain platform. see also Rakefile
   fake_platform = ENV['GEM_BUILD_FAKE_PLATFORM'].to_s


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
* Fixes #4477 for v1.16 branch
* Fixes #4487 for v1.16 branch

**What this PR does / why we need it**: 
console gem v1.24 and v1.25 have some specification changes that influence Fluentd.
Since they have nothing to do with vulnerability, we should keep the version on v1.16 stable branch.

**Docs Changes**:
Not needed.

**Release Note**: 
Not needed since there is no specification change.
