### PR TITLE
command/fluentd: load win32/registry when edit registry for Ruby 4.0

### DIFF
--- a/lib/fluent/command/fluentd.rb
+++ b/lib/fluent/command/fluentd.rb
@@ -344,6 +344,7 @@ if winsvcinstmode = opts[:regwinsvc]
 end
 
 if fluentdopt = opts[:fluentdopt]
+  require "win32/registry"
   Win32::Registry::HKEY_LOCAL_MACHINE.open("SYSTEM\\CurrentControlSet\\Services\\#{opts[:winsvc_name]}", Win32::Registry::KEY_ALL_ACCESS) do |reg|
     reg['fluentdopt', Win32::Registry::REG_SZ] = fluentdopt
   end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
When edit Windows registry like `ruby bin/fluentd --reg-winsvc-fluentdopt "-c '$current_path/duplicated_id.conf' -o '$log_path'"`,
Ruby 4.0 causes `uninitialized constant Win32::Registry (NameError)`.

Ref. https://github.com/fluent/fluentd/actions/runs/20650937408/job/59296698869

Ruby 3.4 has bundled resolv v0.6.2, which loads `win32/registry`.
https://github.com/ruby/resolv/blob/a28aaed4cb700303227f0e81178baf93d6221621/ext/win32/resolv/lib/resolv.rb#L46C15-L46C31
Therefore, we can use `Win32::Registry` implicitly after loading resolv.

It has been removed in the latest version of resolv gem.

**Docs Changes**:

**Release Note**: 
