### PR TITLE
rubocop test: reduce map method chain

### DIFF
--- a/test/test_static_config_analysis.rb
+++ b/test/test_static_config_analysis.rb
@@ -73,9 +73,9 @@ class StaticConfigAnalysisTest < ::Test::Unit::TestCase
 
       c = Fluent::Config.parse(conf_data, '(test)', '(test_dir)', true)
       ret = Fluent::StaticConfigAnalysis.call(c)
-      assert_equal [Fluent::Plugin::ExecOutput, Fluent::Plugin::StdoutOutput, Fluent::Plugin::ForwardOutput], ret.outputs.map(&:plugin).map(&:class)
-      assert_equal [Fluent::Plugin::SampleInput, Fluent::Plugin::ForwardInput], ret.inputs.map(&:plugin).map(&:class)
-      assert_equal [Fluent::Plugin::ParserFilter, Fluent::Plugin::StdoutFilter, Fluent::Plugin::GrepFilter], ret.filters.map(&:plugin).map(&:class)
+      assert_equal [Fluent::Plugin::ExecOutput, Fluent::Plugin::StdoutOutput, Fluent::Plugin::ForwardOutput], ret.outputs.map { |x| x.plugin.class }
+      assert_equal [Fluent::Plugin::SampleInput, Fluent::Plugin::ForwardInput], ret.inputs.map { |x| x.plugin.class }
+      assert_equal [Fluent::Plugin::ParserFilter, Fluent::Plugin::StdoutFilter, Fluent::Plugin::GrepFilter], ret.filters.map { |x| x.plugin.class }
       assert_equal 1, ret.labels.size
       assert_equal '@test', ret.labels[0].name
     end


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

  Fixes #

**What this PR does / why we need it**:

  This is cosmetic change, it does not change behavior at all. The
  following rubocop configuration detects it.

  ```
  Performance/MapMethodChain:
    Enabled: true
  ```

Benchmark result:

```
  ruby 3.2.8 (2025-03-26 revision 13f495dc2c) +YJIT [x86_64-linux]
  Warming up --------------------------------------
      map method chain   139.000 i/100ms
          method chain   225.000 i/100ms
  Calculating -------------------------------------
      map method chain      1.429k (± 1.5%) i/s  (699.83 μs/i) -      7.228k in   5.059646s
          method chain      2.154k (± 3.1%) i/s  (464.15 μs/i) -     10.800k in   5.018163s

  Comparison:
          method chain:     2154.5 i/s
      map method chain:     1428.9 i/s - 1.51x  slower
```

Appendix: benchmark script

  ```ruby
  require 'bundler/inline'
  gemfile do
    source 'https://rubygems.org'
    gem 'benchmark-ips'
  end

  class Plugin
    def class
      "klass"
    end
  end

  class Sample
    def plugin
      Plugin.new
    end
  end

  Benchmark.ips do |x|
    data = Array.new(4096) { Sample.new }
    x.report("map method chain") {
      data.map(&:plugin).map(&:class)
    }
    x.report("method chain") {
      data.map { |x| x.plugin.class }
    }
    x.compare!
  end
  ```

**Docs Changes**:

N/A

**Release Note**: 

N/A
