### PR TITLE
test_out_exec_filter: fix flaky test on Windows

### DIFF
--- a/test/plugin/test_out_exec_filter.rb
+++ b/test/plugin/test_out_exec_filter.rb
@@ -521,17 +521,10 @@ class ExecFilterOutputTest < Test::Unit::TestCase
     events = d.events
     assert_equal 4, events.length
 
-    pid_list = []
-    events.each do |event|
-      pid = event[2]['child_pid']
-      pid_list << pid unless pid_list.include?(pid)
-    end
-    assert_equal 2, pid_list.size, "the number of pids should be same with number of child processes: #{pid_list.inspect}"
+    pid_counts = events.map { |event| event[2]['child_pid'] }.tally
 
-    assert_equal pid_list[0], events[0][2]['child_pid']
-    assert_equal pid_list[1], events[1][2]['child_pid']
-    assert_equal pid_list[0], events[2][2]['child_pid']
-    assert_equal pid_list[1], events[3][2]['child_pid']
+    assert_equal 2, pid_counts.size, "the number of pids should be same with number of child processes: #{pid_counts.inspect}"
+    assert_equal [2, 2], pid_counts.values, "each child process should handle exactly 2 events"
   end
 
   # child process exits per 3 lines


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
The `test 'using child processes by round robin'` in `test_out_exec_filter.rb` was occasionally failing on Windows.

Like:
```
3) Failure: test: using child processes by round robin[with sections](ExecFilterOutputTest)
D:/a/fluentd/fluentd/test/plugin/test_out_exec_filter.rb:533:in 'block in <class:ExecFilterOutputTest>'
     530:
     531:     assert_equal pid_list[0], events[0][2]['child_pid']
     532:     assert_equal pid_list[1], events[1][2]['child_pid']
  => 533:     assert_equal pid_list[0], events[2][2]['child_pid']
     534:     assert_equal pid_list[1], events[3][2]['child_pid']
     535:   end
     536:
<"8944"> expected but was
<"2728">

diff:
? 2728944
Error: <"8944"> expected but was
<"2728">.
```

The test previously assumed that the events would be processed and returned in a strictly alternating order (e.g., A -> B -> A -> B).

However, on Windows, the overhead of process creation and unpredictable I/O scheduling can cause the child processes to become ready and return events out of order (e.g., A -> B -> B -> A), resulting in false-positive test failures.

This commit fixes the flaky behavior by verifying the even distribution of events rather than their strict chronological return order.

**Docs Changes**:
N/A

**Release Note**: 
N/A