### PR TITLE
v1.16: ci: update actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         ruby-version: ['3.3', '3.2', '3.1', '3.0', '2.7']
     name: Ruby ${{ matrix.ruby-version }} on ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -51,9 +51,9 @@ jobs:
         ruby-version: ['3.3', '3.2', '3.1', '3.0', '2.7']
     name: Windows service (Ruby ${{ matrix.ruby-version }})
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@v5
       - name: Set up Ruby
-        uses: ruby/setup-ruby@e34163cd15f4bb403dcd72d98e295997e6a55798 # v1.238.0
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
       - name: Install dependencies


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None.

**What this PR does / why we need it**: 
Update GitHub Actions to fix Windows Service tests failures.

    <internal:C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in
    `require': 127: The specified procedure could not be found. 
     - C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/strptime-0.2.5/lib/strptime/strptime.so (LoadError)

* ref: https://github.com/ruby/setup-msys2-gcc/pull/26

Note: It might be better to have it automatically updated by a bot, just like `master`.

**Docs Changes**:
Not needed.

**Release Note**: 
CI fixes.
