### PR TITLE
Backport(v1.16): rubocop: fix trailing-whitespace (#4928)

### DIFF
--- a/lib/fluent/plugin/in_http.rb
+++ b/lib/fluent/plugin/in_http.rb
@@ -580,7 +580,7 @@ module Fluent::Plugin
         end
         path_info = uri.path
 
-        if (@add_query_params) 
+        if (@add_query_params)
 
           query_params = WEBrick::HTTPUtils.parse_query(uri.query)
 

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -534,7 +534,7 @@ module Fluent::Plugin
       if @follow_inodes && new_inode.nil?
         # nil inode means the file disappeared, so we only need to stop it.
         @tails.delete(tail_watcher.path)
-        # https://github.com/fluent/fluentd/pull/4237#issuecomment-1633358632 
+        # https://github.com/fluent/fluentd/pull/4237#issuecomment-1633358632
         # Because of this problem, log duplication can occur during `rotate_wait`.
         # Need to set `rotate_wait 0` for a workaround.
         # Duplication will occur if `refresh_watcher` is called during the `rotate_wait`.

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -742,7 +742,7 @@ module Fluent
       $log.enable_debug if system_config.log_level <= Fluent::Log::LEVEL_DEBUG
 
       $log.info "init #{process_type} logger",
-                path: actual_log_path, 
+                path: actual_log_path,
                 rotate_age: @log_rotate_age,
                 rotate_size: @log_rotate_size
     end
@@ -995,7 +995,7 @@ module Fluent
     def build_system_config(conf)
       system_config = SystemConfig.create(conf, @cl_opt[:strict_config_value])
       # Prefer the options explicitly specified in the command line
-      # 
+      #
       # TODO: There is a bug that `system_config.log.rotate_age/rotate_size` are
       # not merged with the command line options since they are not in
       # `SYSTEM_CONFIG_PARAMETERS`.

--- a/lib/fluent/winsvc.rb
+++ b/lib/fluent/winsvc.rb
@@ -32,7 +32,7 @@ begin
   op.parse(ARGV)
   if opts[:service_name] == nil
     raise "Error: No Windows Service name set. Use '--service-name'"
-  end 
+  end
 
   def read_fluentdopt(service_name)
     Win32::Registry::HKEY_LOCAL_MACHINE.open("SYSTEM\\CurrentControlSet\\Services\\#{service_name}") do |reg|
@@ -54,7 +54,7 @@ begin
     def initialize(service_name)
       @service_name = service_name
     end
-    
+
     def service_main
       @pid = service_main_start(@service_name)
       while running?

--- a/test/config/test_plugin_configuration.rb
+++ b/test/config/test_plugin_configuration.rb
@@ -19,9 +19,9 @@ module ConfigurationForPlugins
 
   class BooleanParamsWithoutValue < ::Test::Unit::TestCase
     CONFIG = <<CONFIG
-    flag1 
+    flag1
     flag2 # yaaaaaaaaaay
-    flag3 
+    flag3
     flag4 # yaaaaaaaaaay
     <child>
       flag1
@@ -37,10 +37,10 @@ module ConfigurationForPlugins
     </child>
     # with following whitespace
     <child>
-      flag1 
-      flag2 
-      flag3 
-      flag4 
+      flag1
+      flag2
+      flag3
+      flag4
     </child>
 CONFIG
 

--- a/test/plugin/test_buffer.rb
+++ b/test/plugin/test_buffer.rb
@@ -946,9 +946,9 @@ class BufferTest < Test::Unit::TestCase
       # 1. `write_once`: 42 [events] * 1 [stream]
       # 2. `write_step_by_step`: 4 [events]* 10 [streams] + 2 [events] * 1 [stream]
       # 3. `write_step_by_step` (by `ShouldRetry`): 1 [event] * 42 [streams]
-      # 
+      #
       # Example of staged chunk lock behavior:
-      # 
+      #
       # 1. mon_enter in write_step_by_step
       # 2. ShouldRetry occurs
       # 3. mon_exit in write_step_by_step

--- a/test/plugin/test_filter_grep.rb
+++ b/test/plugin/test_filter_grep.rb
@@ -328,7 +328,7 @@ class GrepFilterTest < Test::Unit::TestCase
       end
 
       test "don't raise an exception" do
-        assert_nothing_raised { 
+        assert_nothing_raised {
           filter(%[regexp1 message WARN], ["\xff".force_encoding('UTF-8')])
         }
       end

--- a/test/plugin/test_in_http.rb
+++ b/test/plugin/test_in_http.rb
@@ -982,7 +982,7 @@ class HttpInputTest < Test::Unit::TestCase
     assert_equal ["403", "403"], res_codes
   end
 
-  def test_add_query_params 
+  def test_add_query_params
     d = create_driver(config + "add_query_params true")
     assert_equal true, d.instance.add_query_params
 

--- a/test/plugin/test_output.rb
+++ b/test/plugin/test_output.rb
@@ -1111,7 +1111,7 @@ class OutputTest < Test::Unit::TestCase
         config: config_element(
           "ROOT", "", {},
           [
-            config_element("buffer", "", {}), 
+            config_element("buffer", "", {}),
             config_element("secondary", "", {"@type" => "test", "name" => "test"}),
           ]
         ),

--- a/test/plugin/test_parser_csv.rb
+++ b/test/plugin/test_parser_csv.rb
@@ -164,7 +164,7 @@ class CSVParserTest < ::Test::Unit::TestCase
       text = 'a"b,"a"""c"'
       assert_raise(CSV::MalformedCSVError) {
         normal.instance.parse(text) { |t, r| }
-      } 
+      }
       assert_nothing_raised {
         # generate broken record
         fast.instance.parse(text) { |t, r| }

--- a/test/test_tls.rb
+++ b/test/test_tls.rb
@@ -9,7 +9,7 @@ class UniqueIdTest < Test::Unit::TestCase
   TEST_TLS1_2_CASES = {
     'New TLS v1.2' => :'TLS1_2',
     'Old TLS v1.2' => :'TLSv1_2'
-  } 
+  }
   TEST_TLS_CASES = TEST_TLS1_1_CASES.merge(TEST_TLS1_2_CASES)
 
   sub_test_case 'constants' do


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Backport: #4928
Fixes #

**What this PR does / why we need it**:

It will reduce rubocop warnings with the following configuration:

```yml
  Layout/TrailingWhitespace:
    Enabled: true
```

This is just cosmetic change. It will not break tests.

NOTE: the following files are additionally detected only in v1.16 branch
* lib/fluent/plugin/in_http.rb
* lib/fluent/plugin/in_tail.rb
* test/plugin/test_in_http.rb

**Docs Changes**:

N/A

**Release Note**:

N/A
