### PR TITLE
formatter_json: reduce memory usage

### DIFF
--- a/lib/fluent/plugin/formatter_json.rb
+++ b/lib/fluent/plugin/formatter_json.rb
@@ -48,7 +48,10 @@ module Fluent
       end
 
       def format(tag, time, record)
-        "#{@dump_proc.call(record)}#{@newline}"
+        json_str = @dump_proc.call(record)
+        "#{json_str}#{@newline}"
+      ensure
+        json_str&.clear
       end
 
       def format_without_nl(tag, time, record)


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
When dealing with long logs at fast, it might improve memory efficient to clear the original strings used in string interpolation.

This is similar with #4884 .

![chart](https://github.com/user-attachments/assets/2a179770-a99f-45c0-bf60-797c567e9505)

* config
```
<source>
  @type sample
  tag test
  sample {"message": "#{'a' * 100 * 1024}"}
  size 100
</source>

<match **>
  @type file
  path "#{File.expand_path '~/tmp/log'}"
  format json
</match>
```

**Docs Changes**:

**Release Note**: 
