### PR TITLE
Add `frozen_string_literal: true` in order to suppress 'warning: literal string will be frozen in the future'

### DIFF
--- a/lib/fluent/command/ctl.rb
+++ b/lib/fluent/command/ctl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Fluentd
 #
@@ -67,7 +69,7 @@ module Fluent
     end
 
     def help_text
-      text = "\n"
+      text = +"\n"
       if Fluent.windows?
         text << "Usage: #{$PROGRAM_NAME} COMMAND [PID_OR_SVCNAME]\n"
       else

--- a/lib/fluent/command/plugin_config_formatter.rb
+++ b/lib/fluent/command/plugin_config_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Fluentd
 #
@@ -79,7 +81,7 @@ class FluentPluginConfigFormatter
   private
 
   def dump_txt(dumped_config)
-    dumped = ""
+    dumped = +""
     plugin_helpers = dumped_config.delete(:plugin_helpers)
     if plugin_helpers && !plugin_helpers.empty?
       dumped << "helpers: #{plugin_helpers.join(',')}\n"
@@ -101,7 +103,7 @@ class FluentPluginConfigFormatter
   end
 
   def dump_section_txt(base_section, level = 0)
-    dumped = ""
+    dumped = +""
     indent = " " * level
     if base_section[:section]
       sections = []
@@ -135,10 +137,10 @@ class FluentPluginConfigFormatter
   end
 
   def dump_markdown(dumped_config)
-    dumped = ""
+    dumped = +""
     plugin_helpers = dumped_config.delete(:plugin_helpers)
     if plugin_helpers && !plugin_helpers.empty?
-      dumped = "## Plugin helpers\n\n"
+      dumped = +"## Plugin helpers\n\n"
       plugin_helpers.each do |plugin_helper|
         dumped << "* #{plugin_helper_markdown_link(plugin_helper)}\n"
       end
@@ -156,7 +158,7 @@ class FluentPluginConfigFormatter
   end
 
   def dump_section_markdown(base_section, level = 0)
-    dumped = ""
+    dumped = +""
     if base_section[:section]
       sections = []
       params = base_section

--- a/lib/fluent/compat/formatter_utils.rb
+++ b/lib/fluent/compat/formatter_utils.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Fluentd
 #

--- a/lib/fluent/compat/output.rb
+++ b/lib/fluent/compat/output.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Fluentd
 #

--- a/lib/fluent/compat/record_filter_mixin.rb
+++ b/lib/fluent/compat/record_filter_mixin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Fluentd
 #
@@ -21,7 +23,7 @@ module Fluent
       end
 
       def format_stream(tag, es)
