### PR TITLE
Backport(v1.16) test_output_as_buffered_retries: fix flaky test (#4877)

### DIFF
--- a/test/plugin/test_output_as_buffered_retries.rb
+++ b/test/plugin/test_output_as_buffered_retries.rb
@@ -941,7 +941,7 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
       @i.enqueue_thread_wait
 
       @i.flush_thread_wakeup
-      waiting(4){ Thread.pass until @i.write_count > 0 }
+      waiting(4){ Thread.pass until @i.write_count > 0 && @i.num_errors > 0 }
       waiting(4) do
         state = @i.instance_variable_get(:@output_flush_threads).first
         state.thread.status == 'sleep'
@@ -953,7 +953,7 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
       now = @i.next_flush_time
       Timecop.freeze( now )
       @i.flush_thread_wakeup
-      waiting(4){ Thread.pass until @i.write_count > 1 }
+      waiting(4){ Thread.pass until @i.write_count > 1 && @i.num_errors > 1 }
       waiting(4) do
         state = @i.instance_variable_get(:@output_flush_threads).first
         state.thread.status == 'sleep'


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Backport #4877
Fixes #4873

**What this PR does / why we need it**:
Before invoke `@num_errors_metrics.inc`, the `does retries correctly when #try_write fails` test will be failed if thread will be switched at https://github.com/fluent/fluentd/blob/f34a2531fcfc4e8958f665301d48558de200aa3a/lib/fluent/plugin/output.rb#L1313-L1315

It is easy to reproduce by adding `sleep` just before `@num_errors_metrics.inc`, like:

```diff
diff --git a/lib/fluent/plugin/output.rb b/lib/fluent/plugin/output.rb
index a987937b..d97d8ec6 100644
--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -1312,6 +1312,7 @@ def check_slow_flush(start)

       def update_retry_state(chunk_id, using_secondary, error = nil)
         @retry_mutex.synchronize do
+          sleep 0.1
           @num_errors_metrics.inc
           chunk_id_hex = dump_unique_id_hex(chunk_id)

```

This patch will wait until `@num_errors_metrics.inc` is invoked.

**Docs Changes**:

**Release Note**:

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

**Docs Changes**:

**Release Note**: 
