### PR TITLE
time: use Numeric#divmod to create Fluent::EventTime instance

### DIFF
--- a/lib/fluent/time.rb
+++ b/lib/fluent/time.rb
@@ -114,7 +114,8 @@ module Fluent
     def self.now
       # This method is called many time. so call Process.clock_gettime directly instead of Fluent::Clock.real_now
       now = Process.clock_gettime(Process::CLOCK_REALTIME, :nanosecond)
-      Fluent::EventTime.new(now / 1_000_000_000, now % 1_000_000_000)
+      sec, nsec = now.divmod(1_000_000_000)
+      Fluent::EventTime.new(sec, nsec)
     end
 
     def self.parse(*args)


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
This PR slightly improves the performance of creating `Fluent::EventTime` instances by replacing separate `/` and `%` operations with a single `divmod` call. 

When run `rake benchmark:run:in_tail` with 10 GB data, here is the result of before/after changing:

&nbsp; | before | after
-- | -- | --
rake benchmark:run:in_tail | 43.305892 | 43.170137 |

### Microbenchmark
```ruby
require 'bundler/inline'
gemfile do
  source 'https://rubygems.org'
  gem 'benchmark-ips'
end

Benchmark.ips do |x|

  now = Process.clock_gettime(Process::CLOCK_REALTIME, :nanosecond)

  x.report("div + mod") {
    now / 1_000_000_000
    now % 1_000_000_000
  }

  x.report("divmod") {
    now.divmod(1_000_000_000)
  }

  x.compare!
end
```

* result
```
ruby 4.0.1 (2026-01-13 revision e04267a14b) +PRISM [x64-mingw-ucrt]
Warming up --------------------------------------
           div + mod   769.369k i/100ms
              divmod     1.053M i/100ms
Calculating -------------------------------------
           div + mod      7.356M (± 3.6%) i/s  (135.94 ns/i) -     36.930M in   5.027199s
              divmod     10.262M (± 5.5%) i/s   (97.45 ns/i) -     51.612M in   5.045684s

Comparison:
              divmod: 10262087.7 i/s
           div + mod:  7356170.0 i/s - 1.40x  slower
```


**Docs Changes**:
N/A

**Release Note**: 
* core: Improve performance of Fluent::EventTime creation using divmod