### PR TITLE
ci: drop v1.16 backport task

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version: ['3.4']
-        task: ['backport:v1_16', 'backport:v1_19']
+        task: ['backport:v1_19']
 
     name: Backport PR ( ${{ matrix.task }} )
     steps:

--- a/tasks/backport.rb
+++ b/tasks/backport.rb
@@ -32,14 +32,6 @@ end
 
 namespace :backport do
 
-  desc "Backport PR to v1.16 branch"
-  task :v1_16 do
-    backporter = PullRequestBackporter.new
-    commands = ['--branch', 'v1.16', '--log-level', 'debug']
-    commands = append_additional_arguments(commands)
-    exit(backporter.run(commands))
-  end
-
   desc "Backport PR to v1.19 branch"
   task :v1_19 do
     commands = ['--branch', 'v1.19', '--log-level', 'debug']


### PR DESCRIPTION

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

v1.16 had reached EOL, so no need anymore.

**Docs Changes**:

N/A

**Release Note**: 

N/A
