### PR TITLE
Backport(v1.16) ci: use latest rubygems again for Ruby 3.1 on windows (#4750)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
+          rubygems: latest
       - name: Install addons
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: sudo apt-get install libgmp3-dev libcap-ng-dev


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

Backport #4750

**What this PR does / why we need it**:

It seems that it fixes failure with Ruby 3.1 on windows.

```
   undefined method `ignored?' for #<Gem::Specification:0x000001dccaf43168
```

NOTE: Initially introduced by #4681, then reverted in #4746. Thus, it's a side-effect of #4746.

**Docs Changes**:

N/A

**Release Note**:

N/A
