### PR TITLE
Config File Syntax: Extend Embedded Ruby Code support for Hashes and Arrays

### DIFF
--- a/lib/fluent/config/literal_parser.rb
+++ b/lib/fluent/config/literal_parser.rb
@@ -254,7 +254,7 @@ EOM
               buffer << line_buffer + "\n"
               line_buffer = ""
             else
-              if @ss.exist?(/\{[^}]+\}/)
+              if @ss.exist?(/^\{[^}]+\}/)
                 # if it's interpolated string
                 skip(/\{/)
                 line_buffer << eval_embedded_code(scan_embedded_code)

--- a/lib/fluent/config/literal_parser.rb
+++ b/lib/fluent/config/literal_parser.rb
@@ -176,7 +176,7 @@ module Fluent
         end
 
         @ss.pos += code.length
-
+        p code
         '"#{' + code + '}"'
       end
 
@@ -254,11 +254,13 @@ EOM
               buffer << line_buffer + "\n"
               line_buffer = ""
             else
-              # '#' is a char in json string
-              if skip(/\{/)
+              if @ss.exist?(/\{[^}]+\}/)
+                # if it's interpolated string
+                skip(/\{/)
                 line_buffer << eval_embedded_code(scan_embedded_code)
                 skip(/\}/)
               else
+                # '#' is a char in json string
                 line_buffer << char
               end
             end

--- a/lib/fluent/config/literal_parser.rb
+++ b/lib/fluent/config/literal_parser.rb
@@ -155,11 +155,11 @@ module Fluent
       end
 
       def scan_embedded_code
-        src = '#{'+@ss.rest+"\n=begin\n=end\n}"
+        src = '"#{'+@ss.rest+"\n=begin\n=end\n}"
 
         seek = -1
         while (seek = src.index('}', seek + 1))
-          unless Ripper.sexp(src[0..seek]).nil? # eager parsing until valid expression
+          unless Ripper.sexp(src[0..seek] + '"').nil? # eager parsing until valid expression
             break
           end
         end
@@ -168,7 +168,7 @@ module Fluent
           raise Fluent::ConfigParseError, @ss.rest
         end
 
-        code = src[2, seek-2]
+        code = src[3, seek-3]
 
         if @ss.rest.length < code.length
           @ss.pos += @ss.rest.length
@@ -176,6 +176,7 @@ module Fluent
         end
 
         @ss.pos += code.length
+
         '"#{' + code + '}"'
       end
 

--- a/lib/fluent/config/literal_parser.rb
+++ b/lib/fluent/config/literal_parser.rb
@@ -176,7 +176,6 @@ module Fluent
         end
 
         @ss.pos += code.length
-        p code
         '"#{' + code + '}"'
       end
 

--- a/lib/fluent/config/literal_parser.rb
+++ b/lib/fluent/config/literal_parser.rb
@@ -285,7 +285,6 @@ EOM
         end
 
         JSON.dump(result)
-
       end
     end
   end

--- a/test/config/test_literal_parser.rb
+++ b/test/config/test_literal_parser.rb
@@ -259,6 +259,17 @@ module Fluent::Config
       test('[ "a" , "b" ]') { assert_text_parsed_as_json(["a","b"], '[ "a" , "b" ]') }
       test("[\n\"a\"\n,\n\"b\"\n]") { assert_text_parsed_as_json(["a","b"], "[\n\"a\"\n,\n\"b\"\n]") }
       test('["ab","cd"]') { assert_text_parsed_as_json(["ab","cd"], '["ab","cd"]') }
+      test('["a","#{v1}"') { assert_text_parsed_as_json(["a","#{v1}"], '["a","#{v1}"]') }
+      test('["a","#{v1}","#{v2}"]') { assert_text_parsed_as_json(["a","#{v1}","#{v2}"], '["a","#{v1}","#{v2}"]') }
+      test('["a","#{v1} #{v2}"]') { assert_text_parsed_as_json(["a","#{v1} #{v2}"], '["a","#{v1} #{v2}"]') }
+      test('["a","#{hostname}"]') { assert_text_parsed_as_json(["a","#{Socket.gethostname}"], '["a","#{hostname}"]') }
+      test('["a","foo#{worker_id}"]') {
+        ENV.delete('SERVERENGINE_WORKER_ID')
+        assert_text_parsed_as('["a","foo"]', '["a","foo#{worker_id}"]')
+        ENV['SERVERENGINE_WORKER_ID'] = '1'
+        assert_text_parsed_as('["a","foo1"]', '["a","foo#{worker_id}"]')
+        ENV.delete('SERVERENGINE_WORKER_ID')
+      }
       json_array_with_js_comment = <<EOA
 [
  "a", // this is a
@@ -296,6 +307,18 @@ EOA
       test('{"a":"b","c":"d"}') { assert_text_parsed_as_json({"a"=>"b","c"=>"d"}, '{"a":"b","c":"d"}') }
       test('{ "a" : "b" , "c" : "d" }') { assert_text_parsed_as_json({"a"=>"b","c"=>"d"}, '{ "a" : "b" , "c" : "d" }') }
       test('{\n\"a\"\n:\n\"b\"\n,\n\"c\"\n:\n\"d\"\n}') { assert_text_parsed_as_json({"a"=>"b","c"=>"d"}, "{\n\"a\"\n:\n\"b\"\n,\n\"c\"\n:\n\"d\"\n}") }
+      test('{"a":"b","c":"#{v1}"}') { assert_text_parsed_as_json({"a"=>"b","c"=>"#{v1}"}, '{"a":"b","c":"#{v1}"}') }
+      test('{"a":"b","#{v1}":"d"}') { assert_text_parsed_as_json({"a"=>"b","#{v1}"=>"d"}, '{"a":"b","#{v1}":"d"}') }
+      test('{"a":"#{v1}","c":"#{v2}"}') { assert_text_parsed_as_json({"a"=>"#{v1}","c"=>"#{v2}"}, '{"a":"#{v1}","c":"#{v2}"}') }
+      test('{"a":"b","c":"d #{v1} #{v2}"}') { assert_text_parsed_as_json({"a"=>"b","c"=>"d #{v1} #{v2}"}, '{"a":"b","c":"d #{v1} #{v2}"}') }
+      test('{"a":"#{hostname}"}') { assert_text_parsed_as_json({"a"=>"#{Socket.gethostname}"}, '{"a":"#{hostname}"}') }
+      test('{"a":"foo#{worker_id}"}') {
+        ENV.delete('SERVERENGINE_WORKER_ID')
+        assert_text_parsed_as('{"a":"foo"}', '{"a":"foo#{worker_id}"}')
+        ENV['SERVERENGINE_WORKER_ID'] = '1'
+        assert_text_parsed_as('{"a":"foo1"}', '{"a":"foo#{worker_id}"}')
+        ENV.delete('SERVERENGINE_WORKER_ID')
+      }
       json_hash_with_comment = <<EOH
 {
  "a": 1, # this is a

--- a/test/config/test_literal_parser.rb
+++ b/test/config/test_literal_parser.rb
@@ -319,6 +319,9 @@ EOA
         assert_text_parsed_as('{"a":"foo1"}', '{"a":"foo#{worker_id}"}')
         ENV.delete('SERVERENGINE_WORKER_ID')
       }
+      test('no quote') { assert_text_parsed_as_json({'a'=>'b','c'=>'test'}, '{"a":"b","c":"#{v1}"}') }
+      test('single quote') { assert_text_parsed_as_json({'a'=>'b','c'=>'#{v1}'}, '\'{"a":"b","c":"#{v1}"}\'') }
+      test('double quote') { assert_text_parsed_as_json({'a'=>'b','c'=>'test'}, '"{\"a\":\"b\",\"c\":\"#{v1}\"}"') }
       json_hash_with_comment = <<EOH
 {
  "a": 1, # this is a


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #4385 

**What this PR does / why we need it**: 
Support [Embedded Ruby Code](https://docs.fluentd.org/configuration/config-file#embedded-ruby-code) for Hashes and Arrays.

```
key ["foo","#{1 + 1}"] => key ["foo","2"]
key {"foo":"#{1 + 1}"} => key {"foo":"2"}
```

This is not backward compatible.
We can disable this feature by surrounding the entire value with single quotes.

```
key `["foo","#{1 + 1}"]` => key ["foo","#{1 + 1}"]
key `{"foo":"#{1 + 1}"}` => key {"foo":"#{1 + 1}"}
```

**Note: this feature is for JSON literals**

This feature is for literals that using `[]` or `{}`.

* We need to sort out the `literal` and `value` of the Fluentd Config Syntax.
  * Fluentd first interprets `literal` by parsing the config file.
  * `literal` is String or JSON.
  * Then, Fluentd interprets `value` by parsing the `literal`.
  * `value` has [various types](https://docs.fluentd.org/configuration/config-file#supported-data-types-for-values).
* **This feature has nothing to do with parsing the `value`.**

For example, we can specify Array/Hash `value` by using **String** `literal`
We don't necessarily need to use **JSON** `literal` to specify Array/Hash `value`.
The following formats works from previous versions, and there is no specification change at all.

```
key foo,bar
key foo:bar
key "foo,#{1 + 1}"
key "foo:#{1 + 1}"
```

**Note: support only String of JSON**

For example, this does not support Number of JSON.

```
key ["foo",2] => key ["foo",2]
key ["foo",#{1 + 1}] => ERROR
```

It is because JSON `literal` supports multiple lines and comments.
`#` not in String is considered the start of a comment line.

```
key ["foo", # comment
"bar", # comment
"boo" # comment
]
```

**Docs Changes**:
TODO

**Release Note**: 
* Config File Syntax: Extend Embedded Ruby Code support for Hashes and Arrays
  * Example: `key {"foo":"#{1 + 1}"} => key {"foo":"2"}`
  * Please note that this is not backward compatible, although we assume that this will never affect to actual existing configs.
  * In case the behavior changes unintentionally, you can disable this feature by surrounding the entire value with single quotes.
    * `key '{"foo":"#{1 + 1}"}' => key {"foo":"#{1 + 1}"}`
