### PR TITLE
Backport(v1.16): ci: refactor out_forward compress setting test (#4896)

### DIFF
--- a/test/plugin/test_out_forward.rb
+++ b/test/plugin/test_out_forward.rb
@@ -178,6 +178,42 @@ EOL
     assert{ logs.any?{|log| log.include?(expected_log) && log.include?(expected_detail) } }
   end
 
+  sub_test_case 'configure compress' do
+    data('default', ['', :text])
+    data('gzip', ['compress gzip', :gzip])
+    test 'should be applied' do |(option, expected)|
+      @d = d = create_driver(config + option)
+      node = d.instance.nodes.first
+
+      assert_equal(
+        [expected, expected],
+        [d.instance.compress, node.instance_variable_get(:@compress)]
+      )
+    end
+
+    # TODO add tests that we cannot configure the different compress type between owner and buffer except for :text
+    data('gzip', ['compress gzip', :text, :gzip])
+    test 'can configure buffer compress separately when owner uses :text' do |(buffer_option, expected_owner_compress, expected_buffer_compress)|
+      @d = d = create_driver(config + %[
+         <buffer>
+           type memory
+           #{buffer_option}
+         </buffer>
+       ])
+      node = d.instance.nodes.first
+
+      assert_equal(
+        [expected_owner_compress, expected_owner_compress, expected_buffer_compress],
+        [d.instance.compress, node.instance_variable_get(:@compress), d.instance.buffer.compress],
+      )
+
+      log_message = "buffer is compressed.  If you also want to save the bandwidth of a network, Add `compress` configuration in <match>"
+      assert do
+        d.logs.any? { |log| log.include?(log_message) }
+      end
+    end
+  end
+
   data('CA cert'     => 'tls_ca_cert_path',
        'non CA cert' => 'tls_cert_path')
   test 'configure tls_cert_path/tls_ca_cert_path' do |param|
@@ -324,40 +360,6 @@ EOL
     assert_equal 1, d.instance.discovery_manager.services.size
     assert_equal '127.0.0.1', d.instance.discovery_manager.services[0].host
     assert_equal 1234, d.instance.discovery_manager.services[0].port
-  end
-
-  test 'compress_default_value' do
-    @d = d = create_driver
-    assert_equal :text, d.instance.compress
-
-    node = d.instance.nodes.first
-    assert_equal :text, node.instance_variable_get(:@compress)
-  end
-
-  test 'set_compress_is_gzip' do
-    @d = d = create_driver(config + %[compress gzip])
-    assert_equal :gzip, d.instance.compress
-    assert_equal :gzip, d.instance.buffer.compress
-
-    node = d.instance.nodes.first
-    assert_equal :gzip, node.instance_variable_get(:@compress)
-  end
-
-  test 'set_compress_is_gzip_in_buffer_section' do
-    mock = flexmock($log.dup)
-    mock.should_receive(:log).with("buffer is compressed.  If you also want to save the bandwidth of a network, Add `compress` configuration in <match>")
-
-    @d = d = create_driver(config + %[
-       <buffer>
-         type memory
-         compress gzip
-       </buffer>
-     ])
-    assert_equal :text, d.instance.compress
-    assert_equal :gzip, d.instance.buffer.compress
-
-    node = d.instance.nodes.first
-    assert_equal :text, node.instance_variable_get(:@compress)
   end
 
   test 'phi_failure_detector disabled' do


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
* Partially backported from #4896

**What this PR does / why we need it**: 
Refactor out_forward compress setting tests.

**Docs Changes**:
Not needed.

**Release Note**: 
CI fixes.