### PR TITLE
tests: use never instead of dont_allow

### DIFF
--- a/test/plugin/out_forward/test_socket_cache.rb
+++ b/test/plugin/out_forward/test_socket_cache.rb
@@ -17,7 +17,7 @@ class SocketCacheTest < Test::Unit::TestCase
       assert_equal(socket, c.checkout_or('key') { socket })
       c.checkin(socket)
 
-      sock = dont_allow(mock!).open
+      sock = mock!.open.never.subject
       assert_equal(socket, c.checkout_or('key') { sock.open })
     end
 
@@ -130,7 +130,7 @@ class SocketCacheTest < Test::Unit::TestCase
 
       c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
       sock = mock!.close { 'closed' }.subject
-      sock2 = dont_allow(mock!).close
+      sock2 = mock!.close.never.subject
       stub(sock).inspect
       stub(sock2).inspect
 
@@ -154,7 +154,7 @@ class SocketCacheTest < Test::Unit::TestCase
       Timecop.freeze(Time.parse('2016-04-13 14:00:00 +0900'))
 
       c = Fluent::Plugin::ForwardOutput::SocketCache.new(10, $log)
-      sock = dont_allow(mock!).close
+      sock = mock!.close.never.subject
       stub(sock).inspect
       c.checkout_or('key') { sock }
 

--- a/test/test_event_router.rb
+++ b/test/test_event_router.rb
@@ -175,7 +175,7 @@ class EventRouterTest < ::Test::Unit::TestCase
       test "don't call default collector when tag matched" do
         event_router.add_rule('test', output)
         assert_rr do
-          dont_allow(default_collector).emit_events('test', is_a(OneEventStream))
+          mock(default_collector).emit_events('test', is_a(OneEventStream)).never
           event_router.emit('test', Engine.now, 'k' => 'v')
         end
         # check emit handler doesn't catch rr error
@@ -201,7 +201,7 @@ class EventRouterTest < ::Test::Unit::TestCase
         event_router.add_rule('test', filter)
 
         assert_rr do
-          dont_allow(filter).filter_stream('test', is_a(OneEventStream)) { events }
+          mock(filter).filter_stream('test', is_a(OneEventStream)).never
           event_router.emit('foo', Engine.now, 'k' => 'v')
         end
       end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #4063

**What this PR does / why we need it**: 
If it use the object applied `dont_allow` in the other test through `ObjectSpace.each_object`, it will cause the error.
To relax object constraints, this patch will use `never` instead.

See sample code in https://github.com/fluent/fluentd/issues/4063#issuecomment-2416121325

**Docs Changes**:

**Release Note**: 
