### PR TITLE
parser_csv: skip empty or unparseable lines

### DIFF
--- a/lib/fluent/plugin/parser_csv.rb
+++ b/lib/fluent/plugin/parser_csv.rb
@@ -47,6 +47,11 @@ module Fluent
 
       def parse(text, &block)
         values = CSV.parse_line(text, col_sep: @delimiter)
+        unless values
+          yield nil, nil
+          return
+        end
+
         r = Hash[@keys.zip(values)]
         time, record = convert_values(parse_time(r), r)
         yield time, record

--- a/test/plugin/test_parser_csv.rb
+++ b/test/plugin/test_parser_csv.rb
@@ -101,6 +101,14 @@ class CSVParserTest < ::Test::Unit::TestCase
     end
   end
 
+  def test_parse_empty_line
+    d = create_driver('keys' => '["k1","k2","k3"]')
+    d.instance.parse("") do |time, record|
+      assert_nil time
+      assert_nil record
+    end
+  end
+
   sub_test_case 'parser' do
     data('normal' => 'normal',
          'fast' => 'fast')


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
This PR fixes an issue in `parser_csv` where processing an empty line causes a `TypeError`.

When `parser_csv` receives an empty line, `CSV.parse_line` returns `nil`.
Currently, passing this `nil` value to `Array#zip` throws a `TypeError: wrong argument type NilClass (must respond to :each)`.

### Reproduce
config:
```
<source>
  @type tail
  path "#{File.expand_path '~/tmp/fluentd/test.csv'}"
  tag test.csv
  read_from_head true
  <parse>
    @type csv
    keys k1,k2,k3
  </parse>
</source>

<match test.csv>
  @type stdout
</match>
```

Prepare input data:
```
$ echo "A,B,C"  > ~/tmp/fluentd/test.csv
$ echo ""      >> ~/tmp/fluentd/test.csv
$ echo "D,E,F" >> ~/tmp/fluentd/test.csv
```

Result of before changing:
```
2026-05-09 17:23:14 +0900 [info]: #0 following tail of /home/watson/tmp/fluentd/test.csv
2026-05-09 17:23:14 +0900 [warn]: #0 invalid line found 
2026-05-09 17:23:14 +0900 [warn]: #0 this parameter is highly recommended to save the position to resume tailing.
2026-05-09 17:23:14 +0900 [info]: #0 starting fluentd worker pid=41671 ppid=41646 worker=0
2026-05-09 17:23:14 +0900 [info]: #0 following tail of /home/watson/tmp/fluentd/test.csv
2026-05-09 17:23:14 +0900 [warn]: #0 invalid line found file="/home/watson/tmp/fluentd/test.csv" line="" error="wrong argument type NilClass (must respond to :each)"
2026-05-09 17:23:14.692710744 +0900 test.csv: {"k1":"A","k2":"B","k3":"C"}
2026-05-09 17:23:14.692801343 +0900 test.csv: {"k1":"D","k2":"E","k3":"F"}
2026-05-09 17:23:14 +0900 [info]: #0 fluentd worker is now running worker=0
```

**Docs Changes**:
N/A

**Release Note**: 
* parser_csv: skip empty or unparseable lines