### PR TITLE
Backport(v1.16) test: fix unstable buffer test (#4849)

### DIFF
--- a/test/plugin/test_output_as_buffered.rb
+++ b/test/plugin/test_output_as_buffered.rb
@@ -1343,6 +1343,7 @@ class BufferedOutputTest < Test::Unit::TestCase
       hash = {
         'flush_interval' => 10,
         'flush_thread_count' => 1,
+        'flush_thread_interval' => 0.1,
         'flush_thread_burst_interval' => 0.1,
         'chunk_limit_size' => 1024,
       }
@@ -1445,7 +1446,7 @@ class BufferedOutputTest < Test::Unit::TestCase
 
       assert{ @i.buffer.stage.size == 3 }
 
-      # to trigger try_flush with flush_thread_burst_interval
+      # to trigger try_flush with flush_thread_interval
       Timecop.freeze( Time.parse('2016-04-13 14:04:11 +0900') )
       @i.enqueue_thread_wait
       Timecop.freeze( Time.parse('2016-04-13 14:04:12 +0900') )
@@ -1454,7 +1455,6 @@ class BufferedOutputTest < Test::Unit::TestCase
       @i.enqueue_thread_wait
       Timecop.freeze( Time.parse('2016-04-13 14:04:14 +0900') )
       @i.enqueue_thread_wait
-      @i.flush_thread_wakeup
 
       assert{ @i.buffer.stage.size == 0 }
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
* Backport #4849

**What this PR does / why we need it**:
Fix occasional test failure:
https://github.com/fluent/fluentd/actions/runs/13650069134/job/38156420830?pr=4846#step:6:4985

The max size of the buffer queue is `1` by default. So, `try_flush` will be called with `flush_thread_interval`, not `flush_thread_burst_interval`.

The previous test code assumes that the interval is 0.1s, but it was actually 1s.
This would be the cause of the occasional failure.

test: #write is called per value combination of variables, per flush_interval & chunk sizes, and buffer chunk is
purged(BufferedOutputTest::buffered output feature with variables):
            assert{ @i.buffer.stage.size == 0 }
                    |  |      |     |    |
                    |  |      |     |    false
                    |  |      |     1
                    |  |      {...}
                    |  #<...>
                    #<...>

/Users/runner/work/fluentd/fluentd/test/plugin/test_output_as_buffered.rb:1459:in `block (2 levels) in <class:BufferedOutputTest>'
         1456:       @i.enqueue_thread_wait
         1457:       @i.flush_thread_wakeup
         1458:
      => 1459:       assert{ @i.buffer.stage.size == 0 }
         1460:
         1461:       waiting(4) do
         1462:         Thread.pass until @i.write_count > 1

**Docs Changes**:
Not needed.

**Release Note**:
Not needed.
