### PR TITLE
Replace yajl with built-in json for simple cases

### DIFF
--- a/lib/fluent/command/cat.rb
+++ b/lib/fluent/command/cat.rb
@@ -107,7 +107,7 @@ rescue
 end
 
 require 'socket'
-require 'yajl'
+require 'json'
 require 'msgpack'
 require 'fluent/ext_monitor_require'
 
@@ -304,7 +304,7 @@ class Writer
   end
 
   def abort_message(time, record)
-    $stdout.puts "!#{time}:#{Yajl.dump(record)}"
+    $stdout.puts "!#{time}:#{JSON.generate(record)}"
   end
 end
 
@@ -326,7 +326,7 @@ case format
 when 'json'
   begin
     while line = $stdin.gets
-      record = Yajl.load(line)
+      record = JSON.parse(line)
       w.write(record)
     end
   rescue

--- a/lib/fluent/compat/exec_util.rb
+++ b/lib/fluent/compat/exec_util.rb
@@ -15,6 +15,7 @@
 #
 
 require 'msgpack'
+require 'json'
 require 'yajl'
 
 require 'fluent/engine'
@@ -115,7 +116,7 @@ module Fluent
 
       class JSONFormatter < Formatter
         def call(record, out)
-          out << Yajl.dump(record) << "\n"
+          out << JSON.generate(record) << "\n"
         end
       end
 

--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -221,7 +221,7 @@ module Fluent
           if wid = get_worker_id(type)
             r['worker_id'] = wid
           end
-          Yajl.dump(r)
+          JSON.generate(r)
         }
       end
 
@@ -554,7 +554,7 @@ module Fluent
           Thread.current[:last_repeated_stacktrace] = CachedLog.new(backtrace, time) if @suppress_repeated_stacktrace
         end
 
-        puts Yajl.dump(r)
+        puts JSON.generate(r)
       end
 
       nil

--- a/lib/fluent/plugin/in_exec.rb
+++ b/lib/fluent/plugin/in_exec.rb
@@ -15,7 +15,7 @@
 #
 
 require 'fluent/plugin/input'
-require 'yajl'
+require 'json'
 
 module Fluent::Plugin
   class ExecInput < Fluent::Plugin::Input
@@ -115,7 +115,7 @@ module Fluent::Plugin
       time ||= extract_time_from_record(record) || Fluent::EventTime.now
       router.emit(tag, time, record)
     rescue => e
-      log.error "exec failed to emit", tag: tag, record: Yajl.dump(record), error: e
+      log.error "exec failed to emit", tag: tag, record: JSON.generate(record), error: e
       router.emit_error_event(tag, time, record, e) if tag && time && record
     end
   end

--- a/lib/fluent/plugin/in_object_space.rb
+++ b/lib/fluent/plugin/in_object_space.rb
@@ -14,7 +14,7 @@
 #    limitations under the License.
 #
 
-require 'yajl'
+require 'json'
 
 require 'fluent/plugin/input'
 
@@ -86,7 +86,7 @@ module Fluent::Plugin
 
       router.emit(@tag, now, record)
     rescue => e
-      log.error "object space failed to emit", error: e, tag: @tag, record: Yajl.dump(record)
+      log.error "object space failed to emit", error: e, tag: @tag, record: JSON.generate(record)
       log.error_backtrace
     end
   end

--- a/lib/fluent/plugin/in_syslog.rb
+++ b/lib/fluent/plugin/in_syslog.rb
@@ -18,7 +18,7 @@ require 'fluent/plugin/input'
 require 'fluent/config/error'
 require 'fluent/plugin/parser'
 
-require 'yajl'
+require 'json'
 
 module Fluent::Plugin
   class SyslogInput < Input
@@ -274,7 +274,7 @@ module Fluent::Plugin
     def emit(tag, time, record)
       router.emit(tag, time, record)
     rescue => e
-      log.error "syslog failed to emit", error: e, tag: tag, record: Yajl.dump(record)
+      log.error "syslog failed to emit", error: e, tag: tag, record: JSON.generate(record)
     end
   end
 end

--- a/lib/fluent/plugin/out_exec_filter.rb
+++ b/lib/fluent/plugin/out_exec_filter.rb
@@ -17,7 +17,7 @@ require 'fluent/plugin/output'
 require 'fluent/env'
 require 'fluent/config/error'
 
-require 'yajl'
+require 'json'
 
 module Fluent::Plugin
   class ExecFilterOutput < Output
@@ -309,7 +309,7 @@ module Fluent::Plugin
       router.emit(tag, time, record)
     rescue => e
       if @suppress_error_log_interval == 0 || Time.now.to_i > @next_log_time
