### PR TITLE
test_supervisor: use expected temporary directory for tests

### DIFF
--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -495,7 +495,7 @@ class SupervisorTest < ::Test::Unit::TestCase
     # https://github.com/fluent/fluentd/issues/4063
     GC.start
 
-    ENV['SIGDUMP_PATH'] = TMP_DIR + "/sigdump.log"
+    ENV['SIGDUMP_PATH'] = @tmp_dir + "/sigdump.log"
 
     server = DummyServer.new
     def server.config
@@ -513,7 +513,7 @@ class SupervisorTest < ::Test::Unit::TestCase
       server.stop_windows_event_thread
     end
 
-    result_filepaths = Dir.glob("#{TMP_DIR}/*")
+    result_filepaths = Dir.glob("#{@tmp_dir}/*")
     assert {result_filepaths.length > 0}
   ensure
     ENV.delete('SIGDUMP_PATH')


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
test_supervisor.rb uses a constant named `TMP_DIR`.
However, the constant is not defined in this file, it is defined in another file.
https://github.com/fluent/fluentd/blob/5a875090dde0222edf789422c7b2f27a828c72c3/test/config/test_dsl.rb#L5

This PR will use expected temporary directory for tests.

**Docs Changes**:

**Release Note**: 
