### PR TITLE
maintainers: update Eduardo & Hiroshi's emails

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,12 +2,18 @@
 
 - [Naotoshi Seo](https://github.com/sonots), [ZOZO Technologies](https://tech.zozo.com/en/)
 - [Okkez](https://github.com/okkez)
-- [Hiroshi Hatake](https://github.com/cosmo0920), [Calyptia](https://calyptia.com/)
+- [Hiroshi Hatake](https://github.com/cosmo0920), [Chronosphere](https://chronosphere.io/)
 - [Masahiro Nakagawa](https://github.com/repeatedly)
 - [Satoshi Tagomori](https://github.com/tagomoris)
 - [Toru Takahashi](https://github.com/toru-takahashi), [Treasure Data](https://www.treasuredata.com/)
-- [Eduardo Silva](https://github.com/edsiper), [Calyptia](https://calyptia/)
+- [Eduardo Silva](https://github.com/edsiper), [Chronosphere](https://chronosphere.io/)
 - [Fujimoto Seiji](https://github.com/fujimots)
 - [Takuro Ashie](https://github.com/ashie), [ClearCode](https://www.clear-code.com/)
 - [Kentaro Hayashi](https://github.com/kenhys), [ClearCode](https://www.clear-code.com/)
 - [Daijiro Fukuda](https://github.com/daipom), [ClearCode](https://www.clear-code.com/)
+
+## Sub Projects: Fluent Bit
+
+Fluent Bit maintainers list can be found here:
+
+- https://github.com/fluent/fluent-bit/blob/master/MAINTAINERS.md


### PR DESCRIPTION
Update maintainers file with new Eduardo and Hiroshi's email/companies. As well add a reference to Fluent Bit maintainers file