-        log.error "exec_filter failed to emit", record: Yajl.dump(record), error: e
+        log.error "exec_filter failed to emit", record: JSON.generate(record), error: e
         log.error_backtrace e.backtrace
         @next_log_time = Time.now.to_i + @suppress_error_log_interval
       end

--- a/test/command/test_binlog_reader.rb
+++ b/test/command/test_binlog_reader.rb
@@ -1,6 +1,6 @@
 require_relative '../helper'
 
-require 'yajl'
+require 'json'
 require 'flexmock/test_unit'
 
 require 'fluent/command/binlog_reader'
@@ -146,7 +146,7 @@ class TestHead < TestBaseCommand
         create_message_packed_file(@file_name, [event_time(@t).to_i] * 6, [@record] * 6)
         head = BinlogReaderCommand::Head.new(argv)
         out = capture_stdout { head.call }
-        assert_equal "2011-01-02T13:14:15+00:00\t#{TMP_DIR}/#{@file_name}\t#{Yajl.dump(@record)}#{@default_newline}" * 5, out
+        assert_equal "2011-01-02T13:14:15+00:00\t#{TMP_DIR}/#{@file_name}\t#{JSON.generate(@record)}#{@default_newline}" * 5, out
       end
     end
 
@@ -157,7 +157,7 @@ class TestHead < TestBaseCommand
         create_message_packed_file(@file_name, [event_time(@t).to_i] * 6, [@record] * 6)
         head = BinlogReaderCommand::Head.new(argv)
         out = capture_stdout { head.call }
-        assert_equal "2011-01-02T13:14:15+00:00\t#{TMP_DIR}/#{@file_name}\t#{Yajl.dump(@record)}#{@default_newline}", out
+        assert_equal "2011-01-02T13:14:15+00:00\t#{TMP_DIR}/#{@file_name}\t#{JSON.generate(@record)}#{@default_newline}", out
       end
     end
 
@@ -177,7 +177,7 @@ class TestHead < TestBaseCommand
         create_message_packed_file(@file_name, [event_time(@t).to_i], [@record])
         head = BinlogReaderCommand::Head.new(argv)
         out = capture_stdout { head.call }
-        assert_equal "#{Yajl.dump(@record)}#{@default_newline}", out
+        assert_equal "#{JSON.generate(@record)}#{@default_newline}", out
       end
     end
 
@@ -270,7 +270,7 @@ class TestCat < TestBaseCommand
         create_message_packed_file(@file_name, [event_time(@t).to_i] * 6, [@record] * 6)
         head = BinlogReaderCommand::Cat.new(argv)
         out = capture_stdout { head.call }
-        assert_equal "2011-01-02T13:14:15+00:00\t#{TMP_DIR}/#{@file_name}\t#{Yajl.dump(@record)}#{@default_newline}" * 6, out
+        assert_equal "2011-01-02T13:14:15+00:00\t#{TMP_DIR}/#{@file_name}\t#{JSON.generate(@record)}#{@default_newline}" * 6, out
       end
     end
 
@@ -281,7 +281,7 @@ class TestCat < TestBaseCommand
         create_message_packed_file(@file_name, [event_time(@t).to_i] * 6, [@record] * 6)
         head = BinlogReaderCommand::Cat.new(argv)
         out = capture_stdout { head.call }
-        assert_equal "2011-01-02T13:14:15+00:00\t#{TMP_DIR}/#{@file_name}\t#{Yajl.dump(@record)}#{@default_newline}", out
+        assert_equal "2011-01-02T13:14:15+00:00\t#{TMP_DIR}/#{@file_name}\t#{JSON.generate(@record)}#{@default_newline}", out
       end
     end
 
@@ -292,7 +292,7 @@ class TestCat < TestBaseCommand
         create_message_packed_file(@file_name, [event_time(@t).to_i], [@record])
         head = BinlogReaderCommand::Cat.new(argv)
         out = capture_stdout { head.call }
-        assert_equal "#{Yajl.dump(@record)}#{@default_newline}", out
+        assert_equal "#{JSON.generate(@record)}#{@default_newline}", out
       end
     end
 

--- a/test/command/test_ca_generate.rb
+++ b/test/command/test_ca_generate.rb
@@ -1,6 +1,5 @@
 require_relative '../helper'
 
-require 'yajl'
 require 'flexmock/test_unit'
 require 'tmpdir'
 

--- a/test/plugin/test_formatter_out_file.rb
+++ b/test/plugin/test_formatter_out_file.rb
@@ -53,7 +53,7 @@ class OutFileFormatterTest < ::Test::Unit::TestCase
       oldtz, ENV['TZ'] = ENV['TZ'], "UTC+07"
       d = create_driver(config_element('ROOT', '', {key => value}))
       tag = 'test'
