### PR TITLE
test_output_as_buffered: ensure to shutdown plugin instances

### DIFF
--- a/test/plugin/test_output_as_buffered.rb
+++ b/test/plugin/test_output_as_buffered.rb
@@ -2067,7 +2067,10 @@ class BufferedOutputTest < Test::Unit::TestCase
       end
       # staged buffer (.b) was picked up, then ready to flush by enqueuing (.q)
       assert{ @resumer.buffer.stage.size == 0 && @resumer.buffer.queue.size == 1 }
+      @resumer.stop
+      @resumer.before_shutdown
       @resumer.shutdown
+      @resumer.after_shutdown
     end
   end
 end


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
Fix thread and resource leaks in test_output.rb by ensuring proper shutdown sequences for plugin instances.

Before:
```
$ ruby -Ilib:test -e "at_exit { puts '--- Thread count at exit: ' + Thread.list.size.to_s;  pp Thread.list }; require './test/plugin/test_output_as_buffered.rb'"
Loaded suite -e
Started
Finished in 53.238291615 seconds.
-------------------------------------------------------------------------------------------------------------------------------------------
56 tests, 393 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-------------------------------------------------------------------------------------------------------------------------------------------
1.05 tests/s, 7.38 assertions/s
--- Thread count at exit: 10
[#<Thread:0x00007f9fba067f50 run>,
 #<Thread:0x00007f9f9cb744c0@Timeout stdlib thread /home/watson/.rbenv/versions/4.0.2/lib/ruby/4.0.0/timeout.rb:87 sleep_forever>,
 #<Thread:0x00007f9f9d401160@flush_thread_0 /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f9f9d400170@enqueue_thread /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f9f9cde87b0@flush_thread_0 /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f9f9cde81e8@enqueue_thread /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f9f9cd0dae8@flush_thread_0 /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f9f9cd0d660@enqueue_thread /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f9f9cbfb6f0@flush_thread_0 /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f9f9cbfb330@enqueue_thread /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>]
 ```
 
 After:
 ```
 $ ruby -Ilib:test -e "at_exit { puts '--- Thread count at exit: ' + Thread.list.size.to_s;  pp Thread.list }; require './test/plugin/test_output_as_buffered.rb'"
Loaded suite -e
Started
Finished in 53.240484088 seconds.
-------------------------------------------------------------------------------------------------------------------------------------------
56 tests, 393 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-------------------------------------------------------------------------------------------------------------------------------------------
1.05 tests/s, 7.38 assertions/s
--- Thread count at exit: 2
[#<Thread:0x00007f2df88d7f70 run>,
 #<Thread:0x00007f2ddb3e3bd0@Timeout stdlib thread /home/watson/.rbenv/versions/4.0.2/lib/ruby/4.0.0/timeout.rb:87 sleep_forever>]
```

**Docs Changes**:
N/A

**Release Note**: 
N/A