### PR TITLE
Backport(v1.16) tests: fix unused_port (PR#4675)

### DIFF
--- a/test/command/test_cat.rb
+++ b/test/command/test_cat.rb
@@ -18,7 +18,7 @@ class TestFluentCat < ::Test::Unit::TestCase
     @primary = create_primary
     metadata = @primary.buffer.new_metadata
     @chunk = create_chunk(@primary, metadata, @es)
-    @port = unused_port
+    @port = unused_port(protocol: :tcp)
   end
 
   def teardown

--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -1175,7 +1175,7 @@ CONF
     end
   end
 
-  sub_test_case 'sahred socket options' do
+  sub_test_case 'shared socket options' do
     test 'enable shared socket by default' do
       conf = ""
       conf_path = create_conf_file('empty.conf', conf)

--- a/test/plugin/test_in_forward.rb
+++ b/test/plugin/test_in_forward.rb
@@ -18,7 +18,8 @@ class ForwardInputTest < Test::Unit::TestCase
     Fluent::Test.setup
     @responses = []  # for testing responses after sending data
     @d = nil
-    @port = unused_port
+    # forward plugin uses TCP and UDP sockets on the same port number
+    @port = unused_port(protocol: :all)
   end
 
   def teardown

--- a/test/plugin/test_in_http.rb
+++ b/test/plugin/test_in_http.rb
@@ -18,7 +18,7 @@ class HttpInputTest < Test::Unit::TestCase
 
   def setup
     Fluent::Test.setup
-    @port = unused_port
+    @port = unused_port(protocol: :tcp)
   end
 
   def teardown

--- a/test/plugin/test_in_monitor_agent.rb
+++ b/test/plugin/test_in_monitor_agent.rb
@@ -392,7 +392,7 @@ EOC
     end
 
     test "emit" do
-      port = unused_port
+      port = unused_port(protocol: :tcp)
       d = create_driver("
   @type monitor_agent
   bind '127.0.0.1'
@@ -451,7 +451,7 @@ EOC
 
   sub_test_case "servlets" do
     setup do
-      @port = unused_port
+      @port = unused_port(protocol: :tcp)
       # check @type and type in one configuration
       conf = <<-EOC
 <source>
@@ -759,7 +759,7 @@ plugin_id:test_filter\tplugin_category:filter\ttype:test_filter\toutput_plugin:f
     end
 
     setup do
-      @port = unused_port
+      @port = unused_port(protocol: :tcp)
       # check @type and type in one configuration
       conf = <<-EOC
 <source>
@@ -840,7 +840,7 @@ plugin_id:test_filter\tplugin_category:filter\ttype:test_filter\toutput_plugin:f
 
   sub_test_case "check the port number of http server" do
     test "on single worker environment" do
-      port = unused_port
+      port = unused_port(protocol: :tcp)
       d = create_driver("
   @type monitor_agent
   bind '127.0.0.1'
@@ -851,7 +851,7 @@ plugin_id:test_filter\tplugin_category:filter\ttype:test_filter\toutput_plugin:f
     end
 
     test "worker_id = 2 on multi worker environment" do
-      port = unused_port
+      port = unused_port(protocol: :tcp)
       Fluent::SystemConfig.overwrite_system_config('workers' => 4) do
         d = Fluent::Test::Driver::Input.new(Fluent::Plugin::MonitorAgentInput)
         d.instance.instance_eval{ @_fluentd_worker_id = 2 }
@@ -905,7 +905,7 @@ EOC
     end
 
     test "plugins have a variable named buffer does not throws NoMethodError" do
-      port = unused_port
+      port = unused_port(protocol: :tcp)
       d = create_driver("
   @type monitor_agent
   bind '127.0.0.1'

--- a/test/plugin/test_in_tcp.rb
+++ b/test/plugin/test_in_tcp.rb
@@ -5,7 +5,7 @@ require 'fluent/plugin/in_tcp'
 class TcpInputTest < Test::Unit::TestCase
   def setup
     Fluent::Test.setup
-    @port = unused_port
+    @port = unused_port(protocol: :tcp)
   end
 
   def teardown

--- a/test/plugin/test_in_udp.rb
+++ b/test/plugin/test_in_udp.rb
@@ -5,7 +5,7 @@ require 'fluent/plugin/in_udp'
 class UdpInputTest < Test::Unit::TestCase
   def setup
     Fluent::Test.setup
-    @port = unused_port
+    @port = unused_port(protocol: :udp)
   end
 
   def teardown

--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -12,7 +12,8 @@ class ForwardOutputTest < Test::Unit::TestCase
     FileUtils.rm_rf(TMP_DIR)
     FileUtils.mkdir_p(TMP_DIR)
     @d = nil
-    @target_port = unused_port
+    # forward plugin uses TCP and UDP sockets on the same port number
+    @target_port = unused_port(protocol: :all)
   end
 
   def teardown

--- a/test/plugin/test_out_stream.rb
+++ b/test/plugin/test_out_stream.rb
@@ -54,7 +54,7 @@ class TcpOutputTest < Test::Unit::TestCase
 
   def setup
     super
-    @port = unused_port
+    @port = unused_port(protocol: :tcp)
   end
 
   def teardown

--- a/test/plugin_helper/test_http_server_helper.rb
+++ b/test/plugin_helper/test_http_server_helper.rb
@@ -14,7 +14,7 @@ class HttpHelperTest < Test::Unit::TestCase
   CERT_CA_DIR = File.expand_path(File.dirname(__FILE__) + '/data/cert/with_ca')
 
   def setup
-    @port = unused_port
+    @port = unused_port(protocol: :tcp)
   end
 
   def teardown

--- a/test/plugin_helper/test_socket.rb
+++ b/test/plugin_helper/test_socket.rb
@@ -11,7 +11,7 @@ class SocketHelperTest < Test::Unit::TestCase
   CERT_CHAINS_DIR = File.expand_path(File.dirname(__FILE__) + '/data/cert/cert_chains')
 
   def setup
-    @port = unused_port
+    @port = unused_port(protocol: :tcp)
   end
 
   def teardown


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

Fixes https://github.com/fluent/fluentd/issues/4674

**What this PR does / why we need it**: 

It obtains unused port number for TCP by unused_port method and the number has been used in UDP.
And that number may be already used by UDP sockets.

This patch will obtain and use unused ports appropriately for each protocol.

Backported from https://github.com/fluent/fluentd/pull/4675

**Docs Changes**:

**Release Note**: 
