### PR TITLE
formatter_out_file: reduce memory usage

### DIFF
--- a/lib/fluent/plugin/formatter_out_file.rb
+++ b/lib/fluent/plugin/formatter_out_file.rb
@@ -43,10 +43,13 @@ module Fluent
       end
 
       def format(tag, time, record)
+        json_str = JSON.generate(record)
         header = ''
         header << "#{@timef.format(time)}#{@delimiter}" if @output_time
         header << "#{tag}#{@delimiter}" if @output_tag
-        "#{header}#{JSON.generate(record)}#{@newline}"
+        "#{header}#{json_str}#{@newline}"
+      ensure
+        json_str&.clear
       end
     end
   end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
When dealing with long logs at fast, it might improve memory efficient to clear the original strings used in string interpolation.

![chart](https://github.com/user-attachments/assets/42822460-b381-4ab0-8dc3-18e5e08e9b78)

* config
```
<source>
  @type tail
  path "#{File.expand_path '~/tmp/access*.log'}"
  pos_file "#{File.expand_path '~/tmp/fluentd/access.log.pos'}"
  tag log
  refresh_interval 5s
  <parse>
    @type none
  </parse>
</source>

<match **>
  @type file
  path "#{File.expand_path '~/tmp/log'}"
</match>
```

* script to generate log data
```ruby
require "json"

path = File.expand_path("~/tmp/access.log")

File.open(path, "w") do |f|
  loop do
    log = { time: Time.now, message: "a" * 50 * 1024 }.to_json
    f.puts log
    sleep 0.0001
  end
end
```

**Docs Changes**:

**Release Note**: 
