### PR TITLE
SIGUSR2:  zero downtime restart

### DIFF
--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -51,7 +51,7 @@ module Fluent
 
     attr_reader :root_agent, :system_config, :supervisor_mode
 
-    def init(system_config, supervisor_mode: false)
+    def init(system_config, supervisor_mode: false, start_in_parallel: false)
       @system_config = system_config
       @supervisor_mode = supervisor_mode
 
@@ -60,7 +60,7 @@ module Fluent
 
       @log_event_verbose = system_config.log_event_verbose unless system_config.log_event_verbose.nil?
 
-      @root_agent = RootAgent.new(log: log, system_config: @system_config)
+      @root_agent = RootAgent.new(log: log, system_config: @system_config, start_in_parallel: start_in_parallel)
 
       self
     end

--- a/lib/fluent/plugin/in_syslog.rb
+++ b/lib/fluent/plugin/in_syslog.rb
@@ -156,6 +156,10 @@ module Fluent::Plugin
       true
     end
 
+    def zero_downtime_restart_ready?
+      true
+    end
+
     def start
       super
 

--- a/lib/fluent/plugin/in_tcp.rb
+++ b/lib/fluent/plugin/in_tcp.rb
@@ -101,6 +101,10 @@ module Fluent::Plugin
       true
     end
 
+    def zero_downtime_restart_ready?
+      true
+    end
+
     def start
       super
 

--- a/lib/fluent/plugin/in_udp.rb
+++ b/lib/fluent/plugin/in_udp.rb
@@ -70,6 +70,10 @@ module Fluent::Plugin
       true
     end
 
+    def zero_downtime_restart_ready?
+      true
+    end
+
     def start
       super
 

--- a/lib/fluent/plugin/input.rb
+++ b/lib/fluent/plugin/input.rb
@@ -70,6 +70,10 @@ module Fluent
       def multi_workers_ready?
         false
       end
+
+      def zero_downtime_restart_ready?
+        false
+      end
     end
   end
 end

--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -1350,4 +1350,182 @@ CONF
                          patterns_not_match: ["[error]"])
     end
   end