-      assert_equal "#{expected}\t#{tag}\t#{Yajl.dump(record)}#{@default_newline}", d.instance.format(tag, time, record)
+      assert_equal "#{expected}\t#{tag}\t#{JSON.generate(record)}#{@default_newline}", d.instance.format(tag, time, record)
     ensure
       ENV['TZ'] = oldtz
     end
@@ -66,7 +66,7 @@ class OutFileFormatterTest < ::Test::Unit::TestCase
     d = create_driver({"newline" => newline_conf})
     formatted = d.instance.format(tag, @time, record)
 
-    assert_equal("#{time2str(@time)}\t#{tag}\t#{Yajl.dump(record)}#{newline}", formatted)
+    assert_equal("#{time2str(@time)}\t#{tag}\t#{JSON.generate(record)}#{newline}", formatted)
   end
 
   data("newline (LF)" => ["lf", "\n"],
@@ -76,7 +76,7 @@ class OutFileFormatterTest < ::Test::Unit::TestCase
     d = create_driver('output_time' => 'false', 'newline' => newline_conf)
     formatted = d.instance.format(tag, @time, record)
 
-    assert_equal("#{tag}\t#{Yajl.dump(record)}#{newline}", formatted)
+    assert_equal("#{tag}\t#{JSON.generate(record)}#{newline}", formatted)
   end
 
   data("newline (LF)" => ["lf", "\n"],
@@ -86,7 +86,7 @@ class OutFileFormatterTest < ::Test::Unit::TestCase
     d = create_driver('output_tag' => 'false', 'newline' => newline_conf)
     formatted = d.instance.format(tag, @time, record)
 
-    assert_equal("#{time2str(@time)}\t#{Yajl.dump(record)}#{newline}", formatted)
+    assert_equal("#{time2str(@time)}\t#{JSON.generate(record)}#{newline}", formatted)
   end
 
   data("newline (LF)" => ["lf", "\n"],
@@ -96,7 +96,7 @@ class OutFileFormatterTest < ::Test::Unit::TestCase
     d = create_driver('output_tag' => 'false', 'output_time' => 'false', 'newline' => newline_conf)
     formatted = d.instance.format('tag', @time, record)
 
-    assert_equal("#{Yajl.dump(record)}#{newline}", formatted)
+    assert_equal("#{JSON.generate(record)}#{newline}", formatted)
   end
 
   data("newline (LF)" => ["lf", "\n"],
@@ -111,6 +111,6 @@ class OutFileFormatterTest < ::Test::Unit::TestCase
                       ])
     formatted = d.instance.format('tag', @time, record)
 
-    assert_equal("#{Yajl.dump(record)}#{newline}", formatted)
+    assert_equal("#{JSON.generate(record)}#{newline}", formatted)
   end
 end

--- a/test/plugin/test_out_exec.rb
+++ b/test/plugin/test_out_exec.rb
@@ -174,8 +174,8 @@ class ExecOutputTest < Test::Unit::TestCase
       d.feed(time, records[1])
     end
 
-    assert_equal Yajl.dump(records[0]) + "\n", d.formatted[0]
-    assert_equal Yajl.dump(records[1]) + "\n", d.formatted[1]
+    assert_equal JSON.generate(records[0]) + "\n", d.formatted[0]
+    assert_equal JSON.generate(records[1]) + "\n", d.formatted[1]
   end
 
   data(

--- a/test/plugin/test_out_file.rb
+++ b/test/plugin/test_out_file.rb
@@ -535,7 +535,7 @@ class FileOutputTest < Test::Unit::TestCase
       end
 
       path = d.instance.last_written_path
-      check_zipped_result(path, %[#{Yajl.dump({"a" => 1, 'time' => time.to_i})}#{@default_newline}] + %[#{Yajl.dump({"a" => 2, 'time' => time.to_i})}#{@default_newline}])
+      check_zipped_result(path, %[#{JSON.generate({"a" => 1, 'time' => time.to_i})}#{@default_newline}] + %[#{JSON.generate({"a" => 2, 'time' => time.to_i})}#{@default_newline}])
     end
 
     test 'ltsv' do

--- a/test/plugin/test_parser_json.rb
+++ b/test/plugin/test_parser_json.rb
@@ -23,7 +23,7 @@ class JsonParserTest < ::Test::Unit::TestCase
       end
     end
 
-    def test_fall_back_oj_to_yajl_if_oj_not_available
+    def test_fall_back_oj_to_json_if_oj_not_available
       stub(Fluent::OjOptions).available? { false }
 
       result = @parser.instance.configure_json_parser(:oj)


### PR DESCRIPTION
yajl is much slower than json nowadays.

See 1d5b0dec495a57e4fd8603735d4477a9f28186af and maintainer comment in https://github.com/brianmario/yajl-ruby/pull/228.
