### PR TITLE
test_fluentd: fix assert pattern of syntax error for Ruby HEAD

### DIFF
--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -570,7 +570,7 @@ CONF
 
       assert_fluentd_fails_to_start(
         create_cmdline(conf_path, "-p", File.dirname(plugin_path)),
-        "in_buggy.rb:5: syntax error, unexpected end-of-input"
+        /in_buggy.rb:\d+:.+\(SyntaxError\)/
       )
     end
   end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

Related to #4584

**What this PR does / why we need it**: 
Ruby parser will be replaced new parser in Ruby 3.4. https://github.com/ruby/ruby/commit/ea2af5782df63266577ba08a4ef4c30b6d63e564

The new parser might not have a fully compatible of Syntax error messages.

So I modified the assert pattern to succeed in the Ruby HEAD.

### example
```ruby
module Foo
  class Bar
    def say
      puts "hello"
    end
  end
```

### result with Ruby 3.3.5
```
$ ruby -v test.rb
ruby 3.3.5 (2024-09-03 revision ef084cc8f4) [x86_64-linux]
test.rb: --> test.rb
Unmatched keyword, missing `end' ?
> 1  module Foo

test.rb:6: syntax error, unexpected end-of-input, expecting `end' or dummy end (SyntaxError)
  end
     ^

```

### result with Ruby 3.4-dev
```ruby
ruby -v test.rb
ruby 3.4.0dev (2024-09-25T02:45:33Z master 76543a34ab) +PRISM [x86_64-linux]
test.rb: --> test.rb
Unmatched keyword, missing `end' ?
> 1  module Foo

test.rb:7: syntax errors found (SyntaxError)
  5 |     end
  6 |   end
> 7 | 
    | ^ expected an `end` to close the `module` statement

    | ^ unexpected end-of-input, assuming it is closing the parent top level context

```

Ruby 3.3.5 has `test.rb:6: syntax error,..`, but Ruby 3.4-dev has `test.rb:7: syntax errors...`.

**Docs Changes**:

**Release Note**: 
