### PR TITLE
log: add system_config option to force stacktrace level

### DIFF
--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -138,6 +138,7 @@ module Fluent
       @optional_attrs = nil
 
       @suppress_repeated_stacktrace = opts[:suppress_repeated_stacktrace]
+      @forced_stacktrace_level = nil
       @ignore_repeated_log_interval = opts[:ignore_repeated_log_interval]
       @ignore_same_log_interval = opts[:ignore_same_log_interval]
 
@@ -238,6 +239,14 @@ module Fluent
     def reopen!
       @out.reopen(@path, "a") if @path && @path != "-"
       nil
+    end
+
+    def force_stacktrace_level?
+      not @forced_stacktrace_level.nil?
+    end
+
+    def force_stacktrace_level(level)
+      @forced_stacktrace_level = level
     end
 
     def enable_debug(b=true)
@@ -498,6 +507,16 @@ module Fluent
     end
 
     def dump_stacktrace(type, backtrace, level)
+      return if @level > level
+
+      dump_stacktrace_internal(
+        type,
+        backtrace,
+        force_stacktrace_level? ? @forced_stacktrace_level : level,
+      )
+    end
+
+    def dump_stacktrace_internal(type, backtrace, level)
       return if @level > level
 
       time = Time.now

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -908,6 +908,7 @@ module Fluent
         ignore_repeated_log_interval: system_config.ignore_repeated_log_interval,
         ignore_same_log_interval: system_config.ignore_same_log_interval,
       )
+      $log.force_stacktrace_level(system_config.log.forced_stacktrace_level) if system_config.force_stacktrace_level?
       $log.enable_color(false) if actual_log_path
       $log.enable_debug if system_config.log_level <= Fluent::Log::LEVEL_DEBUG
 

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -79,6 +79,7 @@ module Fluent
         end
       end
       config_param :rotate_size, :size, default: nil
+      config_param :forced_stacktrace_level, :enum, list: [:none, :trace, :debug, :info, :warn, :error, :fatal], default: :none
     end
 
     config_section :counter_server, multi: false do
@@ -116,6 +117,10 @@ module Fluent
       config_param :chunk_limit_size, :size, default: nil
       config_param :total_limit_size, :size, default: nil
       config_param :compress, :enum, list: [:text, :gzip], default: nil
+    end
+
+    def force_stacktrace_level?
+      @log.forced_stacktrace_level != :none
     end
 
     def self.create(conf, strict_config_value=false)
@@ -162,6 +167,7 @@ module Fluent
       end
 
       @log_level = Log.str_to_level(@log_level.to_s) if @log_level
+      @log[:forced_stacktrace_level] = Log.str_to_level(@log.forced_stacktrace_level.to_s) if force_stacktrace_level?
     end
 
     def dup

--- a/test/config/test_system_config.rb
+++ b/test/config/test_system_config.rb
@@ -82,6 +82,7 @@ module Fluent::Config
       assert_nil(sc.log.path)
       assert_equal(:text, sc.log.format)
       assert_equal('%Y-%m-%d %H:%M:%S %z', sc.log.time_format)
