### PR TITLE
Use `#match?` method instead of `#match`

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -147,7 +147,7 @@ module Fluent::Plugin
         raise Fluent::ConfigError, "cannot use glob_policy as always with the default path_delimitor: `,\""
       end
 
-      if @glob_policy == :extended && /\{.*,.*\}/.match(@path) && extended_glob_pattern(@path)
+      if @glob_policy == :extended && /\{.*,.*\}/.match?(@path) && extended_glob_pattern(@path)
         raise Fluent::ConfigError, "cannot include curly braces with glob patterns in `#{@path}\". Use glob_policy always instead."
       end
 
@@ -300,7 +300,7 @@ module Fluent::Plugin
     end
 
     def extended_glob_pattern(path)
-      path.include?('*') || path.include?('?') || /\[.*\]/.match(path)
+      path.include?('*') || path.include?('?') || /\[.*\]/.match?(path)
     end
 
     # Curly braces is not supported with default path_delimiter
@@ -313,7 +313,7 @@ module Fluent::Plugin
         # regular expressions as much as possible.
         # This is because not using `true' as a returning value
         # when choosing :always here.
-        extended_glob_pattern(path) || /\{.*,.*\}/.match(path)
+        extended_glob_pattern(path) || /\{.*,.*\}/.match?(path)
       elsif @glob_policy == :extended
         extended_glob_pattern(path)
       elsif @glob_policy == :backward_compatible

--- a/lib/fluent/plugin/out_secondary_file.rb
+++ b/lib/fluent/plugin/out_secondary_file.rb
@@ -98,11 +98,11 @@ module Fluent::Plugin
         raise Fluent::ConfigError, "out_secondary_file: basename or directory has an incompatible placeholder, remove time formats, like `%Y%m%d`, from basename or directory"
       end
 
-      if !@chunk_key_tag && (ph = placeholders.find { |placeholder| placeholder.match(/tag(\[\d+\])?/) })
+      if !@chunk_key_tag && (ph = placeholders.find { |placeholder| placeholder.match?(/tag(\[\d+\])?/) })
         raise Fluent::ConfigError, "out_secondary_file: basename or directory has an incompatible placeholder #{ph}, remove tag placeholder, like `${tag}`, from basename or directory"
       end
 
-      vars = placeholders.reject { |placeholder| placeholder.match(/tag(\[\d+\])?/) || (placeholder == 'chunk_id') }
+      vars = placeholders.reject { |placeholder| placeholder.match?(/tag(\[\d+\])?/) || (placeholder == 'chunk_id') }
 
       if ph = vars.find { |v| !@chunk_keys.include?(v) }
         raise Fluent::ConfigError, "out_secondary_file: basename or directory has an incompatible placeholder #{ph}, remove variable placeholder, like `${varname}`, from basename or directory"

--- a/lib/fluent/plugin/parser.rb
+++ b/lib/fluent/plugin/parser.rb
@@ -220,7 +220,7 @@ module Fluent
       end
 
       def string_like_null(value, null_empty_string = @null_empty_string, null_value_regexp = @null_value_pattern)
-        null_empty_string && value.empty? || null_value_regexp && string_safe_encoding(value){|s| null_value_regexp.match(s) }
+        null_empty_string && value.empty? || null_value_regexp && string_safe_encoding(value){|s| null_value_regexp.match?(s) }
       end
 
       TRUTHY_VALUES = ['true', 'yes', '1']


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
#match method returns MatchData, it has some cost to create the MatchData object.
If it does not use MatchData object, it is better to use #match? method instead. 

* verify
```ruby
require 'bundler/inline'
gemfile do
  source 'https://rubygems.org'
  gem 'benchmark-ips'
  gem 'benchmark-memory'
end

Benchmark.ips do |x|
  pattern = /\{.*,.*\}/
  path = 'path/to/file'

  x.report("match") {
    pattern.match(path)
  }

  x.report("match?") {
    pattern.match?(path)
  }

  x.compare!
end
```

```
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [x86_64-linux]
Warming up --------------------------------------
               match     1.082M i/100ms
              match?     1.683M i/100ms
Calculating -------------------------------------
               match     11.116M (± 0.8%) i/s   (89.96 ns/i) -     56.266M in   5.062181s
              match?     16.779M (± 0.5%) i/s   (59.60 ns/i) -     84.142M in   5.014786s

Comparison:
              match?: 16779085.3 i/s
               match: 11115820.6 i/s - 1.51x  slower
```

**Docs Changes**:

**Release Note**: 
