### PR TITLE
Backport(v1.19): gem: fix uri gem version to keep IPv6 tests (#5142)

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -39,7 +39,9 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("strptime", [">= 0.2.4", "< 1.0.0"])
   gem.add_runtime_dependency("webrick", ["~> 1.4"])
   gem.add_runtime_dependency("zstd-ruby", ["~> 1.5"])
-  gem.add_runtime_dependency("uri", '~> 1.0')
+  # uri v1.1.0 breaks the tests using IPv6 addresses.
+  # https://github.com/fluent/fluentd/issues/5141
+  gem.add_runtime_dependency("uri", ['~> 1.0', "< 1.1.0"])
   gem.add_runtime_dependency("async-http", "~> 0.86")
 
   # gems that aren't default gems as of Ruby 3.4


### PR DESCRIPTION
Backport https://github.com/fluent/fluentd/pull/5142

**Which issue(s) this PR fixes**:
Related to #5141

**What this PR does / why we need it**:
Since uri 1.1.0, `Net::HTTP` will cause a `URI::InvalidComponentError` if we use IPv6 address.
To avoid the error, this PR will fix uri version to 1.0.x.

**Docs Changes**:

**Release Note**:
