### PR TITLE
test_cat: use proper protocol in unused_port method (#4686)

### DIFF
--- a/test/command/test_cat.rb
+++ b/test/command/test_cat.rb
@@ -18,7 +18,7 @@ class TestFluentCat < ::Test::Unit::TestCase
     @primary = create_primary
     metadata = @primary.buffer.new_metadata
     @chunk = create_chunk(@primary, metadata, @es)
-    @port = unused_port(protocol: :tcp)
+    @port = unused_port(protocol: :all)
   end
 
   def teardown


### PR DESCRIPTION

**Which issue(s) this PR fixes**: 

Backport #4686

**What this PR does / why we need it**: 

Fixes an issue where an inappropriate protocol was specified in the unused_port method.
See https://github.com/fluent/fluentd/issues/4674#issuecomment-2440522606

**Docs Changes**:

**Release Note**: 
