### PR TITLE
parser_ltsv: optimize key-value parsing by removing redundant string scan

### DIFF
--- a/lib/fluent/plugin/parser_ltsv.rb
+++ b/lib/fluent/plugin/parser_ltsv.rb
@@ -38,10 +38,8 @@ module Fluent
       def parse(text)
         r = {}
         text.split(@delimiter).each do |pair|
-          if pair.include? @label_delimiter
-            key, value = pair.split(@label_delimiter, 2)
-            r[key] = value
-          end
+          key, value = pair.split(@label_delimiter, 2)
+          r[key] = value if value
         end
         time, record = convert_values(parse_time(r), r)
         yield time, record


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
Remove the redundant `String#include?` check before `String#split` in the LTSV parser.
Previously, `pair.include?(@label_delimiter)` scanned the string once, 
and then `pair.split(@label_delimiter, 2)` scanned it again.

### Microbenchmark
```ruby
require 'bundler/inline'
gemfile do
  source 'https://rubygems.org'
  gem 'benchmark-ips'
end

message = "time:2013/02/28 12:00:00\thost:192.168.0.1\treq_id:111"

Benchmark.ips do |x|
  x.report('before') do
    r = {}
    message.split("\t").each do |pair|
      if pair.include? ":"
        key, value = pair.split(":", 2)
        r[key] = value
      end
    end
  end

  x.report('after') do
    r = {}
    message.split("\t").each do |pair|
      key, value = pair.split(":", 2)
      r[key] = value if value
    end
  end

  x.compare!
end
```

```
ruby 4.0.3 (2026-04-21 revision 85ddef263a) +PRISM [x86_64-linux]
Warming up --------------------------------------
              before   114.156k i/100ms
               after   128.758k i/100ms
Calculating -------------------------------------
              before      1.140M (± 0.1%) i/s  (877.32 ns/i) -      5.708M in   5.007564s
               after      1.285M (± 0.1%) i/s  (777.98 ns/i) -      6.438M in   5.008577s

Comparison:
               after:  1285378.0 i/s
              before:  1139837.2 i/s - 1.13x  slower
```


**Docs Changes**:
N/A

**Release Note**: 
* parser_ltsv: optimize key-value parsing by removing redundant string scan