-        out = ''
+        out = +''
         es.each {|time,record|
           tag_temp = tag.dup
           filter_record(tag_temp, time, record)

--- a/lib/fluent/config/element.rb
+++ b/lib/fluent/config/element.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Fluentd
 #
@@ -141,7 +143,7 @@ module Fluent
       def to_s(nest = 0)
         indent = "  " * nest
         nindent = "  " * (nest + 1)
-        out = ""
+        out = +""
         if @arg.nil? || @arg.empty?
           out << "#{indent}<#{@name}>\n"
         else
@@ -230,7 +232,7 @@ module Fluent
       end
 
       def self.unescape_parameter(v)
-        result = ''
+        result = +''
         v.each_char { |c| result << LiteralParser.unescape_char(c) }
         result
       end

--- a/lib/fluent/config/literal_parser.rb
+++ b/lib/fluent/config/literal_parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Fluentd
 #
@@ -228,8 +230,8 @@ EOM
         # Yajl does not raise ParseError for incomplete json string, like '[1', '{"h"', '{"h":' or '{"h1":1'
         # This is the reason to use JSON module.
 
-        buffer = (is_array ? "[" : "{")
-        line_buffer = ""
+        buffer = +(is_array ? "[" : "{")
+        line_buffer = +""
 
         until result
           char = getch
@@ -252,7 +254,7 @@ EOM
                 # ignore comment char
               end
               buffer << line_buffer + "\n"
-              line_buffer = ""
+              line_buffer = +""
             else
               # '#' is a char in json string
               line_buffer << char
@@ -263,7 +265,7 @@ EOM
 
           if char == "\n"
             buffer << line_buffer + "\n"
-            line_buffer = ""
+            line_buffer = +""
             next
           end
 

--- a/lib/fluent/config/types.rb
+++ b/lib/fluent/config/types.rb
@@ -183,7 +183,7 @@ module Fluent
         value
       else
         case type
-        when :string  then value.to_s.force_encoding(Encoding::UTF_8)
+        when :string  then (+(value.to_s)).force_encoding(Encoding::UTF_8)
         when :integer then INTEGER_TYPE.call(value, opts, name)
         when :float   then FLOAT_TYPE.call(value, opts, name)
         when :size then Config.size_value(value, opts, name)

--- a/lib/fluent/config/yaml_parser/fluent_value.rb
+++ b/lib/fluent/config/yaml_parser/fluent_value.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Fluentd
 #
@@ -30,7 +32,7 @@ module Fluent
 
         StringValue = Struct.new(:val, :context) do
           def to_s
-            context.instance_eval("\"#{val}\"")
+            context.instance_eval("\"#{val}\"").freeze
           rescue Fluent::SetNil => _
             ''
           rescue Fluent::SetDefault => _

--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Fluentd
 #
@@ -205,7 +207,7 @@ module Fluent
         @format = :text
         @formatter = Proc.new { |type, time, level, msg|
           r = caller_line(type, time, @depth_offset, level)
-          r << msg
+          r += msg
           r
         }
       when :json
@@ -550,7 +552,7 @@ module Fluent
 
     def event(level, args)
       time = Time.now
-      message = @optional_header ? @optional_header.dup : ''
+      message = @optional_header ? @optional_header.dup : +''
       map = @optional_attrs ? @optional_attrs.dup : {}
       args.each {|a|
         if a.is_a?(Hash)

--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -565,7 +565,7 @@ module Fluent
       }
 
       map.each_pair {|k,v|
-        if k == "error".freeze && v.is_a?(Exception) && !map.has_key?("error_class")
+        if k == "error" && v.is_a?(Exception) && !map.has_key?("error_class")
           message << " error_class=#{v.class.to_s} error=#{v.to_s.inspect}"
         else
           message << " #{k}=#{v.inspect}"
@@ -600,7 +600,7 @@ module Fluent
       worker_id_part = if type == :default && (@process_type == :worker0 || @process_type == :workers)
                          @worker_id_part
                        else
-                         "".freeze
+                         ""
                        end
       log_msg = "#{format_time(time)} [#{LEVEL_TEXT[level]}]: #{worker_id_part}"
       if @debug_mode

--- a/lib/fluent/match.rb
+++ b/lib/fluent/match.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Fluentd
 #
@@ -43,7 +45,7 @@ module Fluent
       end
 
       stack = []
-      regex = ['']
+      regex = [+'']
       escape = false
       dot = false
 
@@ -105,7 +107,7 @@ module Fluent
         elsif c == "{"
           # or
           stack.push []
-          regex.push ''
+          regex.push(+'')
 
         elsif c == "}" && !stack.empty?
           stack.last << regex.pop
@@ -113,7 +115,7 @@ module Fluent
 
         elsif c == "," && !stack.empty?
           stack.last << regex.pop
-          regex.push ''
+          regex.push(+'')
 
         elsif /[a-zA-Z0-9_]/.match?(c)
           regex.last << c

--- a/lib/fluent/plugin/buffer/file_chunk.rb
+++ b/lib/fluent/plugin/buffer/file_chunk.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Fluentd
 #
@@ -24,7 +26,7 @@ module Fluent
       class FileChunk < Chunk
         class FileChunkError < StandardError; end
 
-        BUFFER_HEADER = "\xc1\x00".force_encoding(Encoding::ASCII_8BIT).freeze
+        BUFFER_HEADER = (+"\xc1\x00").force_encoding(Encoding::ASCII_8BIT).freeze
 
         ### buffer path user specified : /path/to/directory/user_specified_prefix.*.log
         ### buffer chunk path          : /path/to/directory/user_specified_prefix.b513b61c9791029c2513b61c9791029c2.log

--- a/lib/fluent/plugin/buffer/memory_chunk.rb
+++ b/lib/fluent/plugin/buffer/memory_chunk.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Fluentd
 #
@@ -22,7 +24,7 @@ module Fluent
       class MemoryChunk < Chunk
         def initialize(metadata, compress: :text)
           super
-          @chunk = ''.force_encoding(Encoding::ASCII_8BIT)
+          @chunk = (+'').force_encoding(Encoding::ASCII_8BIT)
           @chunk_bytes = 0
           @adding_bytes = 0
           @adding_size = 0
@@ -68,7 +70,7 @@ module Fluent
 
         def purge
           super
-          @chunk = ''.force_encoding("ASCII-8BIT")
+          @chunk = (+'').force_encoding("ASCII-8BIT")
           @chunk_bytes = @size = @adding_bytes = @adding_size = 0
           true
         end

--- a/lib/fluent/plugin/compressable.rb
+++ b/lib/fluent/plugin/compressable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Fluentd
 #
@@ -57,7 +59,7 @@ module Fluent
       def string_decompress(compressed_data)
         io = StringIO.new(compressed_data)
 
-        out = ''
+        out = +''
         loop do
           gz = Zlib::GzipReader.new(io)
           out << gz.read

--- a/lib/fluent/plugin/formatter_csv.rb
+++ b/lib/fluent/plugin/formatter_csv.rb
@@ -29,7 +29,7 @@ module Fluent
       helpers :record_accessor
 
       config_param :delimiter, default: ',' do |val|
-        ['\t', 'TAB'].include?(val) ? "\t".freeze : val.freeze
+        ['\t', 'TAB'].include?(val) ? "\t" : val.freeze
       end
       config_param :force_quotes, :bool, default: true
       # "array" looks good for type of :fields, but this implementation removes tailing comma

--- a/lib/fluent/plugin/formatter_csv.rb
+++ b/lib/fluent/plugin/formatter_csv.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Fluentd
 #
@@ -50,13 +52,13 @@ module Fluent
         end
 
         @generate_opts = {col_sep: @delimiter, force_quotes: @force_quotes, headers: @fields,
-                          row_sep: @add_newline ? :auto : "".force_encoding(Encoding::ASCII_8BIT)}
+                          row_sep: @add_newline ? :auto : (+"").force_encoding(Encoding::ASCII_8BIT)}
         # Cache CSV object per thread to avoid internal state sharing
         @cache = {}
       end
 
       def format(tag, time, record)
-        csv = (@cache[Thread.current] ||= CSV.new("".force_encoding(Encoding::ASCII_8BIT), **@generate_opts))
+        csv = (@cache[Thread.current] ||= CSV.new((+"").force_encoding(Encoding::ASCII_8BIT), **@generate_opts))
         line = (csv << record).string.dup
         # Need manual cleanup because CSV writer doesn't provide such method.
         csv.rewind
@@ -65,7 +67,7 @@ module Fluent
       end
 
       def format_with_nested_fields(tag, time, record)
-        csv = (@cache[Thread.current] ||= CSV.new("".force_encoding(Encoding::ASCII_8BIT), **@generate_opts))
+        csv = (@cache[Thread.current] ||= CSV.new((+"").force_encoding(Encoding::ASCII_8BIT), **@generate_opts))
         values = @accessors.map { |a| a.call(record) }
         line = (csv << values).string.dup
         # Need manual cleanup because CSV writer doesn't provide such method.

--- a/lib/fluent/plugin/formatter_json.rb
+++ b/lib/fluent/plugin/formatter_json.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Fluentd
 #

--- a/lib/fluent/plugin/formatter_ltsv.rb
+++ b/lib/fluent/plugin/formatter_ltsv.rb
@@ -27,9 +27,9 @@ module Fluent
 
       # http://ltsv.org/
 
-      config_param :delimiter, :string, default: "\t".freeze
-      config_param :label_delimiter, :string, default: ":".freeze
-      config_param :replacement, :string, default: " ".freeze
+      config_param :delimiter, :string, default: "\t"
+      config_param :label_delimiter, :string, default: ":"
+      config_param :replacement, :string, default: " "
       config_param :add_newline, :bool, default: true
 
       def format(tag, time, record)

--- a/lib/fluent/plugin/formatter_ltsv.rb
+++ b/lib/fluent/plugin/formatter_ltsv.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Fluentd
 #
@@ -31,7 +33,7 @@ module Fluent
       config_param :add_newline, :bool, default: true
 
       def format(tag, time, record)
-        formatted = ""
+        formatted = +""
         record.each do |label, value|
           formatted << @delimiter if formatted.length.nonzero?
           formatted << "#{label}#{@label_delimiter}#{value.to_s.gsub(@delimiter, @replacement)}"

--- a/lib/fluent/plugin/formatter_out_file.rb
+++ b/lib/fluent/plugin/formatter_out_file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Fluentd
 #
@@ -43,7 +45,7 @@ module Fluent
       end
 
       def format(tag, time, record)
-        header = ''
+        header = +''
         header << "#{@timef.format(time)}#{@delimiter}" if @output_time
         header << "#{tag}#{@delimiter}" if @output_tag
         "#{header}#{Yajl.dump(record)}#{@newline}"

--- a/lib/fluent/plugin/formatter_out_file.rb
+++ b/lib/fluent/plugin/formatter_out_file.rb
@@ -31,9 +31,9 @@ module Fluent
       config_param :output_tag, :bool, default: true
       config_param :delimiter, default: "\t" do |val|
         case val
-        when /SPACE/i then ' '.freeze
-        when /COMMA/i then ','.freeze
-        else "\t".freeze
+        when /SPACE/i then ' '
+        when /COMMA/i then ','
+        else "\t"
         end
       end
       config_set_default :time_type, :string

--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Fluentd
 #
@@ -56,7 +58,7 @@ module Fluent::Plugin
 
     helpers :parser, :compat_parameters, :event_loop, :server
 
-    EMPTY_GIF_IMAGE = "GIF89a\u0001\u0000\u0001\u0000\x80\xFF\u0000\xFF\xFF\xFF\u0000\u0000\u0000,\u0000\u0000\u0000\u0000\u0001\u0000\u0001\u0000\u0000\u0002\u0002D\u0001\u0000;".force_encoding("UTF-8")
+    EMPTY_GIF_IMAGE = (+"GIF89a\u0001\u0000\u0001\u0000\x80\xFF\u0000\xFF\xFF\xFF\u0000\u0000\u0000,\u0000\u0000\u0000\u0000\u0001\u0000\u0001\u0000\u0000\u0002\u0002D\u0001\u0000;").force_encoding("UTF-8")
 
     desc 'The port to listen to.'
     config_param :port, :integer, default: 9880
@@ -375,7 +377,7 @@ module Fluent::Plugin
       end
 
       def on_message_begin
-        @body = ''
+        @body = +''
       end
 
       def on_headers_complete(headers)
@@ -602,7 +604,7 @@ module Fluent::Plugin
         header['Content-Length'] ||= body.bytesize
         header['Content-Type'] ||= 'text/plain'.freeze
 
-        data = %[HTTP/1.1 #{code}\r\n]
+        data = +"HTTP/1.1 #{code}\r\n"
         header.each_pair {|k,v|
           data << "#{k}: #{v}\r\n"
         }
@@ -613,7 +615,7 @@ module Fluent::Plugin
       end
 
       def send_response_nobody(code, header)
-        data = %[HTTP/1.1 #{code}\r\n]
+        data = +"HTTP/1.1 #{code}\r\n"
         header.each_pair {|k,v|
           data << "#{k}: #{v}\r\n"
         }

--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -195,11 +195,11 @@ module Fluent::Plugin
     end
 
     RES_TEXT_HEADER = {'Content-Type' => 'text/plain'}.freeze
-    RESPONSE_200 = ["200 OK".freeze, RES_TEXT_HEADER, "".freeze].freeze
-    RESPONSE_204 = ["204 No Content".freeze, {}.freeze].freeze
-    RESPONSE_IMG = ["200 OK".freeze, {'Content-Type'=>'image/gif; charset=utf-8'}.freeze, EMPTY_GIF_IMAGE].freeze
-    RES_400_STATUS = "400 Bad Request".freeze
-    RES_500_STATUS = "500 Internal Server Error".freeze
+    RESPONSE_200 = ["200 OK", RES_TEXT_HEADER, ""].freeze
+    RESPONSE_204 = ["204 No Content", {}.freeze].freeze
+    RESPONSE_IMG = ["200 OK", {'Content-Type'=>'image/gif; charset=utf-8'}.freeze, EMPTY_GIF_IMAGE].freeze
+    RES_400_STATUS = "400 Bad Request"
+    RES_500_STATUS = "500 Internal Server Error"
 
     def on_request(path_info, params)
       begin
@@ -306,7 +306,7 @@ module Fluent::Plugin
     def add_params_to_record(record, params)
       if @add_http_headers
         params.each_pair { |k, v|
-          if k.start_with?("HTTP_".freeze)
+          if k.start_with?("HTTP_")
             record[k] = v
           end
         }
@@ -314,7 +314,7 @@ module Fluent::Plugin
 
       if @add_query_params
         params.each_pair { |k, v|
-          if k.start_with?("QUERY_".freeze)
+          if k.start_with?("QUERY_")
             record[k] = v
           end
         }
@@ -422,7 +422,7 @@ module Fluent::Plugin
           end
         }
         if expect
-          if expect == '100-continue'.freeze
+          if expect == '100-continue'
             if !size || size < @body_size_limit
               send_response_nobody("100 Continue", {})
             else
@@ -444,8 +444,8 @@ module Fluent::Plugin
         @body << chunk
       end
 
-      RES_200_STATUS = "200 OK".freeze
-      RES_403_STATUS = "403 Forbidden".freeze
+      RES_200_STATUS = "200 OK"
+      RES_403_STATUS = "403 Forbidden"
 
       # Azure App Service sends GET requests for health checking purpose.
       # Respond with `200 OK` to accommodate it.
@@ -489,11 +489,11 @@ module Fluent::Plugin
       def on_message_complete
         return if closing?
 
-        if @parser.http_method == 'GET'.freeze
+        if @parser.http_method == 'GET'
           return handle_get_request()
         end
 
-        if @parser.http_method == 'OPTIONS'.freeze
+        if @parser.http_method == 'OPTIONS'
           return handle_options_request()
         end
 
@@ -513,9 +513,9 @@ module Fluent::Plugin
         # Decode payload according to the "Content-Encoding" header.
         # For now, we only support 'gzip' and 'deflate'.
         begin
-          if @content_encoding == 'gzip'.freeze
+          if @content_encoding == 'gzip'
             @body = Zlib::GzipReader.new(StringIO.new(@body)).read
-          elsif @content_encoding == 'deflate'.freeze
+          elsif @content_encoding == 'deflate'
             @body = Zlib::Inflate.inflate(@body)
           end
         rescue
@@ -576,7 +576,7 @@ module Fluent::Plugin
         end
 
         if @keep_alive
-          header['Connection'] = 'Keep-Alive'.freeze
+          header['Connection'] = 'Keep-Alive'
           send_response(code, header, body)
         else
           send_response_and_close(code, header, body)
@@ -602,13 +602,13 @@ module Fluent::Plugin
 
       def send_response(code, header, body)
         header['Content-Length'] ||= body.bytesize
-        header['Content-Type'] ||= 'text/plain'.freeze
+        header['Content-Type'] ||= 'text/plain'
 
         data = +"HTTP/1.1 #{code}\r\n"
         header.each_pair {|k,v|
           data << "#{k}: #{v}\r\n"
         }
-        data << "\r\n".freeze
+        data << "\r\n"
         @io.write(data)
 
         @io.write(body)
@@ -619,7 +619,7 @@ module Fluent::Plugin
         header.each_pair {|k,v|
           data << "#{k}: #{v}\r\n"
         }
-        data << "\r\n".freeze
+        data << "\r\n"
         @io.write(data)
       end
 

--- a/lib/fluent/plugin/in_monitor_agent.rb
+++ b/lib/fluent/plugin/in_monitor_agent.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Fluentd
 #
@@ -102,7 +104,7 @@ module Fluent::Plugin
 
       def render_ltsv(obj, code: 200)
         normalized = JSON.parse(obj.to_json)
-        text = ''
+        text = +''
         normalized.each do |hash|
           row = []
           hash.each do |k, v|

--- a/lib/fluent/plugin/in_monitor_agent.rb
+++ b/lib/fluent/plugin/in_monitor_agent.rb
@@ -125,21 +125,21 @@ module Fluent::Plugin
 
       def build_object(opts)
         qs = opts[:query]
-        if tag = qs['tag'.freeze].first
+        if tag = qs['tag'].first
           # ?tag= to search an output plugin by match pattern
           if obj = @agent.plugin_info_by_tag(tag, opts)
             list = [obj]
           else
             list = []
           end
-        elsif plugin_id = (qs['@id'.freeze].first || qs['id'.freeze].first)
+        elsif plugin_id = (qs['@id'].first || qs['id'].first)
           # ?@id= to search a plugin by 'id <plugin_id>' config param
           if obj = @agent.plugin_info_by_id(plugin_id, opts)
             list = [obj]
           else
             list = []
           end
-        elsif plugin_type = (qs['@type'.freeze].first || qs['type'.freeze].first)
+        elsif plugin_type = (qs['@type'].first || qs['type'].first)
           # ?@type= to search plugins by 'type <type>' config param
           list = @agent.plugins_info_by_type(plugin_type, opts)
         else
@@ -160,22 +160,22 @@ module Fluent::Plugin
         # if ?debug=1 is set, set :with_debug_info for get_monitor_info
         # and :pretty_json for render_json_error
         opts = { query: qs }
-        if qs['debug'.freeze].first
+        if qs['debug'].first
           opts[:with_debug_info] = true
           opts[:pretty_json] = true
         end
 
-        if ivars = qs['with_ivars'.freeze].first
+        if ivars = qs['with_ivars'].first
           opts[:ivars] = ivars.split(',')
         end
 
-        if with_config = qs['with_config'.freeze].first
+        if with_config = qs['with_config'].first
           opts[:with_config] = Fluent::Config.bool_value(with_config)
         else
           opts[:with_config] = @agent.include_config
         end
 
-        if with_retry = qs['with_retry'.freeze].first
+        if with_retry = qs['with_retry'].first
           opts[:with_retry] = Fluent::Config.bool_value(with_retry)
         else
           opts[:with_retry] = @agent.include_retry
@@ -388,13 +388,13 @@ module Fluent::Plugin
     def plugin_category(pe)
       case pe
       when Fluent::Plugin::Input
-        'input'.freeze
+        'input'
       when Fluent::Plugin::Output, Fluent::Plugin::MultiOutput, Fluent::Plugin::BareOutput
-        'output'.freeze
+        'output'
       when Fluent::Plugin::Filter
-        'filter'.freeze
+        'filter'
       else
-        'unknown'.freeze
+        'unknown'
       end
     end
 

--- a/lib/fluent/plugin/in_syslog.rb
+++ b/lib/fluent/plugin/in_syslog.rb
@@ -83,7 +83,7 @@ module Fluent::Plugin
     desc 'If true, add source host to event record.'
     config_param :include_source_host, :bool, default: false, deprecated: 'use "source_hostname_key" or "source_address_key" instead.'
     desc 'Specify key of source host when include_source_host is true.'
-    config_param :source_host_key, :string, default: 'source_host'.freeze
+    config_param :source_host_key, :string, default: 'source_host'
     desc 'Enable the option to emit unmatched lines.'
     config_param :emit_unmatched_lines, :bool, default: false
 

--- a/lib/fluent/plugin/in_syslog.rb
+++ b/lib/fluent/plugin/in_syslog.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Fluentd
 #
@@ -187,8 +189,7 @@ module Fluent::Plugin
         send_keepalive_packet: @send_keepalive_packet
       ) do |conn|
         conn.data do |data|
-          buffer = conn.buffer
-          buffer << data
+          buffer = conn.buffer + data
           pos = 0
           if octet_count_frame
             while idx = buffer.index(delimiter, pos)

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Fluentd
 #
@@ -719,7 +721,7 @@ module Fluent::Plugin
 
     def convert_line_to_event(line, es, tail_watcher)
       begin
-        line.chomp!  # remove \n
+        line = line.chomp # remove \n
         @parser.parse(line) { |time, record|
           if time && record
             record[@path_key] ||= tail_watcher.path unless @path_key.nil?
@@ -771,13 +773,13 @@ module Fluent::Plugin
           end
         }
       else
-        lb ||= ''
+        lb ||= +''
         lines.each do |line|
           lb << line
           @parser.parse(lb) { |time, record|
             if time && record
               convert_line_to_event(lb, es, tail_watcher)
-              lb = ''
+              lb = +''
             end
           }
         end
@@ -1010,7 +1012,7 @@ module Fluent::Plugin
           @from_encoding = from_encoding
           @encoding = encoding
           @need_enc = from_encoding != encoding
-          @buffer = ''.force_encoding(from_encoding)
+          @buffer = (+'').force_encoding(from_encoding)
           @eol = "\n".encode(from_encoding).freeze
           @max_line_size = max_line_size
           @skip_current_line = false
@@ -1032,6 +1034,7 @@ module Fluent::Plugin
           # quad-byte encoding to IO#readpartial as the second arguments results in an
           # assertion failure on Ruby < 2.4.0 for unknown reasons.
           orig_encoding = chunk.encoding
+          chunk = chunk.frozen? ? chunk.dup : chunk
           chunk.force_encoding(from_encoding)
           @buffer << chunk
           # Thus the encoding needs to be reverted back here
@@ -1118,7 +1121,7 @@ module Fluent::Plugin
           @receive_lines = receive_lines
           @open_on_every_update = open_on_every_update
           @fifo = FIFO.new(from_encoding || Encoding::ASCII_8BIT, encoding || Encoding::ASCII_8BIT, log, max_line_size)
-          @iobuf = ''.force_encoding('ASCII-8BIT')
+          @iobuf = (+'').force_encoding('ASCII-8BIT')
           @lines = []
           @io = nil
           @notify_mutex = Mutex.new

--- a/lib/fluent/plugin/out_http.rb
+++ b/lib/fluent/plugin/out_http.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Fluentd
 #
@@ -202,7 +204,7 @@ module Fluent::Plugin
     end
 
     def format_json_array(tag, time, record)
-      @formatter.format(tag, time, record) << ","
+      @formatter.format(tag, time, record) + ","
     end
 
     def write(chunk)

--- a/lib/fluent/plugin/parser_csv.rb
+++ b/lib/fluent/plugin/parser_csv.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Fluentd
 #
@@ -63,7 +65,7 @@ module Fluent
       # This method avoids the overhead of CSV.parse_line for typical patterns
       def parse_fast_internal(text)
         record = {}
-        text.chomp!
+        text = text.chomp
 
         return record if text.empty?
 

--- a/lib/fluent/plugin_helper/compat_parameters.rb
+++ b/lib/fluent/plugin_helper/compat_parameters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Fluentd
 #

--- a/lib/fluent/plugin_helper/http_server/server.rb
+++ b/lib/fluent/plugin_helper/http_server/server.rb
@@ -78,7 +78,7 @@ module Fluent
         HttpServer::Methods::ALL.map { |e| e.downcase.to_sym }.each do |name|
           define_method(name) do |path, app = nil, &block|
             unless path.end_with?('/')
-              path << '/'
+              path += '/'
             end
 
             if (block && app) || (!block && !app)

--- a/lib/fluent/plugin_helper/server.rb
+++ b/lib/fluent/plugin_helper/server.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Fluentd
 #
@@ -465,7 +467,7 @@ module Fluent
         def initialize(sock)
           super("tcp", sock, ENABLED_EVENTS)
           @peeraddr = (@sock.peeraddr rescue PEERADDR_FAILED)
-          @buffer = ''
+          @buffer = +''
         end
 
         def write(data)
@@ -675,7 +677,7 @@ module Fluent
             socket_option_setter.call(sock)
             @_handler_socket = OpenSSL::SSL::SSLSocket.new(sock, context)
             @_handler_socket.sync_close = true
-            @_handler_write_buffer = ''.force_encoding('ascii-8bit')
+            @_handler_write_buffer = (+'').force_encoding('ascii-8bit')
             @_handler_accepted = false
             super(@_handler_socket)
 

--- a/lib/fluent/test/output_test.rb
+++ b/lib/fluent/test/output_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Fluentd
 #
@@ -116,7 +118,7 @@ module Fluent
       end
 
       def expect_format(str)
-        (@expected_buffer ||= '') << str
+        (@expected_buffer ||= +'') << str
       end
 
       def run(&block)
@@ -124,7 +126,7 @@ module Fluent
         super {
           block.call if block
 
-          buffer = ''
+          buffer = +''
           lines = {}
           # v0.12 TimeSlicedOutput doesn't call #format_stream
           @entries.each do |time, record|

--- a/test/command/test_ctl.rb
+++ b/test/command/test_ctl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 
 require 'test-unit'
@@ -28,7 +30,7 @@ class TestFluentdCtl < ::Test::Unit::TestCase
 
     if Fluent.windows?
       event_name = "fluentd_54321"
-      event_name << "_#{event_suffix}" unless event_suffix.empty?
+      event_name += "_#{event_suffix}" unless event_suffix.empty?
       assert_win32_event(event_name, command, "54321")
     else
       got_signal = false
@@ -49,7 +51,7 @@ class TestFluentdCtl < ::Test::Unit::TestCase
 
     command, event_suffix = data
     event_name = "testfluentdwinsvc"
-    event_name << "_#{event_suffix}" unless event_suffix.empty?
+    event_name += "_#{event_suffix}" unless event_suffix.empty?
 
     assert_win32_event(event_name, command, "testfluentdwinsvc")
   end

--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 
 # require 'fluent/command/fluentd'
@@ -132,7 +134,7 @@ class TestFluentdCommand < ::Test::Unit::TestCase
     matched = false
     matched_wrongly = false
     assert_error_msg = ""
-    stdio_buf = ""
+    stdio_buf = +""
     begin
       execute_command(cmdline, @tmp_dir, env) do |pid, stdout|
         begin
@@ -197,6 +199,7 @@ class TestFluentdCommand < ::Test::Unit::TestCase
                             lines.any?{|line| line.include?(ptn) }
                           end
         if matched_wrongly
+          assert_error_msg = assert_error_msg.frozen? ? assert_error_msg.dup : assert_error_msg
           assert_error_msg << "\n" unless assert_error_msg.empty?
           assert_error_msg << "pattern exists in logs wrongly: #{ptn}"
         end
@@ -214,7 +217,7 @@ class TestFluentdCommand < ::Test::Unit::TestCase
     matched = false
     running = false
     assert_error_msg = "failed to start correctly"
-    stdio_buf = ""
+    stdio_buf = +""
     begin
       execute_command(cmdline) do |pid, stdout|
         begin
@@ -532,7 +535,7 @@ CONF
 
   sub_test_case 'configuration to load plugin file with syntax error' do
     test 'failed to start' do
-      script =  "require 'fluent/plugin/input'\n"
+      script = +"require 'fluent/plugin/input'\n"
       script << "module Fluent::Plugin\n"
       script << "  class BuggyInput < Input\n"
       script << "    Fluent::Plugin.register_input('buggy', self)\n"
@@ -566,7 +569,7 @@ CONF
 
   sub_test_case 'configuration to load plugin which raises unrecoverable error in #start' do
     test 'failed to start' do
-      script =  "require 'fluent/plugin/input'\n"
+      script = +"require 'fluent/plugin/input'\n"
       script << "require 'fluent/error'\n"
       script << "module Fluent::Plugin\n"
       script << "  class CrashingInput < Input\n"
@@ -701,7 +704,7 @@ CONF
     end
 
     test 'failed to start workers when configured plugins do not support multi worker configuration' do
-      script =  "require 'fluent/plugin/input'\n"
+      script = +"require 'fluent/plugin/input'\n"
       script << "module Fluent::Plugin\n"
       script << "  class SingleInput < Input\n"
       script << "    Fluent::Plugin.register_input('single', self)\n"

--- a/test/config/test_configurable.rb
+++ b/test/config/test_configurable.rb
@@ -535,7 +535,7 @@ module Fluent::Config
 
         test 'can accept frozen string' do
           b2 = ConfigurableSpec::Base2.new
-          assert_instance_of(ConfigurableSpec::Base2, b2.configure(config_element("", "", {"name1" => "t1".freeze, "name5" => "t5", "opt3" => "a"})))
+          assert_instance_of(ConfigurableSpec::Base2, b2.configure(config_element("", "", {"name1" => "t1", "name5" => "t5", "opt3" => "a"})))
         end
 
         test 'raise errors without any specifications for param without defaults' do

--- a/test/config/test_configurable.rb
+++ b/test/config/test_configurable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/configurable'
 require 'fluent/config/element'

--- a/test/config/test_types.rb
+++ b/test/config/test_types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 require 'fluent/config/types'
 

--- a/test/plugin/in_tail/test_fifo.rb
+++ b/test/plugin/in_tail/test_fifo.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../helper'
 
 require 'fluent/plugin/in_tail'
@@ -57,7 +59,7 @@ class IntailFIFO < Test::Unit::TestCase
         lines = []
         fifo.read_lines(lines)
         assert_equal Encoding::ASCII_8BIT, lines[0].encoding
-        assert_equal ["てすと\n", "てすと\n", "てすと\n"].map { |e| e.force_encoding(Encoding::ASCII_8BIT) }, lines
+        assert_equal ["てすと\n", "てすと\n", "てすと\n"].map { |e| (+e).force_encoding(Encoding::ASCII_8BIT) }, lines
       end
 
       test 'replaces character with ? when convert error happens' do
@@ -67,7 +69,7 @@ class IntailFIFO < Test::Unit::TestCase
         lines = []
         fifo.read_lines(lines)
         assert_equal Encoding::ASCII_8BIT, lines[0].encoding
-        assert_equal ["???\n", "???\n", "???\n"].map { |e| e.force_encoding(Encoding::ASCII_8BIT) }, lines
+        assert_equal ["???\n", "???\n", "???\n"].map { |e| (+e).force_encoding(Encoding::ASCII_8BIT) }, lines
       end
     end
 
@@ -121,7 +123,7 @@ class IntailFIFO < Test::Unit::TestCase
       lines = []
 
       input_texts.each do |text|
-        fifo << text.force_encoding(Encoding::ASCII_8BIT)
+        fifo << (+text).force_encoding(Encoding::ASCII_8BIT)
         fifo.read_lines(lines)
         # The size of remaining buffer (i.e. a line still not having EOL) must not exceed max_line_size.
         assert { fifo.buffer.bytesize <= max_line_size }

--- a/test/plugin/in_tail/test_io_handler.rb
+++ b/test/plugin/in_tail/test_io_handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../helper'
 
 require 'fluent/plugin/in_tail'
@@ -40,13 +42,13 @@ class IntailIOHandlerTest < Test::Unit::TestCase
     update_pos = 0
 
     stub(watcher).pe do
-      pe = 'position_file'
+      pe = +'position_file'
       stub(pe).read_pos { 0 }
       stub(pe).update_pos { |val| update_pos = val }
       pe
     end
 
-    returned_lines = ''
+    returned_lines = +''
     r = Fluent::Plugin::TailInput::TailWatcher::IOHandler.new(watcher, path: @file.path, read_lines_limit: 100, read_bytes_limit_per_second: -1, log: $log, open_on_every_update: false, metrics: @metrics) do |lines, _watcher|
       returned_lines << lines.join
       true
@@ -72,13 +74,13 @@ class IntailIOHandlerTest < Test::Unit::TestCase
 
       watcher = create_watcher
       stub(watcher).pe do
-        pe = 'position_file'
+        pe = +'position_file'
         stub(pe).read_pos { 0 }
         stub(pe).update_pos { |val| update_pos = val }
         pe
       end
 
-      returned_lines = ''
+      returned_lines = +''
       r = Fluent::Plugin::TailInput::TailWatcher::IOHandler.new(watcher, path: @file.path, read_lines_limit: 100, read_bytes_limit_per_second: -1, log: $log, open_on_every_update: true, metrics: @metrics) do |lines, _watcher|
         returned_lines << lines.join
         true
@@ -103,7 +105,7 @@ class IntailIOHandlerTest < Test::Unit::TestCase
 
       watcher = create_watcher
       stub(watcher).pe do
-        pe = 'position_file'
+        pe = +'position_file'
         stub(pe).read_pos { 0 }
         stub(pe).update_pos { |val| update_pos = val }
         pe
@@ -130,7 +132,7 @@ class IntailIOHandlerTest < Test::Unit::TestCase
 
       watcher = create_watcher
       stub(watcher).pe do
-        pe = 'position_file'
+        pe = +'position_file'
         stub(pe).read_pos { 0 }
         stub(pe).update_pos { |val| update_pos = val }
         pe
@@ -163,7 +165,7 @@ class IntailIOHandlerTest < Test::Unit::TestCase
 
       watcher = create_watcher
       stub(watcher).pe do
-        pe = 'position_file'
+        pe = +'position_file'
         stub(pe).read_pos {0}
         stub(pe).update_pos { |val| update_pos = val }
         pe
@@ -191,7 +193,7 @@ class IntailIOHandlerTest < Test::Unit::TestCase
 
       watcher = create_watcher
       stub(watcher).pe do
-        pe = 'position_file'
+        pe = +'position_file'
         stub(pe).read_pos { pos }
         stub(pe).update_pos { |val| pos = val }
         pe
@@ -242,7 +244,7 @@ class IntailIOHandlerTest < Test::Unit::TestCase
 
       watcher = create_watcher
       stub(watcher).pe do
-        pe = 'position_file'
+        pe = +'position_file'
         stub(pe).read_pos { pos }
         stub(pe).update_pos { |val| pos = val }
         pe

--- a/test/plugin/out_forward/test_connection_manager.rb
+++ b/test/plugin/out_forward/test_connection_manager.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../helper'
 require 'fluent/test/driver/output'
 require 'flexmock/test_unit'
@@ -13,7 +15,7 @@ class ConnectionManager < Test::Unit::TestCase
         cm = Fluent::Plugin::ForwardOutput::ConnectionManager.new(
           log: $log,
           secure: false,
-          connection_factory: -> (_, _, _) { sock = 'sock'; mock(sock).close.never; sock },
+          connection_factory: -> (_, _, _) { sock = +'sock'; mock(sock).close.never; sock },
           socket_cache: nil,
         )
 
@@ -28,7 +30,7 @@ class ConnectionManager < Test::Unit::TestCase
           log: $log,
           secure: false,
           connection_factory: -> (_, _, _) {
-            sock = 'sock'
+            sock = +'sock'
             mock(sock).close.once
             mock(sock).close_write.once
             sock
@@ -47,7 +49,7 @@ class ConnectionManager < Test::Unit::TestCase
         cm = Fluent::Plugin::ForwardOutput::ConnectionManager.new(
           log: $log,
           secure: true,
-          connection_factory: -> (_, _, _) { sock = 'sock'; mock(sock).close.never; sock },
+          connection_factory: -> (_, _, _) { sock = +'sock'; mock(sock).close.never; sock },
           socket_cache: nil,
         )
 
@@ -58,7 +60,7 @@ class ConnectionManager < Test::Unit::TestCase
       end
 
       test 'when passed ack' do
-        sock = 'sock'
+        sock = +'sock'
         cm = Fluent::Plugin::ForwardOutput::ConnectionManager.new(
           log: $log,
           secure: false,
@@ -71,7 +73,7 @@ class ConnectionManager < Test::Unit::TestCase
         )
 
         mock.proxy(cm).connect_keepalive(anything).never
-        ack = mock('ack').enqueue(sock).once.subject
+        ack = mock(+'ack').enqueue(sock).once.subject
         cm.connect(host: 'host', port: 1234, hostname: 'hostname', ack: ack) do |sock, ri|
           assert_equal(sock, 'sock')
           assert_equal(ri.state, :established)
@@ -87,7 +89,7 @@ class ConnectionManager < Test::Unit::TestCase
         cm = Fluent::Plugin::ForwardOutput::ConnectionManager.new(
           log: $log,
           secure: false,
-          connection_factory: -> (_, _, _) { sock = 'sock'; mock(sock).close.never; sock },
+          connection_factory: -> (_, _, _) { sock = +'sock'; mock(sock).close.never; sock },
           socket_cache: cache,
         )
 
@@ -105,7 +107,7 @@ class ConnectionManager < Test::Unit::TestCase
         cm = Fluent::Plugin::ForwardOutput::ConnectionManager.new(
           log: $log,
           secure: false,
-          connection_factory: -> (_, _, _) { sock = 'sock'; mock(sock); sock },
+          connection_factory: -> (_, _, _) { sock = +'sock'; mock(sock); sock },
           socket_cache: cache,
         )
 
@@ -120,8 +122,8 @@ class ConnectionManager < Test::Unit::TestCase
       test 'does not call dec_ref when ack is passed' do
         cache = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
         mock(cache).checkin('sock').never
-        sock = 'sock'
-        ack = stub('ack').enqueue(sock).once.subject
+        sock = +'sock'
+        ack = stub(+'ack').enqueue(sock).once.subject
 
         cm = Fluent::Plugin::ForwardOutput::ConnectionManager.new(
           log: $log,

--- a/test/plugin/out_forward/test_handshake_protocol.rb
+++ b/test/plugin/out_forward/test_handshake_protocol.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../helper'
 require 'flexmock/test_unit'
 
@@ -12,7 +14,7 @@ class HandshakeProtocolTest < Test::Unit::TestCase
       handshake = Fluent::Plugin::ForwardOutput::HandshakeProtocol.new(log: $log, hostname: hostname, shared_key: 'shared_key', password: nil, username: nil)
       ri = Fluent::Plugin::ForwardOutput::ConnectionManager::RequestInfo.new(:helo)
 
-      sock = StringIO.new('')
+      sock = StringIO.new(+'')
       handshake.invoke(sock, ri, ['HELO', {}])
 
       assert_equal(ri.state, :pingpong)
@@ -34,7 +36,7 @@ class HandshakeProtocolTest < Test::Unit::TestCase
       handshake = Fluent::Plugin::ForwardOutput::HandshakeProtocol.new(log: $log, hostname: hostname, shared_key: 'shared_key', password: pass, username: username)
       ri = Fluent::Plugin::ForwardOutput::ConnectionManager::RequestInfo.new(:helo)
 
-      sock = StringIO.new('')
+      sock = StringIO.new(+'')
       handshake.invoke(sock, ri, ['HELO', { 'auth' => 'auth' }])
 
       assert_equal(ri.state, :pingpong)
@@ -57,7 +59,7 @@ class HandshakeProtocolTest < Test::Unit::TestCase
       handshake = Fluent::Plugin::ForwardOutput::HandshakeProtocol.new(log: $log, hostname: 'hostname', shared_key: 'shared_key', password: nil, username: nil)
       ri = Fluent::Plugin::ForwardOutput::ConnectionManager::RequestInfo.new(:helo)
 
-      sock = StringIO.new('')
+      sock = StringIO.new(+'')
       assert_raise(Fluent::Plugin::ForwardOutput::HeloError) do
         handshake.invoke(sock, ri, msg)
       end

--- a/test/plugin/test_bare_output.rb
+++ b/test/plugin/test_bare_output.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/plugin/bare_output'
 require 'fluent/event'

--- a/test/plugin/test_base.rb
+++ b/test/plugin/test_base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'tmpdir'
 require 'fluent/plugin/base'

--- a/test/plugin/test_buf_file.rb
+++ b/test/plugin/test_buf_file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/plugin/buf_file'
 require 'fluent/plugin/output'

--- a/test/plugin/test_buffer_chunk.rb
+++ b/test/plugin/test_buffer_chunk.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/plugin/buffer/chunk'
 
@@ -83,7 +85,7 @@ class BufferChunkTest < Test::Unit::TestCase
     attr_accessor :data
     def initialize(meta)
       super
-      @data = ''
+      @data = +''
     end
     def size
       @data.size

--- a/test/plugin/test_buffer_file_chunk.rb
+++ b/test/plugin/test_buffer_file_chunk.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/plugin/buffer/file_chunk'
 require 'fluent/plugin/compressable'
@@ -212,7 +214,7 @@ class BufferFileChunkTest < Test::Unit::TestCase
     end
 
     test 'has its contents in binary (ascii-8bit)' do
-      data1 = "aaa bbb ccc".force_encoding('utf-8')
+      data1 = (+"aaa bbb ccc").force_encoding('utf-8')
       @c.append([data1])
       @c.commit
       assert_equal Encoding::ASCII_8BIT, @c.instance_eval{ @chunk.external_encoding }

--- a/test/plugin/test_buffer_file_single_chunk.rb
+++ b/test/plugin/test_buffer_file_single_chunk.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/plugin/buffer/file_single_chunk'
 require 'fluent/plugin/compressable'
@@ -178,7 +180,7 @@ class BufferFileSingleChunkTest < Test::Unit::TestCase
     end
 
     test 'has its contents in binary (ascii-8bit)' do
-      data1 = "aaa bbb ccc".force_encoding('utf-8')
+      data1 = (+"aaa bbb ccc").force_encoding('utf-8')
       @c.append([data1])
       @c.commit
       assert_equal Encoding::ASCII_8BIT, @c.instance_eval{ @chunk.external_encoding }

--- a/test/plugin/test_buffer_memory_chunk.rb
+++ b/test/plugin/test_buffer_memory_chunk.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/plugin/buffer/memory_chunk'
 require 'fluent/plugin/compressable'
@@ -82,7 +84,7 @@ class BufferMemoryChunkTest < Test::Unit::TestCase
   end
 
   test 'has its contents in binary (ascii-8bit)' do
-    data1 = "aaa bbb ccc".force_encoding('utf-8')
+    data1 = (+"aaa bbb ccc").force_encoding('utf-8')
     @c.append([data1])
     @c.commit
     assert_equal Encoding::ASCII_8BIT, @c.instance_eval{ @chunk.encoding }

--- a/test/plugin/test_filter.rb
+++ b/test/plugin/test_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/plugin/filter'
 require 'fluent/event'

--- a/test/plugin/test_filter_grep.rb
+++ b/test/plugin/test_filter_grep.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/plugin/filter_grep'
 require 'fluent/test/driver/filter'
@@ -329,7 +331,7 @@ class GrepFilterTest < Test::Unit::TestCase
 
       test "don't raise an exception" do
         assert_nothing_raised { 
-          filter(%[regexp1 message WARN], ["\xff".force_encoding('UTF-8')])
+          filter(%[regexp1 message WARN], [(+"\xff").force_encoding('UTF-8')])
         }
       end
     end

--- a/test/plugin/test_filter_parser.rb
+++ b/test/plugin/test_filter_parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'timecop'
 require 'fluent/test/driver/filter'
@@ -575,7 +577,7 @@ class ParserFilterTest < Test::Unit::TestCase
     replace_invalid_sequence true
   ]
   def test_filter_invalid_byte
-    invalid_utf8 = "\xff".force_encoding('UTF-8')
+    invalid_utf8 = (+"\xff").force_encoding('UTF-8')
 
     d = create_driver(CONFIG_NOT_REPLACE)
     d.run do
@@ -594,7 +596,7 @@ class ParserFilterTest < Test::Unit::TestCase
     filtered = d.filtered
     assert_equal 1, filtered.length
     assert_nil filtered[0][1]['data']
-    assert_equal '?'.force_encoding('UTF-8'), filtered[0][1]['message']
+    assert_equal (+'?').force_encoding('UTF-8'), filtered[0][1]['message']
 
     d = create_driver(CONFIG_INVALID_BYTE + %[reserve_data yes])
     assert_nothing_raised {
@@ -605,9 +607,9 @@ class ParserFilterTest < Test::Unit::TestCase
     filtered = d.filtered
     assert_equal 1, filtered.length
     assert_equal invalid_utf8, filtered[0][1]['data']
-    assert_equal '?'.force_encoding('UTF-8'), filtered[0][1]['message']
+    assert_equal (+'?').force_encoding('UTF-8'), filtered[0][1]['message']
 
-    invalid_ascii = "\xff".force_encoding('US-ASCII')
+    invalid_ascii = (+"\xff").force_encoding('US-ASCII')
     d = create_driver(CONFIG_INVALID_BYTE)
     assert_nothing_raised {
       d.run do
@@ -617,7 +619,7 @@ class ParserFilterTest < Test::Unit::TestCase
     filtered = d.filtered
     assert_equal 1, filtered.length
     assert_nil filtered[0][1]['data']
-    assert_equal '?'.force_encoding('US-ASCII'), filtered[0][1]['message']
+    assert_equal (+'?').force_encoding('US-ASCII'), filtered[0][1]['message']
   end
 
   CONFIG_NOT_IGNORE = %[

--- a/test/plugin/test_filter_stdout.rb
+++ b/test/plugin/test_filter_stdout.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/test/driver/filter'
 require 'fluent/plugin/filter_stdout'

--- a/test/plugin/test_formatter_json.rb
+++ b/test/plugin/test_formatter_json.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'json'
 require 'fluent/test/driver/formatter'

--- a/test/plugin/test_formatter_ltsv.rb
+++ b/test/plugin/test_formatter_ltsv.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/test/driver/formatter'
 require 'fluent/plugin/formatter_ltsv'

--- a/test/plugin/test_formatter_single_value.rb
+++ b/test/plugin/test_formatter_single_value.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/test/driver/formatter'
 require 'fluent/plugin/formatter_single_value'

--- a/test/plugin/test_formatter_tsv.rb
+++ b/test/plugin/test_formatter_tsv.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/test/driver/formatter'
 require 'fluent/plugin/formatter_tsv'

--- a/test/plugin/test_in_forward.rb
+++ b/test/plugin/test_in_forward.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 
 require 'fluent/test/driver/input'
@@ -397,7 +399,7 @@ class ForwardInputTest < Test::Unit::TestCase
       ]
 
       d.run(expect_records: records.length, timeout: 20) do
-        entries = ''
+        entries = +''
         records.each {|_tag, _time, record|
           packer(entries).write([_time, record]).flush
         }
@@ -425,7 +427,7 @@ class ForwardInputTest < Test::Unit::TestCase
       ]
 
       @d.run(expect_records: records.length, timeout: 20) do
-        entries = ''
+        entries = +''
         records.each {|_tag, _time, record|
           packer(entries).write([_time, record]).flush
         }
@@ -457,7 +459,7 @@ class ForwardInputTest < Test::Unit::TestCase
       ]
 
       d.run(expect_records: records.length, timeout: 20) do
-        entries = ''
+        entries = +''
         records.each {|tag, _time, record|
           packer(entries).write([_time, record]).flush
         }
@@ -493,7 +495,7 @@ class ForwardInputTest < Test::Unit::TestCase
         # These entries are skipped
         entries << ['invalid time', {'a' => 3}] << [time, 'invalid record']
 
-        packed_entries = ''
+        packed_entries = +''
         entries.each { |_time, record|
           packer(packed_entries).write([_time, record]).flush
         }
@@ -518,7 +520,7 @@ class ForwardInputTest < Test::Unit::TestCase
       ]
 
       # create compressed entries
-      entries = ''
+      entries = +''
       events.each do |_tag, _time, record|
         v = [_time, record].to_msgpack
         entries << compress(v)
@@ -545,7 +547,7 @@ class ForwardInputTest < Test::Unit::TestCase
       ]
 
       # create compressed entries
-      entries = ''
+      entries = +''
       events.each do |_tag, _time, record|
         v = [_time, record].to_msgpack
         entries << compress(v)
@@ -785,7 +787,7 @@ class ForwardInputTest < Test::Unit::TestCase
       expected_acks = []
 
       d.run(expect_records: events.size) do
-        entries = ''
+        entries = +''
         events.each {|_tag, _time,record|
           [time, record].to_msgpack(entries)
         }
@@ -928,7 +930,7 @@ class ForwardInputTest < Test::Unit::TestCase
       ]
 
       d.run(expect_records: events.size, timeout: 20) do
