### PR TITLE
Mark v1.16 out-of-support

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@
 | 1.19.x    | :white_check_mark: |
 | 1.18.x    | :x:                |
 | 1.17.x    | :x:                |
-| 1.16.x    | :white_check_mark: |
+| 1.16.x    | :x:                |
 | <= 1.15.x | :x:                |
 
 ## Reporting a Vulnerability


### PR DESCRIPTION

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

Fluentd v1.16 was maintained for fluent-package v5 LTS, but it was already reached EOL in Dec, 2025.

https://www.fluentd.org/blog/schedule-for-fluent-package-5-eol/

**Docs Changes**:

N/A

**Release Note**: 

N/A
