### PR TITLE
test_buf_file_single: ensure to shutdown plugin instances

### DIFF
--- a/test/plugin/test_buf_file_single.rb
+++ b/test/plugin/test_buf_file_single.rb
@@ -790,6 +790,12 @@ class FileSingleBufferTest < Test::Unit::TestCase
         @p.close unless @p.closed?
         @p.terminate unless @p.terminated?
       end
+      if @d
+        @d.stop unless @d.stopped?
+        @d.before_shutdown unless @d.before_shutdown?
+        @d.shutdown unless @d.shutdown?
+        @d.after_shutdown unless @d.after_shutdown?
+      end
     end
 
     test 'worker(id=0) #resume returns staged/queued chunks with metadata, not only in worker dir, including the directory specified by path' do


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
Fix thread and resource leaks in test_buf_file_single.rb by ensuring proper shutdown sequences for plugin instances.

Before:
```
$ ruby -Ilib:test -e "at_exit { puts '--- Thread count at exit: ' + Thread.list.size.to_s;  pp Thread.list }; require './test/plugin/test_buf_file_single.rb'"
Loaded suite -e
Started
Finished in 2.147468004 seconds.
-----------------------------------------------------------------------------------------------------------------------------------------------------------------
31 tests, 124 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-----------------------------------------------------------------------------------------------------------------------------------------------------------------
14.44 tests/s, 57.74 assertions/s
--- Thread count at exit: 6
[#<Thread:0x00007f5a0b287f78 run>,
 #<Thread:0x00007f59edc30958@Timeout stdlib thread /home/watson/.rbenv/versions/4.0.2/lib/ruby/4.0.0/timeout.rb:87 sleep>,
 #<Thread:0x00007f59edeb9a80@flush_thread_0 /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f59edeb9698@enqueue_thread /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f59edf0cf28@flush_thread_0 /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f59edf0cb90@enqueue_thread /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>]
```

After:
```
$ ruby -Ilib:test -e "at_exit { puts '--- Thread count at exit: ' + Thread.list.size.to_s;  pp Thread.list }; require './test/plugin/test_buf_file_single.rb'"
Loaded suite -e
Started
Finished in 2.14757856 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
31 tests, 124 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
14.43 tests/s, 57.74 assertions/s
--- Thread count at exit: 2
[#<Thread:0x00007f1d2e087fa8 run>, #<Thread:0x00007f1d10ac8dc8@Timeout stdlib thread /home/watson/.rbenv/versions/4.0.2/lib/ruby/4.0.0/timeout.rb:87 sleep>]
```


**Docs Changes**:

**Release Note**: 
