### PR TITLE
plugin_helper/http_server: Ensure request body is closed to prevent socket leaks in POST requests

### DIFF
--- a/lib/fluent/plugin_helper/http_server/app.rb
+++ b/lib/fluent/plugin_helper/http_server/app.rb
@@ -71,6 +71,8 @@ module Fluent
                 path
               end
             @router.route!(name, canonical_path, req)
+          ensure
+            request.body&.close
           end
         end
       end

--- a/test/plugin_helper/http_server/test_app.rb
+++ b/test/plugin_helper/http_server/test_app.rb
@@ -37,7 +37,7 @@ unless skip
       test 'dispatch correct path' do |method|
         r = DummyRouter.new(method.downcase.to_sym => { '/path/' => 'hi' })
         app = Fluent::PluginHelper::HttpServer::App.new(r, NULL_LOGGER)
-        m = flexmock('request', method: method, path: '/path/')
+        m = flexmock('request', method: method, path: '/path/', body: nil)
         r = app.call(m)
         assert_equal(r.body.read, 'hi')
         assert_equal(r.status, 200)
@@ -46,7 +46,7 @@ unless skip
       test 'dispatch correct path for head' do |method|
         r = DummyRouter.new(head: { '/path/' => 'hi' })
         app = Fluent::PluginHelper::HttpServer::App.new(r, NULL_LOGGER)
-        m = flexmock('request', method: method, path: '/path')
+        m = flexmock('request', method: method, path: '/path', body: nil)
         r = app.call(m)
         assert_equal(r.body.read, '')
         assert_equal(r.status, 200)
@@ -55,7 +55,7 @@ unless skip
       test 'if path does not end with `/`' do |method|
         r = DummyRouter.new(head: { '/path/' => 'hi' })
         app = Fluent::PluginHelper::HttpServer::App.new(r, NULL_LOGGER)
-        m = flexmock('request', method: method, path: '/path')
+        m = flexmock('request', method: method, path: '/path', body: nil)
         r = app.call(m)
         assert_equal(r.body.read, '')
         assert_equal(r.status, 200)


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes https://github.com/fluent-plugins-nursery/fluent-plugin-opentelemetry/issues/24

**What this PR does / why we need it**: 
When using the `http_server` helper to handle POST requests (e.g., in plugins like `fluent-plugin-opentelemetry`),
a socket leak occurs, eventually leading to `Errno::EMFILE` (Too many open files).

This happens because `Async::HTTP` requires the request body to be fully consumed or explicitly closed to release the resources and allow connection reuse (Keep-Alive). If the body is left unclosed, the socket remains in a CLOSE_WAIT state on the server side indefinitely.

**Docs Changes**:
N/A

**Release Note**: 
* plugin_helper/http_server: Ensure request body is closed to prevent socket leaks in POST requests