### PR TITLE
in_exec: add option 'encoding' to handle non-ASCII characters

### DIFF
--- a/lib/fluent/plugin/in_exec.rb
+++ b/lib/fluent/plugin/in_exec.rb
@@ -45,7 +45,7 @@ module Fluent::Plugin
     config_param :run_interval, :time, default: nil
     desc 'The default block size to read if parser requires partial read.'
     config_param :read_block_size, :size, default: 10240 # 10k
-    desc 'The encoding to receive the result of the command, especially for none-ascii characters.'
+    desc 'The encoding to receive the result of the command, especially for non-ascii characters.'
     config_param :encoding, :string, default: nil
 
     attr_reader :parser

--- a/test/plugin/test_in_exec.rb
+++ b/test/plugin/test_in_exec.rb
@@ -218,6 +218,43 @@ EOC
     end
   end
 
+  sub_test_case 'encoding' do
+    data(immediate: "")
+    data(run_interval: "run_interval 1")
+    test 'can handle none-ascii characters' do |additional_setting|
+      content = 'ひらがな漢字'
+
+      d = create_driver %[
+        command ruby -e "puts '#{content}'"
+        tag test
+        encoding utf-8
+        <parse>
+          @type none
+        </parse>
+        #{additional_setting}
+      ]
+
+      d.run(expect_records: 1, timeout: 10)
+
+      assert_equal 1, d.events.length
+      tag, time, record = d.events.first
+      assert_equal({"message" => content}, record)
+    end
+
+    test 'raise ConfigError for invalid encoding' do
+      assert_raise Fluent::ConfigError do
+        d = create_driver %[
+          command ruby -e "puts foo"
+          tag test
+          encoding invalid-encode
+          <parse>
+            @type none
+          </parse>
+        ]
+      end
+    end
+  end
+
   data(
     'default' => [TSV_CONFIG,     "tag1", event_time("2011-01-02 13:14:15"), {"k1"=>"ok"}],
     'json'    => [JSON_CONFIG,    "tag1", event_time("2011-01-02 13:14:15"), {"k1"=>"ok"}],

--- a/test/plugin/test_in_exec.rb
+++ b/test/plugin/test_in_exec.rb
@@ -221,7 +221,7 @@ EOC
   sub_test_case 'encoding' do
     data(immediate: "")
     data(run_interval: "run_interval 1")
-    test 'can handle none-ascii characters' do |additional_setting|
+    test 'can handle non-ascii characters' do |additional_setting|
       content = 'ひらがな漢字'
 
       d = create_driver %[


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
* Fixes #4460

**What this PR does / why we need it**: 
Add option: `encoding` to handle non-ASCII characters.

**Docs Changes**:
TODO

**Release Note**: 
Same as the title.
