### PR TITLE
ci: explicitly return status code

### DIFF
--- a/tasks/backport.rb
+++ b/tasks/backport.rb
@@ -37,7 +37,7 @@ namespace :backport do
     backporter = PullRequestBackporter.new
     commands = ['--branch', 'v1.16', '--log-level', 'debug']
     commands = append_additional_arguments(commands)
-    backporter.run(commands)
+    eixt(backporter.run(commands))
   end
 
   desc "Backport PR to v1.19 branch"
@@ -45,6 +45,6 @@ namespace :backport do
     commands = ['--branch', 'v1.19', '--log-level', 'debug']
     commands = append_additional_arguments(commands)
     backporter = PullRequestBackporter.new
-    backporter.run(commands)
+    exit(backporter.run(commands))
   end
 end

--- a/tasks/backport/backporter.rb
+++ b/tasks/backport/backporter.rb
@@ -148,6 +148,7 @@ class PullRequestBackporter
     failed.each do |backport|
       @logger.error "FAILED: #{backport[:number]} #{backport[:title]}"
     end
+    failed.empty?
   end
 
   def run(argv)


### PR DESCRIPTION

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

This PR is follow-up of #5169.

backporter should return true(success)/false(failure) and it should be handled as exit status.

This commit fixes silent failure when cherry-pick fails

**Docs Changes**:

N/A

**Release Note**: 

N/A