### PR TITLE
Ensure FIPS compliant mode by ensure_fips option

### DIFF
--- a/lib/fluent/plugin_helper/cert_option.rb
+++ b/lib/fluent/plugin_helper/cert_option.rb
@@ -37,6 +37,12 @@ module Fluent
           ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE
         end
 
+        if conf.ensure_fips
+          unless OpenSSL.fips_mode
+            raise Fluent::ConfigError, "Cannot enable FIPS compliant mode. OpenSSL FIPS configuration is disabled"
+          end
+        end
+
         ctx.ca_file = conf.ca_path
         ctx.cert = cert
         ctx.key = key

--- a/lib/fluent/plugin_helper/server.rb
+++ b/lib/fluent/plugin_helper/server.rb
@@ -251,6 +251,7 @@ module Fluent
         :generate_cert_country, :generate_cert_state, :generate_cert_state,
         :generate_cert_locality, :generate_cert_common_name,
         :generate_cert_expiration, :generate_cert_digest,
+        :ensure_fips,
       ]
 
       def server_create_transport_section_object(opts)
@@ -294,6 +295,7 @@ module Fluent
           config_param :max_version, :enum, list: Fluent::TLS::SUPPORTED_VERSIONS, default: nil
           config_param :ciphers, :string, default: Fluent::TLS::CIPHERS_DEFAULT
           config_param :insecure, :bool, default: false
+          config_param :ensure_fips, :bool, default: false
 
           # Cert signed by public CA
           config_param :ca_path, :string, default: nil

--- a/test/plugin_helper/test_cert_option.rb
+++ b/test/plugin_helper/test_cert_option.rb
@@ -1,9 +1,14 @@
 require_relative '../helper'
+require 'fluent/plugin_helper/server'
 require 'fluent/plugin_helper/cert_option'
 
 class CertOptionPluginHelperTest < Test::Unit::TestCase
   class Dummy < Fluent::Plugin::TestBase
     helpers :cert_option
+  end
+
+  class DummyServer < Fluent::Plugin::TestBase
+    helpers :server
   end
 
   test 'can load PEM encoded certificate file' do
@@ -20,6 +25,44 @@ class CertOptionPluginHelperTest < Test::Unit::TestCase
     d = Dummy.new
     assert_raise Fluent::ConfigError do
       d.cert_option_certificates_from_file("test/plugin_helper/data/cert/empty.pem")
+    end
+  end
+
+  sub_test_case "ensure OpenSSL FIPS mode" do
+    setup do
+      cert_dir = File.expand_path(File.join(File.dirname(__FILE__), "../plugin_helper/data/cert/"))
+      @tls_options = {
+        cert_path: File.join(cert_dir, "cert.pem"),
+        private_key_path: File.join(cert_dir, "cert-key.pem"),
+      }
+      @d = DummyServer.new
+    end
+
+    data(
+      enabled_fips_mode: [true, true, nil],
+      skip_checking_fips_mode: [true, false, nil],
+      block_incompatible_fips_mode: [false, true,
+                                     Fluent::ConfigError.new("Cannot enable FIPS compliant mode. OpenSSL FIPS configuration is disabled")],
+      not_care_fips_mode: [false, false, nil]
+    )
+    test 'ensure FIPS error' do |(fips_mode, ensure_fips, expected)|
+      stub(OpenSSL).fips_mode { fips_mode }
+      conf = @d.server_create_transport_section_object(@tls_options.merge({ensure_fips: ensure_fips}))
+      if expected
+        assert_raise(expected) do
+          @d.cert_option_create_context(Fluent::TLS::DEFAULT_VERSION,
+                                        false,
+                                        Fluent::TLS::CIPHERS_DEFAULT,
+                                        conf)
+        end
+      else
+        assert_nothing_raised do
+          @d.cert_option_create_context(Fluent::TLS::DEFAULT_VERSION,
+                                        false,
+                                        Fluent::TLS::CIPHERS_DEFAULT,
+                                        conf)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION

**Which issue(s) this PR fixes**: 

Fixes #3121

**What this PR does / why we need it**: 

ensure_fips option checks whether FIPS mode is
enabled by OpenSSL side.
If FIPS is not enabled in OpenSSL side, it raise an error (blocking launching fluentd) when ensure_fips is true.

NOTE: If FIPS mode is enabled by default, ensure_fips does nothing.

**Docs Changes**:

Document ensure_fips option in transport-section.

https://docs.fluentd.org/configuration/transport-section#tls-setting

**Release Note**: 

N/A
