### PR TITLE
http_server: add an accessor to read request header

### DIFF
--- a/lib/fluent/plugin_helper/http_server/request.rb
+++ b/lib/fluent/plugin_helper/http_server/request.rb
@@ -14,6 +14,7 @@
 #    limitations under the License.
 #
 
+require 'cgi'
 require 'async/http/protocol'
 require 'fluent/plugin_helper/http_server/methods'
 

--- a/lib/fluent/plugin_helper/http_server/request.rb
+++ b/lib/fluent/plugin_helper/http_server/request.rb
@@ -29,6 +29,10 @@ module Fluent
           @path, @query_string = path.split('?', 2)
         end
 
+        def headers
+          @request.headers
+        end
+
         def query
           @query_string && CGI.parse(@query_string)
         end

--- a/test/plugin_helper/http_server/test_request.rb
+++ b/test/plugin_helper/http_server/test_request.rb
@@ -1,0 +1,18 @@
+require_relative '../../helper'
+require 'flexmock/test_unit'
+require 'fluent/plugin_helper/http_server/request'
+
+class HttpHelperRequestTest < Test::Unit::TestCase
+  def test_request
+    headers = Protocol::HTTP::Headers.new({ 'Content-Type' => 'text/html', 'Content-Encoding' => 'gzip' })
+    req = flexmock('request', path: '/path?foo=42', headers: headers)
+
+    request = Fluent::PluginHelper::HttpServer::Request.new(req)
+
+    assert_equal('/path', request.path)
+    assert_equal('foo=42', request.query_string)
+    assert_equal({'foo'=>['42']}, request.query)
+    assert_equal('text/html', request.headers['content-type'])
+    assert_equal(['gzip'], request.headers['content-encoding'])
+  end
+end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
I'm creating a plugin using http_server, but I need to change the processing depending on the received request header.
So, I want an accessor to read request header in `Fluent::PluginHelper::HttpServer::Request`

**Docs Changes**:
TODO: https://docs.fluentd.org/plugin-helper-overview/api-plugin-helper-http_server#request

**Release Note**: 
* `http_server` helper: add `header` method for `Request`.
