### PR TITLE
README: remove Code Climate badge as the service has ended

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ Fluentd: Open-Source Log Collector
 
 [![Test](https://github.com/fluent/fluentd/actions/workflows/test.yml/badge.svg)](https://github.com/fluent/fluentd/actions/workflows/test.yml)
 [![Test with Ruby head](https://github.com/fluent/fluentd/actions/workflows/test-ruby-head.yml/badge.svg)](https://github.com/fluent/fluentd/actions/workflows/test-ruby-head.yml)
-[![Code Climate](https://codeclimate.com/github/fluent/fluentd/badges/gpa.svg)](https://codeclimate.com/github/fluent/fluentd)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1189/badge)](https://bestpractices.coreinfrastructure.org/projects/1189)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/fluent/fluentd/badge)](https://scorecard.dev/viewer/?uri=github.com/fluent/fluentd)
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
* Fixes #5034

**What this PR does / why we need it**: 
Remove the Code Climate badge as the service has ended.
It appears that it hasn't been used recently, so just removing it would be sufficient for now.

**Docs Changes**:
Not needed.

**Release Note**: 
Not needed.
