### PR TITLE
compressable: fix RuntimeError with large zstd compressed data

### DIFF
--- a/lib/fluent/plugin/compressable.rb
+++ b/lib/fluent/plugin/compressable.rb
@@ -79,9 +79,9 @@ module Fluent
 
       def string_decompress_zstd(compressed_data)
         io = StringIO.new(compressed_data)
+        reader = Zstd::StreamReader.new(io)
         out = ''
         loop do
-          reader = Zstd::StreamReader.new(io)
           # Zstd::StreamReader needs to specify the size of the buffer
           out << reader.read(1024)
           # Zstd::StreamReader doesn't provide unused data, so we have to manually adjust the position
@@ -117,8 +117,8 @@ module Fluent
       end
 
       def io_decompress_zstd(input, output)
+        reader = Zstd::StreamReader.new(input)
         loop do
-          reader = Zstd::StreamReader.new(input)
           # Zstd::StreamReader needs to specify the size of the buffer
           v = reader.read(1024)
           output.write(v)

--- a/test/plugin/test_compressable.rb
+++ b/test/plugin/test_compressable.rb
@@ -83,5 +83,29 @@ class CompressableTest < Test::Unit::TestCase
       assert_equal '', decompress('')
       assert_equal '', decompress('', output_io: StringIO.new)
     end
+
+    test 'decompress large zstd compressed data' do
+      src1 = SecureRandom.random_bytes(1024)
+      src2 = SecureRandom.random_bytes(1024)
+      src3 = SecureRandom.random_bytes(1024)
+
+      zstd_compressed_data = compress(src1, type: :zstd) + compress(src2, type: :zstd) + compress(src3, type: :zstd)
+      assert_equal src1 + src2 + src3, decompress(zstd_compressed_data, type: :zstd)
+    end
+
+    test 'decompress large zstd compressed data with input_io and output_io' do
+      src1 = SecureRandom.random_bytes(1024)
+      src2 = SecureRandom.random_bytes(1024)
+      src3 = SecureRandom.random_bytes(1024)
+
+      zstd_compressed_data = compress(src1, type: :zstd) + compress(src2, type: :zstd) + compress(src3, type: :zstd)
+
+      input_io = StringIO.new(zstd_compressed_data)
+      output_io = StringIO.new
+      output_io.set_encoding(src1.encoding)
+
+      decompress(input_io: input_io, output_io: output_io, type: :zstd)
+      assert_equal src1 + src2 + src3, output_io.string
+    end
   end
 end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #5005

**What this PR does / why we need it**: 
This PR will fix RuntimeError with large zstd compressed data

**Docs Changes**:
Not needed because this feature has not been released yet.

**Release Note**: 
Should be described with #4657
