### PR TITLE
buffer: warn if default timekey (1d) will be used

### DIFF
--- a/lib/fluent/plugin/out_file.rb
+++ b/lib/fluent/plugin/out_file.rb
@@ -117,7 +117,17 @@ module Fluent::Plugin
       configured_time_slice_format = conf['time_slice_format']
 
       if conf.elements(name: 'buffer').empty?
+        # no <buffer> section, default time chunk key and timekey (1d) will be used.
+        log.warn "default timekey interval (1d) will be used because of missing <buffer> section. To change the output frequency, please modify the timekey value"
+
         conf.add_element('buffer', 'time')
+      else
+        unless conf.elements(name: 'buffer').first.has_key?('timekey')
+          if conf.elements(name: 'buffer').first.arg != "[]"
+            # with <buffer> section (except <buffer []>), and no timekey
+            log.warn "default timekey interval (1d) will be used. To change the output frequency, please modify the timekey value"
+          end
+        end
       end
       buffer_conf = conf.elements(name: 'buffer').first
       # Fluent::PluginId#configure is not called yet, so we can't use #plugin_root_dir here.

--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -1712,4 +1712,52 @@ CONF
                          expected_warning_message)
     end
   end
+
+  sub_test_case "test suspicious timekey interval (1d) in out_file configuration" do
+    data('without buffer' => {buffer: nil, buffer_arg: nil, message: :missing_buffer},
+         'buffer' => {buffer: true, buffer_arg: '', message: :warning},
+         'buffer time' => {buffer: true, buffer_arg: 'time', message: :warning},
+         'buffer []' => {buffer: true, buffer_arg: '[]', message: nil})
+    test 'warn the default value of timekey (1d) is used as-is' do |data|
+      prefix = "default timekey interval (1d) will be used"
+      advice = "To change the output frequency, please modify the timekey value"
+      missing_warning = "#{prefix} because of missing <buffer> section. #{advice}"
+      warning = "#{prefix}. #{advice}"
+
+      conf_path = if data[:buffer]
+                    create_conf_file("warning.conf", <<~EOF)
+                      <system>
+                        config_include_dir ""
+                      </system>
+                      <match>
+                        @type file
+                        tag test
+                        path #{@tmp_dir}/test.log
+                        <buffer #{data[:buffer_arg]}>
+                          @type file
+                        </buffer>
+                      </match>
+                    EOF
+                  else
+                    create_conf_file("warning.conf", <<~EOF)
+                      <system>
+                        config_include_dir ""
+                      </system>
+                      <match>
+                        @type file
+                        tag test
+                        path #{@tmp_dir}/test.log
+                      </match>
+                    EOF
+      end
+      case data[:message]
+      when :missing_buffer
+        assert_log_matches(create_cmdline(conf_path, '--dry-run'), missing_warning, patterns_not_match: [warning])
+      when :warning
+        assert_log_matches(create_cmdline(conf_path, '--dry-run'), "warning", patterns_not_match: [missing_warning])
+      else
+        assert_log_matches(create_cmdline(conf_path, '--dry-run'), patterns_not_match: [warning, missing_warning])
+      end
+    end
+  end
 end


### PR DESCRIPTION

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

By default, the value of timekey interval was set as interval 1d. Without changing flush related parameters, it will not be flushed at all in that period. This behavior is intentional design, but it might be surprised in some use cases.

So, in some doubtful use-case, emit warning for it.

```
Before:

  no buffer configuration # no warning

  <buffer>
    @type file # no warning
  </buffer>

  <buffer time>
    @type file # no warning
  </buffer>

  <buffer []>
    @type file # no warning
  </buffer>

After:

  no buffer configuration # warning

  <buffer>
    @type file # warning
  </buffer>

  <buffer time>
    @type file # warning
  </buffer>

  <buffer []>
    @type file # no warning
  </buffer>

```

**Docs Changes**:

N/A

**Release Note**: 

N/A
