### PR TITLE
Backport(v1.16): gem: use latest net-http to solve IPv6 addr error (#5162)

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -30,6 +30,8 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("strptime", [">= 0.2.4", "< 1.0.0"])
   gem.add_runtime_dependency("webrick", ["~> 1.4"])
   gem.add_runtime_dependency("console", ["< 1.24"])
+  gem.add_runtime_dependency("uri", '~> 1.0')
+  gem.add_runtime_dependency("net-http", '~> 0.8')
 
   # gems that aren't default gems as of Ruby 3.4
   gem.add_runtime_dependency("base64", ["~> 0.2"])


### PR DESCRIPTION
Backport https://github.com/fluent/fluentd/pull/5162

**Which issue(s) this PR fixes**:
Fixes #5141

**What this PR does / why we need it**:
`net-http` had a bug in handling IPv6 addresses, and updating the `uri` would trigger strict checking, causing errors.

This PR will use `net-http` that has the bug fixed.

**Docs Changes**:
N/A

**Release Note**:
gem: use latest net-http to solve IPv6 addr error
