### PR TITLE
server: remove codes for async v1.x

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("test-unit", ["~> 3.3"])
   gem.add_development_dependency("test-unit-rr", ["~> 1.0"])
   gem.add_development_dependency("oj", [">= 2.14", "< 4"])
-  gem.add_development_dependency("async-http", ">= 0.50.0")
+  gem.add_development_dependency("async-http", "~> 0.86")
   gem.add_development_dependency("aws-sigv4", ["~> 1.8"])
   gem.add_development_dependency("aws-sdk-core", ["~> 3.191"])
   gem.add_development_dependency("rexml", ["~> 3.2"])

--- a/lib/fluent/plugin_helper/http_server/server.rb
+++ b/lib/fluent/plugin_helper/http_server/server.rb
@@ -68,11 +68,9 @@ module Fluent
               notify.push(:ready)
             end
 
-            if async_v2?
-              @server_task_queue = ::Thread::Queue.new
-              @server_task_queue.pop
-              @server_task&.stop
-            end
+            @server_task_queue = ::Thread::Queue.new
+            @server_task_queue.pop
+            @server_task&.stop
           end
 
           @logger.debug('Finished HTTP server')
@@ -80,11 +78,7 @@ module Fluent
 
         def stop
           @logger.debug('closing HTTP server')
-          if async_v2?
-            @server_task_queue&.push(:stop)
-          else
-            @server_task&.stop
-          end
+          @server_task_queue.push(:stop)
         end
 
         HttpServer::Methods::ALL.map { |e| e.downcase.to_sym }.each do |name|
@@ -99,10 +93,6 @@ module Fluent
 
             @router.mount(name, path, app || block)
           end
-        end
-
-        private def async_v2?
-          Gem::Version.new(Async::VERSION) >= Gem::Version.new('2.0')
         end
       end
     end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
Async v2.0 just supports Ruby 3.1 or above.
When we had been supporting Ruby 2.7 and 3.0, we need async v1.x and v2.x both.
Related to https://github.com/fluent/fluentd/pull/4619

Next fluentd version will drop support of Ruby 3.1 or below.
So, now we can remove the codes for async v1.x
Ref. https://github.com/fluent/fluentd/pull/4745

**Docs Changes**:

**Release Note**: 
