### PR TITLE
rubocop test: reduce redundant merge!

### DIFF
--- a/test/plugin/test_in_monitor_agent.rb
+++ b/test/plugin/test_in_monitor_agent.rb
@@ -160,7 +160,7 @@ CONF
         "emit_records"   => 0, # This field is not updated due to not to be assigned metric callback.
         "emit_size"      => 0, # Ditto.
       }
-      input_info.merge!("config" => {"@id" => "test_in_gen", "@type" => "test_in_gen", "num" => "10"}) if with_config
+      input_info["config"] = {"@id" => "test_in_gen", "@type" => "test_in_gen", "num" => "10"} if with_config
       filter_info = {
         "output_plugin"   => false,
         "plugin_category" => "filter",
@@ -170,7 +170,7 @@ CONF
         "emit_records"   => Integer,
         "emit_size"      => Integer,
       }
-      filter_info.merge!("config" => {"@id" => "test_filter", "@type" => "test_filter"}) if with_config
+      filter_info["config"] = {"@id" => "test_filter", "@type" => "test_filter"} if with_config
       output_info = {
         "output_plugin"   => true,
         "plugin_category" => "output",
@@ -186,7 +186,7 @@ CONF
         "slow_flush_count" => Integer,
         "flush_time_count" => Integer,
       }
-      output_info.merge!("config" => {"@id" => "test_out", "@type" => "test_out"}) if with_config
+      output_info["config"] = {"@id" => "test_out", "@type" => "test_out"} if with_config
       error_label_info = {
         "buffer_queue_length" => 0,
         "buffer_timekeys" => [],
@@ -209,7 +209,7 @@ CONF
         "slow_flush_count" => Integer,
         "flush_time_count" => Integer,
       }
-      error_label_info.merge!("config" => {"@id"=>"null", "@type" => "null"}) if with_config
+      error_label_info["config"] = {"@id"=>"null", "@type" => "null"} if with_config
       opts = {with_config: with_config}
       assert_equal(input_info, d.instance.get_monitor_info(@ra.inputs.first, opts))
       assert_fuzzy_equal(filter_info, d.instance.get_monitor_info(@ra.filters.first, opts))
@@ -301,7 +301,7 @@ EOC
         "emit_records"   => 0,
         "emit_size"      => 0,
       }
-      input_info.merge!("config" => {"@id" => "test_in", "@type" => "test_in"}) if with_config
+      input_info["config"] = {"@id" => "test_in", "@type" => "test_in"} if with_config
       filter_info = {
         "output_plugin"   => false,
         "plugin_category" => "filter",
@@ -311,7 +311,7 @@ EOC
         "emit_records"   => 0,
         "emit_size"      => 0,
       }
-      filter_info.merge!("config" => {"@id" => "test_filter", "@type" => "test_filter"}) if with_config
+      filter_info["config"] = {"@id" => "test_filter", "@type" => "test_filter"} if with_config
       output_info = {
         "output_plugin"   => true,
         "plugin_category" => "output",
@@ -327,7 +327,7 @@ EOC
         "slow_flush_count" => Integer,
         "flush_time_count" => Integer,
       }
-      output_info.merge!("config" => {"@id" => "test_out", "@type" => "test_out"}) if with_config
+      output_info["config"] = {"@id" => "test_out", "@type" => "test_out"} if with_config
       error_label_info = {
         "buffer_queue_length" => 0,
         "buffer_timekeys" => [],
@@ -350,7 +350,7 @@ EOC
         "slow_flush_count" => Integer,
         "flush_time_count" => Integer,
       }
-      error_label_info.merge!("config" => {"@id"=>"null", "@type" => "null"}) if with_config
+      error_label_info["config"] = {"@id"=>"null", "@type" => "null"} if with_config
       opts = {with_config: with_config}
       assert_equal(input_info, d.instance.get_monitor_info(@ra.inputs.first, opts))
       assert_fuzzy_equal(filter_info, d.instance.get_monitor_info(@ra.filters.first, opts))