+
+  sub_test_case "zero_downtime_restart" do
+    setup do
+      omit "Not supported on Windows" if Fluent.windows?
+    end
+
+    def conf(udp_port, tcp_port, syslog_port)
+      <<~CONF
+        <system>
+          rpc_endpoint localhost:24444
+        </system>
+        <source>
+          @type monitor_agent
+        </source>
+        <source>
+          @type udp
+          tag test.udp
+          port #{udp_port}
+          <parse>
+            @type none
+          </parse>
+        </source>
+        <source>
+          @type tcp
+          tag test.tcp
+          port #{tcp_port}
+          <parse>
+            @type none
+          </parse>
+        </source>
+        <source>
+          @type syslog
+          tag test.syslog
+          port #{syslog_port}
+        </source>
+        <filter test.**>
+          @type record_transformer
+          <record>
+            foo foo
+          </record>
+        </filter>
+        <match test.**>
+          @type stdout
+        </match>
+      CONF
+    end
+
+    def run_fluentd(config)
+      conf_path = create_conf_file("test.conf", config)
+      assert File.exist?(conf_path)
+      cmdline = create_cmdline(conf_path)
+
+      stdio_buf = ""
+      execute_command(cmdline) do |pid, stdout|
+        begin
+          waiting(60) do
+            while true
+              readables, _, _ = IO.select([stdout], nil, nil, 1)
+              next unless readables
+              break if readables.first.eof?
+
+              buf = eager_read(readables.first)
+              stdio_buf << buf
+              logs = buf.split("\n")
+
+              yield logs
+
+              break if buf.include? "finish test"
+            end
+          end
+        ensure
+          supervisor_pids = stdio_buf.scan(SUPERVISOR_PID_PATTERN)
+          @supervisor_pid = supervisor_pids.last.first.to_i if supervisor_pids.size >= 2
+          stdio_buf.scan(WORKER_PID_PATTERN) do |worker_pid|
+            @worker_pids << worker_pid.first.to_i
+          end
+        end
+      end
+    end
+
+    def send_udp(port, count:, interval_sec:)
+      count.times do |i|
+        s = UDPSocket.new
+        s.send("udp-#{i}", 0, "localhost", port)
+        s.close
+        sleep interval_sec
+      end
+    end
+
+    def send_tcp(port, count:, interval_sec:)
+      count.times do |i|
+        s = TCPSocket.new("localhost", port)
+        s.write("tcp-#{i}\n")
+        s.close
+        sleep interval_sec
+      end
+    end
+
+    def send_syslog(port, count:, interval_sec:)
+      count.times do |i|
+        s = UDPSocket.new
+        s.send("<6>Sep 10 00:00:00 localhost test: syslog-#{i}", 0, "localhost", port)
+        s.close
+        sleep interval_sec
+      end
+    end
+
+    def send_end(port)
+      s = TCPSocket.new("localhost", port)
+      s.write("finish test\n")
+      s.close
+    end
+
+    test "should restart with zero downtime (no data loss)" do
+      udp_port, syslog_port = unused_port(2, protocol: :udp)
+      tcp_port = unused_port(protocol: :tcp)
+
+      client_threads = []
+      end_thread = nil
+      records_by_type = {
+        "udp" => [],
+        "tcp" => [],
+        "syslog" => [],
+      }
+
+      phase = "startup"
+      run_fluentd(conf(udp_port, tcp_port, syslog_port)) do |logs|
+        logs.each do |log|
+          next unless /"message":"(udp|tcp|syslog)-(\d+)","foo":"foo"}/ =~ log
+          type = $1
+          num = $2.to_i
+          assert_true records_by_type.key?(type)
+          records_by_type[type].append(num)
+        end
+
+        if phase == "startup" and logs.any? { |log| log.include?("fluentd worker is now running worker") }
+          phase = "zero-downtime-restart"
+
+          client_threads << Thread.new do
+            send_udp(udp_port, count: 500, interval_sec: 0.01)
+          end
+          client_threads << Thread.new do
+            send_tcp(tcp_port, count: 500, interval_sec: 0.01)
+          end
+          client_threads << Thread.new do
+            send_syslog(syslog_port, count: 500, interval_sec: 0.01)
+          end
+
+          sleep 1
+          response = Net::HTTP.get(URI.parse("http://localhost:24444/api/processes.zeroDowntimeRestart"))
+          assert_equal '{"ok":true}', response
+        elsif phase == "zero-downtime-restart" and logs.any? { |log| log.include?("zero-downtime-restart: done all sequences") }
+          phase = "flush"
+          response = Net::HTTP.get(URI.parse("http://localhost:24444/api/plugins.flushBuffers"))
+          assert_equal '{"ok":true}', response
+        elsif phase == "flush"
+          phase = "done"
+          end_thread = Thread.new do
+            client_threads.each(&:join)
+            sleep 5 # make sure to flush each chunk (1s flush interval for 1chunk)
+            send_end(tcp_port)
+          end
+        end
+      end
+
+      assert_equal(
+        [(0..499).to_a, (0..499).to_a, (0..499).to_a],
+        [
+          records_by_type["udp"].sort,
+          records_by_type["tcp"].sort,
+          records_by_type["syslog"].sort,
+        ]
+      )
+    ensure
+      client_threads.each(&:kill)
+      end_thread&.kill
+    end
+  end
 end

--- a/test/test_plugin_classes.rb
+++ b/test/test_plugin_classes.rb
@@ -106,6 +106,14 @@ module FluentTest
       @emit_size_metrics = FluentTest::FluentTestCounterMetrics.new
     end
 
+    def multi_workers_ready?
+      true
+    end
+
+    def zero_downtime_restart_ready?
+      true
+    end
+
     def start
       super
       @started = true

--- a/test/test_root_agent.rb
+++ b/test/test_root_agent.rb
@@ -1045,6 +1045,122 @@ EOC
         sleep 1 until @root_agent.outputs[0].events["test.event"].any? { |record| record["num"] == 0 }
       end
 
