### PR TITLE
system_config: add path attribute in system/log section

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -518,7 +518,6 @@ module Fluent
       @inline_config = opt[:inline_config]
       @use_v1_config = opt[:use_v1_config]
       @conf_encoding = opt[:conf_encoding]
-      @log_path = opt[:log_path]
       @show_plugin_config = opt[:show_plugin_config]
       @libs = opt[:libs]
       @plugin_dirs = opt[:plugin_dirs]
@@ -527,13 +526,15 @@ module Fluent
       @chumask = opt[:chumask]
       @signame = opt[:signame]
 
-      # TODO: `@log_rotate_age` and `@log_rotate_size` should be removed
+      # TODO: `@log_path`, `@log_rotate_age` and `@log_rotate_size` should be removed
       # since it should be merged with SystemConfig in `build_system_config()`.
-      # We should always use `system_config.log.rotate_age` and `system_config.log.rotate_size`.
+      # We should always use `system_config.log.path`, `system_config.log.rotate_age`
+      # and `system_config.log.rotate_size`.
       # However, currently, there is a bug that `system_config.log` parameters
       # are not in `Fluent::SystemConfig::SYSTEM_CONFIG_PARAMETERS`, and these
       # parameters are not merged in `build_system_config()`.
       # Until we fix the bug of `Fluent::SystemConfig`, we need to use these instance variables.
+      @log_path = opt[:log_path]
       @log_rotate_age = opt[:log_rotate_age]
       @log_rotate_size = opt[:log_rotate_size]
 
@@ -690,6 +691,7 @@ module Fluent
 
       # TODO: we should remove this logic. This merging process should be done
       # in `build_system_config()`.
+      @log_path ||= system_config.log.path
       @log_rotate_age ||= system_config.log.rotate_age
       @log_rotate_size ||= system_config.log.rotate_size
 

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -58,6 +58,7 @@ module Fluent
       v.to_i(8)
     end
     config_section :log, required: false, init: true, multi: false do
+      config_param :path, :string, default: nil
       config_param :format, :enum, list: [:text, :json], default: :text
       config_param :time_format, :string, default: '%Y-%m-%d %H:%M:%S %z'
       config_param :rotate_age, default: nil do |v|

--- a/test/config/test_system_config.rb
+++ b/test/config/test_system_config.rb
@@ -77,6 +77,7 @@ module Fluent::Config
       assert_nil(sc.enable_size_metrics)
       assert_nil(sc.enable_msgpack_time_support)
       assert(!sc.enable_jit)
+      assert_nil(sc.log.path)
       assert_equal(:text, sc.log.format)
       assert_equal('%Y-%m-%d %H:%M:%S %z', sc.log.time_format)
     end
@@ -117,6 +118,7 @@ module Fluent::Config
       conf = parse_text(<<-EOS)
           <system>
             <log>
+              path /tmp/fluentd.log
               format json
               time_format %Y
             </log>
@@ -125,6 +127,7 @@ module Fluent::Config
       s = FakeSupervisor.new
       sc = Fluent::SystemConfig.new(conf)
       sc.overwrite_variables(**s.for_system_config)
+      assert_equal('/tmp/fluentd.log', sc.log.path)
       assert_equal(:json, sc.log.format)
       assert_equal('%Y', sc.log.time_format)
     end

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -67,6 +67,7 @@ class SupervisorTest < ::Test::Unit::TestCase
   log_level info
   root_dir #{@tmp_root_dir}
   <log>
+    path /tmp/fluentd.log
     format json
     time_format %Y
   </log>
@@ -94,6 +95,7 @@ class SupervisorTest < ::Test::Unit::TestCase
     assert_equal "process_name", sys_conf.process_name
     assert_equal 2, sys_conf.log_level
     assert_equal @tmp_root_dir, sys_conf.root_dir
+    assert_equal "/tmp/fluentd.log", sys_conf.log.path
     assert_equal :json, sys_conf.log.format
     assert_equal '%Y', sys_conf.log.time_format
     counter_server = sys_conf.counter_server
@@ -134,6 +136,7 @@ class SupervisorTest < ::Test::Unit::TestCase
         log_level: info
         root_dir: !fluent/s "#{@tmp_root_dir}"
         log:
+          path: /tmp/fluentd.log
           format: json
           time_format: "%Y"
         counter_server:
@@ -161,6 +164,7 @@ class SupervisorTest < ::Test::Unit::TestCase
         "process_name",
         2,
         @tmp_root_dir,
+        "/tmp/fluentd.log",
         :json,
         '%Y',
         '127.0.0.1',
@@ -180,6 +184,7 @@ class SupervisorTest < ::Test::Unit::TestCase
         sys_conf.process_name,
         sys_conf.log_level,
         sys_conf.root_dir,
+        sys_conf.log.path,
         sys_conf.log.format,
         sys_conf.log.time_format,
         counter_server.bind,


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #4418

**What this PR does / why we need it**: 
This patch will add `path` attribute in sytem/log section due to configure log file path  by System Configuration.


**Docs Changes**:

**Release Note**: 
