### PR TITLE
filter_record_transformer: use cgi/escape to avoid Ruby 4.0 deprecation

### DIFF
--- a/lib/fluent/plugin/filter_record_transformer.rb
+++ b/lib/fluent/plugin/filter_record_transformer.rb
@@ -71,7 +71,7 @@ module Fluent::Plugin
           # require utilities which would be used in ruby placeholders
           require 'pathname'
           require 'uri'
-          require 'cgi'
+          require 'cgi/escape'
           RubyPlaceholderExpander.new(placeholder_expander_params)
         else
           PlaceholderExpander.new(placeholder_expander_params)

--- a/test/plugin/test_filter_record_transformer.rb
+++ b/test/plugin/test_filter_record_transformer.rb
@@ -557,6 +557,25 @@ class RecordTransformerFilterTest < Test::Unit::TestCase
         assert_equal([message["@timestamp"]], r['foo'])
       end
     end
+
+    test 'CGI.escape / CGI.unescape' do
+      config = %[
+        tag tag
+        enable_ruby yes
+        <record>
+          encoded_url ${CGI.escape(record["url"])}
+          decoded_text ${CGI.unescape(record["quoted"])}
+        </record>
+      ]
+      d = create_driver(config)
+      message = {"url": "http://example.com/?q=ruby & cgi", "quoted": "hello%21"}
+      d.run { d.feed(@tag, @time, message) }
+      filtered = d.filtered
+      filtered.each do |t, r|
+        assert_equal("http%3A%2F%2Fexample.com%2F%3Fq%3Druby+%26+cgi", r['encoded_url'])
+        assert_equal("hello!", r['decoded_text'])
+      end
+    end
   end # test placeholders
 
   sub_test_case 'test error record' do


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

This PR will fix the following warning in Ruby 4.0:
```
"warning: CGI library is removed from Ruby 4.0. Please use cgi/escape instead"
```

Ref. https://github.com/ruby/ruby/pull/13275

By using `cgi/escape`, we provide the necessary methods (CGI.escape/unescape)
for Ruby placeholders.

In additional, this PR will add test cases for `CGI.escape/unescape` in `filter_record_transformer.rb`

**Reproduce**:

```
$ RUBYOPT="--disable-frozen_string_literal" ruby -w -I'lib:test' test/plugin/test_filter_record_transformer.rb
/home/watson/src/fluentd/lib/fluent/plugin_helper.rb:46: warning: method redefined; discarding old inherited
/home/watson/src/fluentd/lib/fluent/plugin_helper.rb:46: warning: previous definition of inherited was here
Loaded suite test/plugin/test_filter_record_transformer
Started
//home/watson/src/fluentd/lib/fluent/plugin/filter_record_transformer.rb:74: warning: CGI library is removed from Ruby 4.0. Please use cgi/escape instead for CGI.escape and CGI.unescape features.
If you need to use the full features of CGI library, Please install cgi gem.
Finished in 0.058886954 seconds.
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
44 tests, 116 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
747.19 tests/s, 1969.88 assertions/s
```

**Docs Changes**:
N/A

**Release Note**: 
* filter_record_transformer: use cgi/escape to avoid Ruby 4.0 deprecation