### PR TITLE
parser_json: use JSON.parse instead of .load

### DIFF
--- a/lib/fluent/plugin/parser_json.rb
+++ b/lib/fluent/plugin/parser_json.rb
@@ -54,7 +54,7 @@ module Fluent
 
           log&.info "Oj is not installed, and failing back to JSON for json parser"
           configure_json_parser(:json)
-        when :json then [JSON.method(:load), JSON::ParserError]
+        when :json then [JSON.method(:parse), JSON::ParserError]
         when :yajl then [Yajl.method(:load), Yajl::ParseError]
         else
           raise "BUG: unknown json parser specified: #{name}"

--- a/test/log/test_console_adapter.rb
+++ b/test/log/test_console_adapter.rb
@@ -73,7 +73,7 @@ class ConsoleAdapterTest < Test::Unit::TestCase
   def test_options(level)
     @console_logger.send(level, "subject", kwarg1: "opt1", kwarg2: "opt2")
     lines = @logdev.logs[0].split("\n")
-    args = JSON.load(lines[1..].collect { |str| str.sub(/\s+\|/, "") }.join("\n"));
+    args = JSON.parse(lines[1..].collect { |str| str.sub(/\s+\|/, "") }.join("\n"));
     assert_equal([
                    1,
                    "#{@timestamp_str} [#{level}]:   0.0s: subject",

--- a/test/plugin/test_parser_json.rb
+++ b/test/plugin/test_parser_json.rb
@@ -10,7 +10,7 @@ class JsonParserTest < ::Test::Unit::TestCase
 
   sub_test_case "configure_json_parser" do
     data("oj", [:oj, [Oj.method(:load), Oj::ParseError]])
-    data("json", [:json, [JSON.method(:load), JSON::ParserError]])
+    data("json", [:json, [JSON.method(:parse), JSON::ParserError]])
     data("yajl", [:yajl, [Yajl.method(:load), Yajl::ParseError]])
     def test_return_each_loader((input, expected_return))
       result = @parser.instance.configure_json_parser(input)
@@ -28,7 +28,7 @@ class JsonParserTest < ::Test::Unit::TestCase
 
       result = @parser.instance.configure_json_parser(:oj)
 
-      assert_equal [JSON.method(:load), JSON::ParserError], result
+      assert_equal [JSON.method(:parse), JSON::ParserError], result
       logs = @parser.logs.collect do |log|
         log.gsub(/\A\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} [-+]\d{4} /, "")
       end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
Ref. https://github.com/fluent/fluentd/pull/4813#discussion_r1937321034
Fix wrong usage of `JSON.load` method.
We should use `JSON.parse` instead.

JSON.load performs unnecessary deserialisation.

```
irb(main):001> JSON.load('{ "json_class": "String", "raw": [72, 101, 108, 108, 111] }')
=> "Hello"
irb(main):002> JSON.parse('{ "json_class": "String", "raw": [72, 101, 108, 108, 111] }')
=> {"json_class" => "String", "raw" => [72, 101, 108, 108, 111]}
```


**Docs Changes**:

**Release Note**: 
