### PR TITLE
gem: use latest net-http to solve IPv6 addr error

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -39,9 +39,8 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("strptime", [">= 0.2.4", "< 1.0.0"])
   gem.add_runtime_dependency("webrick", ["~> 1.4"])
   gem.add_runtime_dependency("zstd-ruby", ["~> 1.5"])
-  # uri v1.1.0 breaks the tests using IPv6 addresses.
-  # https://github.com/fluent/fluentd/issues/5141
-  gem.add_runtime_dependency("uri", ['~> 1.0', "< 1.1.0"])
+  gem.add_runtime_dependency("uri", '~> 1.0')
+  gem.add_runtime_dependency("net-http", '~> 0.8')
   gem.add_runtime_dependency("async-http", "~> 0.86")
 
   # gems that aren't default gems as of Ruby 3.4


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #5141

**What this PR does / why we need it**: 
`net-http` had a bug in handling IPv6 addresses, and updating the `uri` would trigger strict checking, causing errors.

This PR will use `net-http` that has the bug fixed.

**Docs Changes**:
N/A

**Release Note**: 
gem: use latest net-http to solve IPv6 addr error