### PR TITLE
fluent-plugin-generate: add .gitignore file

### DIFF
--- a/templates/new_gem/.gitignore
+++ b/templates/new_gem/.gitignore
@@ -1,0 +1,8 @@
+/.bundle/
+/.yardoc
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
When generating a library template with `bundle gem`, a `.gitignore` file is included by default. However, `fluent-plugin-generate` does not currently include it, which forces developers to add it manually.

This commit adds a default `.gitignore` to the plugin template.

**Docs Changes**:
N/A

**Release Note**: 
N/A