### PR TITLE
Add with-source-only feature

### DIFF
--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -127,6 +127,12 @@ op.on('--without-source', "invoke a fluentd without input plugins", TrueClass) {
   cmd_opts[:without_source] = b
 }
 
+unless Fluent.windows?
+  op.on('--with-source-only', "Invoke a fluentd only with input plugins. The data is stored in a temporary buffer. Send SIGWINCH to cancel this mode and process the data (Not supported on Windows).", TrueClass) {|b|
+    cmd_opts[:with_source_only] = b
+  }
+end
+
 op.on('--config-file-type VALU', 'guessing file type of fluentd configuration. yaml/yml or guess') { |s|
   if (s == 'yaml') || (s == 'yml')
     cmd_opts[:config_file_type] = s.to_sym

--- a/lib/fluent/env.rb
+++ b/lib/fluent/env.rb
@@ -14,6 +14,8 @@
 #    limitations under the License.
 #
 
+require 'securerandom'
+
 require 'serverengine/utils'
 require 'fluent/oj_options'
 
@@ -25,6 +27,7 @@ module Fluent
   DEFAULT_OJ_OPTIONS = Fluent::OjOptions.load_env
   DEFAULT_DIR_PERMISSION = 0755
   DEFAULT_FILE_PERMISSION = 0644
+  INSTANCE_ID = ENV['FLUENT_INSTANCE_ID'] || SecureRandom.uuid
 
   def self.windows?
     ServerEngine.windows?

--- a/lib/fluent/plugin/out_buffer.rb
+++ b/lib/fluent/plugin/out_buffer.rb
@@ -1,0 +1,40 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'fluent/plugin/output'
+
+module Fluent::Plugin
+  class BufferOutput < Output
+    Fluent::Plugin.register_output("buffer", self)
+    helpers :event_emitter
+
+    config_section :buffer do
+      config_set_default :@type, "file"
+      config_set_default :chunk_keys, ["tag"]
+      config_set_default :flush_mode, :interval
+      config_set_default :flush_interval, 10
+    end
+
+    def multi_workers_ready?
+      true
+    end
+
+    def write(chunk)
+      return if chunk.empty?
+      router.emit_stream(chunk.metadata.tag, Fluent::MessagePackEventStream.new(chunk.read))
+    end
+  end
+end

--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -1384,6 +1384,7 @@ module Fluent
       end
 
       def submit_flush_once
+        return unless @buffer_config.flush_thread_count > 0
         # Without locks: it is rough but enough to select "next" writer selection
         @output_flush_thread_current_position = (@output_flush_thread_current_position + 1) % @buffer_config.flush_thread_count
         state = @output_flush_threads[@output_flush_thread_current_position]
@@ -1406,6 +1407,7 @@ module Fluent
       end
 
       def submit_flush_all
+        return unless @buffer_config.flush_thread_count > 0
         while !@retry && @buffer.queued?
           submit_flush_once
           sleep @buffer_config.flush_thread_burst_interval

--- a/lib/fluent/plugin_helper/event_emitter.rb
+++ b/lib/fluent/plugin_helper/event_emitter.rb
@@ -26,6 +26,9 @@ module Fluent
 
       def router
         @_event_emitter_used_actually = true
+
+        return Engine.root_agent.source_only_router if @_event_emitter_force_source_only_router
+
         if @_event_emitter_lazy_init
           @router = @primary_instance.router
         end
@@ -46,6 +49,14 @@ module Fluent
 
       def event_emitter_used_actually?
         @_event_emitter_used_actually
+      end
+
+      def event_emitter_apply_source_only
+        @_event_emitter_force_source_only_router = true
+      end
+
+      def event_emitter_cancel_source_only
+        @_event_emitter_force_source_only_router = false
       end
 
       def event_emitter_router(label_name)
@@ -72,6 +83,7 @@ module Fluent
         super
         @_event_emitter_used_actually = false
         @_event_emitter_lazy_init = false
+        @_event_emitter_force_source_only_router = false
         @router = nil
       end
 

--- a/lib/fluent/source_only_buffer_agent.rb
+++ b/lib/fluent/source_only_buffer_agent.rb
@@ -1,0 +1,102 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'fluent/agent'
+require 'fluent/system_config'
+
+module Fluent
+  class SourceOnlyBufferAgent < Agent
+    # Use INSTANCE_ID to use the same base dir as the other workers.
+    # This will make recovery easier.
+    BUFFER_DIR_NAME = Fluent::INSTANCE_ID
+
+    def initialize(log:, system_config:)
+      super(log: log)
+
+      @default_buffer_path = File.join(system_config.root_dir || DEFAULT_BACKUP_DIR, 'source-only-buffer', BUFFER_DIR_NAME)
+      @optional_buffer_config = system_config.source_only_buffer.to_h.transform_keys(&:to_s)
+      @base_buffer_dir = nil
+      @actual_buffer_dir = nil
+    end
+
+    def configure(flush: false)
+      buffer_config = @optional_buffer_config.compact
+      buffer_config['flush_at_shutdown'] = flush ? 'true' : 'false'
+      buffer_config['flush_thread_count'] = 0 unless flush
+      buffer_config['path'] ||= @default_buffer_path
+
+      super(
+        Config::Element.new('SOURCE_ONLY_BUFFER', '', {}, [
+          Config::Element.new('match', '**', {'@type' => 'buffer', '@label' => '@ROOT'}, [
+            Config::Element.new('buffer', '', buffer_config, [])
+          ])
+        ])
+      )
+
+      @base_buffer_dir = buffer_config['path']
+      # It can be "#{@base_buffer_dir}/worker#{fluentd_worker_id}/" when using multiple workers
+      @actual_buffer_dir = File.dirname(outputs[0].buffer.path)
+
+      unless flush
+        log.info "with-source-only: the emitted data will be stored in the buffer files under" +
+                 " #{@base_buffer_dir}. You can send SIGWINCH to the supervisor process to cancel" +
+                 " with-source-only mode and process data."
+      end
+    end
+
+    def cleanup
+      unless (Dir.empty?(@actual_buffer_dir) rescue true)
+        log.warn "some buffer files remain in #{@base_buffer_dir}." +
+                 " Please consider recovering or saving the buffer files in the directory." +
+                 " To recover them, you can set the buffer path manually to system config and" +
+                 " retry, i.e., restart Fluentd with with-source-only mode and send SIGWINCH again." +
+                 " Config Example:\n#{config_example_to_recover(@base_buffer_dir)}"
+        return
+      end
+
+      begin
+        FileUtils.remove_dir(@base_buffer_dir)
+      rescue Errno::ENOENT
+        # This worker doesn't need to do anything. Another worker may remove the dir first.
+      rescue => e
+        log.warn "failed to remove the buffer directory: #{@base_buffer_dir}", error: e
+      end
+    end
+
+    def emit_error_event(tag, time, record, error)
+      error_info = {error: error, location: (error.backtrace ? error.backtrace.first : nil), tag: tag, time: time, record: record}
+      log.warn "SourceOnlyBufferAgent: dump an error event:", error_info
+    end
+
+    def handle_emits_error(tag, es, error)
+      error_info = {error: error, location: (error.backtrace ? error.backtrace.first : nil), tag: tag}
+      log.warn "SourceOnlyBufferAgent: emit transaction failed:", error_info
+      log.warn_backtrace
+    end
+
+    private
+
+    def config_example_to_recover(path)
+      <<~EOC
+        <system>
+          <source_only_buffer>
+            path #{path}
+          </source_only_buffer>
+        </system>
+      EOC
+    end
+  end
+end

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -25,7 +25,7 @@ module Fluent
       :workers, :restart_worker_interval, :root_dir, :log_level,
       :suppress_repeated_stacktrace, :emit_error_log_interval, :suppress_config_dump,
       :log_event_verbose, :ignore_repeated_log_interval, :ignore_same_log_interval,
-      :without_source, :rpc_endpoint, :enable_get_dump, :process_name,
+      :without_source, :with_source_only, :rpc_endpoint, :enable_get_dump, :process_name,
       :file_permission, :dir_permission, :counter_server, :counter_client,
       :strict_config_value, :enable_msgpack_time_support, :disable_shared_socket,
       :metrics, :enable_input_metrics, :enable_size_metrics, :enable_jit
@@ -41,7 +41,8 @@ module Fluent
     config_param :emit_error_log_interval,      :time, default: nil
     config_param :suppress_config_dump, :bool, default: nil
     config_param :log_event_verbose,    :bool, default: nil
-    config_param :without_source,  :bool, default: nil
+    config_param :without_source, :bool, default: nil
+    config_param :with_source_only, :bool, default: nil
     config_param :rpc_endpoint,    :string, default: nil
     config_param :enable_get_dump, :bool, default: nil
     config_param :process_name,    :string, default: nil
@@ -102,6 +103,16 @@ module Fluent
     config_section :metrics, multi: false do
       config_param :@type, :string, default: "local"
       config_param :labels, :hash, default: {}
+    end
+
+    config_section :source_only_buffer, init: true, multi: false do
+      config_param :flush_thread_count, :integer, default: 1
+      config_param :overflow_action, :enum, list: [:throw_exception, :block, :drop_oldest_chunk], default: :drop_oldest_chunk
+      config_param :path, :string, default: nil
+      config_param :flush_interval, :time, default: nil
+      config_param :chunk_limit_size, :size, default: nil
+      config_param :total_limit_size, :size, default: nil
+      config_param :compress, :enum, list: [:text, :gzip], default: nil
     end
 
     def self.create(conf, strict_config_value=false)

--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -1335,4 +1335,19 @@ CONF
       end
     end
   end
+
+  sub_test_case "--with-source-only" do
+    setup do
+      omit "Not supported on Windows" if Fluent.windows?
+    end
+
+    test "should work without error" do
+      conf_path = create_conf_file("empty.conf", "")
+      assert File.exist?(conf_path)
+      assert_log_matches(create_cmdline(conf_path, "--with-source-only"),
+                         "with-source-only: the emitted data will be stored in the buffer files under",
+                         "fluentd worker is now running",
+                         patterns_not_match: ["[error]"])
+    end
+  end
 end

--- a/test/plugin/test_out_buffer.rb
+++ b/test/plugin/test_out_buffer.rb
@@ -1,0 +1,54 @@
+require_relative '../helper'
+require 'fluent/test/driver/output'
+require 'fluent/plugin/out_buffer'
+
+class BufferOutputTest < Test::Unit::TestCase
+  def setup
+    Fluent::Test.setup
+  end
+
+  def create_driver(conf = "")
+    Fluent::Test::Driver::Output.new(Fluent::Plugin::BufferOutput).configure(conf)
+  end
+
+  test "default setting" do
+    d = create_driver(
+      config_element(
+        "ROOT", "", {},
+        [config_element("buffer", "", {"path" => "test"})]
+      )
+    )
+
+    assert_equal(
+      [
+        "file",
+        ["tag"],
+        :interval,
+        10,
+      ],
+      [
+        d.instance.buffer_config["@type"],
+        d.instance.buffer_config.chunk_keys,
+        d.instance.buffer_config.flush_mode,
+        d.instance.buffer_config.flush_interval,
+      ]
+    )
+  end
+
+  test "#write" do
+    d = create_driver(
+      config_element(
+        "ROOT", "", {},
+        [config_element("buffer", "", {"@type" => "memory", "flush_mode" => "immediate"})]
+      )
+    )
+
+    time = event_time
+    record = {"message" => "test"}
+    d.run(default_tag: 'test') do
+      d.feed(time, record)
+    end
+
+    assert_equal [["test", time, record]], d.events
+  end
+end

--- a/test/plugin_helper/test_event_emitter.rb
+++ b/test/plugin_helper/test_event_emitter.rb
@@ -77,4 +77,33 @@ class EventEmitterTest < Test::Unit::TestCase
     router = d.event_emitter_router("@ROOT")
     assert_equal Fluent::Engine.root_agent.event_router, router
   end
+
+  test '#router should return the root router by default' do
+    stub(Fluent::Engine.root_agent).event_router { "root_event_router" }
+    stub(Fluent::Engine.root_agent).source_only_router { "source_only_router" }
+
+    d = Dummy.new
+    d.configure(Fluent::Config::Element.new('source', '', {}, []))
+    assert_equal "root_event_router", d.router
+  end
+
+  test '#router should return source_only_router during source-only' do
+    stub(Fluent::Engine.root_agent).event_router { "root_event_router" }
+    stub(Fluent::Engine.root_agent).source_only_router { "source_only_router" }
+
+    d = Dummy.new
+    d.configure(Fluent::Config::Element.new('source', '', {}, []))
+    d.event_emitter_apply_source_only
+
+    router_when_source_only = d.router
+
+    d.event_emitter_cancel_source_only
+
+    router_after_canceled = d.router
+
+    assert_equal(
+      ["source_only_router", "root_event_router"],
+      [router_when_source_only, router_after_canceled]
+    )
+  end
 end

--- a/test/test_source_only_buffer_agent.rb
+++ b/test/test_source_only_buffer_agent.rb
@@ -1,0 +1,254 @@
+require_relative 'helper'
+
+class SourceOnlyBufferAgentTest < ::Test::Unit::TestCase
+  def log
+    logger = ServerEngine::DaemonLogger.new(
+      Fluent::Test::DummyLogDevice.new,
+      { log_level: ServerEngine::DaemonLogger::INFO }
+    )
+    Fluent::Log.new(logger)
+  end
+
+  def setup
+    omit "Not supported on Windows" if Fluent.windows?
+    @log = log
+  end
+
+  sub_test_case "#configure" do
+    test "default" do
+      system_config = Fluent::SystemConfig.new
+      root_agent = Fluent::RootAgent.new(log: @log, system_config: system_config)
+      stub(Fluent::Engine).root_agent { root_agent }
+      stub(Fluent::Engine).system_config { system_config }
+      root_agent.configure(config_element)
+
+      agent = Fluent::SourceOnlyBufferAgent.new(log: @log, system_config: system_config)
+      agent.configure
+
+      assert_equal(
+        {
+          "num of filter plugins" => 0,
+          "num of output plugins" => 1,
+          "base_buffer_dir" => agent.instance_variable_get(:@default_buffer_path),
+          "actual_buffer_dir" => agent.instance_variable_get(:@default_buffer_path),
+          "EventRouter of BufferOutput" => root_agent.event_router.object_id,
+          "flush_thread_count" => 0,
+          "flush_at_shutdown" => false,
+        },
+        {
+          "num of filter plugins" => agent.filters.size,
+          "num of output plugins" => agent.outputs.size,
+          "base_buffer_dir" => agent.instance_variable_get(:@base_buffer_dir),
+          "actual_buffer_dir" => agent.instance_variable_get(:@actual_buffer_dir),
+          "EventRouter of BufferOutput" => agent.outputs[0].router.object_id,
+          "flush_thread_count" => agent.outputs[0].buffer_config.flush_thread_count,
+          "flush_at_shutdown" => agent.outputs[0].buffer_config.flush_at_shutdown,
+        }
+      )
+
+      assert do
+        @log.out.logs.any? { |log| log.include? "the emitted data will be stored in the buffer files" }
+      end
+    end
+
+    test "flush: true" do
+      system_config = Fluent::SystemConfig.new
+      root_agent = Fluent::RootAgent.new(log: @log, system_config: system_config)
+      stub(Fluent::Engine).root_agent { root_agent }
+      stub(Fluent::Engine).system_config { system_config }
+      root_agent.configure(config_element)
+
+      agent = Fluent::SourceOnlyBufferAgent.new(log: @log, system_config: system_config)
+      agent.configure(flush: true)
+
+      assert_equal(
+        {
+          "num of filter plugins" => 0,
+          "num of output plugins" => 1,
+          "base_buffer_dir" => agent.instance_variable_get(:@default_buffer_path),
+          "actual_buffer_dir" => agent.instance_variable_get(:@default_buffer_path),
+          "EventRouter of BufferOutput" => root_agent.event_router.object_id,
+          "flush_thread_count" => 1,
+          "flush_at_shutdown" => true,
+        },
+        {
+          "num of filter plugins" => agent.filters.size,
+          "num of output plugins" => agent.outputs.size,
+          "base_buffer_dir" => agent.instance_variable_get(:@base_buffer_dir),
+          "actual_buffer_dir" => agent.instance_variable_get(:@actual_buffer_dir),
+          "EventRouter of BufferOutput" => agent.outputs[0].router.object_id,
+          "flush_thread_count" => agent.outputs[0].buffer_config.flush_thread_count,
+          "flush_at_shutdown" => agent.outputs[0].buffer_config.flush_at_shutdown,
+        }
+      )
+
+      assert do
+        not @log.out.logs.any? { |log| log.include? "the emitted data will be stored in the buffer files" }
+      end
+    end
+
+    test "multiple workers" do
+      system_config = Fluent::SystemConfig.new(config_element("system", "", {"workers" => 2}))
+      root_agent = Fluent::RootAgent.new(log: @log, system_config: system_config)
+      stub(Fluent::Engine).root_agent { root_agent }
+      stub(Fluent::Engine).system_config { system_config }
+      root_agent.configure(config_element)
+
+      agent = Fluent::SourceOnlyBufferAgent.new(log: @log, system_config: system_config)
+      agent.configure
+
+      assert_equal(
+        {
+          "num of filter plugins" => 0,
+          "num of output plugins" => 1,
+          "base_buffer_dir" => agent.instance_variable_get(:@default_buffer_path),
+          "actual_buffer_dir" => "#{agent.instance_variable_get(:@default_buffer_path)}/worker0",
+          "EventRouter of BufferOutput" => root_agent.event_router.object_id,
+          "flush_thread_count" => 0,
+          "flush_at_shutdown" => false,
+        },
+        {
+          "num of filter plugins" => agent.filters.size,
+          "num of output plugins" => agent.outputs.size,
+          "base_buffer_dir" => agent.instance_variable_get(:@base_buffer_dir),
+          "actual_buffer_dir" => agent.instance_variable_get(:@actual_buffer_dir),
+          "EventRouter of BufferOutput" => agent.outputs[0].router.object_id,
+          "flush_thread_count" => agent.outputs[0].buffer_config.flush_thread_count,
+          "flush_at_shutdown" => agent.outputs[0].buffer_config.flush_at_shutdown,
+        }
+      )
+    end
+
+    test "full setting with flush:true" do
+      system_config = Fluent::SystemConfig.new(config_element("system", "", {}, [
+        config_element("source_only_buffer", "", {
+          "flush_thread_count" => 4,
+          "overflow_action" => :throw_exception,
+          "path" => "tmp_buffer_path",
+          "flush_interval" => 1,
+          "chunk_limit_size" => 100,
+          "total_limit_size" => 1000,
+          "compress" => :gzip,
+        })
+      ]))
+      root_agent = Fluent::RootAgent.new(log: @log, system_config: system_config)
+      stub(Fluent::Engine).root_agent { root_agent }
+      stub(Fluent::Engine).system_config { system_config }
+      root_agent.configure(config_element)
+
+      agent = Fluent::SourceOnlyBufferAgent.new(log: @log, system_config: system_config)
+      agent.configure(flush: true)
+
+      assert_equal(
+        {
+          "num of filter plugins" => 0,
+          "num of output plugins" => 1,
+          "base_buffer_dir" => "tmp_buffer_path",
+          "actual_buffer_dir" => "tmp_buffer_path",
+          "EventRouter of BufferOutput" => root_agent.event_router.object_id,
+          "flush_thread_count" => 4,
+          "flush_at_shutdown" => true,
+          "overflow_action" => :throw_exception,
+          "flush_interval" => 1,
+          "chunk_limit_size" => 100,
+          "total_limit_size" => 1000,
+          "compress" => :gzip,
+        },
+        {
+          "num of filter plugins" => agent.filters.size,
+          "num of output plugins" => agent.outputs.size,
+          "base_buffer_dir" => agent.instance_variable_get(:@base_buffer_dir),
+          "actual_buffer_dir" => agent.instance_variable_get(:@actual_buffer_dir),
+          "EventRouter of BufferOutput" => agent.outputs[0].router.object_id,
+          "flush_thread_count" => agent.outputs[0].buffer_config.flush_thread_count,
+          "flush_at_shutdown" => agent.outputs[0].buffer_config.flush_at_shutdown,
+          "overflow_action" => agent.outputs[0].buffer_config.overflow_action,
+          "flush_interval" => agent.outputs[0].buffer_config.flush_interval,
+          "chunk_limit_size" => agent.outputs[0].buffer.chunk_limit_size,
+          "total_limit_size" => agent.outputs[0].buffer.total_limit_size,
+          "compress" => agent.outputs[0].buffer.compress,
+        }
+      )
+    end
+  end
+
+  sub_test_case "#cleanup" do
+    test "do not remove the buffer if it is not empty" do
+      system_config = Fluent::SystemConfig.new
+      root_agent = Fluent::RootAgent.new(log: @log, system_config: system_config)
+      stub(Fluent::Engine).root_agent { root_agent }
+      stub(Fluent::Engine).system_config { system_config }
+      root_agent.configure(config_element)
+
+      agent = Fluent::SourceOnlyBufferAgent.new(log: @log, system_config: system_config)
+      agent.configure
+
+      stub(Dir).empty?(agent.instance_variable_get(:@actual_buffer_dir)) { false }
+      mock(FileUtils).remove_dir.never
+
+      agent.cleanup
+
+      assert do
+        @log.out.logs.any? { |log| log.include? "some buffer files remain in" }
+      end
+    end
+
+    test "remove the buffer if it is empty" do
+      system_config = Fluent::SystemConfig.new
+      root_agent = Fluent::RootAgent.new(log: @log, system_config: system_config)
+      stub(Fluent::Engine).root_agent { root_agent }
+      stub(Fluent::Engine).system_config { system_config }
+      root_agent.configure(config_element)
+
+      agent = Fluent::SourceOnlyBufferAgent.new(log: @log, system_config: system_config)
+      agent.configure
+
+      stub(Dir).empty?(agent.instance_variable_get(:@actual_buffer_dir)) { true }
+      mock(FileUtils).remove_dir(agent.instance_variable_get(:@base_buffer_dir)).times(1)
+
+      agent.cleanup
+
+      assert do
+        not @log.out.logs.any? { |log| log.include? "some buffer files remain in" }
+      end
+    end
+  end
+
+  sub_test_case "error" do
+    test "#emit_error_event" do
+      system_config = Fluent::SystemConfig.new
+      root_agent = Fluent::RootAgent.new(log: @log, system_config: system_config)
+      stub(Fluent::Engine).root_agent { root_agent }
+      stub(Fluent::Engine).system_config { system_config }
+      root_agent.configure(config_element)
+
+      agent = Fluent::SourceOnlyBufferAgent.new(log: @log, system_config: system_config)
+      agent.configure
+
+      agent.event_router.emit_error_event("tag", 0, "hello", Exception.new)
+
+      assert do
+        @log.out.logs.any? { |log| log.include? "SourceOnlyBufferAgent: dump an error event" }
+      end
+    end
+
+    test "#handle_emits_error" do
+      system_config = Fluent::SystemConfig.new
+      root_agent = Fluent::RootAgent.new(log: @log, system_config: system_config)
+      stub(Fluent::Engine).root_agent { root_agent }
+      stub(Fluent::Engine).system_config { system_config }
+      root_agent.configure(config_element)
+
+      agent = Fluent::SourceOnlyBufferAgent.new(log: @log, system_config: system_config)
+      agent.configure
+
+      stub(agent.outputs[0]).emit_events { raise "test error" }
+
+      agent.event_router.emit("foo", 0, "hello")
+
+      assert do
+        @log.out.logs.any? { |log| log.include? "SourceOnlyBufferAgent: emit transaction failed" }
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None.
Related to

* #4622

This feature may be useful on its own, but mainly, this feature will help #4622 feature.

**What this PR does / why we need it**: 
Add `--with-source-only` option to `fluentd` command.
(Ref: Similar to existing [--without-source](https://docs.fluentd.org/deployment/command-line-option) option)
(We can use system-config option `with_source_only` as well)

It launches Fluentd with Input plugins only.
Here is the specification.

* Those Input plugins emits the events to SourceOnlyBufferAgent.
* The events is kept in the buf_file during the source-only-mode.
* Send SIGWINCH to the supervisor to cancels the mode.
* After canceled, the new agent starts to load the buffer.
* Not supported on Windows. (It would be possible, but I want to limit the cost of implementation and testing for now)

![Screenshot from 2024-11-07 16-19-16](https://github.com/user-attachments/assets/f393f06a-c4ca-4cb2-9cc1-e11c86855b03)

**Docs Changes**:
TODO

**Release Note**: 
* Add with-source-only feature
  * `fluentd` command: add `--with-source-only` option
  * system config: add `with_source_only` option
* embedded plugin: add `out_buffer` plugin, which can be used for buffering and relabeling events.

# new options for system config

We can use `with_source_only` system config option instead of `--with-source-only` command line option.

We can customize some buffer configs by setting `source_only_buffer` section.
If there is no need to customize, we don't need to set these configs.

* `with_source_only`: default `nil`
* `source_only_buffer` section
  * `flush_thread_count`: default `1`
  * `overflow_action`: default `drop_oldest_chunk`
  * `path`: default `nil` (use unique path for the instance) 
  * `flush_interval`: default `nil` (use the default of `BufferOutput` plugin: `10`)
  * `chunk_limit_size`: default `nil` (use the default of `BufferOutput` plugin: `256 * 1024 * 1024`)
  * `total_limit_size`: default `nil` (use the default of `BufferOutput` plugin: `64 * 1024 * 1024 * 1024`)
  * `compress`: default `nil` (use the default of `BufferOutput` plugin: `text`)

example:

```xml
<system>
  <source_only_buffer>
    chunk_limit_size 100m
    compress gzip
    flush_thread_count 4
  </source_only_buffer>
</system>
```

# new plugin: out_buffer
This feature internally uses the new plugin `out_buffer`.
This plugin can be used for buffering and relabeling events.

Example: in_udp -> out_buffer -> out_stdout

```xml
<source>
  @type udp
  tag foo.udp
  @label @buffer
  <parse>
    @type none
  </parse>
</source>

<match foo.**>
  @type stdout
</match>

<label @buffer>
  <match **>
    @type buffer
    @label @ROOT
    <buffer>
      path /path/to/buffer
    </buffer>
  </match>
</label>
```

# Limitaion

The following warning logs occur when the agent starts to load the buffer after sending SIGWINCH.

```
2024-11-07 18:45:07 +0900 [warn]: #0 restoring buffer file: path = /tmp/fluent/source-only-buffer/...
```

This is because the setting of `flush_at_shutdown` is changed from `false` to `true` internally.

# Behavior example

Config

```xml
<source>
  @type sample
  tag test
  auto_increment_key number
</source>

<match test.**>
  @type stdout
</match>
```

Behavior

```console
$ bundle exec fluentd -c test.conf --with-source-only
...
{datetime} [info]: starting fluentd-1.17.1 pid=195838 ruby="3.2.2"
{datetime} [info]: spawn command to main:  cmdline=[...]
{datetime} [info]: #0 init worker0 logger path=nil rotate_age=nil rotate_size=nil
{datetime} [info]: adding match pattern="test.**" type="stdout"
{datetime} [info]: adding match pattern="**" type="buffer"
{datetime} [info]: #0 with-source-only: the emitted data will be stored in the buffer files under
/tmp/fluent/source-only-buffer/470d7c43-f10c-4f7f-9d00-75731d4fdc3b. You can send SIGWINCH to
the supervisor process to cancel with-source-only mode and process data.
{datetime} [info]: adding source type="sample"
{datetime} [warn]: #0 both of Plugin @id and path for <storage> are not specified. Using on-memory store.
{datetime} [warn]: #0 both of Plugin @id and path for <storage> are not specified. Using on-memory store.
{datetime} [info]: #0 starting fluentd worker pid=195858 ppid=195838 worker=0
{datetime} [info]: #0 fluentd worker is now running worker=0

### (Wait a moment and send SIGWINCH to the supervisor (kill -WINCH 195838)) ###

{datetime} [info]: #0 try to cancel with-source-only mode
{datetime} [info]: #0 cancel with-source-only mode and start the other plugins
{datetime} test: {"message":"sample","number":11}
{datetime} test: {"message":"sample","number":12}
{datetime} test: {"message":"sample","number":13}
{datetime} test: {"message":"sample","number":14}
{datetime} test: {"message":"sample","number":15}
{datetime} [info]: #0 shutting down output plugin type=:buffer plugin_id="object:d48"
{datetime} [info]: #0 starts the loading agent for with-source-only
{datetime} [info]: adding match pattern="**" type="buffer"
{datetime} [warn]: #0 restoring buffer file: path =
/tmp/fluent/source-only-buffer/470d7c43-f10c-4f7f-9d00-75731d4fdc3b/buffer.b626515249c8f8e1b5b487087c033fad5.log
{datetime} test: {"message":"sample","number":16}
{datetime} test: {"message":"sample","number":0} # <--- The data while source-only is loaded here!!
{datetime} test: {"message":"sample","number":1}
{datetime} test: {"message":"sample","number":2}
{datetime} test: {"message":"sample","number":3}
{datetime} test: {"message":"sample","number":4}
{datetime} test: {"message":"sample","number":5}
{datetime} test: {"message":"sample","number":6}
{datetime} test: {"message":"sample","number":7}
{datetime} test: {"message":"sample","number":8}
{datetime} test: {"message":"sample","number":9}
{datetime} test: {"message":"sample","number":10}
{datetime} test: {"message":"sample","number":17}
{datetime} test: {"message":"sample","number":18}
{datetime} test: {"message":"sample","number":19}

### Ctrl + C ###

{datetime} [info]: Received graceful stop
{datetime} test: {"message":"sample","number":20}
{datetime} [info]: #0 fluentd worker is now stopping worker=0
{datetime} [info]: #0 shutting down fluentd worker worker=0
{datetime} [info]: #0 shutting down input plugin type=:sample plugin_id="object:d70"
{datetime} [info]: #0 shutting down output plugin type=:buffer plugin_id="object:e10"
{datetime} [info]: #0 shutting down output plugin type=:stdout plugin_id="object:d20"
{datetime} [info]: Worker 0 finished with status 0
```

Behavior (Stop Fluentd without sending SIGWINCH)

```console
$ bundle exec fluentd -c test.conf --with-source-only
...
{datetime} [info]: starting fluentd-1.17.1 pid=196617 ruby="3.2.2"
{datetime} [info]: spawn command to main:  cmdline=[...]
{datetime} [info]: #0 init worker0 logger path=nil rotate_age=nil rotate_size=nil
{datetime} [info]: adding match pattern="test.**" type="stdout"
{datetime} [info]: adding match pattern="**" type="buffer"
{datetime} [info]: #0 with-source-only: the emitted data will be stored in the buffer files under
/tmp/fluent/source-only-buffer/bbd9006d-bc41-418b-b346-f80888641dda. You can send SIGWINCH to
the supervisor process to cancel with-source-only mode and process data.
{datetime} [info]: adding source type="sample"
{datetime} [warn]: #0 both of Plugin @id and path for <storage> are not specified. Using on-memory store.
{datetime} [warn]: #0 both of Plugin @id and path for <storage> are not specified. Using on-memory store.
{datetime} [info]: #0 starting fluentd worker pid=196638 ppid=196617 worker=0
{datetime} [info]: #0 fluentd worker is now running worker=0

### Ctrl + C ###

{datetime} [info]: Received graceful stop
{datetime} [info]: #0 fluentd worker is now stopping worker=0
{datetime} [info]: #0 shutting down fluentd worker worker=0
{datetime} [info]: #0 shutting down input plugin type=:sample plugin_id="object:d70"
{datetime} [info]: #0 shutting down output plugin type=:buffer plugin_id="object:d48"
{datetime} [warn]: #0 some buffer files remain in /tmp/fluent/source-only-buffer/bbd9006d-bc41-418b-b346-f80888641dda.
Please consider recovering or saving the buffer files in the directory. To recover them, you can set
the buffer path manually to system config and retry, i.e., restart Fluentd with with-source-only mode
and send SIGWINCH again. Config Example:
<system>
  <source_only_buffer>
    path /tmp/fluent/source-only-buffer/bbd9006d-bc41-418b-b346-f80888641dda
  </source_only_buffer>
</system>

{datetime} [info]: Worker 0 finished with status 0
```

# TODO

- [x] Consider race condition
- [x] Fix and add tests
- [x] Consider how to stop the loading agent
  - Not supported because it is not mandatory.
- [x] Consider configurablity of SourceOnlyBufferAgent.
- [x] Consider Windows support
  - Don't support Windows for now. (It would be possible, but I want to limit the cost of implementation and testing for now)