-        entries = ''
+        entries = +''
         events.each {|tag, _time, record|
           [_time, record].to_msgpack(entries)
         }
@@ -988,7 +990,7 @@ class ForwardInputTest < Test::Unit::TestCase
   # '' : socket is disconnected without any data
   # nil: socket read timeout
   def read_data(io, timeout, &block)
-    res = ''
+    res = +''
     select_timeout = 0.5
     clock_id = Process::CLOCK_MONOTONIC_RAW rescue Process::CLOCK_MONOTONIC
     timeout_at = Process.clock_gettime(clock_id) + timeout
@@ -999,7 +1001,7 @@ class ForwardInputTest < Test::Unit::TestCase
         if IO.select([io], nil, nil, select_timeout)
           io_activated = true
           buf = io.readpartial(2048)
-          res ||= ''
+          res ||= +''
           res << buf
 
           break if block.call(res)
@@ -1129,7 +1131,7 @@ class ForwardInputTest < Test::Unit::TestCase
     )
     test 'packed forward protocol' do |keys|
       execute_test_with_source_hostname_key(*keys) { |events|
-        entries = ''
+        entries = +''
         events.each { |tag, time, record|
           Fluent::MessagePackFactory.msgpack_packer(entries).write([time, record]).flush
         }

--- a/test/plugin/test_in_sample.rb
+++ b/test/plugin/test_in_sample.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/test/driver/input'
 require 'fluent/plugin/in_sample'

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/test/driver/input'
 require 'fluent/plugin/in_tail'
@@ -1165,7 +1167,7 @@ class TailInputTest < Test::Unit::TestCase
         "encoding" => "utf-8"
       })
     d = create_driver(conf)
