### PR TITLE
output: add metrics for dropped oldest chunk count

### DIFF
--- a/test/plugin/test_in_monitor_agent.rb
+++ b/test/plugin/test_in_monitor_agent.rb
@@ -185,6 +185,7 @@ CONF
         "rollback_count"  => Integer,
         "slow_flush_count" => Integer,
         "flush_time_count" => Integer,
+        "drop_oldest_chunk_count" => Integer,
       }
       output_info.merge!("config" => {"@id" => "test_out", "@type" => "test_out"}) if with_config
       error_label_info = {
@@ -208,6 +209,7 @@ CONF
         "rollback_count"  => Integer,
         "slow_flush_count" => Integer,
         "flush_time_count" => Integer,
+        "drop_oldest_chunk_count" => Integer,
       }
       error_label_info.merge!("config" => {"@id"=>"null", "@type" => "null"}) if with_config
       opts = {with_config: with_config}
@@ -326,6 +328,7 @@ EOC
         "rollback_count"  => Integer,
         "slow_flush_count" => Integer,
         "flush_time_count" => Integer,
+        "drop_oldest_chunk_count" => Integer,
       }
       output_info.merge!("config" => {"@id" => "test_out", "@type" => "test_out"}) if with_config
       error_label_info = {
@@ -349,6 +352,7 @@ EOC
         "rollback_count"  => Integer,
         "slow_flush_count" => Integer,
         "flush_time_count" => Integer,
+        "drop_oldest_chunk_count" => Integer,
       }
       error_label_info.merge!("config" => {"@id"=>"null", "@type" => "null"}) if with_config
       opts = {with_config: with_config}
@@ -424,6 +428,7 @@ EOC
         "rollback_count"  => Integer,
         "slow_flush_count" => Integer,
         "flush_time_count" => Integer,
+        "drop_oldest_chunk_count" => Integer,
       }
       expect_test_out_record = {
         "plugin_id"       => "test_out",
@@ -439,6 +444,7 @@ EOC
         "rollback_count"  => Integer,
         "slow_flush_count" => Integer,
         "flush_time_count" => Integer,
+        "drop_oldest_chunk_count" => Integer,
       }
       assert_fuzzy_equal(expect_relabel_record, d.events[1][2])
       assert_fuzzy_equal(expect_test_out_record, d.events[3][2])
@@ -578,6 +584,7 @@ plugin_id:test_filter\tplugin_category:filter\ttype:test_filter\toutput_plugin:f
         "rollback_count"  => Integer,
         "slow_flush_count" => Integer,
         "flush_time_count" => Integer,
+        "drop_oldest_chunk_count" => Integer,
       }
       expected_null_response.merge!("config" => {"@id" => "null", "@type" => "null"}) if with_config
       expected_null_response.merge!("retry" => {}) if with_retry
@@ -643,6 +650,7 @@ plugin_id:test_filter\tplugin_category:filter\ttype:test_filter\toutput_plugin:f
         "rollback_count"  => Integer,
         "slow_flush_count" => Integer,
         "flush_time_count" => Integer,
+        "drop_oldest_chunk_count" => Integer,
       }
       expected_null_response.merge!("config" => {"@id" => "null", "@type" => "null"}) if with_config
       expected_null_response.merge!("retry" => {}) if with_retry
@@ -693,6 +701,7 @@ plugin_id:test_filter\tplugin_category:filter\ttype:test_filter\toutput_plugin:f
         "rollback_count"  => Integer,
         "slow_flush_count" => Integer,
         "flush_time_count" => Integer,
+        "drop_oldest_chunk_count" => Integer,
       }
       response = JSON.parse(get("http://127.0.0.1:#{@port}/api/plugins.json?with_config=no&with_retry=no&with_ivars=id,num_errors").body)
       test_in_response = response["plugins"][0]
@@ -825,6 +834,7 @@ plugin_id:test_filter\tplugin_category:filter\ttype:test_filter\toutput_plugin:f
           "rollback_count" => Integer,
           'slow_flush_count' => Integer,
           'flush_time_count' => Integer,
+          "drop_oldest_chunk_count" => Integer,
       }
       output.emit_events('test.tag', Fluent::ArrayEventStream.new([[event_time, {"message" => "test failed flush 1"}]]))
       # flush few times to check steps

--- a/test/plugin/test_output.rb
+++ b/test/plugin/test_output.rb
@@ -227,7 +227,8 @@ class OutputTest < Test::Unit::TestCase
       @i.configure(config_element())
 
       %w[num_errors_metrics emit_count_metrics emit_size_metrics emit_records_metrics write_count_metrics
-         write_secondary_count_metrics rollback_count_metrics flush_time_count_metrics slow_flush_count_metrics].each do |metric_name|
+         write_secondary_count_metrics rollback_count_metrics flush_time_count_metrics slow_flush_count_metrics
+         drop_oldest_chunk_count_metrics].each do |metric_name|
         assert_true @i.instance_variable_get(:"@#{metric_name}").is_a?(Fluent::Plugin::Metrics)
       end
 
@@ -241,6 +242,7 @@ class OutputTest < Test::Unit::TestCase
       assert_equal 0, @i.rollback_count
       assert_equal 0, @i.flush_time_count
       assert_equal 0, @i.slow_flush_count
+      assert_equal 0, @i.drop_oldest_chunk_count
     end
 
     data(:new_api => :chunk,

--- a/test/plugin/test_output_as_buffered_overflow.rb
+++ b/test/plugin/test_output_as_buffered_overflow.rb
@@ -217,6 +217,7 @@ class BufferedOutputOverflowTest < Test::Unit::TestCase
       logs = @i.log.out.logs
       assert{ logs.any?{|line| line.include?("failed to write data into buffer by buffer overflow") } }
       assert{ logs.any?{|line| line.include?("dropping oldest chunk to make space after buffer overflow") } }
+      assert{ @i.drop_oldest_chunk_count > 0 }
     end
 
     test '#emit_events raises OverflowError if all buffer spaces are used by staged chunks' do


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
When `overflow_action drop_oldest_chunk` is configured, the oldest buffer chunk will be automatically discarded when the total buffer capacity is exhausted.

This PR introduces a new metric, `drop_oldest_chunk_count`, which counts the number of discarded chunks.

**Docs Changes**:
https://github.com/fluent/fluentd-docs-gitbook/pull/582

**Release Note**: 
Same as the title
