### PR TITLE
feat(in_exec): add command_timeout option to limit child process exec…

### DIFF
--- a/lib/fluent/plugin/in_exec.rb
+++ b/lib/fluent/plugin/in_exec.rb
@@ -43,6 +43,8 @@ module Fluent::Plugin
     config_param :tag, :string, default: nil
     desc 'The interval time between periodic program runs.'
     config_param :run_interval, :time, default: nil
+    desc 'Command (program) execution timeout.'
+    config_param :command_timeout, :time, default: nil
     desc 'The default block size to read if parser requires partial read.'
     config_param :read_block_size, :size, default: 10240 # 10k
     desc 'The encoding to receive the result of the command, especially for non-ascii characters.'
@@ -86,9 +88,9 @@ module Fluent::Plugin
       options[:external_encoding] = @encoding if @encoding
 
       if @run_interval
-        child_process_execute(:exec_input, @command, interval: @run_interval, **options, &method(:run))
+        child_process_execute(:exec_input, @command, interval: @run_interval, wait_timeout: @command_timeout, **options, &method(:run))
       else
-        child_process_execute(:exec_input, @command, immediate: true, **options, &method(:run))
+        child_process_execute(:exec_input, @command, immediate: true, wait_timeout: @command_timeout, **options, &method(:run))
       end
     end
 

--- a/test/plugin/test_in_exec.rb
+++ b/test/plugin/test_in_exec.rb
@@ -320,10 +320,11 @@ EOC
         </parse>
       ]
       start_time = Time.now
-      d.run(timeout: 3)
+      d.run(timeout: 5) do
+        sleep 1 # avoid to return test immediately
+      end
       elapsed = Time.now - start_time
-
-      assert elapsed < 4, "command should have been killed by command_timeout"
+      assert (elapsed >= 1.0 and elapsed < 5), "command should have been killed by command_timeout"
     end
 
     test 'command_timeout defaults to nil' do

--- a/test/plugin/test_in_exec.rb
+++ b/test/plugin/test_in_exec.rb
@@ -295,4 +295,47 @@ EOC
       assert_match(/LoadError/, event[2]['message'])
     end
   end
+  sub_test_case 'command_timeout' do
+    test 'configure command_timeout' do
+      d = create_driver %[
+        command ruby -e "sleep 10"
+        tag test
+        run_interval 1s
+        command_timeout 1s
+        <parse>
+          @type none
+        </parse>
+      ]
+      assert_equal 1.0, d.instance.command_timeout
+    end
+
+    test 'command_timeout kills long-running child process' do
+      d = create_driver %[
+        command ruby -e "sleep 10"
+        tag test
+        run_interval 5s
+        command_timeout 1s
+        <parse>
+          @type none
+        </parse>
+      ]
+      start_time = Time.now
+      d.run(timeout: 3)
+      elapsed = Time.now - start_time
+
+      assert elapsed < 4, "command should have been killed by command_timeout"
+    end
+
+    test 'command_timeout defaults to nil' do
+      d = create_driver %[
+        command ruby -e "puts 'hello'"
+        tag test
+        run_interval 1s
+        <parse>
+          @type none
+        </parse>
+      ]
+      assert_nil d.instance.command_timeout
+    end
+  end
 end


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes #5319

**What this PR does / why we need it**:
Adds `command_timeout` option to `in_exec` plugin, mirroring the existing
`command_timeout` option in `out_exec`.

Currently, `in_exec` calls `child_process_execute` without `wait_timeout`,
defaulting to `nil` (infinite wait). When the external command hangs,
Fluentd repeatedly shows `previous child process is still running. skipped.`
with no indication of the actual cause, making troubleshooting difficult.

`out_exec` already exposes `command_timeout` which maps to `wait_timeout`
in `child_process_execute`. This PR resolves the inconsistency between
the two plugins.

**Docs Changes**:
https://github.com/fluent/fluentd-docs-gitbook/pull/619

**Release Note**:
Add `command_timeout` option to `in_exec` plugin to kill long-running
child processes and align behavior with `out_exec`.