### PR TITLE
buffer: resume buffer correctly even though path contains []

### DIFF
--- a/lib/fluent/plugin/buf_file.rb
+++ b/lib/fluent/plugin/buf_file.rb
@@ -247,8 +247,8 @@ module Fluent
 
       def escaped_patterns(patterns)
         patterns.map { |pattern|
-          # '{' '}' are special character in Dir.glob
-          pattern.gsub(/[\{\}]/) { |c| "\\#{c}" }
+          # '{', '}', '[' and ']' are special character in Dir.glob
+          pattern.gsub(/[\{\}\[\]]/) { |c| "\\#{c}" }
         }
       end
     end

--- a/test/plugin/test_output_as_buffered.rb
+++ b/test/plugin/test_output_as_buffered.rb
@@ -2021,4 +2021,53 @@ class BufferedOutputTest < Test::Unit::TestCase
       assert{ @i.rollback_count == 2 }
     end
   end
+
+  sub_test_case 'buffered output feature with resuming buffers' do
+    setup do
+      @tmp_dir = File.expand_path(File.dirname(__FILE__) + "/tmp/resuming-buffers")
+    end
+
+    teardown do
+      FileUtils.rm_rf(@tmp_dir)
+    end
+
+    data('buffer path has no brace {}' => 'test-a',
+         'buffer path has brace {}' => 'test-{a}',
+         'buffer path has bracket []' => 'test-[a]',
+         'buffer path has tag {[]}' => 'test-${tag[0]}')
+    test "resuming buffers which contains special characters in path" do |data|
+      options = {
+        '@type' => 'file',
+        'path' => "#{@tmp_dir}/#{data}",
+        'flush_at_shutdown' => 'false' # keep buffer files
+      }
+      @i = create_output(:buffered)
+      @i.configure(config_element('ROOT','',{},[config_element('buffer','tag',options)]))
+      @i.start
+
+      events = [
+        [event_time('2016-10-05 16:16:16 -0700'), {"message" => "yaaaaaaaaay!"}],
+      ]
+
+      @i.emit_events("test.tag", Fluent::ArrayEventStream.new(events))
+      @i.stop
+      # staged buffer file was created (.b) and not ready to flush by enqueuing (.q) here
+      assert{ @i.buffer.stage.size == 1 && @i.buffer.queue.size == 0  }
+
+      @resumer = create_output(:buffered)
+      @resumer.configure(config_element('ROOT','',{},[config_element('buffer','tag',options)]))
+      @resumer.start
+      begin
+        retry_count ||= 0
+        @resumer.buffer.enqueue_all # workaround for grabbed file handle
+      rescue RuntimeError
+        sleep 0.5
+        retry_count += 1
+        retry if retry_count < 3
+      end
+      # staged buffer (.b) was picked up, then ready to flush by enqueuing (.q)
+      assert{ @resumer.buffer.stage.size == 0 && @resumer.buffer.queue.size == 1 }
+      @resumer.shutdown
+    end
+  end
 end


### PR DESCRIPTION

**Which issue(s) this PR fixes**: 

Fixes #4407

**What this PR does / why we need it**: 

If buffer path contains [] such as "path test/${tag[0]}", when resuming buffer process can't find them without escaping bracket.
Thus buffer files remains under that directory.

NOTE: recommended tag spec is specified in routing documentation, but it is easily shoot your legs in practical use-case, so it is better to take care of that case.

https://docs.fluentd.org/configuration/config-file#interlude-routing

**Docs Changes**:

N/A

**Release Note**: 

N/A
