### PR TITLE
http_server: Ready to support Async 2.0 gem

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -63,6 +63,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("test-unit", ["~> 3.3"])
   gem.add_development_dependency("test-unit-rr", ["~> 1.0"])
   gem.add_development_dependency("oj", [">= 2.14", "< 4"])
+  gem.add_development_dependency("async", "~> 1.23")
   gem.add_development_dependency("async-http", ">= 0.50.0")
   gem.add_development_dependency("aws-sigv4", ["~> 1.8"])
   gem.add_development_dependency("aws-sdk-core", ["~> 3.191"])

--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -63,7 +63,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("test-unit", ["~> 3.3"])
   gem.add_development_dependency("test-unit-rr", ["~> 1.0"])
   gem.add_development_dependency("oj", [">= 2.14", "< 4"])
-  gem.add_development_dependency("async", "~> 1.23")
   gem.add_development_dependency("async-http", ">= 0.50.0")
   gem.add_development_dependency("aws-sigv4", ["~> 1.8"])
   gem.add_development_dependency("aws-sdk-core", ["~> 3.191"])

--- a/lib/fluent/plugin_helper/http_server/server.rb
+++ b/lib/fluent/plugin_helper/http_server/server.rb
@@ -55,10 +55,13 @@ module Fluent
         end
 
         def start(notify = nil)
+          Console.logger = Fluent::Log::ConsoleAdapter.wrap(@logger)
           @logger.debug("Start async HTTP server listening #{@uri}")
 
           Async do |task|
+            Console.logger = Fluent::Log::ConsoleAdapter.wrap(@logger)
             @server_task = task.async do
+              Console.logger = Fluent::Log::ConsoleAdapter.wrap(@logger)
               @server.run
             end
             if notify

--- a/test/plugin_helper/test_http_server_helper.rb
+++ b/test/plugin_helper/test_http_server_helper.rb
@@ -132,7 +132,7 @@ class HttpHelperTest < Test::Unit::TestCase
     resp = nil
     error = nil
 
-    Async do
+    Sync do
       Console.logger = Fluent::Log::ConsoleAdapter.wrap(NULL_LOGGER)
       begin
         response = yield(client)
@@ -141,7 +141,7 @@ class HttpHelperTest < Test::Unit::TestCase
       end
 
       if response
-        resp = Response.new(response.status.to_s, response.body.read, response.headers)
+        resp = Response.new(response.status.to_s, response.read, response.headers)
       end
     end
 

--- a/test/plugin_helper/test_http_server_helper.rb
+++ b/test/plugin_helper/test_http_server_helper.rb
@@ -127,12 +127,12 @@ class HttpHelperTest < Test::Unit::TestCase
     end
 
     client = Async::HTTP::Client.new(Async::HTTP::Endpoint.parse("https://#{addr}:#{port}", ssl_context: context))
-    reactor = Async::Reactor.new(nil, logger: Fluent::Log::ConsoleAdapter.wrap(NULL_LOGGER))
+    Console.logger = Fluent::Log::ConsoleAdapter.wrap(NULL_LOGGER)
 
     resp = nil
     error = nil
 
-    reactor.run do
+    Async do |task|
       begin
         response = yield(client)
       rescue => e               # Async::Reactor rescue all error. handle it by myself

--- a/test/plugin_helper/test_http_server_helper.rb
+++ b/test/plugin_helper/test_http_server_helper.rb
@@ -132,7 +132,7 @@ class HttpHelperTest < Test::Unit::TestCase
     resp = nil
     error = nil
 
-    Async do |task|
+    Async do
       begin
         response = yield(client)
       rescue => e               # Async::Reactor rescue all error. handle it by myself

--- a/test/plugin_helper/test_http_server_helper.rb
+++ b/test/plugin_helper/test_http_server_helper.rb
@@ -133,6 +133,7 @@ class HttpHelperTest < Test::Unit::TestCase
     error = nil
 
     Async do
+      Console.logger = Fluent::Log::ConsoleAdapter.wrap(NULL_LOGGER)
       begin
         response = yield(client)
       rescue => e               # Async::Reactor rescue all error. handle it by myself


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
http_server plugin helper doesn't work with Async 2.x gem due to using obsolete usage.
This PR updates it to follow current documented way:
https://github.com/socketry/async-http/blob/0a65acd7cf7486e1877f0da86580e1692cd8207b/readme.md#usage
It's applicable both Async 2.x & Async 1.x.
~~But this PR still stay on Async 1.x because io-event gem which is required by Async 2.x can't build on Windows.~~

- TODO
  - [x] Fix Build error with Ruby 3.1 on Windows
    - https://github.com/socketry/io-event/issues/111
  - [x] Solve https://github.com/socketry/async-http/issues/176 
  - [ ] ~~Replace `cool.io` gem to something~~
    - cool.io introduces IO::Buffer which conflicts with Ruby core classes. It affects the behavior of the Async HTTP server.
    - Ref. https://github.com/socketry/async-http/issues/175
  - [x] https://github.com/socketry/cool.io/pull/82

**Docs Changes**:

**Release Note**: 
