### PR TITLE
test_buf_file: ensure to shutdown plugin instances

### DIFF
--- a/test/plugin/test_buf_file.rb
+++ b/test/plugin/test_buf_file.rb
@@ -755,6 +755,12 @@ class FileBufferTest < Test::Unit::TestCase
         @p.close unless @p.closed?
         @p.terminate unless @p.terminated?
       end
+      if @d
+        @d.stop unless @d.stopped?
+        @d.before_shutdown unless @d.before_shutdown?
+        @d.shutdown unless @d.shutdown?
+        @d.after_shutdown unless @d.after_shutdown?
+      end
     end
 
     test 'worker(id=0) #resume returns staged/queued chunks with metadata, not only in worker dir, including the directory specified by path' do


### PR DESCRIPTION

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
Same with https://github.com/fluent/fluentd/pull/5325

Fix thread and resource leaks in test_buf_file.rb by ensuring proper shutdown sequences for plugin instances.

Before:
```
$ ruby -Ilib:test -e "at_exit { puts '--- Thread count at exit: ' + Thread.list.size.to_s;  pp Thread.list }; require './test/plugin/test_buf_file.rb'"
Loaded suite -e
Started
Finished in 2.152264481 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
37 tests, 204 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
17.19 tests/s, 94.78 assertions/s
--- Thread count at exit: 6
[#<Thread:0x00007f1812e67f68 run>,
 #<Thread:0x00007f17f68df288@Timeout stdlib thread /home/watson/.rbenv/versions/4.0.2/lib/ruby/4.0.0/timeout.rb:87 sleep>,
 #<Thread:0x00007f17f5bdc810@flush_thread_0 /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f17f5bdc108@enqueue_thread /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f17f5a02a30@flush_thread_0 /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f17f5a026e8@enqueue_thread /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>]
```

After:
```
$ ruby -Ilib:test -e "at_exit { puts '--- Thread count at exit: ' + Thread.list.size.to_s;  pp Thread.list }; require './test/plugin/test_buf_file.rb'"
Loaded suite -e
Started
Finished in 2.154188075 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
37 tests, 204 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
17.18 tests/s, 94.70 assertions/s
--- Thread count at exit: 2
[#<Thread:0x00007fc10b277fa8 run>, #<Thread:0x00007fc0eecec9d8@Timeout stdlib thread /home/watson/.rbenv/versions/4.0.2/lib/ruby/4.0.0/timeout.rb:87 sleep>]
```

**Docs Changes**:

**Release Note**: 
