### PR TITLE
Bump required ruby version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        ruby-version: ['3.4', '3.3', '3.2', '3.1']
+        ruby-version: ['3.4', '3.3', '3.2']
 
     name: Ruby ${{ matrix.ruby-version }} on ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Fluentd: Open-Source Log Collector
 
 ### Prerequisites
 
-- Ruby 2.7 or later
+- Ruby 3.2 or later
 - git
 
 `git` should be in `PATH`. On Windows, you can use `Github for Windows` and `GitShell` for easy setup.

--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.license = "Apache-2.0"
 
-  gem.required_ruby_version = '>= 2.7'
+  gem.required_ruby_version = '>= 3.2'
 
   gem.add_runtime_dependency("bundler")
   gem.add_runtime_dependency("msgpack", [">= 1.3.1", "< 2.0.0"])


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

Fixes #

**What this PR does / why we need it**: 

Raise baseline version of Ruby to 3.2.
fluent-package v5 (LTS) adopts ruby 3.2, so it is reasonable to set minimum version to Ruby 3.2. 

NOTE: these kind of changes might be better to apply in v1.19.0

**Docs Changes**:

https://docs.fluentd.org/quickstart/faq

https://github.com/fluent/fluentd-docs-gitbook/pull/524

**Release Note**: 

N/A