-    cp932_message = "\x82\xCD\x82\xEB\x81\x5B\x82\xED\x81\x5B\x82\xE9\x82\xC7".force_encoding(Encoding::CP932)
+    cp932_message = (+"\x82\xCD\x82\xEB\x81\x5B\x82\xED\x81\x5B\x82\xE9\x82\xC7").force_encoding(Encoding::CP932)
     utf8_message = cp932_message.encode(Encoding::UTF_8)
 
     d.run(expect_emits: 1) do
@@ -1375,8 +1377,8 @@ class TailInputTest < Test::Unit::TestCase
                })
       d = create_driver(conf)
 
-      cp932_message = "s \x82\xCD\x82\xEB\x81\x5B\x82\xED\x81\x5B\x82\xE9\x82\xC7".force_encoding(Encoding::CP932)
-      utf8_message = "\x82\xCD\x82\xEB\x81\x5B\x82\xED\x81\x5B\x82\xE9\x82\xC7".encode(Encoding::UTF_8, Encoding::CP932)
+      cp932_message = (+"s \x82\xCD\x82\xEB\x81\x5B\x82\xED\x81\x5B\x82\xE9\x82\xC7").force_encoding(Encoding::CP932)
+      utf8_message = (+"\x82\xCD\x82\xEB\x81\x5B\x82\xED\x81\x5B\x82\xE9\x82\xC7").encode(Encoding::UTF_8, Encoding::CP932)
       d.run(expect_emits: 1) do
         Fluent::FileWrapper.open("#{@tmp_dir}/tail.txt", "w:cp932") { |f|
           f.puts cp932_message

--- a/test/plugin/test_in_udp.rb
+++ b/test/plugin/test_in_udp.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/test/driver/input'
 require 'fluent/plugin/in_udp'

--- a/test/plugin/test_in_unix.rb
+++ b/test/plugin/test_in_unix.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/test/driver/input'
 require 'fluent/plugin/in_unix'
@@ -115,7 +117,7 @@ class UnixInputTest < Test::Unit::TestCase
     ]
 
     @d.run(expect_records: records.length, timeout: 20) do
