### PR TITLE
rake: check GEM_HOST_API_KEY in advance

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -79,4 +79,11 @@ task :coverity do
   FileUtils.rm_rf(['./cov-int', 'cov-fluentd.tar.gz'])
 end
 
+task :check_env do
+  unless ENV['GEM_HOST_API_KEY']
+    abort "Missing required environment variable: GEM_HOST_API_KEY\nSee https://guides.rubygems.org/api-key-scopes/"
+  end
+end
+Rake::Task["release:rubygem_push"].enhance(["check_env"])
+
 task default: [:test, :build]


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

Without it, if you terminate process, you must
manually gem push variant gems such as
-x64-mingw-ucrt.gem, -x64-mingw32.gem and -x86-mingw32.gem.

e.g.

  > rake release
  fluentd 1.19.0 built to pkg/fluentd-1.19.0.gem.
  Tag v1.19.0 has already been created.
  Missing required environment variable: GEM_HOST_API_KEY
  See https://guides.rubygems.org/api-key-scopes/

**Docs Changes**:

N/A

**Release Note**: 

N/A