### PR TITLE
rubocop: reduce string to symbol conversion for performance (define_singleton_method)

### DIFF
--- a/lib/fluent/test/base.rb
+++ b/lib/fluent/test/base.rb
@@ -32,7 +32,7 @@ module Fluent
             #   klass.dup is worse because its ancestors does NOT include original class name
             klass_name = klass.name
             klass = Class.new(klass)
-            klass.define_singleton_method("name") { klass_name }
+            klass.define_singleton_method(:name) { klass_name }
             klass.module_eval(&block)
           end
           @instance = klass.new

--- a/lib/fluent/test/formatter_test.rb
+++ b/lib/fluent/test/formatter_test.rb
@@ -28,7 +28,7 @@ module Fluent
             #   klass.dup is worse because its ancestors does NOT include original class name
             klass_name = klass_or_str.name
             klass_or_str = Class.new(klass_or_str)
-            klass_or_str.define_singleton_method("name") { klass_name }
+            klass_or_str.define_singleton_method(:name) { klass_name }
             klass_or_str.module_eval(&block)
           end
           @instance = klass_or_str.new

--- a/lib/fluent/test/parser_test.rb
+++ b/lib/fluent/test/parser_test.rb
@@ -27,7 +27,7 @@ module Fluent
             #   klass.dup is worse because its ancestors does NOT include original class name
             klass_name = klass_or_str.name
             klass_or_str = Class.new(klass_or_str)
-            klass_or_str.define_singleton_method("name") { klass_name }
+            klass_or_str.define_singleton_method(:name) { klass_name }
             klass_or_str.module_eval(&block)
           end
           case klass_or_str.instance_method(:initialize).arity


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

This is cosmetic change, it does not change behavior at all. It was detected by the following rubocop configuration:

```
  Performance/StringIdentifierArgument:
    Enabled: true
```

string identifier argument should not be used.

Benchmark result:

```
  ruby 3.2.8 (2025-03-26 revision 13f495dc2c) +YJIT [x86_64-linux]
  Warming up --------------------------------------
  define method with string notation
                         225.825k i/100ms
  define method with symbol notation
                         278.180k i/100ms
  Calculating -------------------------------------
  define method with string notation
                            2.337M (± 2.0%) i/s  (427.83 ns/i) -     11.743M in   5.025989s
  define method with symbol notation
                            2.765M (± 3.8%) i/s  (361.70 ns/i) -     13.909M in   5.038885s

  Comparison:
  define method with symbol notation:  2764687.4 i/s
  define method with string notation:  2337378.7 i/s - 1.18x  slower
```

Appendix: benchmark script

```ruby
require 'bundler/inline'
gemfile do
  source 'https://rubygems.org'
  gem 'benchmark-ips'
  gem 'benchmark-memory'
end

class Dummy
end

Benchmark.ips do |x|
  @dummy = Dummy.new
  x.report("define method with string notation") {
    @dummy.define_singleton_method("name") { "class name" }
  }
  x.report("define method with symbol notation") {
    @dummy.define_singleton_method(:name) { "class name" }
  }
  x.compare!
end
```


**Docs Changes**:

N/A

**Release Note**: 

N/A
