### PR TITLE
Backport(v1.19): ci: disable warning of frozen_string_literal (#5250)

### DIFF
--- a/.github/workflows/test-ruby-head.yml
+++ b/.github/workflows/test-ruby-head.yml
@@ -16,7 +16,8 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         ruby-version: ['head']
-
+    env:
+      RUBYOPT: "--disable-frozen_string_literal"
     name: Ruby ${{ matrix.ruby-version }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,8 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         ruby-version: ['4.0', '3.4', '3.3', '3.2']
+    env:
+      RUBYOPT: "--disable-frozen_string_literal"
     name: Ruby ${{ matrix.ruby-version }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Backport https://github.com/fluent/fluentd/pull/5250
Fixes #

**What this PR does / why we need it**:
Related to #4585

Too many warning messages may lead to important ones being overlooked So this PR will disable warnings about frozen-string-literal.

**Docs Changes**:

**Release Note**:
