### PR TITLE
Backport(v1.16) test_out_forward: remove unnecessary ack_response_timeout setting (#4685)

### DIFF
--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -611,7 +611,6 @@ EOL
 
     @d = d = create_driver(config + %[
       require_ack_response true
-      ack_response_timeout 1s
       <buffer tag>
         flush_mode immediate
         retry_type periodic
@@ -659,7 +658,6 @@ EOL
 
     @d = d = create_driver(config + %[
       require_ack_response true
-      ack_response_timeout 10s
       <buffer tag>
         flush_mode immediate
         retry_type periodic


### PR DESCRIPTION

**Which issue(s) this PR fixes**: 

Backport #4685 

**What this PR does / why we need it**: 

Seems that timeout setting is short in ack_response_timeout.
Seems that It may take some time to receive a ACK response
so the process in ack handler has expired and the node is disabled.

This PR will remove unnecessary ack_response_timeout settings for the test

**Docs Changes**:

**Release Note**: 
