### PR TITLE
rubocop: reduce a regex match for performance

### DIFF
--- a/lib/fluent/env.rb
+++ b/lib/fluent/env.rb
@@ -35,10 +35,10 @@ module Fluent
   end
 
   def self.linux?
-    /linux/ === RUBY_PLATFORM
+    RUBY_PLATFORM.include?("linux")
   end
 
   def self.macos?
-    /darwin/ =~ RUBY_PLATFORM
+    RUBY_PLATFORM.include?("darwin")
   end
 end

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -184,7 +184,7 @@ module Fluent::Plugin
       configure_tag
       configure_encoding
 
-      @multiline_mode = parser_config["@type"] =~ /multiline/
+      @multiline_mode = parser_config["@type"].include?("multiline")
       @receive_handler = if @multiline_mode
                            method(:parse_multilines)
                          else


### PR DESCRIPTION


**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

This is cosmetic change, it does not change behavior at all. The following rubocop configuration detects it.

```
Performance/StringInclude:
  Enable: true
```

Benchmark result:

```
ruby 3.2.8 (2025-03-26 revision 13f495dc2c) +YJIT [x86_64-linux]
Warming up --------------------------------------
check method with ===
                       411.815k i/100ms
check method with include?
                         1.180M i/100ms
Calculating -------------------------------------
check method with ===
                          3.797M (± 5.3%) i/s  (263.38 ns/i) -     18.943M in   5.003267s
check method with include?
                         12.067M (± 3.5%) i/s   (82.87 ns/i) -     61.348M in   5.090688s

Comparison:
check method with include?: 12066561.6 i/s
check method with ===:  3796826.8 i/s - 3.18x  slower

ruby 3.2.8 (2025-03-26 revision 13f495dc2c) +YJIT [x86_64-linux]
Warming up --------------------------------------
check method with =~   353.806k i/100ms
check method with include?
                         1.170M i/100ms
Calculating -------------------------------------
check method with =~      3.371M (± 5.1%) i/s  (296.66 ns/i) -     16.983M in   5.051124s
check method with include?
                         12.155M (± 1.0%) i/s   (82.27 ns/i) -     60.849M in   5.006417s

Comparison:
check method with include?: 12155448.7 i/s
check method with =~:  3370848.9 i/s - 3.61x  slower
```

Appendix: benchmark script

```ruby
require 'bundler/inline'
gemfile do
  source 'https://rubygems.org'
  gem 'benchmark-ips'
  gem 'benchmark-memory'
end

Benchmark.ips do |x|
  name = "x86_64-linux"
  x.report("check method with ===") {
    /linux/ === name
  }
  x.report("check method with include?") {
    name.include?("linux")
  }
  x.compare!
end

Benchmark.ips do |x|
  triplet = "powerpc64-apple-darwin"
  x.report("check method with =~") {
    /darwin/ =~ triplet
  }
  x.report("check method with include?") {
    triplet.include?("darwin")
  }
  x.compare!
end
```

**Docs Changes**:

N/A

**Release Note**: 

N/A
