### PR TITLE
ci: exclude test case until Ruby 3.4 is installable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,9 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         ruby-version: ['3.4', '3.3', '3.2', '3.1']
+        exclude:
+          - os: 'windows-latest'
+            ruby-version: '3.4'
 
     name: Ruby ${{ matrix.ruby-version }} on ${{ matrix.os }}
     steps:


### PR DESCRIPTION

**Which issue(s) this PR fixes**: 

Fixes #

**What this PR does / why we need it**: 

Ruby 3.4 binary on Windows is not ready yet.
Exclude it from matrix until it is available.

**Docs Changes**:

N/A

**Release Note**: 

N/A
