### PR TITLE
github: set job permissions

### DIFF
--- a/.github/workflows/stale-actions.yml
+++ b/.github/workflows/stale-actions.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      pull-requests: write
     steps:
     - uses: actions/stale@v8
       with:

--- a/.github/workflows/stale-actions.yml
+++ b/.github/workflows/stale-actions.yml
@@ -3,9 +3,13 @@ on:
   schedule:
   - cron: "00 10 * * *"
 
+permissions: read-all
+
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
     - uses: actions/stale@v8
       with:

--- a/.github/workflows/test-ruby-head.yml
+++ b/.github/workflows/test-ruby-head.yml
@@ -5,6 +5,8 @@ on:
     - cron: '11 14 * * 0'
   workflow_dispatch:
 
+permissions: read-all
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [master]
 
+permissions: read-all
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION

**Which issue(s) this PR fixes**: 

Fixes N/A

It is related token permission topic
https://scorecard.dev/viewer/?uri=github.com/fluent/fluentd

**What this PR does / why we need it**: 

By default, it is enough to give read permission.
For stale actions, it require manipulate issues,
so write permission is given explicitly.

**Docs Changes**:

N/A

**Release Note**: 

N/A
