### PR TITLE
rubocop test: fix Performance/RedundantEqualityComparisonBlock

### DIFF
--- a/test/plugin/test_in_forward.rb
+++ b/test/plugin/test_in_forward.rb
@@ -644,7 +644,7 @@ class ForwardInputTest < Test::Unit::TestCase
       # check emitted data
       emits = d.events
       assert_equal 16, emits.size
-      assert emits.map(&:first).all?{|t| t == "test.tag" }
+      assert emits.map(&:first).all?("test.tag")
       assert_equal (0...16).to_a, emits.map{|_tag, t, _record| t - time }
 
       # check log

--- a/test/plugin/test_output_as_buffered_retries.rb
+++ b/test/plugin/test_output_as_buffered_retries.rb
@@ -327,7 +327,7 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
       assert{ now >= first_failure + 3600 }
 
       assert{ @i.buffer.stage.size == 0 }
-      assert{ written_tags.all?{|t| t == 'test.tag.1' } }
+      assert{ written_tags.all?('test.tag.1') }
 
       @i.emit_events("test.tag.3", dummy_event_stream())
 
@@ -404,7 +404,7 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
         assert{ @i.buffer.queue.first.metadata.tag == 'test.tag.1' }
       end
       assert{ @i.buffer.stage.size == 0 }
-      assert{ written_tags.all?{|t| t == 'test.tag.1' } }
+      assert{ written_tags.all?('test.tag.1') }
 
       @i.emit_events("test.tag.3", dummy_event_stream())
 
@@ -593,7 +593,7 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
       assert{ @i.buffer.queue.first.metadata.tag == 'test.tag.1' }
       assert{ @i.buffer.stage.size == 0 }
 
-      assert{ written_tags.all?{|t| t == 'test.tag.1' } }
+      assert{ written_tags.all?('test.tag.1') }
 
       chunks = @i.buffer.queue.dup
 
@@ -689,7 +689,7 @@ class BufferedOutputRetryTest < Test::Unit::TestCase
         assert{ @i.buffer.queue.first.metadata.tag == 'test.tag.1' }
       end
       assert{ @i.buffer.stage.size == 0 }
-      assert{ written_tags.all?{|t| t == 'test.tag.1' } }
+      assert{ written_tags.all?('test.tag.1') }
 
 
       @i.emit_events("test.tag.3", dummy_event_stream())

--- a/test/plugin_helper/test_server.rb
+++ b/test/plugin_helper/test_server.rb
@@ -489,7 +489,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
       end
       waiting(10){ sleep 0.1 until received.bytesize == 12 }
       assert_equal "yay\nyay\nyay\n", received
-      assert{ sources.all?{|s| s == "127.0.0.1" } }
+      assert{ sources.all?("127.0.0.1") }
     end
 
     test 'does resolve name of client address if resolve_name is true' do
@@ -508,7 +508,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
       end
       waiting(10){ sleep 0.1 until received.bytesize == 12 }
       assert_equal "yay\nyay\nyay\n", received
-      assert{ sources.all?{|s| s == hostname } }
+      assert{ sources.all?(hostname) }
     end
 
     test 'can keep connections alive for tcp if keepalive specified' do
@@ -727,7 +727,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
       end
       waiting(10){ sleep 0.1 until received.bytesize == 12 }
       assert_equal "yay\nyay\nyay\n", received
-      assert{ sources.all?{|s| s == "127.0.0.1" } }
+      assert{ sources.all?("127.0.0.1") }
     end
 
     test 'does resolve name of client address if resolve_name is true' do
@@ -748,7 +748,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
       end
       waiting(10){ sleep 0.1 until received.bytesize == 12 }
       assert_equal "yay\nyay\nyay\n", received
-      assert{ sources.all?{|s| s == hostname } }
+      assert{ sources.all?(hostname) }
     end
 
     test 'raises error if plugin registers data callback for connection object from #server_create' do
@@ -1494,7 +1494,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
       end
       waiting(10){ sleep 0.1 until received.bytesize == 12 }
       assert_equal 3, received.scan("yay\n").size
-      assert{ sources.all?{|s| s == "127.0.0.1" } }
+      assert{ sources.all?("127.0.0.1") }
     end
 
     test 'does resolve name of client address if resolve_name is true' do
@@ -1514,7 +1514,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
       end
       waiting(10){ sleep 0.1 until received.bytesize == 12 }
       assert_equal 3, received.scan("yay\n").size
-      assert{ sources.all?{|s| s == hostname } }
+      assert{ sources.all?(hostname) }
     end
 
     test 'can keep connections alive for tls if keepalive specified' do
@@ -1721,7 +1721,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
       end
       waiting(10){ sleep 0.1 until received.bytesize == 12 }
       assert_equal "yay\nyay\nyay\n", received
-      assert{ sources.all?{|s| s == "127.0.0.1" } }
+      assert{ sources.all?("127.0.0.1") }
     end
 
     data(protocols)
@@ -1743,7 +1743,7 @@ class ServerPluginHelperTest < Test::Unit::TestCase
       end
       waiting(10){ sleep 0.1 until received.bytesize == 12 }
       assert_equal "yay\nyay\nyay\n", received
-      assert{ sources.all?{|s| s == hostname } }
+      assert{ sources.all?(hostname) }
     end
 
     data(protocols)


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

  Fixes #

**What this PR does / why we need it**:

  This is cosmetic change, it does not change behavior at all. The
  following rubocop configuration detects it.

  ```
  Performance/RedundantEqualityComparisonBlock
    Enable: true
  ```

Benchmark result:

  ```
  ruby 3.2.8 (2025-03-26 revision 13f495dc2c) +YJIT [x86_64-linux]
  Warming up --------------------------------------
  all? { |t| t == XXX }
                           1.138M i/100ms
             all?(XXX)     1.330M i/100ms
  Calculating -------------------------------------
  all? { |t| t == XXX }
                           12.599M (± 1.9%) i/s   (79.37 ns/i) -     63.700M in   5.057889s
             all?(XXX)     14.230M (± 2.1%) i/s   (70.27 ns/i) -     71.821M in   5.049436s

  Comparison:
             all?(XXX): 14230128.9 i/s
  all? { |t| t == XXX }: 12598812.4 i/s - 1.13x  slower
  ```

Appendix: benchmark script:

  ```ruby
  require 'bundler/inline'
  gemfile do
    source 'https://rubygems.org'
    gem 'benchmark-ips'
  end

  Benchmark.ips do |x|
    tags = %w(apple orange grape pineapple)
    x.report("all? { |t| t == XXX }") {
      tags.all? { |t| t == "orange" }
    }
    x.report("all?(XXX)") {
      tags.all?("orange")
    }
    x.compare!
  end
  ```

**Docs Changes**:

N/A

**Release Note**: 

N/A
