### PR TITLE
Backport(v1.16): test_supervisor: fix flaky tests for Win32 event (#5174)

### DIFF
--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -353,6 +353,7 @@ class SupervisorTest < ::Test::Unit::TestCase
       event = Win32::Event.open("TestFluentdEvent")
       event.set
       event.close
+      sleep 1.0 # Wait for dumping
     ensure
       server.stop_windows_event_thread
     end
@@ -379,6 +380,7 @@ class SupervisorTest < ::Test::Unit::TestCase
       event = Win32::Event.open("TestFluentdEvent_USR1")
       event.set
       event.close
+      sleep 1.0 # Wait for dumping
     ensure
       server.stop_windows_event_thread
     end


### PR DESCRIPTION
Backport https://github.com/fluent/fluentd/pull/5174

**Which issue(s) this PR fixes**:
This patch will fix following failures on Windows with old Ruby (3.0, 2.7).

```
1) Failure: test_supervisor_event_handler(SupervisorTest): <false> is not true.
D:/a/fluentd/fluentd/test/test_supervisor.rb:388:in `test_supervisor_event_handler'
     385: 
     386:     debug_msg = '[debug]: Got Win32 event "TestFluentdEvent_USR1"'
     387:     logs = $log.out.logs
  => 388:     assert{ logs.any?{|log| log.include?(debug_msg) } }
     389:   ensure
     390:     $log.out.reset if $log&.out&.respond_to?(:reset)
     391:   end

2) Failure: test_windows_shutdown_event(SupervisorTest): <false> is not true.
D:/a/fluentd/fluentd/test/test_supervisor.rb:362:in `test_windows_shutdown_event'
     359: 
     360:     debug_msg = '[debug]: Got Win32 event "TestFluentdEvent"'
     361:     logs = $log.out.logs
  => 362:     assert{ logs.any?{|log| log.include?(debug_msg) } }
     363:   ensure
     364:     $log.out.reset if $log&.out&.respond_to?(:reset)
     365:   end
```


https://github.com/fluent/fluentd/actions/runs/19950323545/job/57208741261

**What this PR does / why we need it**: 
It seems we need to wait a bit to reliably capture events as logs.

Similar to following codes, this also includes sleep.


https://github.com/fluent/fluentd/blob/6d26f8de536601d9c192476f00cd22925a8882ad/test/test_supervisor.rb#L417-L421

**Docs Changes**:
N/A

**Release Note**: 
N/A

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

**Docs Changes**:

**Release Note**: 
