### PR TITLE
Backport(v1.16): github: set job permissions (#4581)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ concurrency:
   group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
 Backport #4581.

**What this PR does / why we need it**:

By default, it is enough to give read permission.
For stale actions, it require manipulate issues,
so write permission is given explicitly.

**Docs Changes**:

N/A

**Release Note**:

N/A
