### PR TITLE
Backport(v1.16) test_cat: specify the reading size to read in binary mode (#4730)

### DIFF
--- a/test/command/test_cat.rb
+++ b/test/command/test_cat.rb
@@ -87,7 +87,7 @@ class TestFluentCat < ::Test::Unit::TestCase
       d = create_driver
       d.run(expect_records: 1) do
         Open3.pipeline_w("#{ServerEngine.ruby_bin_path} #{FLUENT_CAT_COMMAND} --port #{@port} --format msgpack secondary") do |stdin|
-          stdin.write(File.read(path))
+          stdin.write(File.read(path, File.size(path)))
           stdin.close
         end
       end


### PR DESCRIPTION

**Which issue(s) this PR fixes**: 

Backport #4730 

**What this PR does / why we need it**: 

The binary files may not be read properly.
This changes to read files in binary mode.


**Docs Changes**:

**Release Note**: 
