### PR TITLE
security: add note for package or Docker image

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,3 +14,9 @@
 
 Please post your vulnerability report from the following page:
 https://github.com/fluent/fluentd/security/advisories
+
+> [!NOTE]
+> If you use fluent-package, please check [fluent-package-builder](https://github.com/fluent/fluent-package-builder/blob/master/SECURITY.md) and report it there.
+
+> [!NOTE]
+> If you use a Docker image of Fluentd, please check [Fluentd Docker Image](https://github.com/fluent/fluentd-docker-image/blob/master/SECURITY.md) and report it there.


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
None.

**What this PR does / why we need it**: 
Add notes about fluent-package and Docker image.
The appropriate reporting destination varies depending on the type, but the guidance is insufficient now.

**Docs Changes**:
Not needed.

**Release Note**: 
Not needed.