### PR TITLE
robocop: reduce string to symbol conversion for performance

### DIFF
--- a/lib/fluent/compat/socket_util.rb
+++ b/lib/fluent/compat/socket_util.rb
@@ -129,7 +129,7 @@ module Fluent
 
         def shutdown
           @loop.watchers.each { |w| w.detach }
-          @loop.stop if @loop.instance_variable_get("@running")
+          @loop.stop if @loop.instance_variable_get(:@running)
           @handler.close
           @thread.join
 

--- a/lib/fluent/plugin/owned_by_mixin.rb
+++ b/lib/fluent/plugin/owned_by_mixin.rb
@@ -26,13 +26,13 @@ module Fluent
       end
 
       def owner
-        if instance_variable_defined?("@_owner")
+        if instance_variable_defined?(:@_owner)
           @_owner
         end
       end
 
       def log
-        if instance_variable_defined?("@log")
+        if instance_variable_defined?(:@log)
           @log
         end
       end

--- a/lib/fluent/plugin_id.rb
+++ b/lib/fluent/plugin_id.rb
@@ -57,13 +57,13 @@ module Fluent
     end
 
     def plugin_id_configured?
-      if instance_variable_defined?("@_id_configured")
+      if instance_variable_defined?(:@_id_configured)
         @_id_configured
       end
     end
 
     def plugin_id
-      if instance_variable_defined?("@id")
+      if instance_variable_defined?(:@id)
         @id || "object:#{object_id.to_s(16)}"
       else
         "object:#{object_id.to_s(16)}"

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -186,13 +186,13 @@ module Fluent
         unless defined?($_system_config)
           $_system_config = nil
         end
-        (instance_variable_defined?("@_system_config") && @_system_config) ||
+        (instance_variable_defined?(:@_system_config) && @_system_config) ||
           $_system_config || Fluent::Engine.system_config
       end
 
       def system_config_override(opts={})
         require 'fluent/engine'
-        if !instance_variable_defined?("@_system_config") || @_system_config.nil?
+        if !instance_variable_defined?(:@_system_config) || @_system_config.nil?
           @_system_config = (defined?($_system_config) && $_system_config ? $_system_config : Fluent::Engine.system_config).dup
         end
         opts.each_pair do |key, value|

--- a/test/compat/test_parser.rb
+++ b/test/compat/test_parser.rb
@@ -86,7 +86,7 @@ class TextParserTest < ::Test::Unit::TestCase
   def test_regexp_parser_config(options)
     source = "(?<test>.*)"
     parser = Fluent::TextParser::RegexpParser.new(Regexp.new(source, options), { "dummy" => "dummy" })
-    regexp = parser.instance_variable_get("@regexp")
+    regexp = parser.instance_variable_get(:@regexp)
     assert_equal(options, regexp.options)
   end
 end

--- a/test/test_log.rb
+++ b/test/test_log.rb
@@ -580,7 +580,7 @@ class LogTest < Test::Unit::TestCase
     logger = ServerEngine::DaemonLogger.new(logdev, dl_opts)
     log = Fluent::Log.new(logger)
     log.enable_event(true)
-    engine = log.instance_variable_get("@engine")
+    engine = log.instance_variable_get(:@engine)
     mock(engine).push_log_event(anything, anything, anything).once
     log.trace "trace log"
     log.disable_events(Thread.current)
@@ -728,7 +728,7 @@ class PluginLoggerTest < Test::Unit::TestCase
 
   def test_initialize
     log = Fluent::PluginLogger.new(@logger)
-    logger = log.instance_variable_get("@logger")
+    logger = log.instance_variable_get(:@logger)
     assert_equal(logger, @logger)
   end
 


### PR DESCRIPTION

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

This is cosmetic change, it does not change behavior at all. It was detected by the following rubocop configuration:

```
  Performance/StringIdentifierArgument:
    Enabled: true
```

Apparently, string identifier argument should not be used.

Benchmark result:

```
  ruby 3.2.8 (2025-03-26 revision 13f495dc2c) +YJIT [x86_64-linux]
  Warming up --------------------------------------
  get instance variable with string notation
                         918.201k i/100ms
  get instance variable with symbol notation
                           2.186M i/100ms
  Calculating -------------------------------------
  get instance variable with string notation
                           10.480M (± 1.5%) i/s   (95.42 ns/i) -     53.256M in   5.082903s
  get instance variable with symbol notation
                           27.349M (± 1.3%) i/s   (36.56 ns/i) -    137.703M in   5.035946s

  Comparison:
  get instance variable with symbol notation: 27349072.3 i/s
  get instance variable with string notation: 10479751.9 i/s - 2.61x  slower

  ruby 3.2.8 (2025-03-26 revision 13f495dc2c) +YJIT [x86_64-linux]
  Warming up --------------------------------------
  defined? instance variable with string notation
                         919.834k i/100ms
  defined? instance variable with symbol notation
                           2.333M i/100ms
  Calculating -------------------------------------
  defined? instance variable with string notation
                            9.011M (± 3.6%) i/s  (110.98 ns/i) -     45.072M in   5.008998s
  defined? instance variable with symbol notation
                           27.433M (± 2.2%) i/s   (36.45 ns/i) -    137.670M in   5.021011s

  Comparison:
  defined? instance variable with symbol notation: 27432875.4 i/s
  defined? instance variable with string notation:  9010878.0 i/s - 3.04x  slower
```

Appendix: benchmark ruby script

```ruby
  require 'bundler/inline'
  gemfile do
    source 'https://rubygems.org'
    gem 'benchmark-ips'
    gem 'benchmark-memory'
  end

  class Dummy
    def initialize
      @running = nil
    end
  end

  Benchmark.ips do |x|
    @dummy = Dummy.new
    x.report("get instance variable with string notation") {
      @dummy.instance_variable_get("@running")
    }
    x.report("get instance variable with symbol notation") {
      @dummy.instance_variable_get(:@running)
    }
    x.compare!
  end

  Benchmark.ips do |x|
    @dummy = Dummy.new
    x.report("defined? instance variable with string notation") {
      @dummy.instance_variable_defined?("@running")
    }
    x.report("defined? instance variable with symbol notation") {
      @dummy.instance_variable_defined?(:@running)
    }
    x.compare!
  end
```

**Docs Changes**:

N/A

**Release Note**: 

N/A
