### PR TITLE
CI: Add Windows 11 Arm

### DIFF
--- a/.github/workflows/test-ruby-head.yml
+++ b/.github/workflows/test-ruby-head.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest', 'windows-11-arm']
         ruby-version: ['head']
     env:
       RUBYOPT: "--disable-frozen_string_literal"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest', 'windows-11-arm']
         ruby-version: ['4.0', '3.4', '3.3', '3.2']
+        exclude:
+          - os: 'windows-11-arm'
+            ruby-version: '3.3'
+          - os: 'windows-11-arm'
+            ruby-version: '3.2'
     env:
       RUBYOPT: "--disable-frozen_string_literal"
     name: Ruby ${{ matrix.ruby-version }} on ${{ matrix.os }}

--- a/test/command/test_ctl.rb
+++ b/test/command/test_ctl.rb
@@ -46,6 +46,7 @@ class TestFluentdCtl < ::Test::Unit::TestCase
        "reload" => ["reload", "USR2"])
   def test_commands_with_winsvcname(data)
     omit "Only for Windows" unless Fluent.windows?
+    omit "Need ffi 1.17.3 or later but blocked by https://github.com/chef/ffi-win32-extensions/issues/14" if Gem::Version.new(FFI::VERSION) < Gem::Version.new("1.17.3")
 
     command, event_suffix = data
     event_name = "testfluentdwinsvc"


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
N/A

**What this PR does / why we need it**: 
Prepare to support Windows 11 on Arm.
Although a test for `fluent-ctl` command is currently skipped due to https://github.com/chef/ffi-win32-extensions/issues/14, all other tests pass on it.
`fluent-ctl` will also work if you remove the version restriction in ffi-win32-extensions.gemspec by running it without bundler (fluent-pakcage doesn't use it in runtime). 

**Docs Changes**:
N/A

**Release Note**: 
Same with the title