### PR TITLE
config: change inspect format

### DIFF
--- a/lib/fluent/config/element.rb
+++ b/lib/fluent/config/element.rb
@@ -73,7 +73,7 @@ module Fluent
 
       def inspect
         attrs = super
-        "name:#{@name}, arg:#{@arg}, " + attrs + ", " + @elements.inspect
+        "<name:#{@name}, arg:#{@arg}, attrs:" + attrs + ", elements:" + @elements.inspect + ">"
       end
 
       # Used by PP and Pry

--- a/lib/fluent/config/element.rb
+++ b/lib/fluent/config/element.rb
@@ -73,7 +73,7 @@ module Fluent
 
       def inspect
         attrs = super
-        "<name:#{@name}, arg:#{@arg}, attrs:" + attrs + ", elements:" + @elements.inspect + ">"
+        "<name:#{@name}, arg:#{@arg}, attrs:#{attrs}, elements:#{@elements.inspect}>"
       end
 
       # Used by PP and Pry

--- a/test/config/test_element.rb
+++ b/test/config/test_element.rb
@@ -280,7 +280,7 @@ CONF
                    element('test', 'ext', {'k2' => 'v2'}, [])
                   ])
       dump = <<-CONF
-name:ROOT, arg:, {\"k1\"=>\"v1\"}, [name:test, arg:ext, {\"k2\"=>\"v2\"}, []]
+<name:ROOT, arg:, attrs:{\"k1\"=>\"v1\"}, elements:[<name:test, arg:ext, attrs:{\"k2\"=>\"v2\"}, elements:[]>]>
 CONF
       assert_not_equal(e.to_s, e.inspect.gsub(' => ', '=>'))
       assert_equal(dump.chomp, e.inspect.gsub(' => ', '=>'))


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

Fixes #

**What this PR does / why we need it**: 

In the previous versions, it is hard to identify
the separator of elements.
Added attr: and elements: prefix for properties and mark it <...>.

Before:

```
  name:ROOT, arg:, {}, [name:system, arg:,
  {"config_include_dir"=>"..."}, [], name:source, arg:,
  {"@type"=>"forward"}, [], name:source, arg:, {"@type"=>"tcp"}, []]
```

After:

```
  <name:ROOT, arg:, attrs:{}, elements:[<name:system, arg:,
  attrs:{"config_include_dir"=>"..."}, elements:[]>, <name:source,
  arg:, attrs:{"@type"=>"forward"}, []>, <name:source, arg:,
  atrrs:{"@type"=>"tcp"}, elements:[]>]
```

**Docs Changes**:

N/A

**Release Note**: 