-      entries = ''
+      entries = +''
       records.each {|_tag, _time, record|
         packer(entries).write([_time, record]).flush
       }

--- a/test/plugin/test_input.rb
+++ b/test/plugin/test_input.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/plugin/input'
 require 'flexmock/test_unit'

--- a/test/plugin/test_multi_output.rb
+++ b/test/plugin/test_multi_output.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/plugin/multi_output'
 require 'fluent/event'

--- a/test/plugin/test_out_file.rb
+++ b/test/plugin/test_out_file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/test/driver/output'
 require 'fluent/plugin/out_file'
@@ -400,7 +402,7 @@ class FileOutputTest < Test::Unit::TestCase
   def check_gzipped_result(path, expect)
     # Zlib::GzipReader has a bug of concatenated file: https://bugs.ruby-lang.org/issues/9790
     # Following code from https://www.ruby-forum.com/topic/971591#979520
-    result = ''
+    result = +''
     File.open(path, "rb") { |io|
       loop do
         gzr = Zlib::GzipReader.new(StringIO.new(io.read))
@@ -579,7 +581,7 @@ class FileOutputTest < Test::Unit::TestCase
         </buffer>
       ]
       if compression
-        config << "        compress gz"
+        config += "        compress gz"
       end
       d = create_driver(config)
       d.run(default_tag: 'test'){
@@ -589,7 +591,7 @@ class FileOutputTest < Test::Unit::TestCase
       d.instance.last_written_path
     }
 
