### PR TITLE
win32api: remove support for runtime used in old Ruby

### DIFF
--- a/lib/fluent/win32api.rb
+++ b/lib/fluent/win32api.rb
@@ -22,13 +22,7 @@ module Fluent
     require 'fiddle/types'
     extend Fiddle::Importer
 
-    if RUBY_PLATFORM.split('-')[-1] == "ucrt"
-      MSVCRT_DLL = 'ucrtbase.dll'
-    else
-      MSVCRT_DLL = 'msvcrt.dll'
-    end
-
-    dlload MSVCRT_DLL, "kernel32.dll"
+    dlload "ucrtbase.dll", "kernel32.dll"
     include Fiddle::Win32Types
 
     extern "intptr_t _get_osfhandle(int)"


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
This is just refactoring to clean up the branch for old ruby.

Windows Ruby have started using UCRT since 3.1.
Now, we have been supporting Ruby 3.2+ on master.
https://rubyinstaller.org/2021/12/31/rubyinstaller-3.1.0-1-released.html

**Docs Changes**:

**Release Note**: 