+      waiting(3) do
+        # Wait the last data output
+        sleep 1 until @root_agent.outputs[0].events["test.event"].any? { |record| record["num"] == 19 }
+      end
+
+      # all data should be outputted
+      assert { @root_agent.outputs[0].events["test.event"].size == 20 }
+    ensure
+      @root_agent.shutdown
+    end
+  end
+
+  sub_test_case 'start_in_parallel' do
+    def conf
+      <<~EOC
+        <source>
+          @type test_in_gen
+          @id test_in_gen
+          num 20
+          interval_sec 0.1
+          async
+        </source>
+
+        <source>
+          @type test_in
+          @id test_in
+        </source>
+
+        <filter test.**>
+          @type record_transformer
+          @id record_transformer
+          <record>
+            foo foo
+          </record>
+        </filter>
+
+        <match test.**>
+          @type test_out
+          @id test_out
+        </match>
+      EOC
+    end
+
+    def setup
+      omit "Not supported on Windows" if Fluent.windows?
+      system_config = SystemConfig.new(
+        Config::Element.new('system', '', {}, [
+          Config::Element.new('source_only_buffer', '', {
+            'flush_interval' => 1,
+          }, []),
+        ])
+      )
+      @root_agent = RootAgent.new(log: $log, system_config: system_config, start_in_parallel: true)
+      stub(Engine).root_agent { @root_agent }
+      stub(Engine).system_config { system_config }
+      @root_agent.configure(Config.parse(conf, "(test)", "(test_dir)"))
+    end
+
+    test 'only input plugins should start' do
+      @root_agent.start
+
+      assert_equal(
+        {
+          "input started?" => [true, false],
+          "filter started?" => [false],
+          "output started?" => [false],
+        },
+        {
+          "input started?" => @root_agent.inputs.map { |plugin| plugin.started? },
+          "filter started?" => @root_agent.filters.map { |plugin| plugin.started? },
+          "output started?" => @root_agent.outputs.map { |plugin| plugin.started? },
+        }
+      )
+    ensure
+      @root_agent.shutdown
+      # Buffer files remain because not cancelling source-only.
+      # As a test, they should be clean-up-ed.
+      buf_dir = @root_agent.instance_variable_get(:@source_only_buffer_agent).instance_variable_get(:@base_buffer_dir)
+      FileUtils.remove_dir(buf_dir)
+    end
+
+    test '#cancel_source_only! should start all plugins' do
+      @root_agent.start
+      @root_agent.cancel_source_only!
+
+      assert_equal(
+        {
+          "input started?" => [true, true],
+          "filter started?" => [true],
+          "output started?" => [true],
+        },
+        {
+          "input started?" => @root_agent.inputs.map { |plugin| plugin.started? },
+          "filter started?" => @root_agent.filters.map { |plugin| plugin.started? },
+          "output started?" => @root_agent.outputs.map { |plugin| plugin.started? },
+        }
+      )
+    ensure
+      @root_agent.shutdown
+    end
+
+    test 'buffer should be loaded after #cancel_source_only!' do
+      @root_agent.start
+      sleep 1
+      @root_agent.cancel_source_only!
+
+      waiting(3) do
+        # Wait buffer loaded after source-only cancelled
+        sleep 1 until @root_agent.outputs[0].events["test.event"].any? { |record| record["num"] == 0 }
+      end
+
+      waiting(3) do
+        # Wait the last data output
+        sleep 1 until @root_agent.outputs[0].events["test.event"].any? { |record| record["num"] == 19 }
+      end
+
       # all data should be outputted
       assert { @root_agent.outputs[0].events["test.event"].size == 20 }
     ensure

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -19,7 +19,7 @@ end
 class SupervisorTest < ::Test::Unit::TestCase
   class DummyServer
     include Fluent::ServerModule
-    attr_accessor :rpc_endpoint, :enable_get_dump
+    attr_accessor :rpc_endpoint, :enable_get_dump, :socket_manager_server
     def config
       {}
     end
@@ -888,6 +888,127 @@ class SupervisorTest < ::Test::Unit::TestCase
     ensure
       server.after_run
       ENV.delete('SERVERENGINE_SOCKETMANAGER_PATH')
