### PR TITLE
ci: set git identity to fill-up comitter identity

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -33,6 +33,10 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
+      - name: Set up git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
       - name: Run backport task ( ${{ matrix.task }} )
         shell: bash
         env:


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

Follow-up of #5169

It fixes the following error:

    D, [2026-01-07T01:32:37.666456 #2171] DEBUG -- : git cherry-pick --signoff 9aa0a5bfbaabe44b530cbc13617d86d685307216
    Committer identity unknown

    *** Please tell me who you are.
    
    Run
    
    git config --global user.email "you@example.com"
    git config --global user.name "Your Name"

    to set your account's default identity.
    Omit --global to set the identity only in this repository.

ref. https://github.com/actions/checkout?tab=readme-ov-file#push-a-commit-using-the-built-in-token

**Docs Changes**:

N/A

**Release Note**: 

N/A
