### PR TITLE
github: suppress running CI only for documentation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,14 @@ name: Test
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - '*.md'
+      - 'lib/fluent/version.rb'
   pull_request:
     branches: [master]
+    paths-ignore:
+      - '*.md'
+      - 'lib/fluent/version.rb'
 
 permissions: read-all
 


### PR DESCRIPTION

**Which issue(s) this PR fixes**: 

Fixes #

**What this PR does / why we need it**: 

For updating documentation or release task, running GitHub Actions is waste of resource.

https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore


**Docs Changes**:

N/A

**Release Note**: 

N/A
