### PR TITLE
storage_local: fix encoding error when reading non-ASCII characters

### DIFF
--- a/lib/fluent/plugin/storage_local.rb
+++ b/lib/fluent/plugin/storage_local.rb
@@ -85,7 +85,7 @@ module Fluent
           if File.exist?(@path)
             raise Fluent::ConfigError, "Plugin storage path '#{@path}' is not readable/writable" unless File.readable?(@path) && File.writable?(@path)
             begin
-              data = File.open(@path, 'r:utf-8::utf-8') { |io| io.read }
+              data = File.open(@path, 'r:utf-8:utf-8') { |io| io.read }
               if data.empty?
                 log.warn "detect empty plugin storage file during startup. Ignored: #{@path}"
                 return
@@ -113,7 +113,7 @@ module Fluent
         return if @on_memory
         return unless File.exist?(@path)
         begin
-          json_string = File.open(@path, 'r:utf-8::utf-8'){ |io| io.read }
+          json_string = File.open(@path, 'r:utf-8:utf-8'){ |io| io.read }
           json = JSON.parse(json_string)
           unless json.is_a?(Hash)
             log.error "broken content for plugin storage (Hash required: ignored)", type: json.class

--- a/lib/fluent/plugin/storage_local.rb
+++ b/lib/fluent/plugin/storage_local.rb
@@ -85,7 +85,7 @@ module Fluent
           if File.exist?(@path)
             raise Fluent::ConfigError, "Plugin storage path '#{@path}' is not readable/writable" unless File.readable?(@path) && File.writable?(@path)
             begin
-              data = File.open(@path, 'r:utf-8') { |io| io.read }
+              data = File.open(@path, 'r:utf-8::utf-8') { |io| io.read }
               if data.empty?
                 log.warn "detect empty plugin storage file during startup. Ignored: #{@path}"
                 return
@@ -113,7 +113,7 @@ module Fluent
         return if @on_memory
         return unless File.exist?(@path)
         begin
-          json_string = File.open(@path, 'r:utf-8'){ |io| io.read }
+          json_string = File.open(@path, 'r:utf-8::utf-8'){ |io| io.read }
           json = JSON.parse(json_string)
           unless json.is_a?(Hash)
             log.error "broken content for plugin storage (Hash required: ignored)", type: json.class

--- a/test/plugin/test_storage_local.rb
+++ b/test/plugin/test_storage_local.rb
@@ -136,6 +136,35 @@ class LocalStorageTest < Test::Unit::TestCase
         @d.configure(conf)
       end
     end
+
+    test 'start properly if stored value contains non-latin chracters (issue #5378)' do
+      storage_path = File.join(TMP_DIR, 'my_store.json')
+      conf = config_element('ROOT', '', {}, [config_element('storage', '', {'path' => storage_path})])
+      @d.configure(conf)
+      @d.start
+      @p = @d.storage_create()
+      assert_equal storage_path, @p.path
+      assert @p.store.empty?
+
+      @p.put('key', 'Bonne Année François !')
+      assert_equal 'Bonne Année François !', @p.get('key')
+
+      @p.save
+      assert File.exist?(storage_path)
+
+      @d.stop; @d.before_shutdown; @d.shutdown; @d.after_shutdown; @d.close; @d.terminate
+      assert_equal({'key' => 'Bonne Année François !'}, File.open(storage_path){|f| JSON.parse(f.read) })
+
+      # re-create to reload storage contents
+      @d = MyInput.new
+      @d.configure(conf)
+      @d.start
+      @p = @d.storage_create()
+
+      assert_false @p.store.empty?
+      assert_equal 'Bonne Année François !', @p.get('key')
+
+    end
   end
 
   sub_test_case 'configured with root-dir and plugin id' do


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #5378 

**What this PR does / why we need it**: 

If data containing non-latin characters are stored onto disk using the storage_local plugin, the file is properly written but cannot be read again once fluentd restarts. This PR fixes this behaviour by properly handling the file encoding.

**Docs Changes**:
N/A

**Release Note**: 
* storage_local: fix encoding error when reading non-ASCII characters