### PR TITLE
formatter_json: use JSON as fallback parser instead of Yajl for performance

### DIFF
--- a/lib/fluent/plugin/formatter_json.rb
+++ b/lib/fluent/plugin/formatter_json.rb
@@ -34,11 +34,11 @@ module Fluent
           if Fluent::OjOptions.available?
             @dump_proc = Oj.method(:dump)
           else
-            log.info "Oj isn't installed, fallback to Yajl as json parser"
-            @dump_proc = Yajl.method(:dump)
+            log.info "Oj isn't installed, fallback to JSON as json parser"
+            @dump_proc = JSON.method(:generate)
           end
         else
-          @dump_proc = Yajl.method(:dump)
+          @dump_proc = JSON.method(:generate)
         end
 
         # format json is used on various highload environment, so re-define method to skip if check

--- a/test/plugin/test_out_stdout.rb
+++ b/test/plugin/test_out_stdout.rb
@@ -80,7 +80,7 @@ class StdoutOutputTest < Test::Unit::TestCase
 
       if data == 'yajl'
         # NOTE: Float::NAN is not jsonable
-        assert_raise(Yajl::EncodeError) { d.feed('test', time, {'test' => Float::NAN}) }
+        assert_raise(JSON::GeneratorError) { d.feed('test', time, {'test' => Float::NAN}) }
       else
         out = capture_log { d.feed('test', time, {'test' => Float::NAN}) }
         assert_equal "#{Time.at(time).localtime.strftime(TIME_FORMAT)} test: {\"test\":NaN}\n", out


### PR DESCRIPTION

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
Recently, Ruby's json has incredible performance improvements.
It might be faster than oj gem.
So, I think json is a suitable as fallback.

This is similar with https://github.com/fluent/fluentd/pull/4813

* Before
  * It spent 70.708872503 sec to handle 10 GB file 
* After
  * It spent 54.428017716 sec to handle 10 GB file

* config
```
<source>
  @type tail
  path "#{File.expand_path('~/tmp/fluentd/access*.log')}"
  pos_file "#{File.expand_path('~/tmp/fluentd/access.log.pos')}"
  tag log
  read_from_head true
  <parse>
    @type none
  </parse>
</source>

<match **>
  @type file
  path "#{File.expand_path('~/tmp/fluentd/output/log')}"

  # use formatter_json
  format json
</match>
```


**Docs Changes**:

**Release Note**: 
