### PR TITLE
console_adapter: support console gem v1.30

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -66,6 +66,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("test-unit-rr", ["~> 1.0"])
   gem.add_development_dependency("oj", [">= 2.14", "< 4"])
   gem.add_development_dependency("async-http", "~> 0.86")
+  gem.add_development_dependency("console", "~> 1.30")
   gem.add_development_dependency("aws-sigv4", ["~> 1.8"])
   gem.add_development_dependency("aws-sdk-core", ["~> 3.191"])
   gem.add_development_dependency("rexml", ["~> 3.2"])

--- a/lib/fluent/log/console_adapter.rb
+++ b/lib/fluent/log/console_adapter.rb
@@ -21,9 +21,7 @@ module Fluent
     # Async gem which is used by http_server helper switched logger mechanism to
     # Console gem which isn't complatible with Ruby's standard Logger (since
     # v1.17). This class adapts it to Fluentd's logger mechanism.
-    class ConsoleAdapter < Gem::Version.new(Console::VERSION) >= Gem::Version.new("1.25") ?
-      Console::Output::Terminal : Console::Terminal::Logger
-
+    class ConsoleAdapter < Console::Output::Terminal
       def self.wrap(logger)
         _, level = Console::Logger::LEVELS.find { |key, value|
           if logger.level <= 0
@@ -58,10 +56,10 @@ module Fluent
           level = 'warn'
         end
 
-        @io.seek(0)
-        @io.truncate(0)
+        @stream.seek(0)
+        @stream.truncate(0)
         super
-        @logger.send(level, @io.string.chomp)
+        @logger.send(level, @stream.string.chomp)
       end
     end
   end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
This patch will fix following error:
```
NoMethodError: undefined method `seek' for nil:NilClass
/home/runner/work/fluentd/fluentd/lib/fluent/log/console_adapter.rb:61:in `call'
/opt/hostedtoolcache/Ruby/3.2.7/x64/lib/ruby/gems/3.2.0/gems/console-1.30.0/lib/console/output/wrapper.rb:35:in `call'
/opt/hostedtoolcache/Ruby/3.2.7/x64/lib/ruby/gems/3.2.0/gems/console-1.30.0/lib/console/output/failure.rb:38:in `call'
/opt/hostedtoolcache/Ruby/3.2.7/x64/lib/ruby/gems/3.2.0/gems/console-1.30.0/lib/console/filter.rb:48:in `block (3 levels) in []'
/home/runner/work/fluentd/fluentd/test/log/test_console_adapter.rb:58:in `test_args'
```

Ref. https://github.com/fluent/fluentd/actions/runs/13714056838

The variable name was changed at
https://github.com/socketry/console/commit/1529fefb4c7ff1742a54de6ca91eace3226a2947#diff-757206aeb67c0bd1c0d1813dfbff0a140a68920505520e8163b3a274fbab05ceR30

Since now Fluentd assumes Ruby 3.2 or later, this discards the related code to support Ruby before v3.1.

**Docs Changes**:
Not needed.

**Release Note**: 
The same as the title.
