### PR TITLE
CI: Set continue-on-error false for Ruby Head

### DIFF
--- a/.github/workflows/test-ruby-head.yml
+++ b/.github/workflows/test-ruby-head.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    continue-on-error: true
+    continue-on-error: false
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
N/A

**What this PR does / why we need it**: 
When a test is failed, the job should be also treated as failed.
But the current setting ignore errors.

Please see https://github.com/fluent/fluent-plugin-sql/actions/workflows/linux-ruby-head.yml
(Some tests are always failed with recent Ruby Head but jobs are all green.)

**Docs Changes**:
N/A

**Release Note**: 
N/A
