### PR TITLE
in_tail: reduce memory usage slightly

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -1238,6 +1238,8 @@ module Fluent::Plugin
                   end
                 rescue EOFError
                   @eof = true
+                ensure
+                  iobuf.clear
                 end
               end
 


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
Previous, I changed lifespan of `iobuf` at https://github.com/fluent/fluentd/pull/4763 to work GC collector well.

In addition, it seems that clearing `iobuf` manually when it is no longer needed, it might improve memory efficiency.

![memory_usage](https://github.com/user-attachments/assets/2ed3afeb-edd6-4f9f-ab6f-1bb602390f25)

* config
```
<source>
  @type tail
  path "#{File.expand_path '~/tmp/access*.log'}"
  pos_file "#{File.expand_path '~/tmp/fluentd/access.log.pos'}"
  tag log
  refresh_interval 5s
  <parse>
    @type none
  </parse>
</source>

<match **>
  @type file
  path "#{File.expand_path '~/tmp/log'}"
</match>
```

* script to generate log data
```
require "json"

path = File.expand_path("~/tmp/access.log")

File.open(path, "w") do |f|
  loop do
    log = { time: Time.now, message: "a" * 10_000 }.to_json
    f.puts log
    sleep 0.05
  end
end
```

Related to https://github.com/fluent/fluentd/issues/4808

**Docs Changes**:

**Release Note**: 
