### PR TITLE
Use UnboundMethod#bind_call method instead to improve performance

### DIFF
--- a/lib/fluent/compat/call_super_mixin.rb
+++ b/lib/fluent/compat/call_super_mixin.rb
@@ -41,7 +41,7 @@ module Fluent
       def start
         super
         unless self.started?
-          @@_super_start[self.class].bind(self).call
+          @@_super_start[self.class].bind_call(self)
           # #super will reset logdev (especially in test), so this warn should be after calling it
           log.warn "super was not called in #start: called it forcedly", plugin: self.class
         end
@@ -51,7 +51,7 @@ module Fluent
         super
         unless self.before_shutdown?
           log.warn "super was not called in #before_shutdown: calling it forcedly", plugin: self.class
-          @@_super_before_shutdown[self.class].bind(self).call
+          @@_super_before_shutdown[self.class].bind_call(self)
         end
       end
 
@@ -68,7 +68,7 @@ module Fluent
         super
         unless self.shutdown?
           log.warn "super was not called in #shutdown: calling it forcedly", plugin: self.class
-          @@_super_shutdown[self.class].bind(self).call
+          @@_super_shutdown[self.class].bind_call(self)
         end
       end
     end

--- a/lib/fluent/compat/propagate_default.rb
+++ b/lib/fluent/compat/propagate_default.rb
@@ -33,25 +33,25 @@ module Fluent
         CONFIGURABLE_CLASS_METHODS = Fluent::Configurable::ClassMethods
 
         def config_param(name, type = nil, **kwargs, &block)
-          CONFIGURABLE_CLASS_METHODS.instance_method(:config_param).bind(self).call(name, type, **kwargs, &block)
+          CONFIGURABLE_CLASS_METHODS.instance_method(:config_param).bind_call(self, name, type, **kwargs, &block)
           pparams = propagate_default_params
           if kwargs.has_key?(:default) && pparams[name.to_s]
             newer = pparams[name.to_s].to_sym
             overridden_default_value = kwargs[:default]
 
-            CONFIGURABLE_CLASS_METHODS.instance_method(:config_section).bind(self).call(:buffer) do
+            CONFIGURABLE_CLASS_METHODS.instance_method(:config_section).bind_call(self, :buffer) do
               config_set_default newer, overridden_default_value
             end
           end
         end
 
         def config_set_default(name, defval)
-          CONFIGURABLE_CLASS_METHODS.instance_method(:config_set_default).bind(self).call(name, defval)
+          CONFIGURABLE_CLASS_METHODS.instance_method(:config_set_default).bind_call(self, name, defval)
           pparams = propagate_default_params
           if pparams[name.to_s]
             newer = pparams[name.to_s].to_sym
 
-            CONFIGURABLE_CLASS_METHODS.instance_method(:config_section).bind(self).call(:buffer) do
+            CONFIGURABLE_CLASS_METHODS.instance_method(:config_section).bind_call(self, :buffer) do
               self.config_set_default newer, defval
             end
           end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
UnboundMethod#bind_call method had been introduced at Ruby 2.7 that it aims to improve performance.

Ref. https://bugs.ruby-lang.org/issues/15955

### environment
- Linux
  - Manjaro Linux x86_64
  - Kernel: 6.9.12-1-MANJARO
  - CPU: Intel i9-14900 (32) @ 5.500GHz
  - Compiler: gcc 14.1.1
  - Ruby: ruby 3.3.4 (2024-07-09 revision be1089c8ec) [x86_64-linux]

### micro benchmark code
```ruby
require 'bundler/inline'
gemfile do
  source 'https://rubygems.org'
  gem 'benchmark-ips'
end

class Foo
  def foo
  end
end

meth = Foo.instance_method(:foo)
obj = Foo.new

Benchmark.ips do |x|
  x.report("bind.call") {
    meth.bind(obj).call
  }
  x.report("bind_call") {
    meth.bind_call(obj)
  }

  x.compare!
end
```

### result
```
$ ruby bind_call.rb
ruby 3.3.4 (2024-07-09 revision be1089c8ec) [x86_64-linux]
Warming up --------------------------------------
           bind.call   766.396k i/100ms
           bind_call     1.651M i/100ms
Calculating -------------------------------------
           bind.call      7.967M (± 3.4%) i/s -     39.853M in   5.008135s
           bind_call     16.881M (± 4.8%) i/s -     85.852M in   5.097269s

Comparison:
           bind_call: 16880585.1 i/s
           bind.call:  7966891.3 i/s - 2.12x  slower
```
**Docs Changes**:

**Release Note**: 
