### PR TITLE
test_supervisor: ensure to close socket manager server

### DIFF
--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -3,6 +3,7 @@ require 'fluent/event_router'
 require 'fluent/system_config'
 require 'fluent/supervisor'
 require 'fluent/file_wrapper'
+require 'fluent/version'
 require_relative 'test_plugin_classes'
 
 require 'net/http'
@@ -919,6 +920,7 @@ class SupervisorTest < ::Test::Unit::TestCase
     ensure
       server.after_run
       ENV.delete('SERVERENGINE_SOCKETMANAGER_PATH')
+      server.socket_manager_server.close
     end
   end
 
@@ -1013,6 +1015,7 @@ class SupervisorTest < ::Test::Unit::TestCase
     ensure
       Fluent::Supervisor.cleanup_socketmanager_path
       ENV.delete('SERVERENGINE_SOCKETMANAGER_PATH')
+      server.socket_manager_server.close
     end
 
     def test_share_sockets
@@ -1043,6 +1046,8 @@ class SupervisorTest < ::Test::Unit::TestCase
       new_server&.after_run
       ENV.delete('SERVERENGINE_SOCKETMANAGER_PATH')
       ENV.delete("FLUENT_RUNNING_IN_PARALLEL_WITH_OLD")
+      server.socket_manager_server.close
+      new_server.socket_manager_server.close
     end
 
     def test_stop_parallel_old_supervisor_after_delay


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
Fix thread and resource leaks in test_supervisor.rb by ensuring proper shutdown for socket manager.

Before:
```
$ ruby -Ilib:test -e "at_exit { puts '--- Thread count at exit: ' + Thread.list.size.to_s;  pp Thread.list }; require './test/test_supervisor.rb'"
...
====================================================================================================================================================================================================
Omission: Only for Windows. [test_files_for_each_process_with_rotate_on_windows(SupervisorTest::init logger)]
/home/watson/src/fluentd/test/test_supervisor.rb:881:in 'SupervisorTest::TEST_U3VwZXJ2aXNvclRlc3Q6OmluaXQgbG9nZ2Vy#test_files_for_each_process_with_rotate_on_windows'
====================================================================================================================================================================================================
Finished in 23.457651502 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
74 tests, 195 assertions, 0 failures, 0 errors, 0 pendings, 8 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
3.15 tests/s, 8.31 assertions/s
--- Thread count at exit: 10
[#<Thread:0x00007f34974b7fa8 run>,
 #<Thread:0x00007f347932bd88 /home/watson/.rbenv/versions/4.0.2/lib/ruby/gems/4.0.0/gems/serverengine-2.4.0/lib/serverengine/socket_manager_unix.rb:125 sleep>,
 #<Thread:0x00007f347947e050 /home/watson/.rbenv/versions/4.0.2/lib/ruby/gems/4.0.0/gems/webrick-1.9.2/lib/webrick/utils.rb:158 sleep_forever>,
 #<Thread:0x00007f34794da008 /home/watson/.rbenv/versions/4.0.2/lib/ruby/gems/4.0.0/gems/serverengine-2.4.0/lib/serverengine/socket_manager_unix.rb:125 sleep>,
 #<Thread:0x00007f347951d1f0 /home/watson/.rbenv/versions/4.0.2/lib/ruby/gems/4.0.0/gems/serverengine-2.4.0/lib/serverengine/socket_manager_unix.rb:125 sleep>,
 #<Thread:0x00007f347954f970 /home/watson/.rbenv/versions/4.0.2/lib/ruby/gems/4.0.0/gems/serverengine-2.4.0/lib/serverengine/socket_manager_unix.rb:125 sleep>,
 #<Thread:0x00007f34795799c8 /home/watson/.rbenv/versions/4.0.2/lib/ruby/gems/4.0.0/gems/serverengine-2.4.0/lib/serverengine/socket_manager_unix.rb:125 sleep>,
 #<Thread:0x00007f3479580cc8 /home/watson/.rbenv/versions/4.0.2/lib/ruby/gems/4.0.0/gems/serverengine-2.4.0/lib/serverengine/socket_manager_unix.rb:125 sleep>,
 #<Thread:0x00007f34795af938 /home/watson/src/fluentd/lib/fluent/supervisor.rb:419 sleep>,
 #<Thread:0x00007f34795a23a0 /home/watson/.rbenv/versions/4.0.2/lib/ruby/gems/4.0.0/gems/serverengine-2.4.0/lib/serverengine/socket_manager_unix.rb:125 sleep>]
```

After:
```
$ ruby -Ilib:test -e "at_exit { puts '--- Thread count at exit: ' + Thread.list.size.to_s;  pp Thread.list }; require './test/test_supervisor.rb'"
...
====================================================================================================================================================================================================
Omission: Only for Windows. [test_files_for_each_process_with_rotate_on_windows(SupervisorTest::init logger)]
/home/watson/src/fluentd/test/test_supervisor.rb:881:in 'SupervisorTest::TEST_U3VwZXJ2aXNvclRlc3Q6OmluaXQgbG9nZ2Vy#test_files_for_each_process_with_rotate_on_windows'
====================================================================================================================================================================================================
Finished in 23.451976513 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
74 tests, 195 assertions, 0 failures, 0 errors, 0 pendings, 8 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
3.16 tests/s, 8.31 assertions/s
--- Thread count at exit: 3
[#<Thread:0x00007fcf1a057fa8 run>,
 #<Thread:0x00007fcefcc0d938 /home/watson/.rbenv/versions/4.0.2/lib/ruby/gems/4.0.0/gems/webrick-1.9.2/lib/webrick/utils.rb:158 sleep_forever>,
 #<Thread:0x00007fcefcd3ec58 /home/watson/src/fluentd/lib/fluent/supervisor.rb:419 sleep>]
```

**Docs Changes**:
N/A

**Release Note**: 
N/a