### PR TITLE
test_ack_handler: use singleton method instead of stub for stability

### DIFF
--- a/test/plugin/out_forward/test_ack_handler.rb
+++ b/test/plugin/out_forward/test_ack_handler.rb
@@ -111,11 +111,11 @@ class AckHandlerTest < Test::Unit::TestCase
     r, w = IO.pipe
     begin
       w.write(chunk_id)
-      stub(r).recv { |_|
+      def r.recv(arg)
         sleep(1) # To ensure that multiple threads select the socket before closing.
-        raise IOError, 'stream closed in another thread' if r.closed?
+        raise IOError, 'stream closed in another thread' if self.closed?
         MessagePack.pack({ 'ack' => Base64.encode64('chunk_id 111') })
-      }
+      end
       ack.enqueue(r)
 
       threads = []


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #4694

**What this PR does / why we need it**: 
When using stub, sometimes it causes errors when it remove prepared methods by stub. To improve the stability of the CI, this patch will use the singleton method instead of stub.

**Docs Changes**:

**Release Note**: 
