### PR TITLE
Backport(v1.16) test: fix Sigdump tests failure (#4846)

### DIFF
--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -214,6 +214,9 @@ class SupervisorTest < ::Test::Unit::TestCase
   def test_cont_in_main_process_signal_handlers
     omit "Windows cannot handle signals" if Fluent.windows?
 
+    # https://github.com/fluent/fluentd/issues/4063
+    GC.start
+
     sv = Fluent::Supervisor.new({})
     sv.send(:install_main_process_signal_handlers)
 
@@ -228,6 +231,9 @@ class SupervisorTest < ::Test::Unit::TestCase
 
   def test_term_cont_in_main_process_signal_handlers
     omit "Windows cannot handle signals" if Fluent.windows?
+
+    # https://github.com/fluent/fluentd/issues/4063
+    GC.start
 
     create_debug_dummy_logger
 
@@ -296,6 +302,9 @@ class SupervisorTest < ::Test::Unit::TestCase
   def test_cont_in_supervisor_signal_handler
     omit "Windows cannot handle signals" if Fluent.windows?
 
+    # https://github.com/fluent/fluentd/issues/4063
+    GC.start
+
     server = DummyServer.new
     server.install_supervisor_signal_handlers
 
@@ -310,6 +319,9 @@ class SupervisorTest < ::Test::Unit::TestCase
 
   def test_term_cont_in_supervisor_signal_handler
     omit "Windows cannot handle signals" if Fluent.windows?
+
+    # https://github.com/fluent/fluentd/issues/4063
+    GC.start
 
     server = DummyServer.new
     server.install_supervisor_signal_handlers


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
* Backport #4846

**What this PR does / why we need it**:
Sigdump.dump iterates ObjectSpace.
If there are DoubleDefinition objects of RR, it can set some expectations of RR unexpectedly.
It can cause test failure.

By doing GC, we can remove DoubleDefinition objects made in other tests.

See https://github.com/fluent/fluentd/issues/4063

    Failure: test_cont_in_main_process_signal_handlers(SupervisorTest):
      class()
      Called 0 times.
      Expected 1 times.
(...)/sigdump-0.2.5/lib/sigdump.rb:76:in `block in dump_object_count'
    (...)/sigdump-0.2.5/lib/sigdump.rb:75:in `each_object'
    (...)/sigdump-0.2.5/lib/sigdump.rb:75:in `dump_object_count'
    (...)/sigdump-0.2.5/lib/sigdump.rb:18:in `block in dump'
    (...)/sigdump-0.2.5/lib/sigdump.rb:138:in `open'
    (...)/sigdump-0.2.5/lib/sigdump.rb:138:in `_open_dump_path'
    (...)/sigdump-0.2.5/lib/sigdump.rb:14:in `dump'
(...)/fluentd/fluentd/lib/fluent/supervisor.rb:1097:in `dump_non_windows'
(...)/fluentd/fluentd/lib/fluent/supervisor.rb:997:in `block in install_main_process_signal_handlers'
    (...)/fluentd/fluentd/test/test_supervisor.rb:270:in `kill'
(...)/fluentd/fluentd/test/test_supervisor.rb:270:in `test_cont_in_main_process_signal_handlers'
         267:     sv = Fluent::Supervisor.new({})
         268:     sv.send(:install_main_process_signal_handlers)
         269:
      => 270:     Process.kill :CONT, Process.pid
         271:
         272:     sleep 1
         273:

**Docs Changes**:
Not needed.

**Release Note**:
Not needed.

