### PR TITLE
Backport(v1.16): file_single_chunk: use URI::RFC2396_PARSER due to suppress obsoleted message (#4774)

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("strptime", [">= 0.2.4", "< 1.0.0"])
   gem.add_runtime_dependency("webrick", ["~> 1.4"])
   gem.add_runtime_dependency("console", ["< 1.24"])
+  gem.add_runtime_dependency("uri", '~> 1.0')
 
   # gems that aren't default gems as of Ruby 3.4
   gem.add_runtime_dependency("base64", ["~> 0.2"])

--- a/lib/fluent/plugin/buffer/file_single_chunk.rb
+++ b/lib/fluent/plugin/buffer/file_single_chunk.rb
@@ -238,17 +238,16 @@ module Fluent
           callback.call(file) if callback
         end
 
-        URI_PARSER = URI::Parser.new
         ESCAPE_REGEXP = /[^-_.a-zA-Z0-9]/n
 
         def encode_key(metadata)
           k = @key ? metadata.variables[@key] : metadata.tag
           k ||= ''
-          URI_PARSER.escape(k, ESCAPE_REGEXP)
+          URI::RFC2396_PARSER.escape(k, ESCAPE_REGEXP)
         end
 
         def decode_key(key)
-          URI_PARSER.unescape(key)
+          URI::RFC2396_PARSER.unescape(key)
         end
 
         def create_new_chunk(path, metadata, perm)


### PR DESCRIPTION
https://github.com/fluent/fluentd/pull/4774

**Which issue(s) this PR fixes**:
Fixes #

**What this PR does / why we need it**:
Since Ruby 3.4.0, `URI::DEFAULT_PARSER` causes warning of `warning: URI::RFC3986_PARSER.unescape is obsolete. Use
URI::RFC2396_PARSER.unescape explicitly.`.
Ref.
https://github.com/ruby/uri/commit/9997c1aceedfc205aa4f956b17d09b88feaf2fe2

* reproduce
```
$ bundle exec ruby -v -w -I"lib" test/plugin/test_buffer_file_single_chunk.rb -v
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [x86_64-linux]
/home/watson/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/async-2.21.1/lib/async/task.rb:298: warning: assigned but unused variable - error
/home/watson/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/async-pool-0.10.2/lib/async/pool/controller.rb:332: warning: assigned but unused variable - error
/home/watson/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/traces-0.14.1/lib/traces/config.rb:43: warning: assigned but unused variable - error
/home/watson/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/async-http-0.86.0/lib/async/http/protocol/http1/server.rb:55: warning: assigned but unused variable - error
/home/watson/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/async-http-0.86.0/lib/async/http/protocol/http2/connection.rb:98: warning: assigned but unused variable - ignored_error
/home/watson/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/protocol-http-0.47.1/lib/protocol/http/body/stream.rb:263: warning: assigned but unused variable - buffer
/home/watson/src/fluentd/lib/fluent/plugin_helper.rb:46: warning: method redefined; discarding old inherited
/home/watson/src/fluentd/lib/fluent/plugin_helper.rb:46: warning: previous definition of inherited was here
Loaded suite test/plugin/test_buffer_file_single_chunk
Started
BufferFileSingleChunkTest:
  chunk with file for enqueued chunk:
    test: can load as queued chunk (read only) with metadata:																		/home/watson/src/fluentd/lib/fluent/plugin/buffer/file_single_chunk.rb:250: warning: URI::RFC3986_PARSER.unescape is obsolete. Use URI::RFC2396_PARSER.unescape explicitly.
.: (0.001127)
  chunk with file for staged chunk:
    test: #file_rename can rename chunk files even in windows, and call callback with file size:													/home/watson/src/fluentd/lib/fluent/plugin/buffer/file_single_chunk.rb:250: warning: URI::RFC3986_PARSER.unescape is obsolete. Use URI::RFC2396_PARSER.unescape explicitly.
.: (0.000559)
    test: can be enqueued:																						/home/watson/src/fluentd/lib/fluent/plugin/buffer/file_single_chunk.rb:250: warning: URI::RFC3986_PARSER.unescape is obsolete. Use URI::RFC2396_PARSER.unescape explicitly.
.: (0.000361)
    test: can load as staged chunk from file with metadata:																		/home/watson/src/fluentd/lib/fluent/plugin/buffer/file_single_chunk.rb:250: warning: URI::RFC3986_PARSER.unescape is obsolete. Use URI::RFC2396_PARSER.unescape explicitly.
.: (0.000307)
  chunk with queued chunk file:
    test: can load as queued chunk:																					/home/watson/src/fluentd/lib/fluent/plugin/buffer/file_single_chunk.rb:250: warning: URI::RFC3986_PARSER.unescape is obsolete. Use URI::RFC2396_PARSER.unescape explicitly.
.: (0.000431)

...(snip)...
```

<img
src="https://github.com/user-attachments/assets/86240335-dc86-44f9-880f-a16a8992deed" width="50%" />

This patch will use `URI::RFC2396_PARSER` instead due to suppress above warning.

* NOTE:
* `URI::RFC2396_PARSER` constant was introduced since v0.12.3 which bundled in Ruby 3.2.
  * See https://github.com/ruby/uri/issues/118

**Docs Changes**:

**Release Note**:
