### PR TITLE
test_child_process: ensure to shutdown plugin instances

### DIFF
--- a/test/plugin_helper/test_child_process.rb
+++ b/test/plugin_helper/test_child_process.rb
@@ -50,6 +50,11 @@ class ChildProcessTest < Test::Unit::TestCase
     assert d1.log
 
     d1.start
+
+    d1.stop
+    d1.shutdown
+    d1.close
+    d1.terminate
   end
 
   test 'can execute external command asynchronously' do


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
Fix thread and resource leaks in test_output.rb by ensuring proper shutdown sequences for plugin instances.

Before:
```
$ ruby -Ilib:test -e "at_exit { puts '--- Thread count at exit: ' + Thread.list.size.to_s;  pp Thread.list }; require './test/plugin_helper/test_child_process.rb'"
Loaded suite -e
Started
P
===========================================================================================================================================
Pending: test: can scrub characters without exceptions(ChildProcessTest): Behaviour of IO#set_encoding is changed as of Ruby 3.3 (#4058)
/home/watson/src/fluentd/test/plugin_helper/test_child_process.rb:519:in 'block in <class:ChildProcessTest>'
===========================================================================================================================================
P
===========================================================================================================================================
Pending: test: can scrub characters without exceptions and replace specified chars(ChildProcessTest): Behaviour of IO#set_encoding is changed as of Ruby 3.3 (#4058)
/home/watson/src/fluentd/test/plugin_helper/test_child_process.rb:545:in 'block in <class:ChildProcessTest>'
===========================================================================================================================================
Finished in 34.07304912 seconds.
-------------------------------------------------------------------------------------------------------------------------------------------
33 tests, 96 assertions, 0 failures, 0 errors, 2 pendings, 0 omissions, 0 notifications
93.9394% passed
-------------------------------------------------------------------------------------------------------------------------------------------
0.97 tests/s, 2.82 assertions/s
--- Thread count at exit: 3
[#<Thread:0x00007f49708b7f48 run>,
 #<Thread:0x00007f4954bb2908@event_loop /home/watson/src/fluentd/lib/fluent/plugin_helper/thread.rb:70 sleep>,
 #<Thread:0x00007f4954ba6310@Timeout stdlib thread /home/watson/.rbenv/versions/4.0.2/lib/ruby/4.0.0/timeout.rb:87 sleep>]
 ```
 
 After:
 ```
 $ ruby -Ilib:test -e "at_exit { puts '--- Thread count at exit: ' + Thread.list.size.to_s;  pp Thread.list }; require './test/plugin_helper/test_child_process.rb'"
Loaded suite -e
Started
P
===========================================================================================================================================
Pending: test: can scrub characters without exceptions(ChildProcessTest): Behaviour of IO#set_encoding is changed as of Ruby 3.3 (#4058)
/home/watson/src/fluentd/test/plugin_helper/test_child_process.rb:524:in 'block in <class:ChildProcessTest>'
===========================================================================================================================================
P
===========================================================================================================================================
Pending: test: can scrub characters without exceptions and replace specified chars(ChildProcessTest): Behaviour of IO#set_encoding is changed as of Ruby 3.3 (#4058)
/home/watson/src/fluentd/test/plugin_helper/test_child_process.rb:550:in 'block in <class:ChildProcessTest>'
===========================================================================================================================================
Finished in 34.153673569 seconds.
-------------------------------------------------------------------------------------------------------------------------------------------
33 tests, 96 assertions, 0 failures, 0 errors, 2 pendings, 0 omissions, 0 notifications
93.9394% passed
-------------------------------------------------------------------------------------------------------------------------------------------
0.97 tests/s, 2.81 assertions/s
--- Thread count at exit: 2
[#<Thread:0x00007fb335e77fa8 run>,
 #<Thread:0x00007fb319d758b0@Timeout stdlib thread /home/watson/.rbenv/versions/4.0.2/lib/ruby/4.0.0/timeout.rb:87 sleep>]
 ```

**Docs Changes**:

**Release Note**: 
