### PR TITLE
Backport(v1.16) test_in_tail: fix flaky tests for file rotation (#4710)

### DIFF
--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -3172,9 +3172,7 @@ class TailInputTest < Test::Unit::TestCase
         Fluent::FileWrapper.open("#{@tmp_dir}/tail.txt0", "ab") {|f| f.puts "file3 log2"}
       end
 
-      inode_0 = tail_watchers[0]&.ino
-      inode_1 = tail_watchers[1]&.ino
-      inode_2 = tail_watchers[2]&.ino
+      pos_file_inode = tail_watchers[2].pe.read_inode
       record_values = d.events.collect { |event| event[2]["message"] }.sort
       position_entries = []
       Fluent::FileWrapper.open("#{@tmp_dir}/tail.pos", "r") do |f|
@@ -3188,17 +3186,15 @@ class TailInputTest < Test::Unit::TestCase
         {
           record_values: ["file1 log1", "file1 log2", "file2 log1", "file2 log2", "file3 log1", "file3 log2"],
           tail_watcher_paths: ["#{@tmp_dir}/tail.txt0", "#{@tmp_dir}/tail.txt0", "#{@tmp_dir}/tail.txt0"],
-          tail_watcher_inodes: [inode_0, inode_1, inode_2],
           tail_watcher_io_handler_opened_statuses: [false, false, false],
           position_entries: [
             # The recorded path is old, but it is no problem. The path is not used when using follow_inodes.
-            ["#{@tmp_dir}/tail.txt0", "0000000000000016", inode_2],
+            ["#{@tmp_dir}/tail.txt0", "0000000000000016", pos_file_inode],
           ],
         },
         {
           record_values: record_values,
           tail_watcher_paths: tail_watchers.collect { |tw| tw.path },
-          tail_watcher_inodes: tail_watchers.collect { |tw| tw.ino },
           tail_watcher_io_handler_opened_statuses: tail_watchers.collect { |tw| tw.instance_variable_get(:@io_handler)&.opened? || false },
           position_entries: position_entries
         },
@@ -3253,9 +3249,7 @@ class TailInputTest < Test::Unit::TestCase
         sleep 4
       end
 
-      inode_0 = tail_watchers[0]&.ino
-      inode_1 = tail_watchers[1]&.ino
-      inode_2 = tail_watchers[2]&.ino
+      pos_file_inode = tail_watchers[2].pe.read_inode
       record_values = d.events.collect { |event| event[2]["message"] }.sort
       position_entries = []
       Fluent::FileWrapper.open("#{@tmp_dir}/tail.pos", "r") do |f|
@@ -3269,16 +3263,14 @@ class TailInputTest < Test::Unit::TestCase
         {
           record_values: ["file1 log1", "file1 log2", "file2 log1", "file2 log2", "file3 log1", "file3 log2"],
           tail_watcher_paths: ["#{@tmp_dir}/tail.txt0", "#{@tmp_dir}/tail.txt0", "#{@tmp_dir}/tail.txt0"],
-          tail_watcher_inodes: [inode_0, inode_1, inode_2],
           tail_watcher_io_handler_opened_statuses: [false, false, false],
           position_entries: [
-            ["#{@tmp_dir}/tail.txt0", "0000000000000016", inode_2],
+            ["#{@tmp_dir}/tail.txt0", "0000000000000016", pos_file_inode],
           ],
         },
         {
           record_values: record_values,
           tail_watcher_paths: tail_watchers.collect { |tw| tw.path },
-          tail_watcher_inodes: tail_watchers.collect { |tw| tw.ino },
           tail_watcher_io_handler_opened_statuses: tail_watchers.collect { |tw| tw.instance_variable_get(:@io_handler)&.opened? || false },
           position_entries: position_entries
         },


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

Backport #4710 

**What this PR does / why we need it**: 

This PR will fix unstable tests.

* test_in_tail: fix flaky tests for file rotation
* test_in_tail: remove unnecessary inode assertions

**Docs Changes**:

**Release Note**: 
