### PR TITLE
warn recommended exclusion path for antivirus

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -814,6 +814,20 @@ module Fluent
         @conf += additional_conf
       end
 
+      if Fluent.windows?
+        @conf.elements.each do |element|
+          next unless element.name == 'source'
+          if element['@type'] == 'tail' && element['pos_file']
+            $log.warn("Recommend adding #{File.dirname(element['pos_file'])} to the exclusion path of your antivirus software on Windows")
+          else
+            storage = element.elements.find { |v| v.name == 'storage' and v['@type'] == 'local' }
+            if storage
+              $log.warn("Recommend adding #{File.dirname(storage['path'])} to the exclusion path of your antivirus software on Windows")
+            end
+          end
+        end
+      end
+
       @libs.each do |lib|
         require lib
       end

--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -1679,4 +1679,37 @@ CONF
     end
   end
 
+  sub_test_case "test suspicious harmful antivirus exclusion path" do
+    test "warn pos_file path" do
+      omit "skip recommendation warnings about exclusion path for antivirus" unless Fluent.windows?
+      conf_path = create_conf_file("foo.conf", <<~EOF)
+        <source>
+          @type tail
+          tag t1
+          path #{@tmp_dir}/test.log
+          pos_file #{@tmp_dir}/test.pos
+        </source>
+      EOF
+      expected_warning_message = "[warn]: Recommend adding #{@tmp_dir} to the exclusion path of your antivirus software on Windows"
+      assert_log_matches(create_cmdline(conf_path, '--dry-run'),
+                         expected_warning_message)
+    end
+
+    test "warn storage path" do
+      omit "skip recommendation warnings about exclusion path for antivirus" unless Fluent.windows?
+      conf_path = create_conf_file("foo.conf", <<~EOF)
+        <source>
+          @type sample
+          tag t1
+          <storage>
+            @type local
+            path #{@tmp_dir}/test.pos
+          </storage>
+        </source>
+      EOF
+      expected_warning_message = "[warn]: Recommend adding #{@tmp_dir} to the exclusion path of your antivirus software on Windows"
+      assert_log_matches(create_cmdline(conf_path, '--dry-run'),
+                         expected_warning_message)
+    end
+  end
 end


### PR DESCRIPTION

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

It might be better that recommended exclusion path for antivirus because pos file or storage local file might be scanned by antivirus thus there might be possibility to be locked by them.

**Docs Changes**:

**Release Note**: 
