### PR TITLE
in_debug_agent: accept only from local machine by default

### DIFF
--- a/lib/fluent/plugin/in_debug_agent.rb
+++ b/lib/fluent/plugin/in_debug_agent.rb
@@ -26,7 +26,7 @@ module Fluent::Plugin
       super
     end
 
-    config_param :bind, :string, default: '0.0.0.0'
+    config_param :bind, :string, default: '127.0.0.1'
     config_param :port, :integer, default: 24230
     config_param :unix_path, :string, default: nil
     #config_param :unix_mode  # TODO

--- a/test/plugin/test_in_debug_agent.rb
+++ b/test/plugin/test_in_debug_agent.rb
@@ -46,4 +46,12 @@ class DebugAgentInputTest < Test::Unit::TestCase
       assert_false d.instance.multi_workers_ready?
     end
   end
+
+  def test_default_configuration
+    assert_nothing_raised do
+      d = create_driver
+      assert_equal(['127.0.0.1', 24230, 'Fluent::Engine'],
+                   [d.instance.bind, d.instance.port, d.instance.object])
+    end
+  end
 end


### PR DESCRIPTION

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

Usually, in_debug_agent must be explicitly enabled by users who know what you do.
But, there is an security concern which accepts external access by default even though user must enable it explicitly.

With this commit, change that behavior a bit secure by default.

**Docs Changes**:

Need to update default.

https://docs.fluentd.org/monitoring-fluentd/monitoring-rest-api#datadog-dd-agent-integration

**Release Note**: 

N/A
