### PR TITLE
Use relative path instead of absolute path in `symlink_path` for the out file plugin

### DIFF
--- a/lib/fluent/plugin/out_file.rb
+++ b/lib/fluent/plugin/out_file.rb
@@ -17,6 +17,7 @@
 require 'fileutils'
 require 'zlib'
 require 'time'
+require 'pathname'
 
 require 'fluent/plugin/output'
 require 'fluent/config/error'
@@ -97,7 +98,8 @@ module Fluent::Plugin
         if chunk.metadata == @latest_metadata
           sym_path = @_output_plugin_for_symlink.extract_placeholders(@_symlink_path, chunk)
           FileUtils.mkdir_p(File.dirname(sym_path), mode: @_output_plugin_for_symlink.dir_perm)
-          FileUtils.ln_sf(chunk.path, sym_path)
+          relative_path = Pathname.new(chunk.path).relative_path_from(Pathname.new(File.dirname(sym_path)))
+          FileUtils.ln_sf(relative_path, sym_path)
         end
         chunk
       end


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
There is no particular issue associated. If necessary I can create one.

**What this PR does / why we need it**: 
This PR moves from an absolute link to a relative link for `symlink_path` parameter. Otherwise, this does not work in a dockerized environment where the path is wired to the the outside of the container.
I can also add an additional parameter to switch between absolute and relative linking if necessary and/or desired.

**Docs Changes**:
I think doc changes are not necassary. However, as far as I read it the documentation does not state whether its an absolute or relative link and it might be useful to add in the scope of this PR.

**Release Note**: 
Uses relative link for `symlink_path` in the out file plugin.