### PR TITLE
test_out_forward: relax an ack_response_timeout

### DIFF
--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -611,7 +611,7 @@ EOL
 
     @d = d = create_driver(config + %[
       require_ack_response true
-      ack_response_timeout 1s
+      ack_response_timeout 10s
       <buffer tag>
         flush_mode immediate
         retry_type periodic


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #4684

**What this PR does / why we need it**: 
Seems that timeout setting is short in ack_response_timeout.
Seems that It may take some time to receive a ACK response
so the process in ack handler has expired and the node is disabled.

**Docs Changes**:

**Release Note**: 
