### PR TITLE
Backport(v1.16) test_in_udp: add timeout for message_length_limit test (#4676)

### DIFF
--- a/test/plugin/test_in_udp.rb
+++ b/test/plugin/test_in_udp.rb
@@ -272,7 +272,7 @@ class UdpInputTest < Test::Unit::TestCase
       format none
       message_length_limit #{message_length_limit}
     !)
-    d.run(expect_records: 3) do
+    d.run(expect_records: 3, timeout: 5) do
       create_udp_socket('127.0.0.1', @port) do |u|
         3.times do |i|
           u.send("#{i}" * 40 + "\n", 0)


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

On Windows, `message_length_limit` test always take 300s for execution.

```
UdpInputTest:
  test:  configure w/o parse section:			.: (0.002351)
  test: configure[ipv4]:				.: (0.002723)
  test: configure[ipv6]:				.: (0.002602)
  test: message size with format[none]:			.: (1.029781)
  test: message size with format[json]:			.: (1.113799)
  test: message size with format[regexp]:		.: (1.110006)
  test: message_length_limit:				.: (300.538596)
```

The 300 sec comes from https://github.com/fluent/fluentd/blob/a2b935ae2bc4b4d43e5adddbec01092ea4228b9e/lib/fluent/test/driver/base.rb#L36, and it always times out in Windows.

This patch set a short timeout to reduce test execution time on Windows.

Backported from https://github.com/fluent/fluentd/pull/4676

**Docs Changes**:

**Release Note**: 
