### PR TITLE
out_stdout: support output to $stdout independently of logger

### DIFF
--- a/lib/fluent/plugin/out_stdout.rb
+++ b/lib/fluent/plugin/out_stdout.rb
@@ -25,6 +25,9 @@ module Fluent::Plugin
     DEFAULT_LINE_FORMAT_TYPE = 'stdout'
     DEFAULT_FORMAT_TYPE = 'json'
 
+    desc "If Fluentd logger outputs logs to a file, this plugin outputs events to the file as well."
+    config_param :use_logger, :bool, default: true
+
     config_section :buffer do
       config_set_default :chunk_keys, ['tag']
       config_set_default :flush_at_shutdown, true
@@ -44,6 +47,10 @@ module Fluent::Plugin
       true
     end
 
+    def dest_io
+      @use_logger ? $log : $stdout
+    end
+
     attr_accessor :formatter
 
     def configure(conf)
@@ -57,9 +64,9 @@ module Fluent::Plugin
     def process(tag, es)
       es = inject_values_to_event_stream(tag, es)
       es.each {|time,record|
-        $log.write(format(tag, time, record))
+        dest_io.write(format(tag, time, record))
       }
-      $log.flush
+      dest_io.flush
     end
 
     def format(tag, time, record)
@@ -68,7 +75,7 @@ module Fluent::Plugin
     end
 
     def write(chunk)
-      chunk.write_to($log)
+      chunk.write_to(dest_io)
     end
   end
 end

--- a/lib/fluent/plugin/out_stdout.rb
+++ b/lib/fluent/plugin/out_stdout.rb
@@ -25,7 +25,7 @@ module Fluent::Plugin
     DEFAULT_LINE_FORMAT_TYPE = 'stdout'
     DEFAULT_FORMAT_TYPE = 'json'
 
-    desc "If Fluentd logger outputs logs to a file, this plugin outputs events to the file as well."
+    desc "If Fluentd logger outputs logs to a file (with -o option), this plugin outputs events to the file as well."
     config_param :use_logger, :bool, default: true
 
     config_section :buffer do

--- a/test/plugin/test_out_stdout.rb
+++ b/test/plugin/test_out_stdout.rb
@@ -193,13 +193,36 @@ class StdoutOutputTest < Test::Unit::TestCase
     end
   end
 
-  # Capture the log output of the block given
-  def capture_log(&block)
+  test 'use_logger false' do
+    d = create_driver(<<~EOC)
+      use_logger false
+    EOC
+    time = event_time
+
+    out = capture_stdout do
+      d.run(default_tag: 'test', flush: true) do
+        d.feed(time, {'test' => 'test'})
+      end
+    end
+
+    assert_equal "#{Time.at(time).localtime.strftime(TIME_FORMAT)} test: {\"test\":\"test\"}\n", out
+  end
+
+  def capture_log
     tmp = $log
     $log = StringIO.new
     yield
     return $log.string
   ensure
     $log = tmp
+  end
+
+  def capture_stdout
+    tmp = $stdout
+    $stdout = StringIO.new
+    yield
+    return $stdout.string
+  ensure
+    $stdout = tmp
   end
 end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
* Fixes #5029

**What this PR does / why we need it**: 
Add `use_logger` option to `out_stdout` plugin.

* Type: `bool`
* Default: `true`

If you set `false` to this option, `out_stdout` outputs events to `$stdout`, instead of `$logger`.
This feature enables events to be output to STDOUT in containerized environments, such as K8s.

This does not change the default behavior.

Note: Although it's preferable for the default value of a `bool` option to be `false` (because it can be used as a flag), I couldn't think of a suitable name for it.

**Docs Changes**:
https://github.com/fluent/fluentd-docs-gitbook/pull/593

**Release Note**: 
out_stdout: support output to STDOUT independently of Fluentd logger by setting `use_logger` to `false`.
