### PR TITLE
Backport(v1.16) test_out_file: fix file open mode for binary file

### DIFF
--- a/test/plugin/test_out_file.rb
+++ b/test/plugin/test_out_file.rb
@@ -334,7 +334,7 @@ class FileOutputTest < Test::Unit::TestCase
       assert_equal r5, d.formatted[4]
 
       read_gunzip = ->(path){
-        File.open(path){ |fio|
+        File.open(path, 'rb'){ |fio|
           Zlib::GzipReader.new(StringIO.new(fio.read)).read
         }
       }


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

Backport #4728 

**What this PR does / why we need it**: 

Fix the file open mode so that gz files can be read properly.

**Docs Changes**:

**Release Note**: 
