### PR TITLE
engine: fix high memory usage in FluentLogEventRouter

### DIFF
--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -153,12 +153,12 @@ module Fluent
 
     def run
       begin
+        @fluent_log_event_router.start
+
         $log.info "starting fluentd worker", pid: Process.pid, ppid: Process.ppid, worker: worker_id
         @root_agent_mutex.synchronize do
           start
         end
-
-        @fluent_log_event_router.start
 
         $log.info "fluentd worker is now running", worker: worker_id
         sleep MAINLOOP_SLEEP_INTERVAL until @engine_stopped


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #4994

**What this PR does / why we need it**: 
Previously, `FluentLogEventRouter` was designed to start processing only after the worker had started.

As a result, if a large number of warnings were emitted by the `in_tail` plugin immediately after the worker started,
lots of warning messages would accumulate in the `FluentLogEventRouter`'s queue.
And it consumes a significant amount of memory.

This PR changes the behavior so that `FluentLogEventRouter` starts processing before the worker is fully started, allowing it to consume the message queue immediately.

With this change, memory usage is significantly reduced compared to the previous implementation.

Here is the memory usage was obtained using the same operation as #4994.
![](https://github.com/user-attachments/assets/a1a0b2f9-86f0-442a-af60-261209ab1a60)

FYI)
You can confirm the memory usage easily with the following sample code.
```ruby
queue = Thread::Queue.new

500_000.times do |i|
  queue << "a" * 1024
end

while !queue.empty?
  queue.pop
end

GC.start

rss = Integer(`ps -o rss= -p #{Process.pid}`) / 1024.0
puts "Memory Usage: #{rss} MB"
```

```
$ ruby t.rb
Memory Usage: 539.25 MB
```

**Docs Changes**:

**Release Note**: 
