### PR TITLE
rubocop: reduce every regex evaluation for performance

### DIFF
--- a/lib/fluent/config/literal_parser.rb
+++ b/lib/fluent/config/literal_parser.rb
@@ -98,11 +98,11 @@ module Fluent
             else
               return string.join
             end
-          elsif check(/[^"]#{LINE_END_WITHOUT_SPACING_AND_COMMENT}/)
-            if s = check(/[^\\]#{LINE_END_WITHOUT_SPACING_AND_COMMENT}/)
+          elsif check(/[^"]#{LINE_END_WITHOUT_SPACING_AND_COMMENT}/o)
+            if s = check(/[^\\]#{LINE_END_WITHOUT_SPACING_AND_COMMENT}/o)
               string << s
             end
-            skip(/[^"]#{LINE_END_WITHOUT_SPACING_AND_COMMENT}/)
+            skip(/[^"]#{LINE_END_WITHOUT_SPACING_AND_COMMENT}/o)
           elsif s = scan(/\\./)
             string << eval_escape_char(s[1,1])
           elsif skip(/\#\{/)

--- a/lib/fluent/config/v1_parser.rb
+++ b/lib/fluent/config/v1_parser.rb
@@ -83,7 +83,7 @@ module Fluent
           elsif skip(/\</)
             e_name = scan(ELEMENT_NAME)
             spacing
-            e_arg = scan_string(/(?:#{ZERO_OR_MORE_SPACING}\>)/)
+            e_arg = scan_string(/(?:#{ZERO_OR_MORE_SPACING}\>)/o)
             spacing
             unless skip(/\>/)
               parse_error! "expected '>'"
@@ -98,7 +98,7 @@ module Fluent
             new_e.v1_config = true
             elems << new_e
 
-          elsif root_element && skip(/(\@include|include)#{SPACING}/)
+          elsif root_element && skip(/(\@include|include)#{SPACING}/o)
             if !prev_match.start_with?('@')
               @logger.warn "'include' is deprecated. Use '@include' instead" if @logger
             end


### PR DESCRIPTION


**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

This is cosmetic change, it does not change behavior at all. The following rubocop configuration detects it.

```
Performance/ConstantRegexp:
  Enable: true
```

Benchmark result:

```
ruby 3.2.8 (2025-03-26 revision 13f495dc2c) +YJIT [x86_64-linux]
Warming up --------------------------------------
 interpret everytime    26.127k i/100ms
      interpret once     3.172M i/100ms
Calculating -------------------------------------
 interpret everytime    254.171k (± 2.6%) i/s    (3.93 μs/i) -      1.280M in   5.040357s
      interpret once     33.755M (± 1.7%) i/s   (29.62 ns/i) -    171.289M in   5.075867s

Comparison:
      interpret once: 33755320.3 i/s
 interpret everytime:   254171.5 i/s - 132.81x  slower
```

Regex should not be evaluated every time, use /o to evaluate only once because it expands constant in /#{...}/ expression.

Appendix: benchmark script

```ruby
require 'bundler/inline'
gemfile do
  source 'https://rubygems.org'
  gem 'benchmark-ips'
  gem 'benchmark-memory'
end

Benchmark.ips do |x|
  ZERO_OR_MORE_SPACING = /(?:[ \t\r\n]|\z|\#.*?(?:\z|[\r\n]))*/
  x.report("interpret everytime") {
    /(?:#{ZERO_OR_MORE_SPACING}\>)/
  }
  x.report("interpret once") {
    /(?:#{ZERO_OR_MORE_SPACING}\>)/o
  }
  x.compare!
end
```


**Docs Changes**:

N/A

**Release Note**: 

N/A
