### PR TITLE
out_file: remove workaround for Ruby 2.7 and 3.0 on macOS

### DIFF
--- a/lib/fluent/plugin/out_file.rb
+++ b/lib/fluent/plugin/out_file.rb
@@ -189,13 +189,6 @@ module Fluent::Plugin
       @dir_perm = system_config.dir_permission || Fluent::DEFAULT_DIR_PERMISSION
       @file_perm = system_config.file_permission || Fluent::DEFAULT_FILE_PERMISSION
       @need_lock = system_config.workers > 1
-
-      # https://github.com/fluent/fluentd/issues/3569
-      @need_ruby_on_macos_workaround = false
-      if @append && Fluent.macos?
-        condition = Gem::Dependency.new('', [">= 2.7.0", "< 3.1.0"])
-        @need_ruby_on_macos_workaround = true if condition.match?('', RUBY_VERSION)
-      end
     end
 
     def multi_workers_ready?
@@ -244,12 +237,7 @@ module Fluent::Plugin
 
     def write_without_compression(path, chunk)
       File.open(path, "ab", @file_perm) do |f|
-        if @need_ruby_on_macos_workaround
-          content = chunk.read()
-          f.puts content
-        else
-          chunk.write_to(f)
-        end
+        chunk.write_to(f)
       end
     end
 


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
Next fluentd version will drop support of Ruby 3.1 or below.
Ref. https://github.com/fluent/fluentd/pull/4745

So, we can remove the workaround for Ruby 2.7 and 3.0 on macOS that added at https://github.com/fluent/fluentd/pull/3579

**Docs Changes**:

**Release Note**: 