@@ -556,7 +556,7 @@ plugin_id:test_filter\tplugin_category:filter\ttype:test_filter\toutput_plugin:f
         "emit_records"    => 0,
         "emit_size"       => 0,
       }
-      expected_test_in_response.merge!("config" => {"@id" => "test_in", "@type" => "test_in"}) if with_config
+      expected_test_in_response["config"] = {"@id" => "test_in", "@type" => "test_in"} if with_config
       expected_null_response = {
         "buffer_queue_length" => 0,
         "buffer_timekeys" => [],
@@ -579,8 +579,8 @@ plugin_id:test_filter\tplugin_category:filter\ttype:test_filter\toutput_plugin:f
         "slow_flush_count" => Integer,
         "flush_time_count" => Integer,
       }
-      expected_null_response.merge!("config" => {"@id" => "null", "@type" => "null"}) if with_config
-      expected_null_response.merge!("retry" => {}) if with_retry
+      expected_null_response["config"] = {"@id" => "null", "@type" => "null"} if with_config
+      expected_null_response["retry"] = {} if with_retry
       response = JSON.parse(get("http://127.0.0.1:#{@port}/api/plugins.json").body)
       test_in_response = response["plugins"][0]
       null_response = response["plugins"][5]
@@ -622,7 +622,7 @@ plugin_id:test_filter\tplugin_category:filter\ttype:test_filter\toutput_plugin:f
         "emit_records"   => 0,
         "emit_size"      => 0,
       }
-      expected_test_in_response.merge!("config" => {"@id" => "test_in", "@type" => "test_in"}) if with_config
+      expected_test_in_response["config"] = {"@id" => "test_in", "@type" => "test_in"} if with_config
       expected_null_response = {
         "buffer_queue_length" => 0,
         "buffer_timekeys" => [],
@@ -644,8 +644,8 @@ plugin_id:test_filter\tplugin_category:filter\ttype:test_filter\toutput_plugin:f
         "slow_flush_count" => Integer,
         "flush_time_count" => Integer,
       }
-      expected_null_response.merge!("config" => {"@id" => "null", "@type" => "null"}) if with_config
-      expected_null_response.merge!("retry" => {}) if with_retry
+      expected_null_response["config"] = {"@id" => "null", "@type" => "null"} if with_config
+      expected_null_response["retry"] = {} if with_retry
       response = JSON.parse(get("http://127.0.0.1:#{@port}/api/plugins.json#{query_param}").body)
       test_in_response = response["plugins"][0]
       null_response = response["plugins"][5]


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

  Fixes #

**What this PR does / why we need it**:

  This is cosmetic change, it does not change behavior at all. It was
  detected by the following rubocop configuration:

  ```
  Performance/RedundantMerge:
    Enabled: true
  ```

  Use straight forward way.

Benchmark result:

  ```
  ruby 3.2.8 (2025-03-26 revision 13f495dc2c) +YJIT [x86_64-linux]
  Warming up --------------------------------------
                merge!   457.409k i/100ms
  directly assign without merge!
                         764.424k i/100ms
  Calculating -------------------------------------
                merge!      4.825M (± 3.6%) i/s  (207.27 ns/i) -     24.243M in   5.031775s
  directly assign without merge!
                            7.581M (± 1.7%) i/s  (131.91 ns/i) -     38.221M in   5.043344s

  Comparison:
  directly assign without merge!:  7580919.7 i/s
                merge!:  4824567.8 i/s - 1.57x  slower
  ```

Appendix: benchmark script

  ```ruby
  require 'bundler/inline'
  gemfile do
    source 'https://rubygems.org'
    gem 'benchmark-ips'
  end

  Benchmark.ips do |x|
    data = {
      "foo": 1
    }
    x.report("merge!") {
      data.merge!({"config" => {"@id" => "foo"}})
    }
    x.report("directly assign without merge!") {
      data["config"] = {"@id" => "foo"}
    }
    x.compare!
  end
  ```

**Docs Changes**:

N/A

**Release Note**: 

N/A
