### PR TITLE
parser: fix file path into URI#open for Windows

### DIFF
--- a/lib/fluent/config/parser.rb
+++ b/lib/fluent/config/parser.rb
@@ -107,7 +107,7 @@ module Fluent
             #   - uri is 'c:/path/to/file'
             #   - u.path is '/path/to/file' and u.scheme is 'c'
             # Therefore, the condition of the if statement above is not met and it is handled here.
-            File.open(u.path, &parser_proc)
+            File.open(uri, &parser_proc)
           end
         end
 


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
This patch will fix the problem in https://github.com/fluent/fluentd/pull/4848
`u.path` has the file path without a drive letter in Windows environment.

If Fluentd is worked on `c` drive and config file in `d` drive, it can't parse config file, I think.

**Docs Changes**:

**Release Note**: 
