### PR TITLE
test_in_udp: Reduce execution time of message_length_limit test

### DIFF
--- a/test/plugin/test_in_udp.rb
+++ b/test/plugin/test_in_udp.rb
@@ -268,25 +268,31 @@ class UdpInputTest < Test::Unit::TestCase
 
   test 'message_length_limit' do
     message_length_limit = 32
+
+    if Fluent.windows?
+      expected_records = ["0" * 30, "4" * 30]
+    else
+      expected_records = 1.upto(3).collect do |i|
+        "#{i}" * message_length_limit
+      end
+      expected_records.prepend("0" * 30)
+      expected_records.append("4" * 30)
+    end
+
     d = create_driver(base_config + %!
       format none
       message_length_limit #{message_length_limit}
     !)
-    d.run(expect_records: 3, timeout: 5) do
+    d.run(expect_records: expected_records.size, timeout: 5) do
       create_udp_socket('127.0.0.1', @port) do |u|
-        3.times do |i|
+        u.send("0" * 30 + "\n", 0)
+        1.upto(3) do |i|
           u.send("#{i}" * 40 + "\n", 0)
         end
+        u.send("4" * 30 + "\n", 0)
       end
     end
 
-    if Fluent.windows?
-      expected_records = []
-    else
-      expected_records = 3.times.collect do |i|
-        "#{i}" * message_length_limit
-      end
-    end
     actual_records = d.events.collect do |event|
       event[2]["message"]
     end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
N/A

**What this PR does / why we need it**: 
Although it's improved in #4676, it still takes 5 seconds on windows.
It can be reduced more by sending data that doesn't exceed the limit.

```
  test: message_length_limit:                           .: (1.104855)
```

**Docs Changes**:
N/A

**Release Note**: 
N/A
