### PR TITLE
Suppress non-parenthesis warnings

### DIFF
--- a/test/plugin/test_out_http.rb
+++ b/test/plugin/test_out_http.rb
@@ -442,8 +442,8 @@ class HTTPOutputTest < Test::Unit::TestCase
       assert_equal test_events, result.data
       assert_not_empty result.headers
       assert_not_nil result.headers['authorization']
-      assert_match /AWS4-HMAC-SHA256 Credential=[a-zA-Z0-9]*\/\d+\/my-region-1\/someservice\/aws4_request/, result.headers['authorization']
-      assert_match /SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-security-token/, result.headers['authorization']
+      assert_match(/AWS4-HMAC-SHA256 Credential=[a-zA-Z0-9]*\/\d+\/my-region-1\/someservice\/aws4_request/, result.headers['authorization'])
+      assert_match(/SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-security-token/, result.headers['authorization'])
       assert_equal @@fake_aws_credentials.session_token, result.headers['x-amz-security-token']
       assert_not_nil result.headers['x-amz-content-sha256']
       assert_not_empty result.headers['x-amz-content-sha256']
@@ -479,8 +479,8 @@ class HTTPOutputTest < Test::Unit::TestCase
       assert_equal test_events, result.data
       assert_not_empty result.headers
       assert_not_nil result.headers['authorization']
-      assert_match /AWS4-HMAC-SHA256 Credential=[a-zA-Z0-9]*\/\d+\/my-region-1\/someservice\/aws4_request/, result.headers['authorization']
-      assert_match /SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-security-token/, result.headers['authorization']
+      assert_match(/AWS4-HMAC-SHA256 Credential=[a-zA-Z0-9]*\/\d+\/my-region-1\/someservice\/aws4_request/, result.headers['authorization'])
+      assert_match(/SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-security-token/, result.headers['authorization'])
       assert_equal @@fake_aws_credentials.session_token, result.headers['x-amz-security-token']
       assert_not_nil result.headers['x-amz-content-sha256']
       assert_not_empty result.headers['x-amz-content-sha256']


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
This patch will suppress following warnings:
```
$ ruby -w -I"lib:test" test/plugin/test_out_http.rb
test/plugin/test_out_http.rb:445: warning: ambiguity between regexp and two divisions: wrap regexp in parentheses or add a space after `/' operator
test/plugin/test_out_http.rb:446: warning: ambiguity between regexp and two divisions: wrap regexp in parentheses or add a space after `/' operator
test/plugin/test_out_http.rb:482: warning: ambiguity between regexp and two divisions: wrap regexp in parentheses or add a space after `/' operator
test/plugin/test_out_http.rb:483: warning: ambiguity between regexp and two divisions: wrap regexp in parentheses or add a space after `/' operator
```

Seems we will see this warning If we omit the parentheses in the method and pass a regular expression as an argument.

```
irb(main):001> $VERBOSE=true
=> true
irb(main):002> p /m/
(irb):2: warning: ambiguity between regexp and two divisions: wrap regexp in parentheses or add a space after `/' operator
/m/
=> /m/
```

**Docs Changes**:

**Release Note**: 
