### PR TITLE
in_tail: remove workaround of converting encoding

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -1021,21 +1021,7 @@ module Fluent::Plugin
         attr_reader :from_encoding, :encoding, :buffer, :max_line_size
 
         def <<(chunk)
-          # Although "chunk" is most likely transient besides String#force_encoding itself
-          # won't affect the actual content of it, it is also probable that "chunk" is
-          # a reused buffer and changing its encoding causes some problems on the caller side.
-          #
-          # Actually, the caller here is specific and "chunk" comes from IO#partial with
-          # the second argument, which the function always returns as a return value.
-          #
-          # Feeding a string that has its encoding attribute set to any double-byte or
-          # quad-byte encoding to IO#readpartial as the second arguments results in an
-          # assertion failure on Ruby < 2.4.0 for unknown reasons.
-          orig_encoding = chunk.encoding
-          chunk.force_encoding(from_encoding)
           @buffer << chunk
-          # Thus the encoding needs to be reverted back here
-          chunk.force_encoding(orig_encoding)
         end
 
         def convert(s)

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -1022,6 +1022,7 @@ module Fluent::Plugin
 
         def <<(chunk)
           @buffer << chunk
+          @buffer.force_encoding(from_encoding)
         end
 
         def convert(s)


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
This PR will remove workarounds for versions earlier than Ruby 2.4.

The following code is causing SEGV in Ruby 2.3. 
And I think it was workaround for SEGV.

```ruby
a = open('/dev/urandom')
buf = ''.force_encoding(Encoding::UTF_16BE)
a.readpartial(2048, buf)
```

https://github.com/fluent/fluentd/pull/1409#discussion_r95520551

I want to remove it because it works well with currently Ruby.

**Docs Changes**:

**Release Note**: 
