### PR TITLE
plugin_helper/server: Add receive_buffer_size parameter in transport section

### DIFF
--- a/lib/fluent/plugin/in_udp.rb
+++ b/lib/fluent/plugin/in_udp.rb
@@ -43,9 +43,14 @@ module Fluent::Plugin
     desc "Remove newline from the end of incoming payload"
     config_param :remove_newline, :bool, default: true
     desc "The max size of socket receive buffer. SO_RCVBUF"
-    config_param :receive_buffer_size, :size, default: nil
+    config_param :receive_buffer_size, :size, default: nil, deprecated: "use receive_buffer_size in transport section instead."
 
     config_param :blocking_timeout, :time, default: 0.5
+
+    # overwrite server plugin to change default to :udp and remove tcp/tls protocol from list
+    config_section :transport, required: false, multi: false, init: true, param_name: :transport_config do
+      config_argument :protocol, :enum, list: [:udp], default: :udp
+    end
 
     def configure(conf)
       compat_parameters_convert(conf, :parser)

--- a/lib/fluent/plugin_helper/server.rb
+++ b/lib/fluent/plugin_helper/server.rb
@@ -84,6 +84,8 @@ module Fluent
           socket_options[:linger_timeout] ||= @transport_config&.linger_timeout || 0
         end
 
+        socket_options[:receive_buffer_size] ||= @transport_config&.receive_buffer_size
+
         socket_option_validate!(proto, **socket_options)
         socket_option_setter = ->(sock){ socket_option_set(sock, **socket_options) }
 
@@ -135,6 +137,8 @@ module Fluent
         if proto == :tcp || proto == :tls
           socket_options[:linger_timeout] ||= @transport_config&.linger_timeout || 0
         end
+
+        socket_options[:receive_buffer_size] ||= @transport_config&.receive_buffer_size
 
         unless socket
           socket_option_validate!(proto, **socket_options)
@@ -265,6 +269,9 @@ module Fluent
           config_argument :protocol, :enum, list: [:tcp, :tls], default: :tcp
 
           ### Socket Params ###
+
+          desc "The max size of socket receive buffer. SO_RCVBUF"
+          config_param :receive_buffer_size, :size, default: nil
 
           # SO_LINGER 0 to send RST rather than FIN to avoid lots of connections sitting in TIME_WAIT at src.
           # Set positive value if needing to send FIN on closing on non-Windows.

--- a/test/plugin_helper/test_server.rb
+++ b/test/plugin_helper/test_server.rb
@@ -89,6 +89,23 @@ class ServerPluginHelperTest < Test::Unit::TestCase
       assert d.log
       assert_equal 1, d.transport_config.linger_timeout
     end
+
+    test 'can change receive_buffer_size option' do
+      d = Dummy.new
+
+      transport_opts = {
+        'receive_buffer_size' => 1024,
+      }
+      transport_conf = config_element('transport', 'tcp', transport_opts)
+      conf = config_element('source', 'tag.*', {}, [transport_conf])
+
+      assert_nothing_raised do
+        d.configure(conf)
+      end
+      assert d.plugin_id
+      assert d.log
+      assert_equal 1024, d.transport_config.receive_buffer_size
+    end
   end
 
   # run tests for tcp, udp, tls and unix


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
This patch will allow to adjust receive buffer size of UDP socket like in_udp plugin.
Related to https://github.com/fluent/fluentd/pull/1789

**Docs Changes**:
https://github.com/fluent/fluentd-docs-gitbook/pull/518

**Release Note**: 
The same as the title