### PR TITLE
gemspec: Add missing metadata

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -20,6 +20,11 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.license = "Apache-2.0"
 
+  gem.metadata["homepage_uri"] = gem.homepage
+  gem.metadata["source_code_uri"] = "https://github.com/fluent/fluentd"
+  gem.metadata["changelog_uri"] = "https://github.com/fluent/fluentd/blob/master/CHANGELOG.md"
+  gem.metadata["bug_tracker_uri"] = "https://github.com/fluent/fluentd/issues"
+
   gem.required_ruby_version = '>= 3.2'
 
   gem.add_runtime_dependency("bundler")


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

Fixes #

**What this PR does / why we need it**: 

metadata field could be set by gem author.
See https://guides.rubygems.org/specification-reference/

**Docs Changes**:

N/A
**Release Note**: 
