### PR TITLE
plugin-generator: update gemspec to remove unnecessary files

### DIFF
--- a/templates/new_gem/fluent-plugin.gemspec.erb
+++ b/templates/new_gem/fluent-plugin.gemspec.erb
@@ -12,12 +12,13 @@ Gem::Specification.new do |spec|
   spec.homepage      = "TODO: Put your gem's website or public repo URL here."
   spec.license       = "<%= @license.name %>"
 
-  test_files, files  = `git ls-files -z`.split("\x0").partition do |f|
-    f.match(%r{^(test|spec|features)/})
+  spec.files         = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").reject do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w[test/ spec/ features/ .git .circleci appveyor Gemfile])
+    end
   end
-  spec.files         = files
-  spec.executables   = files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = test_files
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> <%= bundler_version %>"


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None.

**What this PR does / why we need it**: 
* Same as #4534 for `fluent-plugin-generate`

**Docs Changes**:
Not needed.
(There is no change needed for https://docs.fluentd.org/plugin-development#generating-plugin-project-skeleton)

**Release Note**: 
Not needed.