### PR TITLE
parser_json: use JSON as fallback parser instead of Yajl for performance

### DIFF
--- a/lib/fluent/plugin/parser_json.rb
+++ b/lib/fluent/plugin/parser_json.rb
@@ -52,8 +52,8 @@ module Fluent
         when :oj
           return [Oj.method(:load), Oj::ParseError] if Fluent::OjOptions.available?
 
-          log&.info "Oj is not installed, and failing back to Yajl for json parser"
-          configure_json_parser(:yajl)
+          log&.info "Oj is not installed, and failing back to JSON for json parser"
+          configure_json_parser(:json)
         when :json then [JSON.method(:load), JSON::ParserError]
         when :yajl then [Yajl.method(:load), Yajl::ParseError]
         else

--- a/test/plugin/test_parser_json.rb
+++ b/test/plugin/test_parser_json.rb
@@ -28,12 +28,12 @@ class JsonParserTest < ::Test::Unit::TestCase
 
       result = @parser.instance.configure_json_parser(:oj)
 
-      assert_equal [Yajl.method(:load), Yajl::ParseError], result
+      assert_equal [JSON.method(:load), JSON::ParserError], result
       logs = @parser.logs.collect do |log|
         log.gsub(/\A\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} [-+]\d{4} /, "")
       end
       assert_equal(
-        ["[info]: Oj is not installed, and failing back to Yajl for json parser\n"],
+        ["[info]: Oj is not installed, and failing back to JSON for json parser\n"],
         logs
       )
     end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
Recently, Ruby's json has incredible performance improvements.
It might be faster than oj gem.
So, I think json is a suitable as fallback.

This is similar with https://github.com/fluent/fluentd/pull/4759

Here is easily benchmark. (I used same log file in #4759)

* Before
  * It spent 90.50963662 sec to handle 10 GB file 
* After
  * It spent 74.624230077 sec to handle 10 GB file

* config
```
<source>
  @type tail
  path "#{File.expand_path '~/tmp/access*.log'}"
  pos_file "#{File.expand_path '~/tmp/fluentd/access.log.pos'}"
  tag log
  read_from_head true
  <parse>
    @type json
  </parse>
</source>

<match **>
  @type file
  path "#{File.expand_path '~/tmp/fluentd/log'}"
</match>
```

FYI)
* https://byroot.github.io/ruby/json/2024/12/15/optimizing-ruby-json-part-1.html
* https://byroot.github.io/ruby/json/2024/12/18/optimizing-ruby-json-part-2.html
* https://byroot.github.io/ruby/json/2024/12/27/optimizing-ruby-json-part-3.html
* https://byroot.github.io/ruby/json/2024/12/29/optimizing-ruby-json-part-4.html
* https://byroot.github.io/ruby/json/2025/01/04/optimizing-ruby-json-part-5.html
* https://byroot.github.io/ruby/json/2025/01/12/optimizing-ruby-json-part-6.html
* https://byroot.github.io/ruby/json/2025/01/14/optimizing-ruby-json-part-7.html



**Docs Changes**:
https://github.com/fluent/fluentd-docs-gitbook/pull/560

**Release Note**: 
