### PR TITLE
ci: tweak supported/dropped version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,6 @@ jobs:
         uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf # v1.204.0
         with:
           ruby-version: ${{ matrix.ruby-version }}
-          rubygems: latest
       - name: Install addons
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: sudo apt-get install libgmp3-dev libcap-ng-dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        ruby-version: ['3.3', '3.2', '3.1', '3.0', '2.7']
+        ruby-version: ['3.4', '3.3', '3.2', '3.1']
 
     name: Ruby ${{ matrix.ruby-version }} on ${{ matrix.os }}
     steps:


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

Fixes #

**What this PR does / why we need it**: 

Tweak current CI targets.

Added: Ruby 3.4
Dropped: Ruby 3.0/2.7

Ruby 2.7 EOL: 2023-03-31
Ruby 3.0 EOL: 2024-04-23

NOTE: until PR is merged [1], 3.4 points 3.4.0-rc1.

[1] https://github.com/ruby/setup-ruby/pull/677

**Docs Changes**:

N/A

**Release Note**: 

N/A
