### PR TITLE
Backport(v1.16): v1_parser: use URI#open instead of URI.open (#4854)

### DIFF
--- a/lib/fluent/config/v1_parser.rb
+++ b/lib/fluent/config/v1_parser.rb
@@ -172,7 +172,7 @@ module Fluent
           require 'open-uri'
           basepath = '/'
           fname = path
-          data = URI.open(uri) { |f| f.read }
+          data = u.open { |f| f.read }
           data.force_encoding('UTF-8')
           ss = StringScanner.new(data)
           V1Parser.new(ss, basepath, fname, @eval_context).parse_element(true, nil, attrs, elems)


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Backport #4854
Fixes #

**What this PR does / why we need it**: 
By [CodeQL documentation](https://codeql.github.com/codeql-query-help/ruby/rb-non-constant-kernel-open/), it is safer to avoid using `URI.open`.

This is similar with https://github.com/fluent/fluentd/pull/4848

**Docs Changes**:

**Release Note**: 
