### PR TITLE
test: fix timecop version to keep clock specs in tests

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -50,7 +50,9 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("parallel_tests", ["~> 0.15.3"])
   gem.add_development_dependency("simplecov", ["~> 0.7"])
   gem.add_development_dependency("rr", ["~> 3.0"])
-  gem.add_development_dependency("timecop", ["~> 0.9"])
+  # timecop v0.9.9 supports `Process.clock_gettime`. It breaks some tests.
+  # (https://github.com/fluent/fluentd/pull/4521)
+  gem.add_development_dependency("timecop", ["< 0.9.9"])
   gem.add_development_dependency("test-unit", ["~> 3.3"])
   gem.add_development_dependency("test-unit-rr", ["~> 1.0"])
   gem.add_development_dependency("oj", [">= 2.14", "< 4"])


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None.

**What this PR does / why we need it**: 
Fix the current situation where CI is failing entirely.

* Example: https://github.com/fluent/fluentd/actions/runs/9312942781

`timecop` 0.9.9 supports `Process.clock_gettime`.
This breaks specifications of `process_extenstion` of Fluentd and `Fluent::Clock`.

* https://github.com/travisjeffery/timecop/pull/419

`Fluent::Clock` uses `CLOCK_MONOTONIC_RAW` if possible and it does not be affected.
However, `CLOCK_MONOTONIC_RAW` is not available on Windows, so the impact on tests on Windows is very significant.

For now, we should avoid this effect by fixing the version.

**Docs Changes**:
Not needed.

**Release Note**: 
Not needed.