### PR TITLE
rubocop: use plugin scope logger

### DIFF
--- a/lib/fluent/plugin/in_monitor_agent.rb
+++ b/lib/fluent/plugin/in_monitor_agent.rb
@@ -204,7 +204,7 @@ module Fluent::Plugin
     def start
       super
 
-      log.debug "listening monitoring http server on http://#{@bind}:#{@port}/api/plugins for worker#{fluentd_worker_id}"
+      log.debug { "listening monitoring http server on http://#{@bind}:#{@port}/api/plugins for worker#{fluentd_worker_id}" }
       api_handler = APIHandler.new(self)
       http_server_create_http_server(:in_monitor_http_server_helper, addr: @bind, port: @port, logger: log, default_app: NotFoundJson) do |serv|
         serv.get('/api/plugins') { |req| api_handler.plugins_ltsv(req) }
@@ -214,7 +214,7 @@ module Fluent::Plugin
       end
 
       if @tag
-        log.debug "tag parameter is specified. Emit plugins info to '#{@tag}'"
+        log.debug { "tag parameter is specified. Emit plugins info to '#{@tag}'" }
 
         opts = {with_config: false, with_retry: false}
         timer_execute(:in_monitor_agent_emit, @emit_interval, repeat: true) {

--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -178,8 +178,8 @@ module Fluent::Plugin
         if @follow_inodes
           raise Fluent::ConfigError, "Can't follow inodes without pos_file configuration parameter"
         end
-        $log.warn "'pos_file PATH' parameter is not set to a 'tail' source."
-        $log.warn "this parameter is highly recommended to save the position to resume tailing."
+        log.warn "'pos_file PATH' parameter is not set to a 'tail' source."
+        log.warn "this parameter is highly recommended to save the position to resume tailing."
       end
 
       configure_tag
@@ -369,7 +369,7 @@ module Fluent::Plugin
                 false
               end
             rescue Errno::ENOENT, Errno::EACCES
-              log.debug("#{p} is missing after refresh file list")
+              log.debug { "#{p} is missing after refresh file list" }
               false
             end
           }
@@ -405,7 +405,7 @@ module Fluent::Plugin
             hash[target_info.path] = target_info
           end
         rescue Errno::ENOENT, Errno::EACCES  => e
-          $log.warn "expand_paths: stat() for #{path} failed with #{e.class.name}. Skip file."
+          log.warn "expand_paths: stat() for #{path} failed with #{e.class.name}. Skip file."
         end
       }
       hash
@@ -523,7 +523,7 @@ module Fluent::Plugin
       begin
         target_info.ino = Fluent::FileWrapper.stat(path).ino
       rescue Errno::ENOENT, Errno::EACCES
-        $log.warn "stat() for #{path} failed. Continuing without tailing it."
+        log.warn "stat() for #{path} failed. Continuing without tailing it."
         return
       end
 

--- a/lib/fluent/plugin/out_stream.rb
+++ b/lib/fluent/plugin/out_stream.rb
@@ -92,8 +92,8 @@ module Fluent
 
     def initialize
       super
-      $log.warn "'tcp' output is obsoleted and will be removed. Use 'forward' instead."
-      $log.warn "see 'forward' section in https://docs.fluentd.org/ for the high-availability configuration."
+      log.warn "'tcp' output is obsoleted and will be removed. Use 'forward' instead."
+      log.warn "see 'forward' section in https://docs.fluentd.org/ for the high-availability configuration."
     end
 
     config_param :port, :integer, default: LISTEN_PORT
@@ -114,7 +114,7 @@ module Fluent
 
     def initialize
       super
-      $log.warn "'unix' output is obsoleted and will be removed."
+      log.warn "'unix' output is obsoleted and will be removed."
     end
 
     config_param :path, :string

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -2553,8 +2553,8 @@ class TailInputTest < Test::Unit::TestCase
     assert_nothing_raised do
       d.run(shutdown: false) {}
     end
-    assert($log.out.logs.any?{|log| log.include?("stat() for #{path} failed. Continuing without tailing it.\n") },
-           $log.out.logs.join("\n"))
+    assert(d.logs.any?{|log| log.include?("stat() for #{path} failed. Continuing without tailing it.\n") },
+           d.logs.join("\n"))
   ensure
     d.instance_shutdown if d&.instance
   end
@@ -2579,8 +2579,8 @@ class TailInputTest < Test::Unit::TestCase
       assert_nothing_raised do
         d.run(shutdown: false) {}
       end
-      assert($log.out.logs.any?{|log| log.include?("stat() for #{path} failed. Continuing without tailing it.\n") },
-             $log.out.logs.join("\n"))
+      assert(d.logs.any?{|log| log.include?("stat() for #{path} failed. Continuing without tailing it.\n") },
+             d.logs.join("\n"))
     end
   ensure
     d.instance_shutdown if d&.instance
@@ -2603,7 +2603,7 @@ class TailInputTest < Test::Unit::TestCase
     assert_nothing_raised do
       d.run(shutdown: false) {}
     end
-    assert($log.out.logs.any?{|log| log.include?("expand_paths: stat() for #{path} failed with Errno::EACCES. Skip file.\n") })
+    assert(d.logs.any?{|log| log.include?("expand_paths: stat() for #{path} failed with Errno::EACCES. Skip file.\n") })
   ensure
     d.instance_shutdown if d&.instance
   end


### PR DESCRIPTION

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

* Delay string interpolation for log.debug
* Use plugin scope logger instead of global scope $log

This issue was found by the following rubocop:

```
  Lint/FluentdPluginLogScope:
    AssumeConfigLogLevel: 'info'
    Exclude:
      - 'lib/fluent/*.rb'
      - 'lib/fluent/compat/*.rb'
    Enabled: true
```

**Docs Changes**:

N/A

**Release Note**: 

N/A