### PR TITLE
test_output: ensure to shutdown plugin instances

### DIFF
--- a/test/test_output.rb
+++ b/test/test_output.rb
@@ -235,14 +235,21 @@ module FluentOutputTest
                    else
                      "\n"
                    end
+        @d = nil
       end
 
       teardown do
         Timecop.return
+        if @d
+          @d.instance.before_shutdown unless @d.instance.before_shutdown?
+          @d.instance.shutdown unless @d.instance.shutdown?
+          @d.instance.after_shutdown unless @d.instance.after_shutdown?
+          @d.instance.close unless @d.instance.closed?
+        end
       end
 
       test "emit with invalid event" do
-        d = create_driver
+        @d = d = create_driver
         d.instance.start
         d.instance.after_start
         assert_raise ArgumentError, "time must be a Fluent::EventTime (or Integer)" do
@@ -251,7 +258,7 @@ module FluentOutputTest
       end
 
       test "plugin can get key of chunk in #write" do
-        d = create_driver
+        @d = d = create_driver
         d.instance.start
         d.instance.after_start
         d.instance.emit_events('test', OneEventStream.new(event_time("2016-11-08 17:44:30 +0900"), {"message" => "yay"}))
@@ -264,7 +271,7 @@ module FluentOutputTest
       end
 
       test "check formatted time compatibility with utc. Should Z, not +00:00" do
-        d = create_driver(CONFIG + %[
+        @d = d = create_driver(CONFIG + %[
           utc
           include_time_key
         ])


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
Fix thread and resource leaks in test_output.rb by ensuring proper shutdown sequences for plugin instances.

Before:
```
$ ruby -Ilib:test -e "at_exit { puts '--- Thread count at exit: ' + Thread.list.size.to_s;  pp Thread.list }; require './test/test_output.rb'"
Loaded suite -e
Started
Finished in 1.593907966 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
13 tests, 23 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
8.16 tests/s, 14.43 assertions/s
--- Thread count at exit: 6
[#<Thread:0x00007f86bac27f48 run>,
 #<Thread:0x00007f869d945590@flush_thread_0 /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f869d945108@enqueue_thread /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f869cebfcb0@flush_thread_0 /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f869cebf990@enqueue_thread /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f869cebad78@Timeout stdlib thread /home/watson/.rbenv/versions/4.0.2/lib/ruby/4.0.0/timeout.rb:87 sleep_forever>]
 ```
 
 After:
 ```
 $ ruby -Ilib:test -e "at_exit { puts '--- Thread count at exit: ' + Thread.list.size.to_s;  pp Thread.list }; require './test/test_output.rb'"
Loaded suite -e
Started
Finished in 1.597772855 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
13 tests, 23 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
8.14 tests/s, 14.40 assertions/s
--- Thread count at exit: 2
[#<Thread:0x00007f547b0c7f48 run>, #<Thread:0x00007f545dca31f0@Timeout stdlib thread /home/watson/.rbenv/versions/4.0.2/lib/ruby/4.0.0/timeout.rb:87 sleep_forever>]
```

**Docs Changes**:
N/A

**Release Note**: 
N/A