### PR TITLE
Use safe navigation operator to clean up the codes

### DIFF
--- a/lib/fluent/config/configure_proxy.rb
+++ b/lib/fluent/config/configure_proxy.rb
@@ -47,7 +47,7 @@ module Fluent
         #   should override "@name".
         @root_section = root
 
-        @param_name = param_name && param_name.to_sym
+        @param_name = param_name&.to_sym
         @init = init
         @required = required
         @multi = multi

--- a/lib/fluent/config/section.rb
+++ b/lib/fluent/config/section.rb
@@ -253,7 +253,7 @@ module Fluent
         elems = conf.respond_to?(:elements) ? conf.elements : []
         elems.each { |e|
           next if plugin_class.nil? && Fluent::Config::V1Parser::ELEM_SYMBOLS.include?(e.name) # skip pre-defined non-plugin elements because it doesn't have proxy section
-          next if e.unused_in && e.unused_in.empty? # the section is used at least once
+          next if e.unused_in&.empty? # the section is used at least once
 
           if proxy.sections.any? { |name, subproxy| e.name == subproxy.name.to_s || e.name == subproxy.alias.to_s }
             e.unused_in = []

--- a/lib/fluent/plugin/buffer.rb
+++ b/lib/fluent/plugin/buffer.rb
@@ -525,7 +525,7 @@ module Fluent
           chunks = @stage.values
           chunks.concat(@queue)
           @timekeys = chunks.each_with_object({}) do |chunk, keys|
-            if chunk.metadata && chunk.metadata.timekey
+            if chunk.metadata&.timekey
               t = chunk.metadata.timekey
               keys[t] = keys.fetch(t, 0) + 1
             end
@@ -958,7 +958,7 @@ module Fluent
       def optimistic_queued?(metadata = nil)
         if metadata
           n = @queued_num[metadata]
-          n && n.nonzero?
+          n&.nonzero?
         else
           !@queue.empty?
         end

--- a/lib/fluent/plugin/out_exec_filter.rb
+++ b/lib/fluent/plugin/out_exec_filter.rb
@@ -193,8 +193,8 @@ module Fluent::Plugin
             log.warn "child process exits with error code", code: status.to_i, status: status.exitstatus, signal: status.termsig
           end
           c.mutex.synchronize do
-            (c.writeio && c.writeio.close) rescue nil
-            (c.readio && c.readio.close) rescue nil
+            c.writeio&.close rescue nil
+            c.readio&.close rescue nil
             c.pid = c.readio = c.writeio = nil
           end
         end

--- a/lib/fluent/plugin/out_forward.rb
+++ b/lib/fluent/plugin/out_forward.rb
@@ -577,8 +577,8 @@ module Fluent::Plugin
 
         @handshake = HandshakeProtocol.new(
           log: @log,
-          hostname: sender.security && sender.security.self_hostname,
-          shared_key: server.shared_key || (sender.security && sender.security.shared_key) || '',
+          hostname: sender.security&.self_hostname,
+          shared_key: server.shared_key || sender.security&.shared_key || '',
           password: server.password || '',
           username: server.username || '',
         )

--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -552,7 +552,7 @@ module Fluent
             @output_flush_threads.each do |state|
               # to wakeup thread and make it to stop by itself
               state.mutex.synchronize {
-                if state.thread && state.thread.status
+                if state.thread&.status
                   state.next_clock = 0
                   state.cond_var.signal
                 end
@@ -1131,7 +1131,7 @@ module Fluent
 
       def try_rollback_write
         @dequeued_chunks_mutex.synchronize do
-          while @dequeued_chunks.first && @dequeued_chunks.first.expired?
+          while @dequeued_chunks.first&.expired?
             info = @dequeued_chunks.shift
             if @buffer.takeback_chunk(info.chunk_id)
               @rollback_count_metrics.inc
@@ -1376,7 +1376,7 @@ module Fluent
         @output_flush_thread_current_position = (@output_flush_thread_current_position + 1) % @buffer_config.flush_thread_count
         state = @output_flush_threads[@output_flush_thread_current_position]
         state.mutex.synchronize {
-          if state.thread && state.thread.status # "run"/"sleep"/"aborting" or false(successfully stop) or nil(killed by exception)
+          if state.thread&.status # "run"/"sleep"/"aborting" or false(successfully stop) or nil(killed by exception)
             state.next_clock = 0
             state.cond_var.signal
           else
@@ -1422,7 +1422,7 @@ module Fluent
       def flush_thread_wakeup
         @output_flush_threads.each do |state|
           state.mutex.synchronize {
-            if state.thread && state.thread.status
+            if state.thread&.status
               state.next_clock = 0
               state.cond_var.signal
             end

--- a/lib/fluent/plugin_helper/child_process.rb
+++ b/lib/fluent/plugin_helper/child_process.rb
@@ -143,7 +143,7 @@ module Fluent
         @_child_process_mutex.synchronize{ @_child_process_processes.keys }.each do |pid|
           process_info = @_child_process_processes[pid]
           next if !process_info
-          process_info.writeio && process_info.writeio.close rescue nil
+          process_info.writeio&.close rescue nil
         end
 
         super

--- a/lib/fluent/plugin_helper/http_server/request.rb
+++ b/lib/fluent/plugin_helper/http_server/request.rb
@@ -45,7 +45,7 @@ module Fluent
         end
 
         def body
-          @request.body && @request.body.read
+          @request.body&.read
         end
       end
     end

--- a/lib/fluent/plugin_helper/storage.rb
+++ b/lib/fluent/plugin_helper/storage.rb
@@ -38,7 +38,7 @@ module Fluent
         end
 
         s = @_storages[usage]
-        if s && s.running
+        if s&.running
           return s.storage
         elsif s
           # storage is already created, but not loaded / started

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -1766,7 +1766,7 @@ class TailInputTest < Test::Unit::TestCase
         }
       )
     ensure
-      d.instance_shutdown if d && d.instance
+      d.instance_shutdown if d&.instance
       cleanup_directory(@tmp_dir)
     end
 
@@ -2540,7 +2540,7 @@ class TailInputTest < Test::Unit::TestCase
     assert($log.out.logs.any?{|log| log.include?("stat() for #{path} failed. Continuing without tailing it.\n") },
            $log.out.logs.join("\n"))
   ensure
-    d.instance_shutdown if d && d.instance
+    d.instance_shutdown if d&.instance
   end
 
   def test_EACCES_error_after_setup_watcher
@@ -2567,7 +2567,7 @@ class TailInputTest < Test::Unit::TestCase
              $log.out.logs.join("\n"))
     end
   ensure
-    d.instance_shutdown if d && d.instance
+    d.instance_shutdown if d&.instance
     if File.exist?("#{@tmp_dir}/noaccess")
       FileUtils.chmod(0755, "#{@tmp_dir}/noaccess")
       FileUtils.rm_rf("#{@tmp_dir}/noaccess")
@@ -2589,7 +2589,7 @@ class TailInputTest < Test::Unit::TestCase
     end
     assert($log.out.logs.any?{|log| log.include?("expand_paths: stat() for #{path} failed with Errno::EACCES. Skip file.\n") })
   ensure
-    d.instance_shutdown if d && d.instance
+    d.instance_shutdown if d&.instance
   end
 
   def test_warn_without_directory_permission

--- a/test/plugin/test_out_exec.rb
+++ b/test/plugin/test_out_exec.rb
@@ -282,7 +282,7 @@ EOC
       assert{ d.instance.dequeued_chunks.empty? }
 
     ensure
-      d.instance_shutdown if d && d.instance
+      d.instance_shutdown if d&.instance
     end
 
     test 'flushed chunk will be taken back after child process unexpectedly exits' do
@@ -306,7 +306,7 @@ EOC
       assert{ File.exist?(expect_path) && File.size(expect_path) == 0 }
 
     ensure
-      d.instance_shutdown if d && d.instance
+      d.instance_shutdown if d&.instance
     end
   end
 end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None.

**What this PR does / why we need it**: 
The safe navigation operator was introduced at [Ruby 2.3](https://www.ruby-lang.org/en/news/2015/12/25/ruby-2-3-0-released/).

I think it makes the code cleaner.

**Docs Changes**:
Not needed.

**Release Note**: 
Minor code refactoring
