### PR TITLE
Backport(v1.16): README: remove Code Climate badge as the service has ended (#5035)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Fluentd: Open-Source Log Collector
 [![Testing on Ubuntu](https://github.com/fluent/fluentd/actions/workflows/linux-test.yaml/badge.svg?branch=master)](https://github.com/fluent/fluentd/actions/workflows/linux-test.yaml)
 [![Testing on Windows](https://github.com/fluent/fluentd/actions/workflows/windows-test.yaml/badge.svg?branch=master)](https://github.com/fluent/fluentd/actions/workflows/windows-test.yaml)
 [![Testing on macOS](https://github.com/fluent/fluentd/actions/workflows/macos-test.yaml/badge.svg?branch=master)](https://github.com/fluent/fluentd/actions/workflows/macos-test.yaml)
-[![Code Climate](https://codeclimate.com/github/fluent/fluentd/badges/gpa.svg)](https://codeclimate.com/github/fluent/fluentd)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1189/badge)](https://bestpractices.coreinfrastructure.org/projects/1189)
 
 [Fluentd](https://www.fluentd.org/) collects events from various data sources and writes them to files, RDBMS, NoSQL, IaaS, SaaS, Hadoop and so on. Fluentd helps you unify your logging infrastructure (Learn more about the [Unified Logging Layer](https://www.fluentd.org/blog/unified-logging-layer)).


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
* Backport #5035
* Fixes #5034

**What this PR does / why we need it**:
Remove the Code Climate badge as the service has ended. It appears that it hasn't been used recently, so just removing it would be sufficient for now.

**Docs Changes**:
Not needed.

**Release Note**:
Not needed.

