### PR TITLE
test_in_tail: fix flaky throttling test

### DIFF
--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -2784,9 +2784,9 @@ class TailInputTest < Test::Unit::TestCase
 
         emit_count = 0
         prev_count = 0
+        start_time = Fluent::Clock.now
 
         while emit_count < 3 do
-          start_time = Fluent::Clock.now
           sleep(sleep_interval) while d.emit_count <= emit_count
           elapsed_seconds = Fluent::Clock.now - start_time
           if emit_count > 0
@@ -2798,6 +2798,7 @@ class TailInputTest < Test::Unit::TestCase
           assert_equal(limit, d.record_count - prev_count)
           emit_count = d.emit_count
           prev_count = d.record_count
+          start_time = Fluent::Clock.now
         end
 
         ## When all the lines are read and rate_period seconds are over


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
The `test "lines collected with throttling"` was intermittently failing, especially on macOS CI runners.

```
4) Failure: test: lines collected with throttling(TailInputTest::throttling logs at in_tail level):
  elapsed_seconds 1.81999524999992 is out of allowed range:
    lower: 1.88 [sec]
    upper: 3.3200000000000003 [sec].
  <true> expected but was
  <false>
/Users/runner/work/fluentd/fluentd/test/plugin/test_in_tail.rb:2793:in 'block (3 levels) in <class:TailInputTest>'
     2790:           sleep(sleep_interval) while d.emit_count <= emit_count
     2791:           elapsed_seconds = Fluent::Clock.now - start_time
     2792:           if emit_count > 0
  => 2793:             assert_true(elapsed_seconds > lower_interval && elapsed_seconds < upper_interval,
     2794:                         "elapsed_seconds #{elapsed_seconds} is out of allowed range:\n" +
     2795:                         "  lower: #{lower_interval} [sec]\n" +
     2796:                         "  upper: #{upper_interval} [sec]")
```

The failure occurred because the test was measuring the test thread's observation delay rather than the actual interval between emit events.

Previously, `start_time` was recorded at the beginning of the `while`loop. If the OS thread scheduling was delayed, the time spent waiting was excluded from the current cycle and bled into the next, causing `elapsed_seconds` to falsely fall below the `lower_interval` threshold.

By moving `start_time = Fluent::Clock.now` outside the loop and updating it immediately after confirming an emit, we accurately measure the duration between consecutive emits. This makes the test resilient to CI scheduling jitter.

**Docs Changes**:
N/A

**Release Note**: 
N/A