### PR TITLE
github: remove needless label

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,7 +3,6 @@ contact_links:
   - name: Ask a Question
     url: https://github.com/fluent/fluentd/discussions
     about: I have questions about Fluentd and plugins. Please ask and answer questions at https://github.com/fluent/fluentd/discussions
-feedback_testimonials:
   - name: Feedback a Fluentd Use-Case/Testimonial
     url: https://github.com/fluent/fluentd-website/issues/new?template=testimonials.yml
     about: Feedback your Fluentd use-case/testimonial, How do you use Fluentd in your service?


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

Follow-up #4781 

**What this PR does / why we need it**: 

It is harmful to add extra label.
Item should be placed under contact_links.

See https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository

**Docs Changes**:

N/A

**Release Note**: 

N/A