+      assert_equal(:none, sc.log.forced_stacktrace_level)
     end
 
     data(
@@ -124,6 +125,7 @@ module Fluent::Config
               path /tmp/fluentd.log
               format json
               time_format %Y
+              forced_stacktrace_level info
             </log>
           </system>
       EOS
@@ -133,6 +135,7 @@ module Fluent::Config
       assert_equal('/tmp/fluentd.log', sc.log.path)
       assert_equal(:json, sc.log.format)
       assert_equal('%Y', sc.log.time_format)
+      assert_equal(Fluent::Log::LEVEL_INFO, sc.log.forced_stacktrace_level)
     end
 
     # info is removed because info level can't be specified via command line

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -715,6 +715,7 @@ class SupervisorTest < ::Test::Unit::TestCase
           <log>
             format json
             time_format %FT%T.%L%z
+            forced_stacktrace_level info
           </log>
         </system>
       EOC
@@ -728,6 +729,8 @@ class SupervisorTest < ::Test::Unit::TestCase
       assert_equal false, $log.suppress_repeated_stacktrace
       assert_equal 10, $log.ignore_repeated_log_interval
       assert_equal 20, $log.ignore_same_log_interval
+      assert_equal Fluent::Log::LEVEL_INFO, $log.instance_variable_get(:@forced_stacktrace_level)
+      assert_true $log.force_stacktrace_level?
     end
 
     data(


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None.

**What this PR does / why we need it**: 

**What this PR does**

Add a new system_config option: `forced_stacktrace_level`.

* Option: `system/log/forced_stacktrace_level`
* Type: `enum`
  * `none`, `trace`, `debug`, `info`, `warn`, `error`, `fatal`
* Default: `none`

By default, the behavior of Fluentd does not change.
So, this does not affect existing users.

If you set this option and change the value, the log levels of stacktraces are forced to that value.

Stacktraces that do not meet the log level are discarded in advance.
After the log level is changed, it is judged again for logging or discarded finally.
For example, by default (`log_level info`), ...

* All `trace`/`debug` stacktraces are not logged regardless of this option. 
* If you set `forced_stacktrace_level debug`, then all stacktraces are not logged.

This is because we should avoid logging logs that contradict `log_level`, and to avoid unexpectedly logging logs that are initially `trace`/`debug` level.

Setting example:

```xml
<system>
  <log>
    forced_stacktrace_level info
  </log>
</system>
```

**why we need it**

To make it easier to exclude stacktraces from monitoring Fluentd's own logs.
(You don't need this feature if using [@FLUENT_LOG](https://docs.fluentd.org/deployment/logging#capture-fluentd-logs) to transfer. For some reason, there are users who need to monitor Fluentd's log files directly. This feature is for those uses.)

For example, there could be a system that raises an alert when an error-level log is detected.
You may want to exclude some error-level logs from the detection.
However, if stacktraces are logged at error level, you need to exclude those stacktraces as well.
With the current specification, that is troublesome.

Ideally, it would be preferable to exclude all stacktraces from the detection.
It is sufficient to have access to stacktraces when investigating the details.

An easy way to improve the current situation is this feature.
If you are detecting error logs as in the previous example, you can easily exclude all stacktraces from the detection by forcing the stacktrace level to `info` with this feature.

**Docs Changes**:
* https://github.com/fluent/fluentd-docs-gitbook/pull/589

**Release Note**: 
System configuration: Add `forced_stacktrace_level` to force the log level of stacktraces.

**Sample**:

```xml
<system>
  <log>
    forced_stacktrace_level info
  </log>
</system>

<source>
  @type sample
  @id test
  tag test.fail
</source>

<match test.fail>
  @type null
  never_flush
</match>
```

Without `forced_stacktrace_level info`:

```
2025-06-23 18:16:45 +0900 [info]: #0 fluent/log.rb:371:info: fluentd worker is now running worker=0
2025-06-23 18:16:46 +0900 [warn]: #0 fluent/log.rb:392:warn: emit transaction failed: error_class=RuntimeError error="failed to flush" location="/home/daipom/work/fluentd/fluentd/lib/fluent/plugin/out_null.rb:54:in `process'" tag="test.fail"
  2025-06-23 18:16:46 +0900 [warn]: #0 fluent/event_router.rb:114:emit_stream: /home/daipom/work/fluentd/fluentd/lib/fluent/plugin/out_null.rb:54:in `process'
  2025-06-23 18:16:46 +0900 [warn]: #0 fluent/event_router.rb:114:emit_stream: /home/daipom/work/fluentd/fluentd/lib/fluent/plugin/output.rb:865:in `emit_sync'
  2025-06-23 18:16:46 +0900 [warn]: #0 fluent/event_router.rb:114:emit_stream: /home/daipom/work/fluentd/fluentd/lib/fluent/event_router.rb:115:in `emit_stream'
  2025-06-23 18:16:46 +0900 [warn]: #0 fluent/event_router.rb:114:emit_stream: /home/daipom/work/fluentd/fluentd/lib/fluent/event_router.rb:106:in `emit'
  2025-06-23 18:16:46 +0900 [warn]: #0 fluent/event_router.rb:114:emit_stream: /home/daipom/work/fluentd/fluentd/lib/fluent/plugin/in_sample.rb:115:in `block in emit'
  2025-06-23 18:16:46 +0900 [warn]: #0 fluent/event_router.rb:114:emit_stream: /home/daipom/work/fluentd/fluentd/lib/fluent/plugin/in_sample.rb:115:in `times'
  2025-06-23 18:16:46 +0900 [warn]: #0 fluent/event_router.rb:114:emit_stream: /home/daipom/work/fluentd/fluentd/lib/fluent/plugin/in_sample.rb:115:in `emit'
  2025-06-23 18:16:46 +0900 [warn]: #0 fluent/event_router.rb:114:emit_stream: /home/daipom/work/fluentd/fluentd/lib/fluent/plugin/in_sample.rb:100:in `run'
  2025-06-23 18:16:46 +0900 [warn]: #0 fluent/event_router.rb:114:emit_stream: /home/daipom/work/fluentd/fluentd/lib/fluent/plugin_helper/thread.rb:78:in `block in thread_create'
```

With `forced_stacktrace_level info`:

```
2025-06-23 18:13:59 +0900 [warn]: #0 fluent/log.rb:392:warn: emit transaction failed: error_class=RuntimeError error="failed to flush" location="/home/daipom/work/fluentd/fluentd/lib/fluent/plugin/out_null.rb:54:in `process'" tag="test.fail"
  2025-06-23 18:13:59 +0900 [info]: #0 fluent/event_router.rb:114:emit_stream: /home/daipom/work/fluentd/fluentd/lib/fluent/plugin/out_null.rb:54:in `process'
  2025-06-23 18:13:59 +0900 [info]: #0 fluent/event_router.rb:114:emit_stream: /home/daipom/work/fluentd/fluentd/lib/fluent/plugin/output.rb:865:in `emit_sync'
  2025-06-23 18:13:59 +0900 [info]: #0 fluent/event_router.rb:114:emit_stream: /home/daipom/work/fluentd/fluentd/lib/fluent/event_router.rb:115:in `emit_stream'
  2025-06-23 18:13:59 +0900 [info]: #0 fluent/event_router.rb:114:emit_stream: /home/daipom/work/fluentd/fluentd/lib/fluent/event_router.rb:106:in `emit'
  2025-06-23 18:13:59 +0900 [info]: #0 fluent/event_router.rb:114:emit_stream: /home/daipom/work/fluentd/fluentd/lib/fluent/plugin/in_sample.rb:115:in `block in emit'
  2025-06-23 18:13:59 +0900 [info]: #0 fluent/event_router.rb:114:emit_stream: /home/daipom/work/fluentd/fluentd/lib/fluent/plugin/in_sample.rb:115:in `times'
  2025-06-23 18:13:59 +0900 [info]: #0 fluent/event_router.rb:114:emit_stream: /home/daipom/work/fluentd/fluentd/lib/fluent/plugin/in_sample.rb:115:in `emit'
  2025-06-23 18:13:59 +0900 [info]: #0 fluent/event_router.rb:114:emit_stream: /home/daipom/work/fluentd/fluentd/lib/fluent/plugin/in_sample.rb:100:in `run'
  2025-06-23 18:13:59 +0900 [info]: #0 fluent/event_router.rb:114:emit_stream: /home/daipom/work/fluentd/fluentd/lib/fluent/plugin_helper/thread.rb:78:in `block in thread_create'
```