-    log_file_name = "out_file_test.20110102.log"
+    log_file_name = +"out_file_test.20110102.log"
     if compression
       log_file_name << ".gz"
     end

--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/test/driver/output'
 require 'fluent/plugin/out_forward'

--- a/test/plugin/test_out_secondary_file.rb
+++ b/test/plugin/test_out_secondary_file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'time'
 require 'fileutils'
@@ -113,7 +115,7 @@ class FileOutputSecondaryTest < Test::Unit::TestCase
   def check_gzipped_result(path, expect)
     # Zlib::GzipReader has a bug of concatenated file: https://bugs.ruby-lang.org/issues/9790
     # Following code from https://www.ruby-forum.com/topic/971591#979520
-    result = ""
+    result = +""
     waiting(10) do
       # we can expect that GzipReader#read can wait unflushed raw data of `io` on disk
       File.open(path, "rb") { |io|

--- a/test/plugin/test_out_stdout.rb
+++ b/test/plugin/test_out_stdout.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/test/driver/output'
 require 'fluent/plugin/out_stdout'

--- a/test/plugin/test_output.rb
+++ b/test/plugin/test_output.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/plugin/output'
 require 'fluent/plugin/buffer'

--- a/test/plugin/test_output_as_buffered.rb
+++ b/test/plugin/test_output_as_buffered.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/plugin/output'
 require 'fluent/plugin/buffer'

--- a/test/plugin/test_output_as_buffered_backup.rb
+++ b/test/plugin/test_output_as_buffered_backup.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/plugin/output'
 require 'fluent/plugin/buffer'

--- a/test/plugin/test_output_as_buffered_compress.rb
+++ b/test/plugin/test_output_as_buffered_compress.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/plugin/output'
 require 'fluent/plugin/buffer'

--- a/test/plugin/test_output_as_buffered_overflow.rb
+++ b/test/plugin/test_output_as_buffered_overflow.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/plugin/output'
 require 'fluent/plugin/buffer'

--- a/test/plugin/test_output_as_buffered_retries.rb
+++ b/test/plugin/test_output_as_buffered_retries.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/plugin/output'
 require 'fluent/plugin/buffer'

--- a/test/plugin/test_output_as_buffered_secondary.rb
+++ b/test/plugin/test_output_as_buffered_secondary.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/plugin/output'
 require 'fluent/plugin/buffer'

--- a/test/plugin/test_owned_by.rb
+++ b/test/plugin/test_owned_by.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/plugin/base'
 require 'fluent/plugin/input'

--- a/test/plugin/test_parser.rb
+++ b/test/plugin/test_parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/test/driver/parser'
 require 'fluent/plugin/parser'

--- a/test/plugin/test_parser_apache.rb
+++ b/test/plugin/test_parser_apache.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/test/driver/parser'
 require 'fluent/plugin/parser_apache'

--- a/test/plugin/test_parser_csv.rb
+++ b/test/plugin/test_parser_csv.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/test/driver/parser'
 require 'fluent/plugin/parser_csv'

--- a/test/plugin/test_parser_json.rb
+++ b/test/plugin/test_parser_json.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/test/driver/parser'
 require 'fluent/plugin/parser'

--- a/test/plugin/test_parser_labeled_tsv.rb
+++ b/test/plugin/test_parser_labeled_tsv.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/test/driver/parser'
 require 'fluent/plugin/parser'

--- a/test/plugin/test_parser_multiline.rb
+++ b/test/plugin/test_parser_multiline.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/test/driver/parser'
 require 'fluent/plugin/parser'

--- a/test/plugin/test_parser_none.rb
+++ b/test/plugin/test_parser_none.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/test/driver/parser'
 require 'fluent/plugin/parser'

--- a/test/plugin/test_parser_regexp.rb
+++ b/test/plugin/test_parser_regexp.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/test/driver/parser'
 require 'fluent/plugin/parser'

--- a/test/plugin/test_parser_syslog.rb
+++ b/test/plugin/test_parser_syslog.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/test/driver/parser'
 require 'fluent/plugin/parser'

--- a/test/plugin/test_parser_tsv.rb
+++ b/test/plugin/test_parser_tsv.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/test/driver/parser'
 require 'fluent/plugin/parser_tsv'

--- a/test/plugin/test_sd_srv.rb
+++ b/test/plugin/test_sd_srv.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/plugin/sd_srv'
 require 'fileutils'

--- a/test/plugin_helper/service_discovery/test_manager.rb
+++ b/test/plugin_helper/service_discovery/test_manager.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../helper'
 require 'fluent/plugin_helper/service_discovery/manager'
 

--- a/test/plugin_helper/test_compat_parameters.rb
+++ b/test/plugin_helper/test_compat_parameters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/plugin_helper/compat_parameters'
 require 'fluent/plugin/input'

--- a/test/plugin_helper/test_extract.rb
+++ b/test/plugin_helper/test_extract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/plugin_helper/extract'
 require 'fluent/time'

--- a/test/plugin_helper/test_formatter.rb
+++ b/test/plugin_helper/test_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/plugin_helper/formatter'
 require 'fluent/plugin/base'

--- a/test/plugin_helper/test_http_server_helper.rb
+++ b/test/plugin_helper/test_http_server_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'flexmock/test_unit'
 require 'fluent/plugin_helper/http_server'

--- a/test/plugin_helper/test_inject.rb
+++ b/test/plugin_helper/test_inject.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/plugin_helper/inject'
 require 'fluent/plugin/output'

--- a/test/plugin_helper/test_parser.rb
+++ b/test/plugin_helper/test_parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/plugin_helper/parser'
 require 'fluent/plugin/base'

--- a/test/plugin_helper/test_retry_state.rb
+++ b/test/plugin_helper/test_retry_state.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/plugin_helper/retry_state'
 require 'fluent/plugin/base'
@@ -965,7 +967,7 @@ class RetryStateHelperTest < Test::Unit::TestCase
       trying_count = 1000 # just for avoiding infinite loop
 
       retry_records = []
-      msg = ""
+      msg = +""
 
       s = @d.retry_state_create(
         :t15, :exponential_backoff, data[:wait], data[:timeout],

--- a/test/plugin_helper/test_server.rb
+++ b/test/plugin_helper/test_server.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/plugin_helper/server'
 require 'fluent/plugin_helper/cert_option' # to create certs for tests
@@ -393,7 +395,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     end
 
     test 'creates a tcp server just to read data' do
-      received = ""
+      received = +""
       @d.server_create_tcp(:s, @port) do |data|
         received << data
       end
@@ -408,7 +410,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     end
 
     test 'creates a tcp server to read and write data' do
-      received = ""
+      received = +""
       responses = []
       @d.server_create_tcp(:s, @port) do |data, conn|
         received << data
@@ -429,7 +431,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     test 'creates a tcp server to read and write data using IPv6' do
       omit "IPv6 unavailable here" unless ipv6_enabled?
 
-      received = ""
+      received = +""
       responses = []
       @d.server_create_tcp(:s, @port, bind: "::1") do |data, conn|
         received << data
@@ -448,7 +450,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     end
 
     test 'does not resolve name of client address in default' do
-      received = ""
+      received = +""
       sources = []
       @d.server_create_tcp(:s, @port) do |data, conn|
         received << data
@@ -467,7 +469,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     test 'does resolve name of client address if resolve_name is true' do
       hostname = Socket.getnameinfo([nil, nil, nil, "127.0.0.1"])[0]
 
-      received = ""
+      received = +""
       sources = []
       @d.server_create_tcp(:s, @port, resolve_name: true) do |data, conn|
         received << data
@@ -488,7 +490,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     end
 
     test 'raises error if plugin registers data callback for connection object from #server_create' do
-      received = ""
+      received = +""
       errors = []
       @d.server_create_tcp(:s, @port) do |data, conn|
         received << data
@@ -508,7 +510,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     end
 
     test 'can call write_complete callback if registered' do
-      buffer = ""
+      buffer = +""
       lines = []
       responses = []
       response_completes = []
@@ -539,7 +541,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     end
 
     test 'can call close callback if registered' do
-      buffer = ""
+      buffer = +""
       lines = []
       callback_results = []
       @d.server_create_tcp(:s, @port) do |data, conn|
@@ -594,7 +596,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     end
 
     test 'creates a udp server just to read data' do
-      received = ""
+      received = +""
       @d.server_create_udp(:s, @port, max_bytes: 128) do |data|
         received << data
       end
@@ -612,7 +614,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     end
 
     test 'creates a udp server to read and write data' do
-      received = ""
+      received = +""
       responses = []
       @d.server_create_udp(:s, @port, max_bytes: 128) do |data, sock|
         received << data
@@ -652,7 +654,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     test 'creates a udp server to read and write data using IPv6' do
       omit "IPv6 unavailable here" unless ipv6_enabled?
 
-      received = ""
+      received = +""
       responses = []
       @d.server_create_udp(:s, @port, bind: "::1", max_bytes: 128) do |data, sock|
         received << data
@@ -680,7 +682,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     end
 
     test 'does not resolve name of client address in default' do
-      received = ""
+      received = +""
       sources = []
       @d.server_create_udp(:s, @port, max_bytes: 128) do |data, sock|
         received << data
@@ -700,7 +702,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     test 'does resolve name of client address if resolve_name is true' do
       hostname = Socket.getnameinfo([nil, nil, nil, "127.0.0.1"])[0]
 
-      received = ""
+      received = +""
       sources = []
       @d.server_create_udp(:s, @port, resolve_name: true, max_bytes: 128) do |data, sock|
         received << data
@@ -718,7 +720,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     end
 
     test 'raises error if plugin registers data callback for connection object from #server_create' do
-      received = ""
+      received = +""
       errors = []
       @d.server_create_udp(:s, @port, max_bytes: 128) do |data, sock|
         received << data
@@ -740,7 +742,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     end
 
     test 'raise error if plugin registers write_complete callback for udp' do
-      received = ""
+      received = +""
       errors = []
       @d.server_create_udp(:s, @port, max_bytes: 128) do |data, sock|
         received << data
@@ -762,7 +764,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     end
 
     test 'raises error if plugin registers close callback for udp' do
-      received = ""
+      received = +""
       errors = []
       @d.server_create_udp(:s, @port, max_bytes: 128) do |data, sock|
         received << data
@@ -995,7 +997,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
           generate_cert_digest: :sha256,
         }
 
-        received = ""
+        received = +""
         @d.server_create_tls(:s, @port, tls_options: tls_options) do |data, conn|
           received << data
         end
@@ -1034,7 +1036,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
           private_key_path: private_key_path,
         }
         tls_options[:private_key_passphrase] = private_key_passphrase if private_key_passphrase
-        received = ""
+        received = +""
         @d.server_create_tls(:s, @port, tls_options: tls_options) do |data, conn|
           received << data
         end
@@ -1069,7 +1071,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
           generate_private_key_length: 2048,
         }
         tls_options[:ca_private_key_passphrase] = ca_key_passphrase if ca_key_passphrase
-        received = ""
+        received = +""
         @d.server_create_tls(:s, @port, tls_options: tls_options) do |data, conn|
           received << data
         end
@@ -1108,7 +1110,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
           private_key_path: private_key_path,
         }
         tls_options[:private_key_passphrase] = private_key_passphrase if private_key_passphrase
-        received = ""
+        received = +""
         @d.server_create_tls(:s, @port, tls_options: tls_options) do |data, conn|
           received << data
         end
@@ -1138,7 +1140,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
           private_key_path: private_key_path,
         }
         tls_options[:private_key_passphrase] = private_key_passphrase if private_key_passphrase
-        received = ""
+        received = +""
         @d.server_create_tls(:s, @port, tls_options: tls_options) do |data, conn|
           received << data
         end
@@ -1162,7 +1164,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
 
         @d.configure(conf); @d.start; @d.after_start
 
-        received = ""
+        received = +""
         @d.server_create_tls(:s, @port) do |data, conn|
           received << data
         end
