### PR TITLE
tail: warn shorter rotate_wait on Windows

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -73,7 +73,7 @@ module Fluent::Plugin
     desc 'The paths to exclude the files from watcher list.'
     config_param :exclude_path, :array, default: []
     desc 'Specify interval to keep reference to old file when rotate a file.'
-    config_param :rotate_wait, :time, default: 5
+    config_param :rotate_wait, :time, default: (Fluent.windows? ? 10 : 5)
     desc 'Fluentd will record the position it last read into this file.'
     config_param :pos_file, :string, default: nil
     desc 'The cleanup interval of pos file'
@@ -181,6 +181,12 @@ module Fluent::Plugin
         end
         log.warn "'pos_file PATH' parameter is not set to a 'tail' source."
         log.warn "this parameter is highly recommended to save the position to resume tailing."
+      end
+
+      if Fluent.windows?
+        if @rotate_wait < 10
+          log.warn "'rotate_wait SECONDS' parameter should not be less than 10s on Windows."
+        end
       end
 
       configure_tag

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -2496,6 +2496,28 @@ class TailInputTest < Test::Unit::TestCase
     end
   end
 
+  sub_test_case "rotate_wait" do
+    test 'default value of rotate_wait must be 5 on non windows' do
+      omit 'skip checking with rotate_wait == 5 on Windows' if Fluent.windows?
+      c = config_element("", "", { "tag" => "t1", "path" => "#{@tmp_dir}/tail.txt" })
+      d = create_driver(c + SINGLE_LINE_CONFIG + PARSE_SINGLE_LINE_CONFIG, false)
+      assert_equal(5, d.instance.rotate_wait)
+    end
+
+    test 'default value of rotate_wait must be 10 on windows' do
+      omit 'skip checking with rotate_wait == 10 on non Windows 10' unless Fluent.windows?
+      c = config_element("", "", { "tag" => "t1", "path" => "#{@tmp_dir}/tail.txt" })
+      d = create_driver(c + SINGLE_LINE_CONFIG + PARSE_SINGLE_LINE_CONFIG, false)
+      assert_equal(10, d.instance.rotate_wait)
+    end
+
+    test 'warn rotate_wait < 10 on windows' do
+      omit 'skip checking with rotate_wait < 10 on non Windows' unless Fluent.windows?
+      d = create_driver
+      assert(d.logs.any?{|log| log.include?("'rotate_wait SECONDS' parameter should not be less than 10s on Windows.") })
+    end
+  end
+
   def test_limit_recently_modified
     now = Time.new(2010, 1, 2, 3, 4, 5)
     FileUtils.touch("#{@tmp_dir}/tail_unwatch.txt", mtime: (now - 3601))


### PR DESCRIPTION

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

The combination with shorter rotate_wait and log rotation might cause "Permission denied @ io_getpartial" when colleting Fluentd logs.

It results in missing tracking partial Fluentd logs.

To mitigate conflicts about file locking during log rotation, relax rotate_wait timespan.

**Docs Changes**:

**Release Note**: 
