### PR TITLE
rubocop test: reduce times.map call

### DIFF
--- a/test/plugin/test_buffer.rb
+++ b/test/plugin/test_buffer.rb
@@ -1038,7 +1038,7 @@ class BufferTest < Test::Unit::TestCase
       @p.write({@dm0 => es}, format: @format)
       @p.enqueue_all(true)
 
-      dequeued_chunks = 6.times.map { |e| @p.dequeue_chunk } # splits: 45000 / 100 => 450 * ...
+      dequeued_chunks = Array.new(6) { |e| @p.dequeue_chunk } # splits: 45000 / 100 => 450 * ...
       assert_equal [5000, 9900, 9900, 9900, 9900, 5400], dequeued_chunks.map(&:size)
       assert_equal [@dm0, @dm0, @dm0, @dm0, @dm0, @dm0], dequeued_chunks.map(&:metadata)
     end

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -553,7 +553,7 @@ class TailInputTest < Test::Unit::TestCase
           end
 
           assert_true(Fluent::Clock.now - start_time > 1)
-          assert_equal(num_events.times.map { {"message" => msg} },
+          assert_equal(Array.new(num_events) { {"message" => msg} },
                        d.events.collect { |event| event[2] })
         end
 
@@ -576,7 +576,7 @@ class TailInputTest < Test::Unit::TestCase
           end
 
           assert_true(Fluent::Clock.now - start_time > 1)
-          assert_equal(4096.times.map { {"message" => msg} },
+          assert_equal(Array.new(4096) { {"message" => msg} },
                        d.events.collect { |event| event[2] })
         end
       end


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

  Fixes #

**What this PR does / why we need it**:

  This is cosmetic change, it does not change behavior at all. The
  following rubocop configuration detects it.

  ```
  Performance/TimesMap:
    Enable: true
  ```

Benchmark result:

  ```
  ruby 3.2.8 (2025-03-26 revision 13f495dc2c) +YJIT [x86_64-linux]
  Warming up --------------------------------------
           Array.new()   983.000 i/100ms
             times.map   681.000 i/100ms
  Calculating -------------------------------------
           Array.new()     10.268k (± 0.8%) i/s   (97.39 μs/i) -     52.099k in   5.074330s
             times.map      6.855k (± 1.0%) i/s  (145.88 μs/i) -     34.731k in   5.066975s

  Comparison:
           Array.new():    10267.8 i/s
             times.map:     6855.0 i/s - 1.50x  slower
  ```

Appendix: benchmark script

  ```ruby
  require 'bundler/inline'
  gemfile do
    source 'https://rubygems.org'
    gem 'benchmark-ips'
  end

  Benchmark.ips do |x|
    x.report("Array.new()") {
      Array.new(4096) { |x| x + 1 }
    }
    x.report("times.map") {
      4096.times.map { |x| x + 1 }
    }
    x.compare!
  end

  ```


**Docs Changes**:

N/A

**Release Note**: 

N/A
