### PR TITLE
fluentd command: fix '--plugin'('-p') option not to overwrite default value

### DIFF
--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -46,7 +46,7 @@ op.on('--show-plugin-config=PLUGIN', "[DEPRECATED] Show PLUGIN configuration and
 }
 
 op.on('-p', '--plugin DIR', "add plugin directory") {|s|
-  (cmd_opts[:plugin_dirs] ||= []) << s
+  (cmd_opts[:plugin_dirs] ||= default_opts[:plugin_dirs]) << s
 }
 
 op.on('-I PATH', "add library path") {|s|


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
* Fixes #4269

**What this PR does / why we need it**: 
This option is explained as "add plugin directory".
However, since v1.16.0, the behavior has changed to overwrite the default value unintentionally.
(PR: #4064, commit: 41678bf0e5f355979fd3b584cea5828690ccbac8).

We should revert it to the original behavior.

**Docs Changes**:
Not needed.

**Release Note**: 
The same as the title.