### PR TITLE
Backport(v1.16) README: remove deprecated google analytics beacon (#4722)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,5 +71,3 @@ See [SECURITY](SECURITY.md) to contact us about vulnerability.
 ## Contributors:
 
 Patches contributed by [great developers](https://github.com/fluent/fluentd/contributors).
-
-[<img src="https://ga-beacon.appspot.com/UA-24890265-6/fluent/fluentd" />](https://github.com/fluent/fluentd)


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

Backport #4722 

**What this PR does / why we need it**: 
Google Universal Analytics (UA) is no longer in service.

I don't know how this was used originally.
So, I remove this for now.

**Docs Changes**:
Not needed.

**Release Note**: 
Not needed.
