### PR TITLE
formatter_csv: fix memory leak

### DIFF
--- a/lib/fluent/compat/formatter.rb
+++ b/lib/fluent/compat/formatter.rb
@@ -104,15 +104,6 @@ module Fluent
 
         # Do not cache because it is hard to consider the thread key correctly.
         # (We can try, but it would be low priority.)
-        def csv_for_thread
-          CSV.new("".force_encoding(Encoding::ASCII_8BIT), **@generate_opts)
-        end
-
-        # It is hard to consider the thread key correctly for the compat layer.
-        def csv_thread_key
-          raise NotImplementedError, "Compat CsvFormatter does not support CSV cache. Do not use this method."
-        end
-
         def csv_cacheable?
           false
         end

--- a/lib/fluent/compat/formatter.rb
+++ b/lib/fluent/compat/formatter.rb
@@ -112,6 +112,10 @@ module Fluent
         def csv_thread_key
           raise NotImplementedError, "Compat CsvFormatter does not support CSV cache. Do not use this method."
         end
+
+        def csv_cacheable?
+          false
+        end
       end
 
       class SingleValueFormatter < Fluent::Plugin::SingleValueFormatter

--- a/lib/fluent/compat/formatter.rb
+++ b/lib/fluent/compat/formatter.rb
@@ -101,6 +101,17 @@ module Fluent
 
       class CsvFormatter < Fluent::Plugin::CsvFormatter
         # TODO: warn when deprecated
+
+        # Do not cache because it is hard to consider the thread key correctly.
+        # (We can try, but it would be low priority.)
+        def csv_for_thread
+          CSV.new("".force_encoding(Encoding::ASCII_8BIT), **@generate_opts)
+        end
+
+        # It is hard to consider the thread key correctly for the compat layer.
+        def csv_thread_key
+          raise NotImplementedError, "Compat CsvFormatter does not support CSV cache. Do not use this method."
+        end
       end
 
       class SingleValueFormatter < Fluent::Plugin::SingleValueFormatter

--- a/lib/fluent/plugin/formatter_csv.rb
+++ b/lib/fluent/plugin/formatter_csv.rb
@@ -52,11 +52,11 @@ module Fluent
         @generate_opts = {col_sep: @delimiter, force_quotes: @force_quotes, headers: @fields,
                           row_sep: @add_newline ? :auto : "".force_encoding(Encoding::ASCII_8BIT)}
         # Cache CSV object per thread to avoid internal state sharing
-        @cache = {}
+        Thread.current[:csv_formatter] = nil
       end
 
       def format(tag, time, record)
-        csv = (@cache[Thread.current] ||= CSV.new("".force_encoding(Encoding::ASCII_8BIT), **@generate_opts))
+        csv = (Thread.current[:csv_formatter] ||= CSV.new("".force_encoding(Encoding::ASCII_8BIT), **@generate_opts))
         line = (csv << record).string.dup
         # Need manual cleanup because CSV writer doesn't provide such method.
         csv.rewind
@@ -65,7 +65,7 @@ module Fluent
       end
 
       def format_with_nested_fields(tag, time, record)
-        csv = (@cache[Thread.current] ||= CSV.new("".force_encoding(Encoding::ASCII_8BIT), **@generate_opts))
+        csv = (Thread.current[:csv_formatter] ||= CSV.new("".force_encoding(Encoding::ASCII_8BIT), **@generate_opts))
         values = @accessors.map { |a| a.call(record) }
         line = (csv << values).string.dup
         # Need manual cleanup because CSV writer doesn't provide such method.

--- a/lib/fluent/plugin/formatter_csv.rb
+++ b/lib/fluent/plugin/formatter_csv.rb
@@ -36,7 +36,7 @@ module Fluent
       config_param :add_newline, :bool, default: true
 
       def csv_cacheable?
-        owner ? true : false
+        !!owner
       end
 
       def csv_thread_key

--- a/lib/fluent/plugin/formatter_csv.rb
+++ b/lib/fluent/plugin/formatter_csv.rb
@@ -35,12 +35,20 @@ module Fluent
       config_param :fields, :array, value_type: :string
       config_param :add_newline, :bool, default: true
 
+      def csv_cacheable?
+        owner ? true : false
+      end
+
       def csv_thread_key
-        "#{owner.plugin_id}_csv_formatter_#{@usage}_csv"
+        csv_cacheable? ? "#{owner.plugin_id}_csv_formatter_#{@usage}_csv" : nil
       end
 
       def csv_for_thread
-        Thread.current[csv_thread_key] ||= CSV.new("".force_encoding(Encoding::ASCII_8BIT), **@generate_opts)
+        if csv_cacheable?
+          Thread.current[csv_thread_key] ||= CSV.new("".force_encoding(Encoding::ASCII_8BIT), **@generate_opts)
+        else
+          CSV.new("".force_encoding(Encoding::ASCII_8BIT), **@generate_opts)
+        end
       end
 
       def configure(conf)

