### PR TITLE
in_http: add `add_tag_prefix` configuration option

### DIFF
--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -84,6 +84,8 @@ module Fluent::Plugin
     config_param :dump_error_log, :bool, default: true
     desc 'Add QUERY_ prefix query params to record'
     config_param :add_query_params, :bool, default: false
+    desc "Add prefix to incoming tag"
+    config_param :add_tag_prefix, :string, default: nil
 
     config_section :parse do
       config_set_default :@type, 'in_http'
@@ -119,6 +121,8 @@ module Fluent::Plugin
           raise Fluent::ConfigError, "Cannot enable cors_allow_credentials without specific origins"
         end
       end
+
+      raise Fluent::ConfigError, "'add_tag_prefix' parameter must not be empty" if @add_tag_prefix && @add_tag_prefix.empty?
 
       m = if @parser_configs.first['@type'] == 'in_http'
             @parser_msgpack = parser_create(usage: 'parser_in_http_msgpack', type: 'msgpack')
@@ -203,6 +207,7 @@ module Fluent::Plugin
       begin
         path = path_info[1..-1]  # remove /
         tag = path.split('/').join('.')
+        tag = "#{@add_tag_prefix}.#{tag}" if @add_tag_prefix
 
         mes = Fluent::MultiEventStream.new
         parse_params(params) do |record_time, record|

--- a/test/plugin/test_in_http.rb
+++ b/test/plugin/test_in_http.rb
@@ -1028,6 +1028,29 @@ class HttpInputTest < Test::Unit::TestCase
     assert_equal events, d.events
   end
 
+  def test_add_tag_prefix
+    d = create_driver(config + "add_tag_prefix test")
+    assert_equal "test", d.instance.add_tag_prefix
+
+    time = event_time("2011-01-02 13:14:15.123 UTC")
+    float_time = time.to_f
+
+    events = [
+      ["tag1", time, {"a"=>1}],
+    ]
+    res_codes = []
+
+    d.run(expect_records: 1) do
+      events.each do |tag, t, record|
+        res = post("/#{tag}", {"json"=>record.to_json, "time"=>float_time.to_s})
+        res_codes << res.code
+      end
+    end
+
+    assert_equal ["200"], res_codes
+    assert_equal [["test.tag1", time, {"a"=>1}]], d.events
+  end
+
   $test_in_http_connection_object_ids = []
   $test_in_http_content_types = []
   $test_in_http_content_types_flag = false


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #4179 

**What this PR does / why we need it**: 
Adds optional configuration option to add prefix tag to records tailed through `in_http` plugin, similar to `in_forward`.

**Docs Changes**:
TODO

**Release Note**: 
The same as the title.