### PR TITLE
logger: force_stacktrace_level was not applied to PluginLogger

### DIFF
--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -174,6 +174,7 @@ module Fluent
       clone.format = @format
       clone.time_format = @time_format
       clone.log_event_enabled = @log_event_enabled
+      clone.force_stacktrace_level(@forced_stacktrace_level)
       # optional headers/attrs are not copied, because new PluginLogger should have another one of it
       clone
     end
@@ -651,6 +652,9 @@ module Fluent
       @depth_offset = 2
       if logger.instance_variable_defined?(:@suppress_repeated_stacktrace)
         @suppress_repeated_stacktrace = logger.instance_variable_get(:@suppress_repeated_stacktrace)
+      end
+      if logger.instance_variable_defined?(:@forced_stacktrace_level)
+        @forced_stacktrace_level = logger.instance_variable_get(:@forced_stacktrace_level)
       end
       if logger.instance_variable_defined?(:@ignore_repeated_log_interval)
         @ignore_repeated_log_interval = logger.instance_variable_get(:@ignore_repeated_log_interval)


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
* Fixes a bug in #5008

**What this PR does / why we need it**: 
In #5008, we have added a new feature `force_stacktrace_level`.
However, it was not applied to `PluginLogger`.
So, depending on the settings and error locations, `force_stacktrace_level` could not work.
This PR fixes it.

**Docs Changes**:
Not needed because #5008 is not released yet.

**Release Note**: 
Not needed because #5008 is not released yet.

**How to reproduce the bug**:

conf:

```xml
<system>
  <log>
    forced_stacktrace_level info
  </log>
</system>

<source>
  @type sample
  @id test
  tag test.fail
</source>

<match test.fail>
  @type null
  @id null
  never_flush
  <buffer>
    flush_mode interval
    flush_interval 1s
  </buffer>
</match>
```

* Set `@id` to use `PluginLogger`.
* Use `buffer` to use `PluginLogger`.
  * Without `buffer`, `RootAgent` outputs the logs for flushing errors by using the global logger. (`RootAgent#handle_emits_error`)

log:

```
2025-07-29 12:39:36 +0900 [info]: #0 fluentd worker is now running worker=0
2025-07-29 12:39:38 +0900 [warn]: #0 [null] failed to flush the buffer. retry_times=0 next_retry_time=2025-07-29 12:39:39 +0900 chunk="63b09284c334efa1927547b5623268ff" error_class=RuntimeError error="failed to flush"
  2025-07-29 12:39:38 +0900 [warn]: #0 /home/daipom/work/fluentd/fluentd/lib/fluent/plugin/out_null.rb:59:in `write'
  2025-07-29 12:39:38 +0900 [warn]: #0 /home/daipom/work/fluentd/fluentd/lib/fluent/plugin/output.rb:1212:in `try_flush'
  2025-07-29 12:39:38 +0900 [warn]: #0 /home/daipom/work/fluentd/fluentd/lib/fluent/plugin/output.rb:1527:in `flush_thread_run'
  2025-07-29 12:39:38 +0900 [warn]: #0 /home/daipom/work/fluentd/fluentd/lib/fluent/plugin/output.rb:490:in `block (2 levels) in start'
  2025-07-29 12:39:38 +0900 [warn]: #0 /home/daipom/work/fluentd/fluentd/lib/fluent/plugin_helper/thread.rb:78:in `block in thread_create'
```

* The log levels of stacktraces are `warn`, although `forced_stacktrace_level` is `info`.
