### PR TITLE
github: Add missing dependabot task

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION


**Which issue(s) this PR fixes**: 

It was turned out by OpenSSF

https://scorecard.dev/viewer/?uri=github.com/fluent/fluentd


**What this PR does / why we need it**: 

Check update about github-actions every weekly.

**Docs Changes**:

N/A

**Release Note**: 

N/A
