### PR TITLE
feat: add umask configuration support

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -589,6 +589,7 @@ module Fluent
         chuser: params['chuser'],
         chgroup: params['chgroup'],
         chumask: params['chumask'].is_a?(Integer) ? params['chumask'] : params['chumask']&.to_i(8),
+        umask: params['umask'],
         daemonize: daemonize,
         rpc_endpoint: params['rpc_endpoint'],
         counter_server: params['counter_server'],
@@ -759,6 +760,11 @@ module Fluent
 
       if @standalone_worker && @system_config.workers != 1
         raise Fluent::ConfigError, "invalid number of workers (must be 1 or unspecified) with --no-supervisor: #{@system_config.workers}"
+      end
+      
+      if @system_config.umask
+        File.umask(@system_config.umask)
+        $log.info "Worker applied system umask", umask: sprintf("%04o", @system_config.umask)
       end
 
       if Fluent.windows? && @system_config.with_source_only
@@ -1202,6 +1208,10 @@ module Fluent
         end
       end
       system_config.overwrite_variables(**opt)
+      if system_config.umask
+        File.umask(system_config.umask)
+        $log.info "Applied system umask", umask: sprintf("%04o", system_config.umask)
+      end
       system_config
     end
 

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -30,7 +30,7 @@ module Fluent
       :file_permission, :dir_permission, :counter_server, :counter_client,
       :strict_config_value, :enable_msgpack_time_support, :disable_shared_socket,
       :metrics, :enable_input_metrics, :enable_size_metrics, :enable_jit, :source_only_buffer,
-      :config_include_dir
+      :config_include_dir,:umask 
     ]
 
     config_param :workers,   :integer, default: 1
@@ -61,6 +61,7 @@ module Fluent
       v.to_i(8)
     end
     config_param :config_include_dir, default: Fluent::DEFAULT_CONFIG_INCLUDE_DIR
+    config_param :umask, :string, default: nil, pattern: /\A[0-7]{3,4}\z/
     config_section :log, required: false, init: true, multi: false do
       config_param :path, :string, default: nil
       config_param :format, :enum, list: [:text, :json], default: :text
@@ -144,6 +145,7 @@ module Fluent
       super()
       conf ||= SystemConfig.blank_system_config
       configure(conf, strict_config_value)
+      @umask = @umask ? @umask.to_i(8) : nil
     end
 
     def configure(conf, strict_config_value=false)


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
增加 umask 配置支持，使日志文件权限控制更灵活。当用户需要指定非默认文件权限时，可通过配置 umask 参数实现。
**Docs Changes**:
无
**Release Note**: 
新增功能: 支持通过 umask 参数控制输出文件权限