### PR TITLE
system_config: add source_only_buffer to SYSTEM_CONFIG_PARAMETERS

### DIFF
--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -28,7 +28,7 @@ module Fluent
       :without_source, :with_source_only, :rpc_endpoint, :enable_get_dump, :process_name,
       :file_permission, :dir_permission, :counter_server, :counter_client,
       :strict_config_value, :enable_msgpack_time_support, :disable_shared_socket,
-      :metrics, :enable_input_metrics, :enable_size_metrics, :enable_jit
+      :metrics, :enable_input_metrics, :enable_size_metrics, :enable_jit, :source_only_buffer
     ]
 
     config_param :workers,   :integer, default: 1


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
* Additional fix for #4661

**What this PR does / why we need it**: 
Need this to the section handled in `SystemConfig#dup`.
This should be added to SYSTEM_CONFIG_PARAMETERS, though this is not affected to the actual behavior,

Note: I don't understand why `log` section is not added. Maybe it should be added as well.
(It should be done by another PR).

**Docs Changes**:
Not needed

**Release Note**: 
Not needed
