### PR TITLE
github: use checkout@v4 to fix a warning

### DIFF
--- a/.github/workflows/test-ruby-head.yml
+++ b/.github/workflows/test-ruby-head.yml
@@ -17,7 +17,7 @@ jobs:
 
     name: Ruby ${{ matrix.ruby-version }} on ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
     name: Ruby ${{ matrix.ruby-version }} on ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

Fixes N/A

**What this PR does / why we need it**: 

run Node 20 instead of Node 16.

It fixes the following warning:

  Node.js 16 actions are deprecated. Please update the following actions
  to use Node.js 20: actions/checkout@v3. For more information see:
  https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

**Docs Changes**:

N/A

**Release Note**: 

N/A
