### PR TITLE
gemspec: Remove unnecessary files from gem file

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -10,9 +10,13 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{Fluentd event collector}
   gem.homepage      = "https://www.fluentd.org/"
 
-  gem.files         = `git ls-files`.split($\)
+  gem.files         = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").reject do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w[test/ .git Gemfile])
+    end
+  end
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
   gem.license = "Apache-2.0"
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None.

**What this PR does / why we need it**: 
Remove the following files from the gem file:

* test files
* git files
* Gemfile

This reduces the gem file size: 867k -> 558k.

We should reflect recent gemspec moves as the current `files` and `test_files` are written more than 10 years ago:

* #116

`test_files` is not documented anymore:

* https://guides.rubygems.org/specification-reference

Looks like it is not recommended:

* https://github.com/rubygems/bundler/pull/3207

Looks like we should also remove git files and Gemfile because the template of Bundler 2.4.13 is as follows:

```rb
spec.files = Dir.chdir(__dir__) do
  `git ls-files -z`.split("\x0").reject do |f|
    (File.expand_path(f) == __FILE__) ||
      f.start_with?(*%w[bin/ test/ spec/ features/ .git .circleci appveyor Gemfile])
  end
end
```

The removed files except for `test/*` are as follows:

```ruby
before = `git ls-files`.split($\)
after = Dir.chdir(__dir__) do
  `git ls-files -z`.split("\x0").reject do |f|
    (File.expand_path(f) == __FILE__) ||
      f.start_with?(*%w[test/ .git Gemfile])
  end
end
before.reject{|path| path.start_with? "test/"}.difference after
=>
[".github/DISCUSSION_TEMPLATE/q-a-japanese.yml",
 ".github/DISCUSSION_TEMPLATE/q-a.yml",
 ".github/ISSUE_TEMPLATE.md",
 ".github/ISSUE_TEMPLATE/bug_report.yml",
 ".github/ISSUE_TEMPLATE/config.yml",
 ".github/ISSUE_TEMPLATE/feature_request.yml",
 ".github/PULL_REQUEST_TEMPLATE.md",
 ".github/workflows/stale-actions.yml",
 ".github/workflows/test-ruby-head.yml",
 ".github/workflows/test.yml",
 ".gitignore",
 "Gemfile"]

after.difference before
=> []
```

**Docs Changes**:
Not needed.

**Release Note**: 
Not needed.
