### PR TITLE
Limit high-memory logging ('pattern not matched' in parsing) to necessary log level

### DIFF
--- a/lib/fluent/compat/socket_util.rb
+++ b/lib/fluent/compat/socket_util.rb
@@ -148,7 +148,7 @@ module Fluent
         def on_message(msg, addr)
           @parser.parse(msg) { |time, record|
             unless time && record
-              log.warn "pattern not matched: #{msg.inspect}"
+              log.warn { "pattern not matched: #{msg.inspect}" }
               return
             end
 

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -754,7 +754,7 @@ module Fluent::Plugin
               record[@path_key] ||= tail_watcher.path unless @path_key.nil?
               es.add(Fluent::EventTime.now, record)
             end
-            log.warn "pattern not matched: #{line.inspect}"
+            log.warn { "pattern not matched: #{line.inspect}" }
           end
         }
       rescue => e

--- a/lib/fluent/plugin/in_tcp.rb
+++ b/lib/fluent/plugin/in_tcp.rb
@@ -137,7 +137,7 @@ module Fluent::Plugin
 
             @parser.parse(msg) do |time, record|
               unless time && record
-                log.warn "pattern not matched", message: msg
+                log.on_warn { log.warn "pattern not matched", message: msg }
                 next
               end
 
@@ -187,7 +187,7 @@ module Fluent::Plugin
 
             @parser.parse(msg) do |time, record|
               unless time && record
-                log.warn "pattern not matched", message: msg
+                log.on_warn { log.warn "pattern not matched", message: msg }
                 next
               end
 

--- a/lib/fluent/plugin/in_udp.rb
+++ b/lib/fluent/plugin/in_udp.rb
@@ -83,7 +83,7 @@ module Fluent::Plugin
         begin
           @parser.parse(data) do |time, record|
             unless time && record
-              log.warn "pattern not matched", data: data
+              log.on_warn { log.warn "pattern not matched", data: data }
               next
             end
 


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
Currently, the “pattern not matched” warning is always generated regardless of the `log_level` setting. This warning might use a lot of memory when the log is very long.

To reduce memory usage, this PR will generate warnings only when necessary, according to `log_level`.

Related to https://github.com/fluent/fluentd/issues/4994

* config
```
<system>
  log_level error
</system>

<source>
  @type tail
  tag test
  path "#{File.expand_path '~/tmp/fluentd/access-*.log'}"
  refresh_interval 5s
  read_from_head true
  <parse>
    @type regexp
    expression /^(?<log>a+)+$/
    timeout 0.1s
  </parse>
</source>

<match **>
  @type stdout
</match>
```

Here is memory usage.
![](https://github.com/user-attachments/assets/613ed741-a285-4e21-99f2-acdc88fbab13)



**Docs Changes**:
Not needed.

**Release Note**: 
Same as the title.
