### PR TITLE
ci: fix excessive GitHub workflow token permissions

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,8 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}
@@ -16,6 +15,9 @@ concurrency:
 
 jobs:
   test:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     continue-on-error: false
     strategy:


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #5273

**What this PR does / why we need it**: 
Moves `contents: write` and `pull-requests: write` permissions from the workflow level to the job level in `backport.yml`, and sets the workflow-level permissions to `contents: read`. This follows the principle of least privilege and resolves the OpenSSF Scorecard Token-Permissions warning.

**Docs Changes**:
N/A

**Release Note**: 
N/A