### PR TITLE
ci: include Ruby 3.4 on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,6 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         ruby-version: ['3.4', '3.3', '3.2', '3.1']
-        exclude:
-          - os: 'windows-latest'
-            ruby-version: '3.4'
 
     name: Ruby ${{ matrix.ruby-version }} on ${{ matrix.os }}
     steps:


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
[RubyInstaller 3.4.1](https://github.com/oneclick/rubyinstaller2/releases/tag/RubyInstaller-3.4.1-1) was released.
So we can use Ruby 3.4 on Windows in CI.

**Docs Changes**:

**Release Note**: 
