### PR TITLE
Add logging for errors about loading dependencies on startup

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -721,6 +721,18 @@ module Fluent
         $log.error 'config error', file: @config_path, error: e
         $log.debug_backtrace
         exit!(1)
+      rescue ScriptError => e # LoadError, NotImplementedError, SyntaxError
+        if e.respond_to?(:path)
+          $log.error e.message, path: e.path, error: e
+        else
+          $log.error e.message, error: e
+        end
+        $log.debug_backtrace
+        exit!(1)
+      rescue => e
+        $log.error "unexpected error", error: e
+        $log.debug_backtrace
+        exit!(1)
       end
 
       if dry_run

--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -570,7 +570,7 @@ CONF
 
       assert_fluentd_fails_to_start(
         create_cmdline(conf_path, "-p", File.dirname(plugin_path)),
-        /in_buggy.rb:\d+:.+\(SyntaxError\)/
+        /\[error\]: .+in_buggy.rb:\d+: syntax error/
       )
     end
   end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None.

**What this PR does / why we need it**: 
Adds error handling similar to worker process.
https://github.com/fluent/fluentd/blob/8df10863769da32459aba2a1408134d0b8e7d9f4/lib/fluent/supervisor.rb#L1149-L1164

`Fluent::Engine.run_configure` calls `Fluent::Registry#search`.
It can run `Kernel.require`.
It can raise `LoadError`, `ConflictError` and others.

Without this error handling, Fluentd cannot log those errors.
This makes a situation where Fluentd fails to start, but there is no error log in the log file.
This solves that problem.

This appears to be an oversight of the following fix:

* https://github.com/fluent/fluentd/pull/2651

**Docs Changes**:
Not needed.

**Release Note**: 
The same as the title.