### PR TITLE
test: fix IOError about Tempfile closed when GC

### DIFF
--- a/test/plugin/in_tail/test_io_handler.rb
+++ b/test/plugin/in_tail/test_io_handler.rb
@@ -5,20 +5,19 @@ require 'fluent/plugin/metrics_local'
 require 'tempfile'
 
 class IntailIOHandlerTest < Test::Unit::TestCase
-  setup do
-    @file = Tempfile.new('intail_io_handler').binmode
-    opened_file_metrics = Fluent::Plugin::LocalMetrics.new
-    opened_file_metrics.configure(config_element('metrics', '', {}))
-    closed_file_metrics = Fluent::Plugin::LocalMetrics.new
-    closed_file_metrics.configure(config_element('metrics', '', {}))
-    rotated_file_metrics = Fluent::Plugin::LocalMetrics.new
-    rotated_file_metrics.configure(config_element('metrics', '', {}))
-    @metrics = Fluent::Plugin::TailInput::MetricsInfo.new(opened_file_metrics, closed_file_metrics, rotated_file_metrics)
-  end
-
-  teardown do
-    @file.close rescue nil
-    @file.unlink rescue nil
+  def setup
+    Tempfile.create('intail_io_handler') do |file|
+      file.binmode
+      @file = file
+      opened_file_metrics = Fluent::Plugin::LocalMetrics.new
+      opened_file_metrics.configure(config_element('metrics', '', {}))
+      closed_file_metrics = Fluent::Plugin::LocalMetrics.new
+      closed_file_metrics.configure(config_element('metrics', '', {}))
+      rotated_file_metrics = Fluent::Plugin::LocalMetrics.new
+      rotated_file_metrics.configure(config_element('metrics', '', {}))
+      @metrics = Fluent::Plugin::TailInput::MetricsInfo.new(opened_file_metrics, closed_file_metrics, rotated_file_metrics)
+      yield
+    end
   end
 
   def create_target_info

--- a/test/plugin/in_tail/test_position_file.rb
+++ b/test/plugin/in_tail/test_position_file.rb
@@ -6,13 +6,12 @@ require 'fileutils'
 require 'tempfile'
 
 class IntailPositionFileTest < Test::Unit::TestCase
-  setup do
-    @file = Tempfile.new('intail_position_file_test').binmode
-  end
-
-  teardown do
-    @file.close rescue nil
-    @file.unlink rescue nil
+  def setup
+    Tempfile.create('intail_position_file_test') do |file|
+      file.binmode
+      @file = file
+      yield
+    end
   end
 
   UNWATCHED_STR = '%016x' % Fluent::Plugin::TailInput::PositionFile::UNWATCHED_POSITION


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None.

**What this PR does / why we need it**: 
`Tempfile#binmode` returns `File` object, not own `Tempfile` object.
So, GC will cause its finalizer and the file can be closed during the test.
This is the cause why these tests sometimes fail by `IOError: closed stream`.

**Docs Changes**:
Not needed.

**Release Note**: 
Not needed.
