### PR TITLE
out_http: TLS1.3 support

### DIFF
--- a/lib/fluent/plugin/out_http.rb
+++ b/lib/fluent/plugin/out_http.rb
@@ -270,7 +270,8 @@ module Fluent::Plugin
                               OpenSSL::SSL::VERIFY_PEER
                             end
         opt[:ciphers] = @tls_ciphers
-        opt[:ssl_version] = @tls_version
+        opt[:min_version] = Fluent::TLS::DEFAULT_VERSION
+        opt[:max_version] = @tls_version
       end
 
       opt

--- a/lib/fluent/plugin/out_http.rb
+++ b/lib/fluent/plugin/out_http.rb
@@ -270,8 +270,7 @@ module Fluent::Plugin
                               OpenSSL::SSL::VERIFY_PEER
                             end
         opt[:ciphers] = @tls_ciphers
-        opt[:min_version] = Fluent::TLS::DEFAULT_VERSION
-        opt[:max_version] = @tls_version
+        opt = Fluent::TLS.set_version_to_options(opt, @tls_version, nil, nil)
       end
 
       opt

--- a/lib/fluent/tls.rb
+++ b/lib/fluent/tls.rb
@@ -76,6 +76,30 @@ module Fluent
       ctx
     end
     module_function :set_version_to_context
+
+    def set_version_to_options(opt, version, min_version, max_version)
+      if MIN_MAX_AVAILABLE
+        case
+        when min_version.nil? && max_version.nil?
+          min_version = METHODS_MAP[version] || version
+          max_version = METHODS_MAP[version] || version
+        when min_version.nil? && max_version
+          raise Fluent::ConfigError, "When you set max_version, must set min_version together"
+        when min_version && max_version.nil?
+          raise Fluent::ConfigError, "When you set min_version, must set max_version together"
+        else
+          min_version = METHODS_MAP[min_version] || min_version
+          max_version = METHODS_MAP[max_version] || max_version
+        end
+        opt[:min_version] = min_version
+        opt[:max_version] = max_version
+      else
+        opt[:ssl_version] = METHODS_MAP[version] || version
+      end
+
+      opt
+    end
+    module_function :set_version_to_options
   end
 end
 

--- a/test/plugin/test_out_http.rb
+++ b/test/plugin/test_out_http.rb
@@ -501,6 +501,7 @@ class HTTPOutputTest < Test::Unit::TestCase
       # WEBrick supports self-generated self-signed certificate
       config[:SSLEnable] = true
       config[:SSLCertName] = [["CN", WEBrick::Utils::getservername]]
+      config[:SSLMaxVersion] = OpenSSL::SSL::TLS1_3_VERSION
       config
     end
 
@@ -512,6 +513,7 @@ class HTTPOutputTest < Test::Unit::TestCase
       d = create_driver(%[
         endpoint https://127.0.0.1:#{server_port}/test
         tls_verify_mode none
+        tls_version TLSv1_3
         ssl_timeout 2s
       ])
       d.run(default_tag: 'test.http') do


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #4332 

**What this PR does / why we need it**: 
Changes the way we configure Net::HTTP client.

**Docs Changes**:
https://github.com/fluent/fluentd-docs-gitbook/pull/579

**Release Note**: 
The same as the title.
