### PR TITLE
gem: add ostruct gem as dependency for Ruby 4.0

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -51,6 +51,9 @@ Gem::Specification.new do |gem|
   # gems that aren't default gems as of Ruby 3.5
   gem.add_runtime_dependency("logger", ["~> 1.6"])
 
+  # gems that aren't default gems as of Ruby 4.0
+  gem.add_runtime_dependency("ostruct", ["~> 0.6"])
+
   # build gem for a certain platform. see also Rakefile
   fake_platform = ENV['GEM_BUILD_FAKE_PLATFORM'].to_s
   gem.platform = fake_platform unless fake_platform.empty?


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
We need to specify the `ostruct` gem as dependency because it is a bundled gem from Ruby 4.0.

https://github.com/ruby/ruby/blob/e4dd078a2734f1f3b7169feb4da8c68587effc6e/gems/bundled_gems#L38

This PR will fix following error.

```
/opt/hostedtoolcache/Ruby/4.0.1/x64/lib/ruby/4.0.0/bundled_gems.rb:60:in 'Kernel.require': cannot load such file -- ostruct (LoadError)
Did you mean?  tsort
	from /opt/hostedtoolcache/Ruby/4.0.1/x64/lib/ruby/4.0.0/bundled_gems.rb:60:in 'block (2 levels) in Kernel#replace_require'
	from /home/runner/work/fluentd/fluentd/lib/fluent/plugin/filter_record_transformer.rb:19:in '<top (required)>'
	from /opt/hostedtoolcache/Ruby/4.0.1/x64/lib/ruby/4.0.0/bundled_gems.rb:60:in 'Kernel.require'
	from /opt/hostedtoolcache/Ruby/4.0.1/x64/lib/ruby/4.0.0/bundled_gems.rb:60:in 'block (2 levels) in Kernel#replace_require'
	from /home/runner/work/fluentd/fluentd/test/plugin/test_filter_record_transformer.rb:4:in '<top (required)>'
	from /opt/hostedtoolcache/Ruby/4.0.1/x64/lib/ruby/4.0.0/bundled_gems.rb:60:in 'Kernel.require'
	from /opt/hostedtoolcache/Ruby/4.0.1/x64/lib/ruby/4.0.0/bundled_gems.rb:60:in 'block (2 levels) in Kernel#replace_require'
	from /opt/hostedtoolcache/Ruby/4.0.1/x64/lib/ruby/gems/4.0.0/gems/rake-13.3.1/lib/rake/rake_test_loader.rb:21:in 'block in <main>'
	from /opt/hostedtoolcache/Ruby/4.0.1/x64/lib/ruby/gems/4.0.0/gems/rake-13.3.1/lib/rake/rake_test_loader.rb:6:in 'Array#select'
	from /opt/hostedtoolcache/Ruby/4.0.1/x64/lib/ruby/gems/4.0.0/gems/rake-13.3.1/lib/rake/rake_test_loader.rb:6:in '<main>'
rake aborted!
```
https://github.com/fluent/fluentd/actions/runs/21718510028/job/62697972725?pr=5239#step:6:22

Ref. https://github.com/fluent/fluentd/blob/82acf75ad6da7c43797bcb8dedcde5570ad15242/lib/fluent/plugin/filter_record_transformer.rb#L19


**Docs Changes**:
N/A

**Release Note**: 
* gem: add ostruct gem as dependency for Ruby 4.0
