### PR TITLE
github: stop using rendering for freestyle text area

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/q-a-japanese.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a-japanese.yml
@@ -12,7 +12,6 @@ body:
       description: |
         何について困っているのかを書いてください。試したことや実際の結果を示してください。
         期待する挙動と実際の結果の違いがあればそれも書くのをおすすめします。
-      render: markdown
     validations:
       required: true
   - type: textarea

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -12,7 +12,6 @@ body:
       description: |
         A clear and concise description of what you want to happen.
         What exactly did you do (or not do) that was effective (or ineffective)?
-      render: markdown
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None.

**What this PR does / why we need it**: 
Stop using rendering for freestyle text area.
Not happy about free style text area being enclosed in a code block automatically.

I think this is not intended, right?
If there is a reason, please let me know.

Q&A:
![Screenshot from 2024-05-29 11-44-38](https://github.com/fluent/fluentd/assets/12229857/a43a92b0-b140-4cac-aefb-476fbb393dce)

**Docs Changes**:
Not needed.

**Release Note**: 
Not needed.