### PR TITLE
test_cat: specify the reading size to read in binary mode

### DIFF
--- a/test/command/test_cat.rb
+++ b/test/command/test_cat.rb
@@ -87,7 +87,7 @@ class TestFluentCat < ::Test::Unit::TestCase
       d = create_driver
       d.run(expect_records: 1) do
         Open3.pipeline_w("#{ServerEngine.ruby_bin_path} #{FLUENT_CAT_COMMAND} --port #{@port} --format msgpack secondary") do |stdin|
-          stdin.write(File.read(path))
+          stdin.write(File.read(path, File.size(path)))
           stdin.close
         end
       end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #4729

**What this PR does / why we need it**: 
The binary files may not be read properly. 
This changes to read files in binary mode.

**Docs Changes**:

**Release Note**: 
