### PR TITLE
rubocop: exclude lib/fluent/config/dsl.rb in Security/Eval

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,6 +50,7 @@ Security/Open:
 # False positive because it's intentional
 Security/Eval:
   Exclude:
+    - lib/fluent/config/dsl.rb
     - lib/fluent/plugin.rb
     - lib/fluent/plugin/in_debug_agent.rb
   Enabled: true


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
Now, `lib/fluent/config/dsl.rb `  causes failure on rubocop check.
So, this PR will excude the file.

Related to https://github.com/fluent/fluentd/pull/5026

**Docs Changes**:

**Release Note**: 
