### PR TITLE
in_monitor_agent: remove needless require

### DIFF
--- a/lib/fluent/plugin/in_monitor_agent.rb
+++ b/lib/fluent/plugin/in_monitor_agent.rb
@@ -15,7 +15,6 @@
 #
 
 require 'json'
-require 'webrick'
 require 'cgi'
 
 require 'fluent/config/types'


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
* Partially Fixes #4648

**What this PR does / why we need it**: 
Stop requiring WEBrick on `in_monitor_agent`. 

Even if async is not installed, http_server helper requires WEBrick on its own.
So, there is no need to require WEBrick here.

There is no impact on the specification. (This is just code refactoring.)

**Docs Changes**:
Not needed.

**Release Note**: 
Not needed. (This is just code refactoring.)
