### PR TITLE
Backport(v1.16) windows: add workaround for unexpected exception (#4747)

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -31,6 +31,11 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("webrick", ["~> 1.4"])
   gem.add_runtime_dependency("console", ["< 1.24"])
 
+  # gems that aren't default gems as of Ruby 3.5
+  # logger 1.6.3 or later cause bug on windows,
+  # hold on 1.6.2 for a while. see https://github.com/ruby/logger/issues/107
+  gem.add_runtime_dependency("logger", ["1.6.2"])
+
   # build gem for a certain platform. see also Rakefile
   fake_platform = ENV['GEM_BUILD_FAKE_PLATFORM'].to_s
   gem.platform = fake_platform unless fake_platform.empty?


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

Backport #4747 

**What this PR does / why we need it**:

Since logger 1.6.3 or later, there is a bug that it cause unexpected exception (no implicit conversion of Integer into String (TypeError)) on windows. So hold on 1.6.2 for a while.

See https://github.com/ruby/logger/issues/107

**Docs Changes**:

N/A

**Release Note**:

N/A
