### PR TITLE
system_config: add umask option to <system> directive

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -808,6 +808,12 @@ module Fluent
       )
       @system_config = build_system_config(@conf)
 
+      # `<system> umask` sets the process umask, just like the `--umask` command
+      # line option. The command line option takes precedence when both are given.
+      if @system_config.umask && !@cl_opt.key?(:chumask)
+        @chumask = @system_config.umask
+      end
+
       $log.info :supervisor, 'parsing config file is succeeded', path: @config_path
 
       build_additional_configurations(parsed_files) do |additional_conf|

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -30,7 +30,7 @@ module Fluent
       :file_permission, :dir_permission, :counter_server, :counter_client,
       :strict_config_value, :enable_msgpack_time_support, :disable_shared_socket,
       :metrics, :enable_input_metrics, :enable_size_metrics, :enable_jit, :source_only_buffer,
-      :config_include_dir
+      :config_include_dir, :umask
     ]
 
     config_param :workers,   :integer, default: 1
@@ -61,6 +61,9 @@ module Fluent
       v.to_i(8)
     end
     config_param :config_include_dir, default: Fluent::DEFAULT_CONFIG_INCLUDE_DIR
+    # Kept as a string (like the `--umask` command line option) so that it flows
+    # through the existing chumask handling, which applies `to_i(8)` later.
+    config_param :umask, :string, default: nil
     config_section :log, required: false, init: true, multi: false do
       config_param :path, :string, default: nil
       config_param :format, :enum, list: [:text, :json], default: :text

--- a/test/command/test_fluentd.rb
+++ b/test/command/test_fluentd.rb
@@ -1344,6 +1344,54 @@ CONF
                        patterns_not_match: ["[error]"])
   end
 
+  test "<system> umask is applied to the permission of generated buffer files" do
+    omit "Windows doesn't support UNIX like permissions" if Fluent.windows?
+
+    buf_dir = File.join(@tmp_dir, "buffer")
+    # 0644 (DEFAULT_FILE_PERMISSION) masked by umask 0077 => 0600.
+    # `--no-supervisor` runs the worker in this process, where `<system> umask`
+    # is applied via File.umask, just like the `--umask` command line option.
+    conf = <<CONF
+<system>
+  umask 0077
+</system>
+<source>
+  @type sample
+  tag test.umask
+  rate 100
+</source>
+<match test.umask>
+  @type null
+  <buffer>
+    @type file
+    path #{buf_dir}
+    flush_mode interval
+    flush_interval 3600s
+    chunk_limit_size 10m
+  </buffer>
+</match>
+CONF
+    conf_path = create_conf_file("system_umask.conf", conf)
+
+    buffer_file = nil
+    buffer_perm = nil
+    assert_log_matches(create_cmdline(conf_path, "--no-supervisor"), "fluentd worker is now running") do
+      # Wait for the worker to stage a buffer chunk on disk, then read its
+      # permission while the process is still alive (the chunk may be flushed
+      # away on shutdown).
+      waiting(10) do
+        until buffer_file
+          buffer_file = Dir.glob(File.join(buf_dir, "buffer.*.log")).first
+          sleep 0.1
+        end
+      end
+      buffer_perm = File.stat(buffer_file).mode.to_s(8)[-3, 3]
+    end
+
+    assert_not_nil buffer_file, "a staged buffer file should be generated"
+    assert_equal "600", buffer_perm
+  end
+
   sub_test_case "--with-source-only" do
     setup do
       omit "Not supported on Windows" if Fluent.windows?

--- a/test/config/test_system_config.rb
+++ b/test/config/test_system_config.rb
@@ -101,6 +101,7 @@ module Fluent::Config
       'enable_input_metrics' => ['enable_input_metrics', false],
       'enable_size_metrics' => ['enable_size_metrics', true],
       'enable_jit' => ['enable_jit', true],
+      'umask' => ['umask', '0022'],
     )
     test "accepts parameters" do |(k, v)|
       conf = parse_text(<<-EOS)

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -704,6 +704,21 @@ class SupervisorTest < ::Test::Unit::TestCase
     supervisor.run_supervisor
   end
 
+  data("system config only", [{}, "0227", "0227"])
+  data("command line takes precedence", [{chumask: "222"}, "0227", "222"])
+  def test_umask_in_system_config_is_passed_to_ServerEngine((cl_opt, system_umask, expected_chumask_value))
+    proxy.mock(Fluent::Supervisor).serverengine_config(hash_including("chumask" => expected_chumask_value))
+    any_instance_of(ServerEngine::Daemon) { |daemon| mock(daemon).run.once }
+
+    supervisor = Fluent::Supervisor.new(cl_opt)
+    system_conf = config_element('ROOT', '', {}, [config_element('system', '', { 'umask' => system_umask })])
+    stub(Fluent::Config).build { system_conf }
+    stub(supervisor).build_spawn_command { "dummy command line" }
+    supervisor.configure(supervisor: true)
+
+    supervisor.run_supervisor
+  end
+
   sub_test_case "init logger" do
     data(supervisor: true)
     data(worker: false)


### PR DESCRIPTION
**Which issue(s) this PR fixes**: Fixes #4816

**What this PR does / why we need it**:
Adds a `umask` option to the `<system>` directive so the process umask can be
set from the config file. Previously this required the `--umask` command line
option, which is inconvenient for services and container images.

It reuses the existing chumask handling: `<system> umask` sets the same value
that `--umask` does, and the command line option takes precedence when both are
given. Both supervised and `--no-supervisor` modes honor it.

    <system>
      umask 0022
    </system>

Tests: added a config round-trip case and a supervisor test asserting the value
reaches ServerEngine, including command-line precedence.

**Docs Changes**:
https://github.com/fluent/fluentd-docs-gitbook/pull/625

**Release Note**:
Add `umask` option to the `<system>` directive.