### PR TITLE
Use JSON instead of Yajl to improve performance of store/load files

### DIFF
--- a/lib/fluent/plugin/formatter_out_file.rb
+++ b/lib/fluent/plugin/formatter_out_file.rb
@@ -16,7 +16,7 @@
 
 require 'fluent/plugin/formatter'
 require 'fluent/time'
-require 'yajl'
+require 'json'
 
 module Fluent
   module Plugin
@@ -46,7 +46,7 @@ module Fluent
         header = ''
         header << "#{@timef.format(time)}#{@delimiter}" if @output_time
         header << "#{tag}#{@delimiter}" if @output_tag
-        "#{header}#{Yajl.dump(record)}#{@newline}"
+        "#{header}#{JSON.generate(record)}#{@newline}"
       end
     end
   end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
When I read 10 GB file using in_tail plugin, it calls Yajl methods many times when it stores to buffer file.

Recently, Ruby's JSON has huge improvement and it is much faster.
Ref. https://byroot.github.io/ruby/json/2024/12/15/optimizing-ruby-json-part-1.html

* Before
  * It spent 88.533409329 sec to handle 10 GB file
* After
  * It spent 72.324643557 sec to handle 10 GB file


* config
```
<source>
  @type tail
  path /home/watson/prj/sandbox/fluentd/log/access*.log
  pos_file /home/watson/prj/sandbox/fluentd/log/access.log.pos
  tag log
  read_from_head true
  follow_inodes true
  # rotate_wait 0
  refresh_interval 5
  # open_on_every_update true
  <parse>
    @type none
  </parse>
</source>

<match **>
  @type file
  path /home/watson/prj/sandbox/fluentd/log/log
</match>
```

**Docs Changes**:

**Release Note**: 
