### PR TITLE
Fix FrozenError in http_server plugin helper

### DIFF
--- a/lib/fluent/plugin_helper/http_server/server.rb
+++ b/lib/fluent/plugin_helper/http_server/server.rb
@@ -78,7 +78,7 @@ module Fluent
         HttpServer::Methods::ALL.map { |e| e.downcase.to_sym }.each do |name|
           define_method(name) do |path, app = nil, &block|
             unless path.end_with?('/')
-              path << '/'
+              path += '/'
             end
 
             if (block && app) || (!block && !app)

--- a/test/plugin_helper/test_http_server_helper.rb
+++ b/test/plugin_helper/test_http_server_helper.rb
@@ -152,7 +152,7 @@ class HttpHelperTest < Test::Unit::TestCase
   end
 
   sub_test_case 'Create a HTTP server' do
-    test 'monunt given path' do
+    test 'mount given path' do
       on_driver do |driver|
         driver.http_server_create_http_server(:http_server_helper_test, addr: '127.0.0.1', port: @port, logger: NULL_LOGGER) do |s|
           s.get('/example/hello') { [200, { 'Content-Type' => 'text/plain' }, 'hello get'] }
@@ -176,6 +176,17 @@ class HttpHelperTest < Test::Unit::TestCase
           assert_equal("hello #{n}", resp.body)
           assert_equal('text/plain', resp['Content-Type'])
         end
+      end
+    end
+
+    test 'mount frozen path' do
+      on_driver do |driver|
+        driver.http_server_create_http_server(:http_server_helper_test, addr: '127.0.0.1', port: @port, logger: NULL_LOGGER) do |s|
+          s.get('/example/hello'.freeze) { [200, { 'Content-Type' => 'text/plain' }, 'hello get'] }
+        end
+
+        resp = get("http://127.0.0.1:#{@port}/example/hello/")
+        assert_equal('200', resp.code)
       end
     end
 


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #4597

**What this PR does / why we need it**: 
This patch will be able to handle frozen strings as paths to mount in http server.


**Docs Changes**:

**Release Note**: 
