### PR TITLE
out_forward: add warning for zstd as experimental

### DIFF
--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -271,9 +271,15 @@ module Fluent::Plugin
       end
 
       raise Fluent::ConfigError, "ack_response_timeout must be a positive integer" if @ack_response_timeout < 1
+
+      if @compress == :zstd
+        log.warn "zstd compression feature is an experimental new feature supported since v1.19.0." +
+                 " Please make sure that the destination server also supports this feature before using it." +
+                 " in_forward plugin for Fluentd supports it since v1.19.0."
+      end
+
       @healthy_nodes_count_metrics = metrics_create(namespace: "fluentd", subsystem: "output", name: "healthy_nodes_count", help_text: "Number of count healthy nodes", prefer_gauge: true)
       @registered_nodes_count_metrics = metrics_create(namespace: "fluentd", subsystem: "output", name: "registered_nodes_count", help_text: "Number of count registered nodes", prefer_gauge: true)
-
     end
 
     def multi_workers_ready?


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
* Related to #4758

**What this PR does / why we need it**: 
When using `compress zstd` for `out_forward`, output the following warning log.

```
zstd compression feature is an experimental new feature supported since v1.19.0.
Please make sure that the destination server also supports this feature before using it.
in_forward plugin for Fluentd supports it since v1.19.0.
```

In #4758, it was agreed that we would refrain from updating [the forward protocol v1.5](https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1.5) for the time being and instead output a log message indicating that this feature is experimental.

> for now, we will make zstd available as an exprimenatal feature on the Fluentd side, and note in the documentation that it is an experimental feature that cannot be used unless the server supports it.

> Just displaying as a warning log to tell: "This is experimental feature and not standardized yet" or similar message should be enough.

* https://github.com/fluent/fluentd/issues/4758#issuecomment-2608873502
* https://github.com/fluent/fluentd/issues/4758#issuecomment-2608918209
* https://github.com/fluent/fluentd/issues/4758#issuecomment-2609160527

**Docs Changes**:
Not needed. (It should be done as #4657)

**Release Note**: 
Not needed. (A note for #4657 would be enough.)

