### PR TITLE
test_server: ensure to shutdown plugin instances

### DIFF
--- a/test/plugin_helper/test_server.rb
+++ b/test/plugin_helper/test_server.rb
@@ -186,6 +186,15 @@ class ServerPluginHelperTest < Test::Unit::TestCase
 
     data(methods)
     test 'creates tls server in default if transport section and tcp protocol specified' do |m|
+      if @d
+        @d.stop unless @d.stopped?
+        @d.before_shutdown unless @d.before_shutdown?
+        @d.shutdown unless @d.shutdown?
+        @d.after_shutdown unless @d.after_shutdown?
+        @d.close unless @d.closed?
+        @d.terminate unless @d.terminated?
+      end
+
       @d = d = Dummy.new
       transport_conf = config_element('transport', 'tcp', {}, [])
       d.configure(config_element('ROOT', '', {}, [transport_conf]))
@@ -215,6 +224,15 @@ class ServerPluginHelperTest < Test::Unit::TestCase
 
     data(methods)
     test 'creates tls server in default if transport section and tls protocol specified' do |m|
+      if @d
+        @d.stop unless @d.stopped?
+        @d.before_shutdown unless @d.before_shutdown?
+        @d.shutdown unless @d.shutdown?
+        @d.after_shutdown unless @d.after_shutdown?
+        @d.close unless @d.closed?
+        @d.terminate unless @d.terminated?
+      end
+
       @d = d = Dummy.new
       transport_conf = config_element('transport', 'tls', {'insecure' => 'true'}, [])
       d.configure(config_element('ROOT', '', {}, [transport_conf]))
@@ -1025,6 +1043,15 @@ class ServerPluginHelperTest < Test::Unit::TestCase
 
   sub_test_case '#server_create_tls with various certificate options' do
     setup do
+      if @d
+        @d.stop unless @d.stopped?
+        @d.before_shutdown unless @d.before_shutdown?
+        @d.shutdown unless @d.shutdown?
+        @d.after_shutdown unless @d.after_shutdown?
+        @d.close unless @d.closed?
+        @d.terminate unless @d.terminated?
+      end
+
       @d = Dummy.new # to get plugin not configured/started yet
 
       @certs_dir = File.join(TMP_DIR, "tls_certs")


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
In some sub_test_case blocks, the @d instance variable was reassigned to a new plugin instance without shutting down the one created in the parent setup. This led to "ghost" plugin instances remaining active in the background, as the test lost any way to reference and stop the original server/event-loops.

Fix thread and resource leaks in test_output.rb by ensuring proper shutdown sequences for plugin instances.

test/plugin_helper/test_server.rb

Before:
```
$ ruby -Ilib:test -e "at_exit { puts '--- Thread count at exit: ' + Thread.list.size.to_s;  pp Thread.list }; require './test/plugin_helper/test_server.rb'"
Loaded suite -e
Started
Finished in 63.124128378 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
128 tests, 283 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
2.03 tests/s, 4.48 assertions/s
--- Thread count at exit: 25
[#<Thread:0x00007f14632d7f70 run>,
 #<Thread:0x00007f14470c5578@Timeout stdlib thread /home/watson/.rbenv/versions/4.0.2/lib/ruby/4.0.0/timeout.rb:87 sleep>,
 #<Thread:0x00007f1447602748@event_loop /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f14476173f0@event_loop /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f144796e0f8@event_loop /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f14479638b0@event_loop /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1444d6d378@event_loop /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1444d9d938@event_loop /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1444d900f8@event_loop /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f14475e27b8@event_loop /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1447603c10@event_loop /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f14476129e0@event_loop /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f144717d100@event_loop /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1446c07d88@event_loop /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f14470dc0c0@event_loop /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f144719f390@event_loop /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f14470ed230@event_loop /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1447185670@event_loop /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f144760f5d8@event_loop /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f144761df70@event_loop /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1444d9aad0@event_loop /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f14475ea440@event_loop /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1444d480c8@event_loop /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1444d64c50@event_loop /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f1444bf37b8@event_loop /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>]
 ```
 
 After:
 ```
 $ ruby -Ilib:test -e "at_exit { puts '--- Thread count at exit: ' + Thread.list.size.to_s;  pp Thread.list }; require './test/plugin_helper/test_server.rb'"
Loaded suite -e
Started
Finished in 86.305570305 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
128 tests, 283 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1.48 tests/s, 3.28 assertions/s
--- Thread count at exit: 2
[#<Thread:0x00007f0ca58b7f78 run>, #<Thread:0x00007f0c8920df90@Timeout stdlib thread /home/watson/.rbenv/versions/4.0.2/lib/ruby/4.0.0/timeout.rb:87 sleep>]
 ```

**Docs Changes**:
N/A

**Release Note**: 
N/A