### PR TITLE
Fix line skipping issue in receive_lines method

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -1070,7 +1070,7 @@ module Fluent::Plugin
             lines << convert(rbuf)
           end
 
-          is_long_line = !@max_line_size.nil? && (
+          is_long_line = @max_line_size && (
             @buffer.bytesize > @max_line_size || @was_long_line
           )
 

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -1060,13 +1060,14 @@ module Fluent::Plugin
               rbuf.bytesize > @max_line_size || @was_long_line
             )
 
-            if !is_long_line
-              lines << convert(rbuf)
-            else
+            if is_long_line
               @log.warn "received line length is longer than #{@max_line_size}"
-              @log.debug "skipped line"
+              @log.debug("skipped line: ") { convert(rbuf).chomp }
               @was_long_line = false
+              next
             end
+
+            lines << convert(rbuf)
           end
 
           is_long_line = !@max_line_size.nil? && (

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -1075,7 +1075,7 @@ module Fluent::Plugin
           )
 
           if is_long_line
-            @buffer = ''.force_encoding(@from_encoding)
+            @buffer.clear
             @was_long_line = true
           end
         end

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -1064,7 +1064,11 @@ module Fluent::Plugin
 
             if is_long_line
               @log.warn "received line length is longer than #{@max_line_size}"
-              @log.debug("skipped line: ") { convert(rbuf).chomp }
+              if @skip_current_line
+                @log.debug("The continuing line is finished. Finally discarded data: ") { convert(rbuf).chomp }
+              else
+                @log.debug("skipped line: ") { convert(rbuf).chomp }
+              end
               has_skipped_line = true
               @skip_current_line = false
               @skipping_current_line_bytesize = 0
@@ -1079,6 +1083,11 @@ module Fluent::Plugin
           )
 
           if is_long_current_line
+            @log.debug(
+              "The continuing current line length is longer than #{@max_line_size}." +
+              " The received data will be discarded until this line is finished." +
+              " Discarded data: "
+            ) { convert(@buffer).chomp }
             @skip_current_line = true
             @skipping_current_line_bytesize += @buffer.bytesize
             @buffer.clear

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -1056,7 +1056,7 @@ module Fluent::Plugin
             @buffer = @buffer.slice(idx + 1, @buffer.size)
             idx = @buffer.index(@eol)
 
