### PR TITLE
gem: add win32-registry as runtime dependency for Ruby 4.1

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -65,6 +65,9 @@ Gem::Specification.new do |gem|
 
     # gems that aren't default gems as of Ruby 3.5
     gem.add_runtime_dependency("fiddle", ["~> 1.1"])
+
+    # gems that aren't default gems as of Ruby 4.1
+    gem.add_runtime_dependency("win32-registry", ["~> 0.1"])
   end
 
   gem.add_development_dependency("rake", ["~> 13.0"])


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
`win32-registry` gem will be moved from default to bundled gem at Ruby 4.1.
Ref. https://github.com/ruby/ruby/pull/16189

Therefore, if we do not add it as a runtime dependency, it will fail to load.

See https://github.com/fluent/fluentd/actions/runs/23711126803/job/69070953279
```
Error: -03-29 14:45:48 +0000 [error]: cannot load such file -- win32/registry path=\"win32/registry\" error_class=LoadError error=\"cannot load such file -- win32/registry\"\r\n">
  was expected to include:
  <["#0 fluentd worker is now running worker=0",
   "#1 fluentd worker is now running worker=1",
   "#1 adding match pattern=\"dummy\" type=\"null\""]>
D:/a/fluentd/fluentd/test/command/test_fluentd.rb:219:in 'TestFluentdCommand#assert_log_matches'
D:/a/fluentd/fluentd/test/command/test_fluentd.rb:1077:in 'block (2 levels) in <class:TestFluentdCommand>'
```

**Docs Changes**:
N/A

**Release Note**: 
* gem: add win32-registry as runtime dependency for Ruby 4.1
