### PR TITLE
in_http: allow empty Origin header requests to pass CORS checks

### DIFF
--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -504,8 +504,9 @@ module Fluent::Plugin
         # ==========
         # For every incoming request, we check if we have some CORS
         # restrictions and allow listed origins through @cors_allow_origins.
+        # If origin is empty, it's likely a server-to-server request and considered safe.
         unless @cors_allow_origins.nil?
-          unless @cors_allow_origins.include?('*') || include_cors_allow_origin
+          unless @cors_allow_origins.include?('*') || include_cors_allow_origin || @origin.nil?
             send_response_and_close(RES_403_STATUS, {'Connection' => 'close'}, "")
             return
           end

--- a/test/plugin/test_in_http.rb
+++ b/test/plugin/test_in_http.rb
@@ -940,6 +940,26 @@ class HttpInputTest < Test::Unit::TestCase
     end
   end
 
+  def test_cors_with_nil_origin
+    d = create_driver(config + %[
+      cors_allow_origins ["http://foo.com"]
+    ])
+    assert_equal ["http://foo.com"], d.instance.cors_allow_origins
+
+    time = event_time("2011-01-02 13:14:15 UTC")
+    event = ["tag1", time, {"a"=>1}]
+    res_code = nil
+
+    d.run do
+      res = post("/#{event[0]}", {"json"=>event[2].to_json, "time"=>time.to_i.to_s})
+      res_code = res.code
+    end
+
+    assert_equal "200", res_code
+    assert_equal [event], d.events
+    assert_equal_event_time time, d.events[0][1]
+  end
+
   def test_content_encoding_gzip
     d = create_driver
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

**What this PR does / why we need it**: 
Some requests, such as those made by apps, certain automated scripts, or older browsers, may not include an Origin header. Previously, such requests were blocked by the CORS check, even though they may not necessarily be cross-origin.

For CORS, the server is responsible for reporting the allowed origins. The web browser is responsible for enforcing that requests are only sent from allowed domains. So this change updates the CORS handling logic to allow requests with an empty Origin header to pass, ensuring compatibility with legitimate non-browser clients while maintaining security.

**Docs Changes**:
https://github.com/fluent/fluentd-docs-gitbook/pull/574

**Release Note**: 
The same as the title.
