### PR TITLE
ci: fix unstable test

### DIFF
--- a/test/plugin_helper/test_server.rb
+++ b/test/plugin_helper/test_server.rb
@@ -685,12 +685,12 @@ class ServerPluginHelperTest < Test::Unit::TestCase
 
       received = ""
       responses = []
-      port = unused_port(protocol: :udp)
+      port = unused_port(protocol: :udp, bind: "::1")
       @d.server_create_udp(:s, port, bind: "::1", max_bytes: 128) do |data, sock|
         received << data
         sock.write "ack\n"
       end
-      bind_port = unused_port(protocol: :udp)
+      bind_port = unused_port(protocol: :udp, bind: "::1")
       3.times do
         begin
           sock = UDPSocket.new(Socket::AF_INET6)


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None.

**What this PR does / why we need it**: 
Fix unstable test.

```
Error: test: creates a udp server to read and write data using IPv6(ServerPluginHelperTest::#server_create_udp): Errno::EADDRINUSE: Address already in use - bind(2) for "::1" port 8859
/home/runner/work/fluentd/fluentd/test/plugin_helper/test_server.rb:697:in 'UDPSocket#bind'
/home/runner/work/fluentd/fluentd/test/plugin_helper/test_server.rb:697:in 'block (3 levels) in <class:ServerPluginHelperTest>'
<internal:numeric>:257:in 'Integer#times'
/home/runner/work/fluentd/fluentd/test/plugin_helper/test_server.rb:694:in 'block (2 levels) in <class:ServerPluginHelperTest>'
```

**Docs Changes**:
Not needed.

**Release Note**: 
The same as the title.
