### PR TITLE
rubocop: reduce hash literals in loops for performance

### DIFF
--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -103,6 +103,7 @@ module Fluent
       used_worker_ids = []
       available_worker_ids = (0..Fluent::Engine.system_config.workers - 1).to_a
       # initialize <worker> elements
+      supported_directives = ['source', 'match', 'filter', 'label']
       conf.elements(name: 'worker').each do |e|
         target_worker_id_str = e.arg
         if target_worker_id_str.empty?
@@ -131,7 +132,7 @@ module Fluent
             used_worker_ids << target_worker_id
 
             e.elements.each do |elem|
-              unless ['source', 'match', 'filter', 'label'].include?(elem.name)
+              unless supported_directives.include?(elem.name)
                 raise Fluent::ConfigError, "<worker> section cannot have <#{elem.name}> directive"
               end
             end
@@ -147,7 +148,7 @@ module Fluent
           end
 
           e.elements.each do |elem|
-            unless ['source', 'match', 'filter', 'label'].include?(elem.name)
+            unless supported_directives.include?(elem.name)
               raise Fluent::ConfigError, "<worker> section cannot have <#{elem.name}> directive"
             end
             elem.set_target_worker_id(target_worker_id)

--- a/lib/fluent/static_config_analysis.rb
+++ b/lib/fluent/static_config_analysis.rb
@@ -72,6 +72,7 @@ module Fluent
       available_worker_ids = [*0...@workers]
 
       ret = []
+      supported_directives = %w[source match filter label]
       conf.elements(name: 'worker').each do |config|
         ids = parse_worker_id(config)
         ids.each do |id|
@@ -83,7 +84,7 @@ module Fluent
         end
 
         config.elements.each do |elem|
-          unless %w[source match filter label].include?(elem.name)
+          unless supported_directives.include?(elem.name)
             raise Fluent::ConfigError, "<worker> section cannot have <#{elem.name}> directive"
           end
         end

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -1211,9 +1211,10 @@ module Fluent
         return
       end
       begin
+        supported_suffixes = [".conf", ".yaml", ".yml"]
         Find.find(@system_config.config_include_dir) do |path|
           next if File.directory?(path)
-          next unless [".conf", ".yaml", ".yml"].include?(File.extname(path))
+          next unless supported_suffixes.include?(File.extname(path))
           # NOTE: both types of normal config (.conf) and YAML will be loaded.
           # Thus, it does not care whether @config_path is .conf or .yml.
           $log.info :supervisor, 'loading additional configuration file', path: path


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

This is cosmetic change, it does not change behavior at all.
The following rubocop configuration detected it:

```
  Performance/CollectionLiteralInLoop:
    Enabled: true
```

hash literals in loops should not be used.

NOTE: hash literals in loops exists in test/*, but it is overkill to
fix them.

Benchmark result:

```
ruby 3.2.8 (2025-03-26 revision 13f495dc2c) +YJIT [x86_64-linux]
Warming up --------------------------------------
            in loops   550.000 i/100ms
        out of loops     1.464k i/100ms
Calculating -------------------------------------
            in loops      5.452k (± 1.5%) i/s  (183.43 μs/i) -     27.500k in   5.045506s
        out of loops     14.592k (± 1.0%) i/s   (68.53 μs/i) -     73.200k in   5.016839s

Comparison:
        out of loops:    14592.4 i/s
            in loops:     5451.7 i/s - 2.68x  slower
```

Appendix: benchmark script

```ruby
require 'bundler/inline'
gemfile do
  source 'https://rubygems.org'
  gem 'benchmark-ips'
  gem 'benchmark-memory'
end

Benchmark.ips do |x|
  x.report("in loops") {
    1000.times do |n|
      ['source', 'match', 'filter', 'label'].include?("dummy")
    end
  }
  x.report("out of loops") {
    supported_directives = ['source', 'match', 'filter', 'label']
    1000.times do |n|
      supported_directives.include?("dummy")
    end
  }
  x.compare!
end
```


**Docs Changes**:

N/A

**Release Note**: 

N/A
