### PR TITLE
rubocop: use yield without block

### DIFF
--- a/lib/fluent/test/driver/base.rb
+++ b/lib/fluent/test/driver/base.rb
@@ -185,7 +185,7 @@ module Fluent
           end
         end
 
-        def run_actual(timeout: DEFAULT_TIMEOUT, &block)
+        def run_actual(timeout: DEFAULT_TIMEOUT)
           if @instance.respond_to?(:_threads)
             sleep 0.1 until @instance._threads.values.all?(&:alive?)
           end
@@ -201,7 +201,7 @@ module Fluent
           return_value = nil
           begin
             Timeout.timeout(timeout * 2) do |sec|
-              return_value = block.call if block_given?
+              return_value = yield if block_given?
             end
           rescue Timeout::Error
             raise TestTimedOut, "Test case timed out with hard limit."

--- a/lib/fluent/test/filter_test.rb
+++ b/lib/fluent/test/filter_test.rb
@@ -59,9 +59,9 @@ module Fluent
       alias_method :emits, :filtered_as_array # emits is for consistent with other drivers
 
       # Almost filters don't use threads so default is 0. It reduces test time.
-      def run(num_waits = 0, &block)
+      def run(num_waits = 0)
         super(num_waits) {
-          block.call if block
+          yield if block_given?
 
           @events.each { |tag, es|
             processed = @instance.filter_stream(tag, es)

--- a/lib/fluent/test/input_test.rb
+++ b/lib/fluent/test/input_test.rb
@@ -109,7 +109,7 @@ module Fluent
         end
       end
 
-      def run(num_waits = 10, &block)
+      def run(num_waits = 10)
         m = method(:emit_stream)
         unless Engine.singleton_class.ancestors.include?(EmitStreamWrapper)
           Engine.singleton_class.prepend EmitStreamWrapper
@@ -121,7 +121,7 @@ module Fluent
         instance.router.emit_stream_callee = m
 
         super(num_waits) {
-          block.call if block
+          yield if block_given?
 
           if @expected_emits_length || @expects || @run_post_conditions
             # counters for emits and emit_streams

--- a/lib/fluent/test/output_test.rb
+++ b/lib/fluent/test/output_test.rb
@@ -71,10 +71,10 @@ module Fluent
         (@expected_buffer ||= '') << str
       end
 
-      def run(num_waits = 10, &block)
+      def run(num_waits = 10)
         result = nil
         super(num_waits) {
-          block.call if block
+          yield if block_given?
 
           es = ArrayEventStream.new(@entries)
           buffer = @instance.format_stream(@tag, es)
@@ -119,10 +119,10 @@ module Fluent
         (@expected_buffer ||= '') << str
       end
 
-      def run(&block)
+      def run
         result = []
         super {
-          block.call if block
+          yield if block_given?
 
           buffer = ''
           lines = {}


### PR DESCRIPTION

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

This is cosmetic change, it does not change behavior at all. The following rubocop configuration detects it.

```
Performance/RedundantBlockCall:
  Exclude:
    - 'test/**/*'
    #- 'lib/fluent/**/*.rb'
    - 'lib/fluent/plugin_helper/*.rb'
    - 'lib/fluent/plugin/*.rb'
    - 'lib/fluent/compat/*.rb'
    - 'lib/fluent/config/*.rb'
    - 'lib/fluent/*.rb'
  Enabled: true
```

Benchmark result:

```
ruby 3.2.8 (2025-03-26 revision 13f495dc2c) +YJIT [x86_64-linux]
Warming up --------------------------------------
          block call     1.315M i/100ms
   yield with &block     1.721M i/100ms
yield without &block     1.692M i/100ms
Calculating -------------------------------------
          block call     13.572M (± 0.5%) i/s   (73.68 ns/i) -     68.365M in   5.037353s
   yield with &block     17.927M (± 3.8%) i/s   (55.78 ns/i) -     89.490M in   5.000061s
yield without &block     18.191M (± 0.3%) i/s   (54.97 ns/i) -     91.355M in   5.021978s

Comparison:
yield without &block: 18191218.3 i/s
   yield with &block: 17927144.4 i/s - same-ish: difference falls within error
          block call: 13572023.6 i/s - 1.34x  slower
```

Appendix: benchmark script

```ruby
require 'bundler/inline'
gemfile do
  source 'https://rubygems.org'
  gem 'benchmark-ips'
  gem 'benchmark-memory'
end

def block_call(s, &block)
  block.call(s) if block_given?
end

def yield_with_block(s, &block)
  yield(s) if block_given?
end

def yield_without_block(s)
  yield(s) if block_given?
end

Benchmark.ips do |x|
  x.report("block call") {
    block_call("dummy") do |message|
      message
    end
  }
  x.report("yield with &block") {
    yield_with_block("dummy") do |message|
      message
    end
  }
  x.report("yield without &block") {
    yield_without_block("dummy") do |message|
      message
    end
  }
  x.compare!
end
```


**Docs Changes**:

N/A

**Release Note**: 

N/A
