### PR TITLE
output: memoize calculate_timekey to reduce redundant calculations

### DIFF
--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -927,11 +927,14 @@ module Fluent
 
       def calculate_timekey(time)
         time_int = time.to_i
+        return @calculate_timekey_last_timekey if @calculate_timekey_last_time_int == time_int
+
+        @calculate_timekey_last_time_int = time_int
         if @timekey_use_utc
-          (time_int - (time_int % @timekey)).to_i
+          @calculate_timekey_last_timekey = (time_int - (time_int % @timekey)).to_i
         else
           offset = @calculate_offset ? @calculate_offset.call(time) : @offset
-          (time_int - ((time_int + offset)% @timekey)).to_i
+          @calculate_timekey_last_timekey = (time_int - ((time_int + offset) % @timekey)).to_i
         end
       end
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
`calculate_timekey` is called for every emitted record.
Since logs usually arrive chronologically, consecutive records almost always fall into the same timekey. 
However, the current implementation performs `%` and `to_i` for every single call.

When running `rake benchmark:run:in_tail` with 10 GB of data, this memoization improved the overall throughput:

| Benchmark | before | after |
|---|---|---|
| `rake benchmark:run:in_tail` | 43.170137 | 41.584905 |

**Docs Changes**:
N/A

**Release Note**:
* output: Improve performance by memoizing calculate_timekey 