+    end
+  end
+
+  sub_test_case "zero_downtime_restart" do
+    setup do
+      omit "Not supported on Windows" if Fluent.windows?
+    end
+
+    data(
+      # When daemonize, exit-status is important. The new spawned process does double-fork and exits soon.
+      "daemonize and succeeded double-fork of new process" => [true, true, 0, false],
+      "daemonize and failed double-fork of new process" => [true, false, 0, true],
+      # When no daemon, whether the new spawned process is alive is important, not exit-status.
+      "no daemon and new process alive" => [false, false, 3, false],
+      "no daemon and new process dead" => [false, false, 0, true],
+    )
+    def test_zero_downtime_restart((daemonize, wait_success, wait_sleep, restart_canceled))
+      # == Arrange ==
+      env_spawn = {}
+      pid_wait = nil
+
+      server = DummyServer.new
+
+      stub(server).config do
+        {
+          daemonize: daemonize,
+          pid_path: "test-pid-file",
+        }
+      end
+      process_stub = stub(Process)
+      process_stub.spawn do |env, commands|
+        env_spawn = env
+        -1
+      end
+      process_stub.wait2 do |pid|
+        pid_wait = pid
+        sleep wait_sleep
+        if wait_success
+          status = Class.new{def success?; true; end}.new
+        else
+          status = Class.new{def success?; false; end}.new
+        end
+        [pid, status]
+      end
+      stub(File).read("test-pid-file") { -1 }
+
+      # mock to check notify_new_supervisor_that_old_one_has_stopped sends SIGWINCH
+      if restart_canceled
+        mock(Process).kill(:WINCH, -1).never
+      else
+        mock(Process).kill(:WINCH, -1)
+      end
+
+      # == Act and Assert ==
+      server.before_run
+      server.zero_downtime_restart.join
+      sleep 1 # To wait a sub thread for waitpid in zero_downtime_restart
+      server.after_run
+
+      assert_equal(
+        [
+          !restart_canceled,
+          true,
+          Process.pid,
+          -1,
+        ],
+        [
+          server.instance_variable_get(:@starting_new_supervisor_with_zero_downtime),
+          env_spawn.key?("SERVERENGINE_SOCKETMANAGER_INTERNAL_TOKEN"),
+          env_spawn["FLUENT_RUNNING_IN_PARALLEL_WITH_OLD"].to_i,
+          pid_wait,
+        ]
+      )
+    ensure
+      Fluent::Supervisor.cleanup_socketmanager_path
+      ENV.delete('SERVERENGINE_SOCKETMANAGER_PATH')
+    end
+
+    def test_share_sockets
+      server = DummyServer.new
+      server.before_run
+      path = ENV['SERVERENGINE_SOCKETMANAGER_PATH']
+
+      client = ServerEngine::SocketManager::Client.new(path)
+      udp_port = unused_port(protocol: :udp)
+      tcp_port = unused_port(protocol: :tcp)
+      client.listen_udp("localhost", udp_port)
+      client.listen_tcp("localhost", tcp_port)
+
+      ENV['FLUENT_RUNNING_IN_PARALLEL_WITH_OLD'] = ""
+      new_server = DummyServer.new
+      stub(new_server).stop_parallel_old_supervisor_after_delay
+      new_server.before_run
+
+      assert_equal(
+        [[udp_port], [tcp_port]],
+        [
+          new_server.socket_manager_server.udp_sockets.values.map { |v| v.addr[1] },
+          new_server.socket_manager_server.tcp_sockets.values.map { |v| v.addr[1] },
+        ]
+      )
+    ensure
+      server&.after_run
+      new_server&.after_run
+      ENV.delete('SERVERENGINE_SOCKETMANAGER_PATH')
+      ENV.delete("FLUENT_RUNNING_IN_PARALLEL_WITH_OLD")
+    end
+
+    def test_stop_parallel_old_supervisor_after_delay
+      ENV['SERVERENGINE_SOCKETMANAGER_PATH'] = ""
+      ENV['FLUENT_RUNNING_IN_PARALLEL_WITH_OLD'] = "-1"
+      stub(ServerEngine::SocketManager::Server).share_sockets_with_another_server
+      mock(Process).kill(:TERM, -1)
+
+      server = DummyServer.new
+      server.before_run
+      sleep 12 # Can't we skip the delay for this test?
+    ensure
+      server&.after_run
+      ENV.delete('SERVERENGINE_SOCKETMANAGER_PATH')
+      ENV.delete("FLUENT_RUNNING_IN_PARALLEL_WITH_OLD")
     end
   end
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
* Fixes #4622

**What this PR does / why we need it**:
This replaces the current `SIGUSR2` (#2716) with the new feature.
(Not supported on Windows).

* Restart the new process with zero downtime

The primary motivation is to enable the update of Fluentd without data loss of plugins such as `in_udp`.
(Please See #4622).

Specification:

* 2 ways to trigger this feature (non-Windows):
  * [Signal](https://docs.fluentd.org/deployment/signals): `SIGUSR2` to the supervisor.
    * Sending `SIGUSR2` to the workers triggers [the traditional GracefulReload](https://github.com/fluent/fluentd/pull/2716).
      * (Leave the traditional way, just in case)
  * [RPC](https://docs.fluentd.org/deployment/rpc): `/api/processes.zeroDowntimeRestart`
    * Leave `/api/config.gracefulReload` for the traditional feature.
* This starts the new supervisor and workers with zero downtime for some plugins.
  * Input plugins with `zero_downtime_restart` supported work in parallel. 
    * Supported input plugins:
      * `in_tcp`
      * `in_udp`
      * `in_syslog`
  * The old processes stop after 10s.
* The new supervisor works in `source-only` mode (#4661) until the old processes stop.
  * After the old processes stop, the data handled by the new processes are loaded and processed.
  * If need, you can configure `source_only_buffer` (see #4661).
* Windows: Not affected at all. Remains [the traditional GracefulReload](https://github.com/fluent/fluentd/pull/2716).

# Mechanism

1. The supervisor receives SIGUSR2.
2. Spawn a new supervisor.
3. Take over shared sockets.
4. Launch new workers, and stop old processes in parallel.
   * Launch new workers with source-only mode
     * Limit to zero_downtime_restart_ready? input plugin
   * Send SIGTERM to the old supervisor after 10s delay from 3.
5. The old supervisor stops and sends SIGWINCH to the new one.
6. The new workers run fully.

![375586975-1ec2b716-03c3-4db6-90c0-f9e7e8a14a17](https://github.com/user-attachments/assets/ca5d4836-2304-4cdd-9dc3-b54dd3295b48)

Needs following:

* #4661
* https://github.com/treasure-data/serverengine/pull/150

Conditions under which `zero_downtime_restart_ready?` can be enabled:

* Must be able to work in parallel with another Fluentd instance.
* Notes:
  * The sockets provided by [server helper](https://docs.fluentd.org/plugin-helper-overview/api-plugin-helper-server) are shared with the new Fluentd instance.
  * Input plugins managing a position such as `in_tail` should not enable its `zero_downtime_restart_ready?`.
    * Such input plugins do not cause data loss on restart, so there is no need to enable this in the first place.
  * `in_http` and `in_forward` could also be supported. Not supporting them this time is simply a matter of time to consider.

# The appropriateness of replacing the traditional SIGUSR2

There are the following reasons:

* The traditional SIGUSR2 feature has some limitations and issues.
  * Limitations:
    > it has 2 limitations.
    > 1. A change to system_config is ignored because it needs to restart(kill/spawn) process.
    > 1. All plugins must not use class variable when restarting.
  * Issues:
    * #2259
    * #3469
    * #3549
* This new feature allows restarts without downtime and such limitations.
  * Although supported plugins are limited, that is not a problem for many plugins.
    (The problem is with server-based input plugins where the stop results in data loss).
* This new feature has a big advantage that it can also be used to update Fluentd.
  * In the future, fluent-package will use this feature to allow update with zero downtime by default.
    * https://github.com/fluent/fluent-package-builder/pull/713
* If needed, we can still use the traditional feature by RPC or directly sending `SIGUSR2` to the workers.

# ETC

**Docs Changes**:
TODO

**Release Note**: 
* Add zero-downtime-restart feature for non-Windows (`USR2` signal and `/api/processes.zeroDowntimeRestart` RPC API)

**TODO**:

- [x] Some implementation TODO referred in code comment.
- [x] Tests
- [ ] Document
