### PR TITLE
memory_chunk: clear internal memory use in buffer string

### DIFF
--- a/lib/fluent/plugin/buffer/memory_chunk.rb
+++ b/lib/fluent/plugin/buffer/memory_chunk.rb
@@ -68,7 +68,7 @@ module Fluent
 
         def purge
           super
-          @chunk = ''.force_encoding("ASCII-8BIT")
+          @chunk.clear
           @chunk_bytes = @size = @adding_bytes = @adding_size = 0
           true
         end

--- a/lib/fluent/plugin/buffer/memory_chunk.rb
+++ b/lib/fluent/plugin/buffer/memory_chunk.rb
@@ -74,7 +74,7 @@ module Fluent
         end
 
         def read(**kwargs)
-          @chunk
+          @chunk.dup
         end
 
         def open(**kwargs, &block)

--- a/test/plugin/test_output_as_buffered_compress.rb
+++ b/test/plugin/test_output_as_buffered_compress.rb
@@ -122,12 +122,7 @@ class BufferedOutputCompressTest < Test::Unit::TestCase
     assert_equal :gzip, @i.buffer.compress
 
     @i.register(:write) do |c|
-      compressed_data = c.instance_variable_get(:@chunk)
-      if compressed_data.is_a?(File)
-        compressed_data.seek(0, IO::SEEK_SET)
-        compressed_data = compressed_data.read
-      end
-      compressed_data = compressed_data.dup
+      compressed_data = c.read(compressed: :gzip)
       c.write_to(io)
     end
 
@@ -161,12 +156,7 @@ class BufferedOutputCompressTest < Test::Unit::TestCase
 
     @i.register(:format) { |tag, time, record| "#{record}\n" }
     @i.register(:write) { |c|
-      compressed_data = c.instance_variable_get(:@chunk)
-      if compressed_data.is_a?(File)
-        compressed_data.seek(0, IO::SEEK_SET)
-        compressed_data = compressed_data.read
-      end
-      compressed_data = compressed_data.dup
+      compressed_data = c.read(compressed: :gzip)
       c.write_to(io)
     }
 

--- a/test/plugin/test_output_as_buffered_compress.rb
+++ b/test/plugin/test_output_as_buffered_compress.rb
@@ -127,6 +127,7 @@ class BufferedOutputCompressTest < Test::Unit::TestCase
         compressed_data.seek(0, IO::SEEK_SET)
         compressed_data = compressed_data.read
       end
+      compressed_data = compressed_data.dup
       c.write_to(io)
     end
 
@@ -165,6 +166,7 @@ class BufferedOutputCompressTest < Test::Unit::TestCase
         compressed_data.seek(0, IO::SEEK_SET)
         compressed_data = compressed_data.read
       end
+      compressed_data = compressed_data.dup
       c.write_to(io)
     }
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #1657

**What this PR does / why we need it**: 
Seems that a full GC have to run in order to collect the wasted String object in `@chunk`.
However, full GC is not performed frequently.

This patch purges internal memory in wasted String object immediately.

Here is memory usage retrieved by `ObjectSpace.memsize_of_all`.

![](https://github.com/user-attachments/assets/a90755ac-15c3-4240-97b3-87e4e4d88617)

> [!NOTE]
> Ruby has various optimization, such as reusing freed heap areas by pooling them.
> For this reason, it may not be reflected in the process's memory usage immediately even if it clear the object.

## Reproduce
* Configuration
```
<source>
  @type tcp
  tag testing
  format json
  port 10130
</source>
<match **>
  @type forward
  require_ack_response true
  <server>
    host 127.0.0.1
    port 10131
  </server>

  ## Tune the buffer parameters
  <buffer tag>
    flush_mode interval
    flush_interval 1s
  </buffer>
</match>
```

* test data
```ruby
require "socket"
require "json"

i = 0

Thread.new do
  s = TCPSocket.open("localhost", 10130)
  data = {"message": "a" * 512 * 1024}

  loop do
    puts "[#{i}]"
    data["number"] = i
    s.puts data.to_json
    i += 1
    sleep 0.01
  end

  s.close
end

sleep 20
```

**Docs Changes**:
Not needed.

**Release Note**: 
buf_memory: improve memory performance
