### PR TITLE
ci: use latest rubygems again for Ruby 3.1 on windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,7 @@ jobs:
         uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf # v1.204.0
         with:
           ruby-version: ${{ matrix.ruby-version }}
+          rubygems: latest
       - name: Install addons
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: sudo apt-get install libgmp3-dev libcap-ng-dev


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

Fixes #

**What this PR does / why we need it**: 

It seems that it fixes failure with Ruby 3.1 on windows.

```
   undefined method `ignored?' for #<Gem::Specification:0x000001dccaf43168
```

**Docs Changes**:

N/A

**Release Note**: 

N/A
