### PR TITLE
Backport(v1.16): ci: add "--report-slow-tests" option (#5063)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install dependencies
         run: bundle install
       - name: Run tests
-        run: bundle exec rake test TESTOPTS="-v --no-show-detail-immediately"
+        run: bundle exec rake test TESTOPTS="-v --report-slow-tests --no-show-detail-immediately"
 
   test-windows-service:
     runs-on: windows-latest


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
* Backport #5063

**What this PR does / why we need it**:
Very rarely, tests may take a long time to run, but it is difficult to determine which tests took a long time.

At [test-unit](https://github.com/test-unit/test-unit) v3.6.3, `--report-slow-tests` option was introduced to show the top 5 slow tests.

https://github.com/test-unit/test-unit/blob/d641c29d4068d407808c42b15c6dcdf9c2f2b439/doc/text/news.md?plain=1#L137-L140

I think it might be useful.

Related to https://github.com/fluent/fluentd/issues/5041

**Docs Changes**:
Not needed.

**Release Note**:
CI improvements.
