### PR TITLE
windows: add workaround for unexpected exception

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -40,7 +40,9 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("drb", ["~> 2.2"])
 
   # gems that aren't default gems as of Ruby 3.5
-  gem.add_runtime_dependency("logger", ["~> 1.6"])
+  # logger 1.6.3 or later cause bug on windows,
+  # hold on 1.6.2 for a while. see https://github.com/ruby/logger/issues/107
+  gem.add_runtime_dependency("logger", ["1.6.2"])
 
   # build gem for a certain platform. see also Rakefile
   fake_platform = ENV['GEM_BUILD_FAKE_PLATFORM'].to_s


### PR DESCRIPTION

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

Since logger 1.6.3 or later, there is a bug that it cause unexpected exception (no implicit conversion of Integer into String (TypeError)) on windows. So hold on 1.6.2 for a while.

See https://github.com/ruby/logger/issues/107

**Docs Changes**:

N/A

**Release Note**: 

N/A
