### PR TITLE
metrics: enable input metrics by default

### DIFF
--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -155,7 +155,11 @@ op.on('--strict-config-value', "Parse config values strictly", TrueClass) {|b|
   cmd_opts[:strict_config_value] = b
 }
 
-op.on('--enable-input-metrics', "Enable input plugin metrics on fluentd", TrueClass) {|b|
+op.on('--enable-input-metrics', "[DEPRECATED] Enable input plugin metrics on fluentd", TrueClass) {|b|
+  cmd_opts[:enable_input_metrics] = b
+}
+
+op.on('--disable-input-metrics', "Disable input plugin metrics on fluentd", FalseClass) {|b|
   cmd_opts[:enable_input_metrics] = b
 }
 

--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -86,7 +86,7 @@ module Fluent
       @without_source = system_config.without_source || false
       @source_only_mode = SourceOnlyMode.new(system_config.with_source_only, start_in_parallel)
       @source_only_buffer_agent = nil
-      @enable_input_metrics = system_config.enable_input_metrics || false
+      @enable_input_metrics = system_config.enable_input_metrics
 
       suppress_interval(system_config.emit_error_log_interval) unless system_config.emit_error_log_interval.nil?
     end

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -631,7 +631,7 @@ module Fluent
         ignore_repeated_log_interval: nil,
         without_source: nil,
         with_source_only: nil,
-        enable_input_metrics: nil,
+        enable_input_metrics: true,
         enable_size_metrics: nil,
         use_v1_config: true,
         strict_config_value: nil,

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -51,7 +51,7 @@ module Fluent
     config_param :strict_config_value, :bool, default: nil
     config_param :enable_msgpack_time_support, :bool, default: nil
     config_param :disable_shared_socket, :bool, default: nil
-    config_param :enable_input_metrics, :bool, default: nil
+    config_param :enable_input_metrics, :bool, default: true
     config_param :enable_size_metrics, :bool, default: nil
     config_param :enable_jit, :bool, default: false
     config_param :file_permission, default: nil do |v|

--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -1608,4 +1608,16 @@ CONF
                          "[info]: loading additional configuration file path=\"#{conf_dir}/child.yml\"")
     end
   end
+
+  test "allow --disable-input-metrics option" do
+    conf = <<CONF
+<system>
+</system>
+CONF
+    conf_path = create_conf_file('input-metrics.conf', conf)
+    assert_log_matches(
+      create_cmdline(conf_path, '--disable-input-metrics'),
+      "#0 fluentd worker is now running worker=0"
+    )
+  end
 end

--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -1610,11 +1610,7 @@ CONF
   end
 
   test "allow --disable-input-metrics option" do
-    conf = <<CONF
-<system>
-</system>
-CONF
-    conf_path = create_conf_file('input-metrics.conf', conf)
+    conf_path = create_conf_file('empty.conf', '')
     assert_log_matches(
       create_cmdline(conf_path, '--disable-input-metrics'),
       "#0 fluentd worker is now running worker=0"

--- a/test/config/test_system_config.rb
+++ b/test/config/test_system_config.rb
@@ -97,7 +97,7 @@ module Fluent::Config
       'with_source_only' => ['with_source_only', true],
       'strict_config_value' => ['strict_config_value', true],
       'enable_msgpack_time_support' => ['enable_msgpack_time_support', true],
-      'enable_input_metrics' => ['enable_input_metrics', true],
+      'enable_input_metrics' => ['enable_input_metrics', false],
       'enable_size_metrics' => ['enable_size_metrics', true],
       'enable_jit' => ['enable_jit', true],
     )

--- a/test/config/test_system_config.rb
+++ b/test/config/test_system_config.rb
@@ -75,7 +75,7 @@ module Fluent::Config
       assert_nil(sc.suppress_config_dump)
       assert_nil(sc.without_source)
       assert_nil(sc.with_source_only)
-      assert_nil(sc.enable_input_metrics)
+      assert_true(sc.enable_input_metrics)
       assert_nil(sc.enable_size_metrics)
       assert_nil(sc.enable_msgpack_time_support)
       assert(!sc.enable_jit)

--- a/test/test_root_agent.rb
+++ b/test/test_root_agent.rb
@@ -18,6 +18,7 @@ class RootAgentTest < ::Test::Unit::TestCase
     'suppress interval' => [{'emit_error_log_interval' => 30}, {:@suppress_emit_error_log_interval => 30}],
     'without source' => [{'without_source' => true}, {:@without_source => true}],
     'enable input metrics' => [{'enable_input_metrics' => true}, {:@enable_input_metrics => true}],
+    'disable input metrics' => [{'enable_input_metrics' => false}, {:@enable_input_metrics => false}],
     )
   def test_initialize_with_opt(data)
     opt, expected = data

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -64,6 +64,7 @@ class SupervisorTest < ::Test::Unit::TestCase
   without_source true
   with_source_only true
   enable_get_dump true
+  enable_input_metrics false
   process_name "process_name"
   log_level info
   root_dir #{@tmp_root_dir}
@@ -103,6 +104,7 @@ class SupervisorTest < ::Test::Unit::TestCase
     assert_equal true, sys_conf.without_source
     assert_equal true, sys_conf.with_source_only
     assert_equal true, sys_conf.enable_get_dump
+    assert_equal false, sys_conf.enable_input_metrics
     assert_equal "process_name", sys_conf.process_name
     assert_equal 2, sys_conf.log_level
     assert_equal @tmp_root_dir, sys_conf.root_dir


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
I ran fluend with `--enable-input-metrics` option and read 10GB file with the `in_tail` plugin
There was no significant performance degradation.


So, I think it is safe to always enable `--enable-input-metrics`.

### environment
* ruby 3.4.3 (2025-04-14 revision d0b7e5b6a0) +PRISM [x86_64-linux]

### results
* fluentd master branch (efbb51d7)
    * `ruby bin/fluentd -c in_tail.conf`
        * 65.939232375 seconds
    * `ruby bin/fluentd --enable-input-metrics -c in_tail.conf`
        * 67.776236261 seconds
* fluentd 1.16.9 (daccbc6f)
    * `ruby bin/fluentd -c in_tail.conf`
        * 106.312500419 seconds

### config
```
<source>
  @type tail
  tag test
  path "#{File.expand_path '~/tmp/fluentd/access-*.log'}"
  read_from_head true
  <parse>
    @type json
  </parse>
</source>

<match **>
  @type file
  path "#{File.expand_path '~/tmp/fluentd/log'}"
</match>
```

### script to generate 10GB
```ruby
# frozen_string_literal: true
require "json"
require "fileutils"

def data_generater(str)
  {
    "message": str * 1000,
  }.to_json
end

FILE_MAX_SIZE = 10 * 1024 * 1024 * 1024
FILE_PATH = "/home/watson/tmp/fluentd/access-1.log"

dir = File.dirname(FILE_PATH)
FileUtils.mkdir_p(dir)

File.open(FILE_PATH, "w") do |f|
  data = data_generater('a')
  loop do
    f.puts data
    break if File.size(FILE_PATH) > FILE_MAX_SIZE
  end
end
```

**Docs Changes**:
https://github.com/fluent/fluentd-docs-gitbook/pull/578

**Release Note**: 
The same as the title.