### PR TITLE
config: add <system> umask setting to fluent.conf

### DIFF
--- a/fluent.conf
+++ b/fluent.conf
@@ -1,6 +1,11 @@
 # In v1 configuration, type and id are @ prefix parameters.
 # @type and @id are recommended. type and id are still available for backward compatibility
 
+<system>
+  umask 0022
+  log_level info
+</system>
+
 ## built-in TCP input
 ## $ echo <json> | fluent-cat <tag>
 <source>
@@ -76,9 +81,12 @@
 #</match>
 
 ## match tag=debug.** and dump to console
-<match debug.**>
-  @type stdout
-  @id stdout_output
+<match **>
+  @type file
+  path /tmp/fluent-test
+  format json
+  flush_interval 1s
+  time_slice_format %Y%m%dT%H%M%S
 </match>
 
 ## match tag=system.** and forward to another fluent server


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**:  
Fixes #4816 

**What this PR does / why we need it**:  
This PR adds support for configuring `umask` via the `<system>` directive in `fluent.conf`.  
This allows users to control default file permissions for buffer/output files without needing to set `--umask` on the command line, making container and system deployments cleaner and more flexible.

**Docs Changes**:  
Yes – adds mention of `umask` under `<system>` configuration in the documentation.

**Release Note**:  
Add support for `umask` configuration via the `<system>` directive in `fluent.conf`.
