### PR TITLE
Backport(v1.16) command: fix NoMethodError of --daemon under Windows

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -440,7 +440,7 @@ module Fluent
         stop_immediately_at_unrecoverable_exit: true,
         root_dir: params['root_dir'],
         logger: $log,
-        log: $log.out,
+        log: $log&.out,
         log_level: params['log_level'],
         chuser: params['chuser'],
         chgroup: params['chgroup'],


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

Backport #4716 

**What this PR does / why we need it**: 
To daemonize the process, the following code will be invoked on Windows:
https://github.com/fluent/fluentd/blob/89f0a76fb2e050659f0a503823beb2ad8cf899eb/lib/fluent/daemon.rb#L13

$log variable does not exist because it has not executed `Superviser#setup_global_logger` method until here.
It will perform a new startup process and prepare a logger in
https://github.com/fluent/fluentd/blob/89f0a76fb2e050659f0a503823beb2ad8cf899eb/lib/fluent/daemon.rb#L13

This patch will only avoid the error since a logger is not required this process.

**Docs Changes**:
Not needed.

**Release Note**: 
The same as the title.