@@ -1197,7 +1199,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
 
         @d.configure(conf); @d.start; @d.after_start
 
-        received = ""
+        received = +""
         @d.server_create_tls(:s, @port) do |data, conn|
           received << data
         end
@@ -1232,7 +1234,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
 
         @d.configure(conf); @d.start; @d.after_start
 
-        received = ""
+        received = +""
         @d.server_create_tls(:s, @port) do |data, conn|
           received << data
         end
@@ -1265,7 +1267,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
 
         @d.configure(conf); @d.start; @d.after_start
 
-        received = ""
+        received = +""
         @d.server_create_tls(:s, @port) do |data, conn|
           received << data
         end
@@ -1296,7 +1298,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
 
         @d.configure(conf); @d.start; @d.after_start
 
-        received = ""
+        received = +""
         @d.server_create_tls(:s, @port) do |data, conn|
           received << data
         end
@@ -1380,7 +1382,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     end
 
     test 'creates a tls server just to read data' do
-      received = ""
+      received = +""
       @d.server_create_tls(:s, @port, tls_options: @tls_options) do |data, conn|
         received << data
       end
@@ -1396,7 +1398,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     end
 
     test 'creates a tls server to read and write data' do
-      received = ""
+      received = +""
       responses = []
       @d.server_create_tls(:s, @port, tls_options: @tls_options) do |data, conn|
         received << data
@@ -1419,7 +1421,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     test 'creates a tls server to read and write data using IPv6' do
       omit "IPv6 unavailable here" unless ipv6_enabled?
 
-      received = ""
+      received = +""
       responses = []
       @d.server_create_tls(:s, @port, bind: "::1",  tls_options: @tls_options) do |data, conn|
         received << data
@@ -1440,7 +1442,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     end
 
     test 'does not resolve name of client address in default' do
-      received = ""
+      received = +""
       sources = []
       @d.server_create_tls(:s, @port, tls_options: @tls_options) do |data, conn|
         received << data
@@ -1460,7 +1462,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     test 'does resolve name of client address if resolve_name is true' do
       hostname = Socket.getnameinfo([nil, nil, nil, "127.0.0.1"])[0]
 
-      received = ""
+      received = +""
       sources = []
       @d.server_create_tls(:s, @port, resolve_name: true, tls_options: @tls_options) do |data, conn|
         received << data
@@ -1482,7 +1484,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     end
 
     test 'raises error if plugin registers data callback for connection object from #server_create' do
-      received = ""
+      received = +""
       errors = []
       @d.server_create_tls(:s, @port, tls_options: @tls_options) do |data, conn|
         received << data
@@ -1502,7 +1504,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     end
 
     test 'can call write_complete callback if registered' do
-      buffer = ""
+      buffer = +""
       lines = []
       responses = []
       response_completes = []
@@ -1533,7 +1535,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     end
 
     test 'can call close callback if registered' do
-      buffer = ""
+      buffer = +""
       lines = []
       callback_results = []
       @d.server_create_tls(:s, @port, tls_options: @tls_options) do |data, conn|
@@ -1666,7 +1668,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
 
     data(protocols)
     test 'does not resolve name of client address in default' do |(proto, kwargs)|
-      received = ""
+      received = +""
       sources = []
       @d.server_create_connection(:s, @port, proto: proto, **kwargs) do |conn|
         sources << conn.remote_host
@@ -1688,7 +1690,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     test 'does resolve name of client address if resolve_name is true' do |(proto, kwargs)|
       hostname = Socket.getnameinfo([nil, nil, nil, "127.0.0.1"])[0]
 
-      received = ""
+      received = +""
       sources = []
       @d.server_create_connection(:s, @port, proto: proto, resolve_name: true, **kwargs) do |conn|
         sources << conn.remote_host
@@ -1709,7 +1711,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     data(protocols)
     test 'creates a server to provide connection, which can read, write and close' do |(proto, kwargs)|
       lines = []
-      buffer = ""
+      buffer = +""
       @d.server_create_connection(:s, @port, proto: proto, **kwargs) do |conn|
         conn.data do |d|
           buffer << d
@@ -1759,7 +1761,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
     data(protocols)
     test 'creates a server to provide connection, which accepts callbacks for data, write_complete, and close' do |(proto, kwargs)|
       lines = []
-      buffer = ""
+      buffer = +""
       written = 0
       closed = 0
       @d.server_create_connection(:s, @port, proto: proto, **kwargs) do |conn|
@@ -1794,7 +1796,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
 
     data(protocols)
     test 'creates a server, and does not leak connections' do |(proto, kwargs)|
-      buffer = ""
+      buffer = +""
       closed = 0
       @d.server_create_connection(:s, @port, proto: proto, **kwargs) do |conn|
         conn.on(:close){|_c| closed += 1 }
@@ -1825,7 +1827,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
 
       assert_false connected
 
-      received = ""
+      received = +""
       @d.server_create_connection(:s, @port, proto: proto, shared: false, **kwargs) do |conn|
         conn.on(:data) do |data|
           received << data

--- a/test/plugin_helper/test_service_discovery.rb
+++ b/test/plugin_helper/test_service_discovery.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'flexmock/test_unit'
 require 'fluent/plugin_helper/service_discovery'

--- a/test/plugin_helper/test_storage.rb
+++ b/test/plugin_helper/test_storage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../helper'
 require 'fluent/plugin_helper/storage'
 require 'fluent/plugin/base'

--- a/test/test_formatter.rb
+++ b/test/test_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'helper'
 require 'fluent/test'
 require 'fluent/formatter'

--- a/test/test_mixin.rb
+++ b/test/test_mixin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'helper'
 require 'fluent/mixin'
 require 'fluent/env'

--- a/test/test_output.rb
+++ b/test/test_output.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'helper'
 require 'fluent/test'
 require 'fluent/output'

--- a/test/test_plugin.rb
+++ b/test/test_plugin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'helper'
 
 require 'fluent/plugin'

--- a/test/test_plugin_classes.rb
+++ b/test/test_plugin_classes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'helper'
 require 'fluent/plugin/input'
 require 'fluent/plugin/output'

--- a/test/test_root_agent.rb
+++ b/test/test_root_agent.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'helper'
 require 'fluent/event_router'
 require 'fluent/system_config'

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'helper'
 require 'fluent/event_router'
 require 'fluent/system_config'

--- a/test/test_time_formatter.rb
+++ b/test/test_time_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'helper'
 require 'fluent/test'
 require 'fluent/time'

--- a/test/test_time_parser.rb
+++ b/test/test_time_parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'helper'
 require 'fluent/test'
 require 'fluent/time'


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
To supress `warning: literal string will be frozen in the future`,
we will require to fix with following proposals.

1. Add `# frozen_string_literal: true` in the beginning of the file
2. Add `# frozen_string_literal: false` in the beginning of the file
3. Add `RUBYOPT="-disable=frozen_string_literal"` as launch option

These suggestions may be combined.


This PR adds `# frozen_string_literal: true` to all required files.
Seems CI will be passed,
however, Fluentd might raise `FrozenError` exception by unexpected frozen string
if it has not sufficient test suites...

Related to GH-4585

**Docs Changes**:

**Release Note**: 
