### PR TITLE
Add logger gem as dependency for Ruby 3.5

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -39,6 +39,9 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("csv", ["~> 3.2"])
   gem.add_runtime_dependency("drb", ["~> 2.2"])
 
+  # gems that aren't default gems as of Ruby 3.5
+  gem.add_runtime_dependency("logger", ["~> 1.6"])
+
   # build gem for a certain platform. see also Rakefile
   fake_platform = ENV['GEM_BUILD_FAKE_PLATFORM'].to_s
   gem.platform = fake_platform unless fake_platform.empty?


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
logger gem was marked as bundled gem for Ruby 3.5. Therefore, it will not work on Ruby 3.5 unless it is added as a dependency.
Ref. https://github.com/ruby/ruby/commit/d7e558e3c48c213d0e8bedca4fb547db55613f7c

(Currently, this patch will suppress `warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.` message.)

Similar with GH-4411

**Docs Changes**:

**Release Note**: 