-            is_long_line = !@max_line_size.nil? && (
+            is_long_line = @max_line_size && (
               rbuf.bytesize > @max_line_size || @was_long_line
             )
 

--- a/test/plugin/in_tail/test_io_handler.rb
+++ b/test/plugin/in_tail/test_io_handler.rb
@@ -146,36 +146,35 @@ class IntailIOHandlerTest < Test::Unit::TestCase
       assert_equal 5, returned_lines[0].size
       assert_equal 3, returned_lines[1].size
     end
+  end
 
-    test 'call receive_lines some times when long line(more than 8192) and max_line_size is 4096' do
-      t = 'line' * (8192 / 8)
-      text = "#{t}\n" * 8
-      t = 'line' * 8
-      text += "#{t}\n" * 8
+  test 'does not call receive_lines when line_size exceeds max_line_size' do
+    t = 'x' * (8192)
+    text = "#{t}\n"
 
-      @file.write(text)
-      @file.close
+    max_line_size = 8192
 
-      update_pos = 0
+    @file.write(text)
+    @file.close
 
-      watcher = create_watcher
-      stub(watcher).pe do
-        pe = 'position_file'
-        stub(pe).read_pos {0}
-        stub(pe).update_pos { |val| update_pos = val }
-        pe
-      end
+    update_pos = 0
 
-      returned_lines = []
-      r = Fluent::Plugin::TailInput::TailWatcher::IOHandler.new(watcher, path: @file.path, read_lines_limit: 5, read_bytes_limit_per_second: -1, max_line_size: 4096, log: $log, open_on_every_update: false, metrics: @metrics) do |lines, _watcher|
-        returned_lines << lines.dup
-        true
-      end
-
-      r.on_notify
-      assert_equal text.bytesize, update_pos
-      assert_equal 1, returned_lines.size
-      assert_equal 8, returned_lines[0].size
+    watcher = create_watcher
+    stub(watcher).pe do
+      pe = 'position_file'
+      stub(pe).read_pos {0}
+      stub(pe).update_pos { |val| update_pos = val }
+      pe
     end
+
+    returned_lines = []
+    r = Fluent::Plugin::TailInput::TailWatcher::IOHandler.new(watcher, path: @file.path, read_lines_limit: 1000, read_bytes_limit_per_second: -1, max_line_size: max_line_size, log: $log, open_on_every_update: false, metrics: @metrics) do |lines, _watcher|
+      returned_lines << lines.dup
+      true
+    end
+
+    r.on_notify
+    assert_equal text.bytesize, update_pos
+    assert_equal 0, returned_lines.size
   end
 end

--- a/test/plugin/in_tail/test_io_handler.rb
+++ b/test/plugin/in_tail/test_io_handler.rb
@@ -146,5 +146,36 @@ class IntailIOHandlerTest < Test::Unit::TestCase
       assert_equal 5, returned_lines[0].size
       assert_equal 3, returned_lines[1].size
     end
+
+    test 'call receive_lines some times when long line(more than 8192) and max_line_size is 4096' do
+      t = 'line' * (8192 / 8)
+      text = "#{t}\n" * 8
+      t = 'line' * 8
+      text += "#{t}\n" * 8
+
+      @file.write(text)
+      @file.close
+
+      update_pos = 0
+
+      watcher = create_watcher
+      stub(watcher).pe do
+        pe = 'position_file'
+        stub(pe).read_pos {0}
+        stub(pe).update_pos { |val| update_pos = val }
+        pe
+      end
+
+      returned_lines = []
+      r = Fluent::Plugin::TailInput::TailWatcher::IOHandler.new(watcher, path: @file.path, read_lines_limit: 5, read_bytes_limit_per_second: -1, max_line_size: 4096, log: $log, open_on_every_update: false, metrics: @metrics) do |lines, _watcher|
+        returned_lines << lines.dup
+        true
+      end
+
+      r.on_notify
+      assert_equal text.bytesize, update_pos
+      assert_equal 1, returned_lines.size
+      assert_equal 8, returned_lines[0].size
+    end
   end
 end

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -3418,7 +3418,7 @@ class TailInputTest < Test::Unit::TestCase
                     [{"message" => "foo"},{"message" => "bar"}],
                     [
                       "2021-11-29 11:22:33 +0000 [warn]: received line length is longer than #{size}\n",
-                      "2021-11-29 11:22:33 +0000 [debug]: skipped line\n"
+                      "2021-11-29 11:22:33 +0000 [debug]: skipped line: #{'x' * size}\n"
                     ]
                   ],
                   [

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -2011,41 +2011,6 @@ class TailInputTest < Test::Unit::TestCase
       mock(plugin.router).emit_stream('pre.foo.bar.log.post', anything).once
       plugin.receive_lines(['foo', 'bar'], DummyWatcher.new('foo.bar.log'))
     end
-
-    data(
-      small: ["128", 128],
-      KiB: ["1k", 1024]
-    )
-    test 'max_line_size' do |(label, size)|
-      config = config_element("", "", {
-                                "tag" => "max_line_size",
-                                "path" => "#{@tmp_dir}/with_long_lines.txt",
-                                "format" => "none",
-                                "read_from_head" => true,
-                                "max_line_size" => label,
-                                "log_level" => "debug"
-                              })
-      Fluent::FileWrapper.open("#{@tmp_dir}/with_long_lines.txt", "w+") do |f|
-        f.puts "foo"
-        f.puts "x" * size # 'x' * size + \n > @max_line_size
-        f.puts "bar"
-      end
-      d = create_driver(config, false)
-      timestamp = Time.parse("Mon Nov 29 11:22:33 UTC 2021")
-      Timecop.freeze(timestamp)
-      d.run(expect_records: 2)
-      assert_equal([
-                     [{"message" => "foo"},{"message" => "bar"}],
-                     [
-                       "2021-11-29 11:22:33 +0000 [warn]: received line length is longer than #{size}\n",
-                       "2021-11-29 11:22:33 +0000 [debug]: skipped line: #{'x' * size}\n"
-                     ]
-                   ],
-                   [
-                     d.events.collect { |event| event.last },
-                     d.logs[-2..]
-                   ])
-    end
   end
 
   # Ensure that no fatal exception is raised when a file is missing and that
@@ -3425,5 +3390,40 @@ class TailInputTest < Test::Unit::TestCase
         },
       )
     end
+  end
+
+  data(
+    small: ["128", 128],
+    KiB: ["1k", 1024]
+  )
+  test 'max_line_size' do |(label, size)|
+    config = config_element("", "", {
+                              "tag" => "max_line_size",
+                              "path" => "#{@tmp_dir}/with_long_lines.txt",
+                              "format" => "none",
+                              "read_from_head" => true,
+                              "max_line_size" => label,
+                              "log_level" => "debug"
+                            })
+    Fluent::FileWrapper.open("#{@tmp_dir}/with_long_lines.txt", "w+") do |f|
+      f.puts "foo"
+      f.puts "x" * size # 'x' * size + \n > @max_line_size
+      f.puts "bar"
+    end
+    d = create_driver(config, false)
+    timestamp = Time.parse("Mon Nov 29 11:22:33 UTC 2021")
+    Timecop.freeze(timestamp)
+    d.run(expect_records: 2)
+    assert_equal([
+                    [{"message" => "foo"},{"message" => "bar"}],
+                    [
+                      "2021-11-29 11:22:33 +0000 [warn]: received line length is longer than #{size}\n",
+                      "2021-11-29 11:22:33 +0000 [debug]: skipped line\n"
+                    ]
+                  ],
+                  [
+                    d.events.collect { |event| event.last },
+                    d.logs[-2..]
+                  ])
   end
 end


### PR DESCRIPTION
**Which issue(s) this PR fixes:**
Fixes https://github.com/fluent/fluentd/issues/4494
recoverd from #4491 

**What this PR does / why we need it:**
Before this patch, long lines could cause breakdowns in fluentd, potentially posing a vulnerability. With this patch, max_line_size will be integrated into the FIFO, enabling the system to skip lines exceeding the maximum size before executing receive_lines.

**Docs Changes:**

**Release Note:**