### PR TITLE
ci: remove latest setting for rubygems

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,6 @@ jobs:
         uses: ruby/setup-ruby@1287d2b408066abada82d5ad1c63652e758428d9 # v1.214.0
         with:
           ruby-version: ${{ matrix.ruby-version }}
-          rubygems: latest
       - name: Install addons
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: sudo apt-get install libgmp3-dev libcap-ng-dev


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None.

**What this PR does / why we need it**: 
Remove `latest` setting for `rubygems`.
We added it for Ruby 3.1 on Windows (#4750).
We have already dropped Ruby 3.1, so we don't need it anymore.

**Docs Changes**:
Not needed.

**Release Note**: 
Not needed.
