### PR TITLE
Backport(v1.16): ci: add cancel-in-progress setting (#4689)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,10 @@ on:
       - '*.md'
       - 'lib/fluent/version.rb'
 
+concurrency:
+  group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 

Backport: #4689 
Fixes #

**What this PR does / why we need it**: 

Often I forget to Signed-off and push new commit again. I would like the github action related to the PR to be automatically cancelled at that time. I want the test to run on the newly pushed commit immediately.

Ref. https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs

**Docs Changes**:

**Release Note**: 
