### PR TITLE
Backport(v1.16): Add missing gem dependency on Ruby 3.4-dev

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -31,6 +31,11 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("webrick", ["~> 1.4"])
   gem.add_runtime_dependency("console", ["< 1.24"])
 
+  # gems that aren't default gems as of Ruby 3.4
+  gem.add_runtime_dependency("base64", ["~> 0.2"])
+  gem.add_runtime_dependency("csv", ["~> 3.2"])
+  gem.add_runtime_dependency("drb", ["~> 2.2"])
+
   # gems that aren't default gems as of Ruby 3.5
   gem.add_runtime_dependency("logger", ["~> 1.6"])
 


### PR DESCRIPTION
Backport https://github.com/fluent/fluentd/pull/4411

**Which issue(s) this PR fixes**: 
N/A

**What this PR does / why we need it**: 
CI is failed on Ruby 3.4-dev:
https://github.com/fluent/fluentd/actions/runs/7949585800

**Docs Changes**:
N/A

**Release Note**: 
N/A