### PR TITLE
log: add caller plugin-id about emitting error events

### DIFF
--- a/lib/fluent/agent.rb
+++ b/lib/fluent/agent.rb
@@ -159,7 +159,7 @@ module Fluent
     end
 
     # For handling invalid record
-    def emit_error_event(tag, time, record, error)
+    def emit_error_event(tag, time, record, error, plugin_id: nil)
     end
 
     def handle_emits_error(tag, es, error)

--- a/lib/fluent/event_router.rb
+++ b/lib/fluent/event_router.rb
@@ -123,7 +123,7 @@ module Fluent
     end
 
     def emit_error_event(tag, time, record, error)
-      @emit_error_handler.emit_error_event(tag, time, record, error)
+      @emit_error_handler.emit_error_event(tag, time, record, error, plugin_id: @caller_plugin_id)
     end
 
     def match?(tag)

--- a/lib/fluent/label.rb
+++ b/lib/fluent/label.rb
@@ -35,8 +35,8 @@ module Fluent
       end
     end
 
-    def emit_error_event(tag, time, record, e)
-      @root_agent.emit_error_event(tag, time, record, e)
+    def emit_error_event(tag, time, record, e, plugin_id: nil)
+      @root_agent.emit_error_event(tag, time, record, e, plugin_id: plugin_id)
     end
 
     def handle_emits_error(tag, es, e)

--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -402,8 +402,9 @@ module Fluent
       end
     end
 
-    def emit_error_event(tag, time, record, error)
+    def emit_error_event(tag, time, record, error, plugin_id: nil)
       error_info = {error: error, location: (error.backtrace ? error.backtrace.first : nil), tag: tag, time: time}
+      error_info[:plugin_id] = plugin_id if plugin_id
       if @error_collector
         # A record is not included in the logs because <@ERROR> handles it. This warn is for the notification
         log.warn "send an error event to @ERROR:", error_info


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
* Fixes #4567

**What this PR does / why we need it**: 
Add caller plugin-id to warning logs about emitting error events.

It would be helpful if we could know what plugin emitted the error event.

We need to care about the compatibility.
This signature change would not break compatibility.

However, I'm concerned that `caller_plugin_id` has a race condition, although I don't confirm it.
It looks to me that the id can be another plugin-id running concurrently...
It is not the issue with this fix, it is the issue of the existing implementation.

**Docs Changes**:
Not needed.

**Release Note**: 
Add plugin-id to warning logs about emitting error events.

**Example**:
From #4567.
```xml
<source>
  @type sample
  @id id_sample_not_json
  sample {"data":"this is not json}"}
  tag sample.json
</source>

<filter sample.json>
  @type parser
  @id id_not_json
  key_name data
  <parse>
    @type json
  </parse>
</filter>

<match sample.**>
  @type stdout
</match>
```

```
2024-09-11 15:26:26 +0900 [info]: #0 fluentd worker is now running worker=0
2024-09-11 15:26:27 +0900 [warn]: #0 dump an error event:
 error_class=Fluent::Plugin::Parser::ParserError
 error="pattern not matched with data 'this is not json}'"
 location=nil tag="sample.json"
 time=2024-09-11 15:26:27.040657722 +0900
 plugin_id="id_not_json" ### <= This info is added by this PR ###
 record={"data"=>"this is not json}"}
...
```
