### PR TITLE
CI: add v1.19 branch to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
 
   # v1.19 branch
   - package-ecosystem: 'github-actions'


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
This PR adds the `v1.19` branch to the Dependabot configuration for GitHub Actions.
To ensure that the maintenance branch (`v1.19`) is also kept up-to-date with the latest  action updates, similar to the `master` branch.

Ref. https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/customizing-dependabot-prs#targeting-pull-requests-against-a-non-default-branch

**Docs Changes**:
N/A

**Release Note**: 
N/A