### PR TITLE
Backport(v1.16): github: backport suppress running CI only for documentation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,14 @@ name: Test
 on:
   push:
     branches: [v1.16]
+    paths-ignore:
+      - '*.md'
+      - 'lib/fluent/version.rb'
   pull_request:
     branches: [v1.16]
+    paths-ignore:
+      - '*.md'
+      - 'lib/fluent/version.rb'
 
 jobs:
   test:


### PR DESCRIPTION

**Which issue(s) this PR fixes**: 

Fixes #

**What this PR does / why we need it**: 

For updating documentation or release task, running GitHub Actions
    is waste of resource.

    https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-



**Docs Changes**:

N/A

**Release Note**: 

N/A
