### PR TITLE
test/base: ensure to shutdown plugin instances

### DIFF
--- a/lib/fluent/test/base.rb
+++ b/lib/fluent/test/base.rb
@@ -70,7 +70,12 @@ module Fluent
           num_waits.times { sleep 0.05 }
           return yield
         ensure
+          @instance.stop
+          @instance.before_shutdown
           @instance.shutdown
+          @instance.after_shutdown
+          @instance.close
+          @instance.terminate
         end
       end
     end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

This PR fixes a thread leak issue where background threads remained alive after test execution. By ensuring the full plugin lifecycle (stop, before_shutdown, shutdown, and after_shutdown) is called in the test driver's base class, all internal threads—such as those managed by plugin helpers—are now properly terminated.

Before:

```
$ ruby -Ilib:test -e "at_exit { puts '--- Thread count at exit: ' + Thread.list.size.to_s;  pp Thread.list }; require './test/test_mixin.rb'"
Loaded suite -e
Started
Finished in 8.348090577 seconds.
-------------------------------------------------------------------------------------------------------------------------------------------
21 tests, 5 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-------------------------------------------------------------------------------------------------------------------------------------------
2.52 tests/s, 0.60 assertions/s
--- Thread count at exit: 33
[#<Thread:0x00007f1d108a7fa8 run>,
 #<Thread:0x00007f1cf34f3500@flush_thread_0 /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1cf34f2fd8@enqueue_thread /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1cf357c648@flush_thread_0 /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1cf357c148@enqueue_thread /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1cf359c8f8@flush_thread_0 /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1cf359c420@enqueue_thread /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1cf3597510@flush_thread_0 /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1cf3596fe8@enqueue_thread /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1cf35949a0@flush_thread_0 /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1cf3594360@enqueue_thread /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1cf35dc570@flush_thread_0 /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1cf35dc070@enqueue_thread /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1cf35dfbd0@flush_thread_0 /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1cf35df720@enqueue_thread /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1cf35ff048@flush_thread_0 /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1cf35fea80@enqueue_thread /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1cf35d1ff8@flush_thread_0 /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1cf35d1b98@enqueue_thread /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1cf35f2f50@flush_thread_0 /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1cf35f2870@enqueue_thread /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1cf3612c88@flush_thread_0 /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1cf3612788@enqueue_thread /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1cf425d380@flush_thread_0 /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,                          #<Thread:0x00007f1cf425cea8@enqueue_thread /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1cf3666748@flush_thread_0 /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1cf3665c80@enqueue_thread /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1cf36e0a98@flush_thread_0 /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1cf36e02f0@enqueue_thread /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1cf3494dc0@flush_thread_0 /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1cf3494848@enqueue_thread /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,                          #<Thread:0x00007f1cf424ba18@flush_thread_0 /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1cf424b1d0@enqueue_thread /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>]
```

After:
```
$ ruby -Ilib:test -e "at_exit { puts '--- Thread count at exit: ' + Thread.list.size.to_s;  pp Thread.list }; require './test/test_mixin.rb'"
Loaded suite -e
Started
Finished in 8.454538737 seconds.
-------------------------------------------------------------------------------------------------------------------------------------------
21 tests, 5 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-------------------------------------------------------------------------------------------------------------------------------------------
2.48 tests/s, 0.59 assertions/s
--- Thread count at exit: 1
[#<Thread:0x00007f1f0f647f78 run>]
```

**Docs Changes**:
N/A

**Release Note**: 
N/A