### PR TITLE
Backport(v1.19): YAML config: Supports parsing array format (#5126)

### DIFF
--- a/lib/fluent/config/yaml_parser/parser.rb
+++ b/lib/fluent/config/yaml_parser/parser.rb
@@ -144,8 +144,12 @@ module Fluent
 
           config.each do |key, val|
             if val.is_a?(Array)
-              val.each do |v|
-                sb.add_section(section_build(key, v, indent: indent + @base_indent))
+              if section?(val.first)
+                val.each do |v|
+                  sb.add_section(section_build(key, v, indent: indent + @base_indent))
+                end
+              else
+                sb.add_line(key, val)
               end
             elsif val.is_a?(Hash)
               harg = val.delete('$arg')
@@ -163,6 +167,10 @@ module Fluent
           end
 
           SectionBuilder.new(name, sb, indent, arg)
+        end
+
+        def section?(value)
+          value.is_a?(Array) or value.is_a?(Hash)
         end
       end
     end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -343,6 +343,155 @@ class ConfigTest < Test::Unit::TestCase
       10.times { match_conf['type'] }
       assert_equal before_size, match_conf.unused.size
     end
+
+    data(
+      "One String for $arg" => <<~CONF,
+        config:
+          - source:
+              $type: sample
+              tag: test
+          - match:
+              $type: stdout
+              $tag: test.**
+              buffer:
+                $arg: tag
+                $type: memory
+                flush_mode: immediate
+      CONF
+      "Comma-separated String for $arg" => <<~CONF,
+        config:
+          - source:
+              $type: sample
+              tag: test
+          - match:
+              $type: stdout
+              $tag: test.**
+              buffer:
+                $arg: tag, time
+                $type: memory
+                timekey: 1h
+                flush_mode: immediate
+      CONF
+      "One-liner Array for $arg" => <<~CONF,
+        config:
+          - source:
+              $type: sample
+              tag: test
+          - match:
+              $type: stdout
+              $tag: test.**
+              buffer:
+                $arg: [tag, time]
+                $type: memory
+                timekey: 1h
+                flush_mode: immediate
+      CONF
+      "Multi-liner Array for $arg" => <<~CONF,
+        config:
+          - source:
+              $type: sample
+              tag: test
+          - match:
+              $type: stdout
+              $tag: test.**
+              buffer:
+                $arg:
+                  - tag
+                  - time
+                $type: memory
+                timekey: 1h
+                flush_mode: immediate
+      CONF
+      "One String for normal Array option" => <<~CONF,
+        config:
+          - source:
+              $type: sample
+              tag: test
+          - match:
+              $type: stdout
+              $tag: test.**
+              format:
+                $type: csv
+                fields: message
+      CONF
+      "Comma-separated String for normal Array option" => <<~CONF,
+        config:
+          - source:
+              $type: sample
+              tag: test
+          - match:
+              $type: stdout
+              $tag: test.**
+              inject:
+                time_key: timestamp
+                time_type: string
+              format:
+                $type: csv
+                fields: timestamp, message
+      CONF
+      "One-liner Array for normal Array option" => <<~CONF,
+        config:
+          - source:
+              $type: sample
+              tag: test
+          - match:
+              $type: stdout
+              $tag: test.**
+              inject:
+                time_key: timestamp
+                time_type: string
+              format:
+                $type: csv
+                fields: [timestamp, message]
+      CONF
+      "Multi-liner Array for normal Array option" => <<~CONF,
+        config:
+          - source:
+              $type: sample
+              tag: test
+          - match:
+              $type: stdout
+              $tag: test.**
+              inject:
+                time_key: timestamp
+                time_type: string
+              format:
+                $type: csv
+                fields:
+                  - timestamp
+                  - message
+      CONF
+      "Multiple sections" => <<~CONF,
+        config:
+          - source:
+              $type: sample
+              tag: test
+          - match:
+              $type: copy
+              $tag: test.**
+              store:
+                - $type: relabel
+                  $label: "@foo"
+                - $type: relabel
+                  $label: "@bar"
+          - label:
+              $name: "@foo"
+              config:
+                - match:
+                    $type: stdout
+                    $tag: test.**
+          - label:
+              $name: "@bar"
+              config:
+                - match:
+                    $type: stdout
+                    $tag: test.**
+      CONF
+    )
+    test "Can parse config without error" do |conf|
+      write_config "#{TMP_DIR}/config.yaml", conf
+      read_config("#{TMP_DIR}/config.yaml", use_yaml: true)
+    end
   end
 
   def write_config(path, data, encoding: 'utf-8')


### PR DESCRIPTION
Backport https://github.com/fluent/fluentd/pull/5126

**Which issue(s) this PR fixes**:
None.

**What this PR does / why we need it**:
Supports parsing array of basic data types when analyzing YAML configuration files.

The current behavior of Fluentd:

* Support YAML Array format for `$args` only.
* Other Array options must be specified in a comma-separated format.
  * `retryable_response_codes: 503, 504`
* If there’s only a single value, it must be specified as String or with the trailing comma.
    * `retryable_response_codes: "503"`
    * `retryable_response_codes: 503,`

This supports YAML Array format for all options.

```
retryable_response_codes:
  - 503
```

```
retryable_response_codes: [503]
```

Note: This PR doesn't address the issue where setting an Int directly to an Array option causes ConfigError: `retryable_response_codes: 503` (The `C` case in
https://github.com/fluent/fluentd/pull/5126#issuecomment-3424253314) It could be a different issue.

**Docs Changes**: Not Need

**Release Note**: Same as the title.
