### PR TITLE
Backport(v1.16): tests: fix Hash#inspect format for Ruby HEAD

### DIFF
--- a/test/config/test_element.rb
+++ b/test/config/test_element.rb
@@ -282,8 +282,8 @@ CONF
       dump = <<-CONF
 name:ROOT, arg:, {\"k1\"=>\"v1\"}, [name:test, arg:ext, {\"k2\"=>\"v2\"}, []]
 CONF
-      assert_not_equal(e.to_s, e.inspect)
-      assert_equal(dump.chomp, e.inspect)
+      assert_not_equal(e.to_s, e.inspect.gsub(' => ', '=>'))
+      assert_equal(dump.chomp, e.inspect.gsub(' => ', '=>'))
     end
   end
 

--- a/test/plugin/test_filter_stdout.rb
+++ b/test/plugin/test_filter_stdout.rb
@@ -86,12 +86,12 @@ class StdoutFilterTest < Test::Unit::TestCase
       d = create_driver(CONFIG + config_element("", "", { "output_type" => "hash" }))
       etime = event_time("2016-10-07 21:09:31.012345678 UTC")
       out = capture_log(d) { filter(d, etime, {'test' => 'test'}) }
-      assert_equal "2016-10-07 21:09:31.012345678 +0000 filter.test: {\"test\"=>\"test\"}\n", out
+      assert_equal "2016-10-07 21:09:31.012345678 +0000 filter.test: {\"test\"=>\"test\"}\n", out.gsub(' => ', '=>')
 
       # NOTE: Float::NAN is not jsonable, but hash string can output it.
       d = create_driver(CONFIG + config_element("", "", { "output_type" => "hash" }))
       out = capture_log(d) { filter(d, etime, {'test' => Float::NAN}) }
-      assert_equal "2016-10-07 21:09:31.012345678 +0000 filter.test: {\"test\"=>NaN}\n", out
+      assert_equal "2016-10-07 21:09:31.012345678 +0000 filter.test: {\"test\"=>NaN}\n", out.gsub(' => ', '=>')
     end
 
     # Use include_time_key to output the message's time
@@ -172,7 +172,7 @@ class StdoutFilterTest < Test::Unit::TestCase
         d = create_driver(conf)
         etime = event_time("2016-10-07 21:09:31.012345678 UTC")
         out = capture_log(d) { filter(d, etime, {'test' => 'test'}) }
-        assert_equal "2016-10-07 21:09:31.012345678 +0000 filter.test: {\"test\"=>\"test\"}\n", out
+        assert_equal "2016-10-07 21:09:31.012345678 +0000 filter.test: {\"test\"=>\"test\"}\n", out.gsub(' => ', '=>')
       end
 
       def test_hash_nan
@@ -182,7 +182,7 @@ class StdoutFilterTest < Test::Unit::TestCase
         d = create_driver(conf)
         etime = event_time("2016-10-07 21:09:31.012345678 UTC")
         out = capture_log(d) { filter(d, etime, {'test' => Float::NAN}) }
-        assert_equal "2016-10-07 21:09:31.012345678 +0000 filter.test: {\"test\"=>NaN}\n", out
+        assert_equal "2016-10-07 21:09:31.012345678 +0000 filter.test: {\"test\"=>NaN}\n", out.gsub(' => ', '=>')
       end
 
       # Use include_time_key to output the message's time

--- a/test/plugin/test_formatter_hash.rb
+++ b/test/plugin/test_formatter_hash.rb
@@ -26,13 +26,13 @@ class HashFormatterTest < ::Test::Unit::TestCase
     d = create_driver({"newline" => newline_conf})
     formatted = d.instance.format(tag, @time, record)
 
-    assert_equal(%Q!{"message"=>"awesome", "greeting"=>"hello"}#{newline}!, formatted.encode(Encoding::UTF_8))
+    assert_equal(%Q!{"message"=>"awesome", "greeting"=>"hello"}#{newline}!, formatted.gsub(' => ', '=>').encode(Encoding::UTF_8))
   end
 
   def test_format_without_newline
     d = create_driver('add_newline' => false)
     formatted = d.instance.format(tag, @time, record)
 
-    assert_equal(%Q!{"message"=>"awesome", "greeting"=>"hello"}!, formatted.encode(Encoding::UTF_8))
+    assert_equal(%Q!{"message"=>"awesome", "greeting"=>"hello"}!, formatted.gsub(' => ', '=>').encode(Encoding::UTF_8))
   end
 end

--- a/test/plugin/test_out_stdout.rb
+++ b/test/plugin/test_out_stdout.rb
@@ -95,11 +95,11 @@ class StdoutOutputTest < Test::Unit::TestCase
           d.feed(time, {'test' => 'test2'})
         end
       end
-      assert_equal "#{Time.at(time).localtime.strftime(TIME_FORMAT)} test: {\"test\"=>\"test2\"}\n", out
+      assert_equal "#{Time.at(time).localtime.strftime(TIME_FORMAT)} test: {\"test\"=>\"test2\"}\n", out.gsub(' => ', '=>')
 
       # NOTE: Float::NAN is not jsonable, but hash string can output it.
       out = capture_log { d.feed('test', time, {'test' => Float::NAN}) }
-      assert_equal "#{Time.at(time).localtime.strftime(TIME_FORMAT)} test: {\"test\"=>NaN}\n", out
+      assert_equal "#{Time.at(time).localtime.strftime(TIME_FORMAT)} test: {\"test\"=>NaN}\n", out.gsub(' => ', '=>')
     end
   end
 
@@ -171,7 +171,7 @@ class StdoutOutputTest < Test::Unit::TestCase
           end
         end
 
-        assert_equal "#{Time.at(time).localtime.strftime(TIME_FORMAT)} test: {\"test\"=>\"test\"}\n", out
+        assert_equal "#{Time.at(time).localtime.strftime(TIME_FORMAT)} test: {\"test\"=>\"test\"}\n", out.gsub(' => ', '=>')
       end
     end
   end


### PR DESCRIPTION
Backport https://github.com/fluent/fluentd/pull/4677

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
Hash#inspect style was updated at
https://github.com/ruby/ruby/commit/a8a059125314a411eaf879a9fbfdc68d6c01a667

Since its changing, fluentd's CI fails with Ruby HEAD. https://github.com/fluent/fluentd/actions/runs/11427054212

This patch will recognize that style changing due to pass the CI tests.

**Docs Changes**:

**Release Note**: 
