### PR TITLE
test_cat: use proper protocol in unused_port method

### DIFF
--- a/test/command/test_cat.rb
+++ b/test/command/test_cat.rb
@@ -18,7 +18,7 @@ class TestFluentCat < ::Test::Unit::TestCase
     @primary = create_primary
     metadata = @primary.buffer.new_metadata
     @chunk = create_chunk(@primary, metadata, @es)
-    @port = unused_port(protocol: :tcp)
+    @port = unused_port(protocol: :udp)
   end
 
   def teardown

--- a/test/command/test_cat.rb
+++ b/test/command/test_cat.rb
@@ -18,7 +18,7 @@ class TestFluentCat < ::Test::Unit::TestCase
     @primary = create_primary
     metadata = @primary.buffer.new_metadata
     @chunk = create_chunk(@primary, metadata, @es)
-    @port = unused_port(protocol: :udp)
+    @port = unused_port(protocol: :all)
   end
 
   def teardown


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #4674

**What this PR does / why we need it**: 
Fixes an issue where an inappropriate protocol was specified in the `unused_port` method.
See https://github.com/fluent/fluentd/issues/4674#issuecomment-2440522606

**Docs Changes**:

**Release Note**: 