--- a/lib/fluent/plugin/formatter_csv.rb
+++ b/lib/fluent/plugin/formatter_csv.rb
@@ -21,7 +21,6 @@ require 'csv'
 module Fluent
   module Plugin
     class CsvFormatter < Formatter
-      include PluginId
       Plugin.register_formatter('csv', self)
 
       include PluginHelper::Mixin
@@ -37,7 +36,7 @@ module Fluent
       config_param :add_newline, :bool, default: true
 
       def thread_key
-        "#{plugin_id}_csv"
+        "#{owner.plugin_id}_csv_formatter_#{@usage}_csv"
       end
 
       def configure(conf)
@@ -56,8 +55,6 @@ module Fluent
 
         @generate_opts = {col_sep: @delimiter, force_quotes: @force_quotes, headers: @fields,
                           row_sep: @add_newline ? :auto : "".force_encoding(Encoding::ASCII_8BIT)}
-        # Cache CSV object per thread to avoid internal state sharing
-        Thread.current[thread_key] = nil
       end
 
       def format(tag, time, record)

--- a/lib/fluent/plugin/formatter_csv.rb
+++ b/lib/fluent/plugin/formatter_csv.rb
@@ -35,13 +35,12 @@ module Fluent
       config_param :fields, :array, value_type: :string
       config_param :add_newline, :bool, default: true
 
-      def thread_key
-        if owner
-          "#{owner.plugin_id}_csv_formatter_#{@usage}_csv"
-        else
-          # For Fluent::Compat::TextFormatter
-          "csv_formatter_#{@usage}_csv"
-        end
+      def csv_thread_key
+        "#{owner.plugin_id}_csv_formatter_#{@usage}_csv"
+      end
+
+      def csv_for_thread
+        Thread.current[csv_thread_key] ||= CSV.new("".force_encoding(Encoding::ASCII_8BIT), **@generate_opts)
       end
 
       def configure(conf)
@@ -60,12 +59,10 @@ module Fluent
 
         @generate_opts = {col_sep: @delimiter, force_quotes: @force_quotes, headers: @fields,
                           row_sep: @add_newline ? :auto : "".force_encoding(Encoding::ASCII_8BIT)}
-        # Cache CSV object per thread to avoid internal state sharing
-        Thread.current[thread_key] = nil
       end
 
       def format(tag, time, record)
-        csv = (Thread.current[thread_key] ||= CSV.new("".force_encoding(Encoding::ASCII_8BIT), **@generate_opts))
+        csv = csv_for_thread
         line = (csv << record).string.dup
         # Need manual cleanup because CSV writer doesn't provide such method.
         csv.rewind
@@ -74,7 +71,7 @@ module Fluent
       end
 
       def format_with_nested_fields(tag, time, record)
-        csv = (Thread.current[thread_key] ||= CSV.new("".force_encoding(Encoding::ASCII_8BIT), **@generate_opts))
+        csv = csv_for_thread
         values = @accessors.map { |a| a.call(record) }
         line = (csv << values).string.dup
         # Need manual cleanup because CSV writer doesn't provide such method.


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #3627

**What this PR does / why we need it**: 
Seems `in_exec` plugin creats Thread object each interval and  it invoke formatter_csv on the thread.

If it use a Thread object as hash key when caching with formatter_csv, that thread will be permanently referenceable and will not be collected by the GC.

Here is memory usage of Ruby's process.
![chart](https://github.com/user-attachments/assets/4e74adda-154b-4c00-9cb4-3b1a0e8745fd)

### Reproduce
See #3627
```
<system>
  process_name fluentd_monitor
</system>

<source>
  @type exec
  tag hardware.memory
  run_interval 0.1
  command /home/watson/prj/sandbox/fluentd/get_memory_metrics.sh
  <parse>
    @type json
    types mem_available:float,swap_total:float,swap_free:float
  </parse>
</source>

<match **>
  @type exec
  command /home/watson/prj/sandbox/fluentd/psql_memory.sh
  <format>
    @type csv
    force_quotes false
    delimiter |
    fields time_local,mem_available,swap_total,swap_free
  </format>
  <buffer time>
    @type file
    path /home/watson/prj/sandbox/fluentd/log
    timekey 50s
    timekey_wait 0s
    flush_mode lazy
    total_limit_size 200MB
    retry_type periodic  # exponential backoff is broken https://github.com/fluent/fluentd/issues/3609
    retry_max_times 0  # need to go to secondary as soon as possible https://github.com/fluent/fluentd/issues/3610
  </buffer>
</match>
```

**Docs Changes**:

**Release Note**: 
formatter_csv: fix memory leak