### PR TITLE
test: ensure removing old engine on setup

### DIFF
--- a/lib/fluent/test.rb
+++ b/lib/fluent/test.rb
@@ -40,9 +40,12 @@ module Fluent
 
       $log = dummy_logger
 
-      Fluent.__send__(:remove_const, :Engine)
-      engine = Fluent.const_set(:Engine, EngineClass.new).init(SystemConfig.new)
+      old_engine = Fluent.__send__(:remove_const, :Engine)
+      # Ensure that GC can remove the objects of the old engine.
+      # Some objects can still exist after `remove_const`. See https://github.com/fluent/fluentd/issues/5054.
+      old_engine.instance_variable_set(:@root_agent, nil)
 
+      engine = Fluent.const_set(:Engine, EngineClass.new).init(SystemConfig.new)
       engine.define_singleton_method(:now=) {|n|
         @now = n
       }

--- a/test/plugin/test_input.rb
+++ b/test/plugin/test_input.rb
@@ -133,7 +133,5 @@ class InputTest < Test::Unit::TestCase
     assert{ @p.router.object_id != original_router.object_id }
 
     @p.router.emit('mytag.testing', ['for mock'])
-  ensure
-    Fluent::Engine.root_agent.labels['@mytest'] = nil
   end
 end

--- a/test/plugin_helper/test_event_emitter.rb
+++ b/test/plugin_helper/test_event_emitter.rb
@@ -70,8 +70,6 @@ class EventEmitterTest < Test::Unit::TestCase
     d.configure(config_element('ROOT', '', {'@label' => '@mytest'}))
     router = d.event_emitter_router("@mytest")
     assert_equal router_mock, router
-  ensure
-    Fluent::Engine.root_agent.labels['@mytest'] = nil
   end
 
   test 'get root router' do


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Continued from

* #5054
* #5055 (6cac9f0fc226a6d6046a64a59789a1b7500242da)

**What this PR does / why we need it**: 
Each test should not consider the initialization of `Fluent::Engine`.
It should be the responsibility of `Fluent::Test.setup`.

Note: Set `nil` explicitly to ensure that GC can remove the objects, though it is very strange that some objects can still exist after `remove_const` and `GC.start`.

**Docs Changes**:
Not needed.

**Release Note**: 
CI improvements.