### PR TITLE
default config: disable out_forward setting

### DIFF
--- a/fluent.conf
+++ b/fluent.conf
@@ -81,20 +81,20 @@
   @id stdout_output
 </match>
 
-# match tag=system.** and forward to another fluent server
-<match system.**>
-  @type forward
-  @id forward_output
-
-  <server>
-    host 192.168.0.11
-  </server>
-  <secondary>
-    <server>
-      host 192.168.0.12
-    </server>
-  </secondary>
-</match>
+## match tag=system.** and forward to another fluent server
+#<match system.**>
+#  @type forward
+#  @id forward_output
+#
+#  <server>
+#    host 192.168.0.11
+#  </server>
+#  <secondary>
+#    <server>
+#      host 192.168.0.12
+#    </server>
+#  </secondary>
+#</match>
 
 ## match tag=myapp.** and forward and write to file
 #<match myapp.**>


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None.

**What this PR does / why we need it**: 
It would be not desirable to try to connect with `192.168.0.11` or `192.168.0.12` by default.
This causes the following warning log:

    ... detached forwarding server ...

Also, this could cause some unintended problems.

**Docs Changes**:
Not needed.
(I have checked https://github.com/fluent/fluentd-docs-gitbook. There are no related documents.)

**Release Note**: 
Same as the title.
