### PR TITLE
ci: allow running test manually

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ on:
     paths-ignore:
       - '*.md'
       - 'lib/fluent/version.rb'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

It enables manual operation.

It is useful when you want to re-run the same tests on the latest runner.
(This feature is enabled for ruby-head, so enable it too)

**Docs Changes**:

**Release Note**: 
