### PR TITLE
Backport(v1.16): test_plugin_helper: fix test class name (#5064)

### DIFF
--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -2,7 +2,7 @@ require_relative 'helper'
 require 'fluent/plugin_helper'
 require 'fluent/plugin/base'
 
-class ConfigTest < Test::Unit::TestCase
+class PluginHelperTest < Test::Unit::TestCase
   module FluentTest; end
 
   sub_test_case 'Fluent::Plugin::Base.helpers method works as shortcut to include helper modules' do


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
* Backport #5064

**What this PR does / why we need it**:

`test_config.rb` and `test_plugin_helper.rb` has same class name.

https://github.com/fluent/fluentd/blob/338050012279f401af41c95049d82cb98b2a370b/test/test_config.rb#L8

https://github.com/fluent/fluentd/blob/338050012279f401af41c95049d82cb98b2a370b/test/test_plugin_helper.rb#L5

The test class name should be unique.

**Docs Changes**:
Not needed.

**Release Note**:
CI improvements.
