### PR TITLE
output: optimize branch condition in metadata generation

### DIFF
--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -903,16 +903,16 @@ module Fluent
         # it's wrong if timezone is configured as one which supports leap second, but it's very rare and
         # we can ignore it (especially in production systems).
         if @chunk_keys.empty?
-          if !@chunk_key_time && !@chunk_key_tag
-            @buffer.metadata()
-          elsif @chunk_key_time && @chunk_key_tag
+          if @chunk_key_time && @chunk_key_tag
             timekey = calculate_timekey(time)
             @buffer.metadata(timekey: timekey, tag: tag)
           elsif @chunk_key_time
             timekey = calculate_timekey(time)
             @buffer.metadata(timekey: timekey)
-          else
+          elsif @chunk_key_tag
             @buffer.metadata(tag: tag)
+          else
+            @buffer.metadata()
           end
         else
           timekey = if @chunk_key_time


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
This PR optimizes the branch conditions inside the `metadata` generation in `Fluent::Plugin::Output`.

In most production use cases, either `time` or `tag` (or both) are used as chunk keys. 

When running `rake benchmark:run:in_tail` with a 10 GB file:

| Benchmark | before (sec) | after (sec) |
|---|---|---|
| `rake benchmark:run:in_tail` | 41.220453 | 40.671516 |

**Docs Changes**:
N/A

**Release Note**: 
* output: optimize branch condition in metadata generation
