### PR TITLE
formatter_out_file: Improve performance by using string interpolation

### DIFF
--- a/lib/fluent/plugin/formatter_out_file.rb
+++ b/lib/fluent/plugin/formatter_out_file.rb
@@ -44,10 +44,9 @@ module Fluent
 
       def format(tag, time, record)
         json_str = JSON.generate(record)
-        header = ''
-        header << "#{@timef.format(time)}#{@delimiter}" if @output_time
-        header << "#{tag}#{@delimiter}" if @output_tag
-        "#{header}#{json_str}#{@newline}"
+        time_str = @output_time ? "#{@timef.format(time)}#{@delimiter}" : ''
+        tag_str = @output_tag ? "#{tag}#{@delimiter}" : ''
+        "#{time_str}#{tag_str}#{json_str}#{@newline}"
       ensure
         json_str&.clear
       end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
Replaced `String#<<` with string interpolation (`#{}`) when building the output line.
This avoids unnecessary buffer expansions (reallocations) and significantly improves performance, particularly on Windows.

## Micro benchmark
```ruby
require 'bundler/inline'
gemfile do
  source 'https://rubygems.org'
  gem 'benchmark-ips'
end

Benchmark.ips do |x|

  tag = "sample"
  delimiter = "\t"
  data = "x" * 256

  x.report("interpolation") {
    "#{tag}#{delimiter}#{data}"
  }

  x.report("concatenation") {
    output = ''
    output << tag << delimiter << data
    output
  }

  x.compare!
end
```

* Result on Windows
```
ruby 4.0.1 (2026-01-13 revision e04267a14b) +PRISM [x64-mingw-ucrt]
Warming up --------------------------------------
       interpolation     1.591M i/100ms
       concatenation   453.294k i/100ms
Calculating -------------------------------------
       interpolation     15.930M (± 1.4%) i/s   (62.77 ns/i) -     81.148M in   5.094948s
       concatenation      6.068M (±22.3%) i/s  (164.79 ns/i) -     29.011M in   5.034606s

Comparison:
       interpolation: 15930005.2 i/s
       concatenation:  6068356.8 i/s - 2.63x  slower
```

* Result on Linux
```
ruby 4.0.1 (2026-01-13 revision e04267a14b) +PRISM [x86_64-linux]
Warming up --------------------------------------
       interpolation     1.831M i/100ms
       concatenation     1.113M i/100ms
Calculating -------------------------------------
       interpolation     18.224M (± 1.4%) i/s   (54.87 ns/i) -     91.567M in   5.025463s
       concatenation     10.988M (± 1.9%) i/s   (91.01 ns/i) -     55.664M in   5.067939s

Comparison:
       interpolation: 18224325.9 i/s
       concatenation: 10987507.2 i/s - 1.66x  slower
```

### Fluentd benchmark
Run `rake benchmark:run:in_tail` with 10 GB data on Windows.
**~7% faster** by this changing.

* Before
```
       user     system      total        real
  38.438000  18.079000  56.517000 ( 48.443897)
```

* After
```
user     system      total        real
  35.078000  17.625000  52.703000 ( 45.104038)
```
**Docs Changes**:
N/A

**Release Note**: 
* formatter_out_file: Improve performance by using string interpolation