### PR TITLE
rubocop: reduce string to symbol conversion for performance

### DIFF
--- a/lib/fluent/config/types.rb
+++ b/lib/fluent/config/types.rb
@@ -71,7 +71,7 @@ module Fluent
       else
         # Current parser passes comment without actual values, e.g. "param #foo".
         # parser should pass empty string in this case but changing behaviour may break existing environment so keep parser behaviour. Just ignore comment value in boolean handling for now.
-        if str.respond_to?('start_with?') && str.start_with?('#')
+        if str.respond_to?(:start_with?) && str.start_with?('#')
           true
         elsif opts[:strict]
           raise Fluent::ConfigError, "#{name}: invalid bool value: #{str}"

--- a/lib/fluent/plugin.rb
+++ b/lib/fluent/plugin.rb
@@ -175,7 +175,7 @@ module Fluent
              else
                raise Fluent::ConfigError, "#{kind} plugin '#{type}' is not a Class nor callable (without arguments)."
              end
-      if parent && impl.respond_to?("owner=")
+      if parent && impl.respond_to?(:owner=)
         impl.owner = parent
       end
       impl.extend FeatureAvailabilityChecker


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

This is cosmetic change, it does not change behavior at all. It was detected by the following rubocop configuration:

```
  Performance/StringIdentifierArgument:
    Enabled: true
```

Apparently, string identifier argument should not be used.

Benchmark result:

```
  ruby 3.2.8 (2025-03-26 revision 13f495dc2c) +YJIT [x86_64-linux]
  Warming up --------------------------------------
  check method with string notation
                         875.323k i/100ms
  check method with symbol notation
                           1.880M i/100ms
  Calculating -------------------------------------
  check method with string notation
                            8.828M (± 1.4%) i/s  (113.28 ns/i) -     44.641M in   5.058002s
  check method with symbol notation
                           19.766M (± 2.2%) i/s   (50.59 ns/i) -     99.631M in   5.043071s

  Comparison:
  check method with symbol notation: 19765521.3 i/s
  check method with string notation:  8827598.1 i/s - 2.24x  slower
```

Appendix: benchmark script

```ruby
require 'bundler/inline'
gemfile do
  source 'https://rubygems.org'
  gem 'benchmark-ips'
  gem 'benchmark-memory'
end

Benchmark.ips do |x|
  x.report("check method with string notation") {
    "test".respond_to?("start_with?")
  }
  x.report("check method with symbol notation") {
    "test".respond_to?(:start_with?)
  }
  x.compare!
end
```

**Docs Changes**:

N/A

**Release Note**: 

N/A