### PR TITLE
test_in_exec: set default_internal / default_external encoding in command

### DIFF
--- a/test/plugin/test_in_exec.rb
+++ b/test/plugin/test_in_exec.rb
@@ -225,7 +225,7 @@ EOC
       content = 'ひらがな漢字'
 
       d = create_driver %[
-        command ruby -e "puts '#{content}'"
+        command ruby -Eascii-8bit:ascii-8bit -e "puts '#{content}'"
         tag test
         encoding utf-8
         <parse>


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #4699

**What this PR does / why we need it**: 
Set default_internal / default_external in order to succeed CI on Ruby HEAD.

**Docs Changes**:

**Release Note**: 
