### PR TITLE
filter_parser: Transition from single record to stream

### DIFF
--- a/test/plugin/test_filter_parser.rb
+++ b/test/plugin/test_filter_parser.rb
@@ -206,6 +206,23 @@ class ParserFilterTest < Test::Unit::TestCase
 
   end
 
+  def test_filter_with_multiple_records
+    d1 = create_driver(%[
+      key_name data
+      <parse>
+        @type json
+      </parse>
+    ])
+    time = Fluent::EventTime.from_time(@default_time)
+    d1.run(default_tag: @tag) do
+      d1.feed(time, {'data' => '[{"xxx_1":"first","yyy":"second"}, {"xxx_2":"first", "yyy_2":"second"}]'})
+    end
+    filtered = d1.filtered
+    assert_equal 2, filtered.length
+    assert_equal ({"xxx_1"=>"first", "yyy"=>"second"}), filtered[0][1]
+    assert_equal ({"xxx_2"=>"first", "yyy_2"=>"second"}), filtered[1][1]
+  end
+
   data(:keep_key_name => false,
        :remove_key_name => true)
   def test_filter_with_reserved_data(remove_key_name)


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #4100

**What this PR does / why we need it**: 
Transition `filter_parser` from using `filter_with_time` to `filter_stream` logic
**Docs Changes**:
N/A
**Release Note**: 
N/A