### PR TITLE
CI: fix error with "No need to backport pull requests"

### DIFF
--- a/tasks/backport/backporter.rb
+++ b/tasks/backport/backporter.rb
@@ -91,7 +91,7 @@ class PullRequestBackporter
     backports = collect_backports
     if backports.empty?
       @logger.info "No need to backport pull requests"
-      return
+      return true
     end
 
     failed = []


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
This PR will fix following error with `No need to backport pull requests`:
```
TypeError: no implicit conversion from nil to integer (TypeError)

    exit(backporter.run(commands))
         ^^^^^^^^^^^^^^^^^^^^^^^^
/home/runner/work/fluentd/fluentd/tasks/backport.rb:40:in 'Kernel#exit'
/home/runner/work/fluentd/fluentd/tasks/backport.rb:40:in 'block (2 levels) in <top (required)>'
/home/runner/work/fluentd/fluentd/vendor/bundle/ruby/3.4.0/gems/rake-13.4.2/exe/rake:27:in '<top (required)>'
/opt/hostedtoolcache/Ruby/3.4.9/x64/bin/bundle:25:in 'Kernel#load'
/opt/hostedtoolcache/Ruby/3.4.9/x64/bin/bundle:25:in '<main>'
Tasks: TOP => backport:v1_19
(See full trace by running task with --trace)
```
Ref. https://github.com/fluent/fluentd/actions/runs/25616786216/job/75196214457

Since the method returns a value that is used as the process's exit code,
it must return a boolean value.

**Docs Changes**:
N/A

**Release Note**: 
N/A