### PR TITLE
engine: remove duplicated word in unreloadable plugin error message

### DIFF
--- a/lib/fluent/engine.rb
+++ b/lib/fluent/engine.rb
@@ -186,7 +186,7 @@ module Fluent
 
         ret.all_plugins.each do |plugin|
           if plugin.respond_to?(:reloadable_plugin?) && !plugin.reloadable_plugin?
-            raise Fluent::ConfigError, "Unreloadable plugin plugin: #{Fluent::Plugin.lookup_type_from_class(plugin.class)}, plugin_id: #{plugin.plugin_id}, class_name: #{plugin.class})"
+            raise Fluent::ConfigError, "Unreloadable plugin: #{Fluent::Plugin.lookup_type_from_class(plugin.class)}, plugin_id: #{plugin.plugin_id}, class_name: #{plugin.class})"
           end
         end
 

--- a/test/test_engine.rb
+++ b/test/test_engine.rb
@@ -194,7 +194,7 @@ class EngineTest < ::Test::Unit::TestCase
       e = assert_raise(Fluent::ConfigError) do
         engine.reload_config(new_conf)
       end
-      assert e.message.match?('Unreloadable plugin plugin: dummy_engine_class_var_test')
+      assert e.message.match?('Unreloadable plugin: dummy_engine_class_var_test')
 
       assert_kind_of DummyEngineTestInput, engine.root_agent.inputs[0]
       assert_kind_of DummyEngineTestOutput, engine.root_agent.outputs[0]


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
The ConfigError raised on reload read "Unreloadable plugin plugin: ..." — removed the duplicated "plugin".

**Docs Changes**:
N/A

**Release Note**: 
* engine: remove duplicated word in unreloadable plugin error message