### PR TITLE
Config: accept a bare scalar for an array option in YAML syntax

### DIFF
--- a/lib/fluent/config/types.rb
+++ b/lib/fluent/config/types.rb
@@ -229,8 +229,10 @@ module Fluent
 
       param = if val.is_a?(String)
                 val.start_with?('[') ? JSON.parse(val, Fluent::DEFAULT_JSON_PARSE_OPTIONS) : val.strip.split(/\s*,\s*/)
-              else
+              elsif val.is_a?(Array) || val.is_a?(Hash)
                 val
+              else
+                [val]
               end
       if param.class != Array
         raise ConfigError, "array required but got #{val.inspect}"

--- a/lib/fluent/config/types.rb
+++ b/lib/fluent/config/types.rb
@@ -229,10 +229,16 @@ module Fluent
 
       param = if val.is_a?(String)
                 val.start_with?('[') ? JSON.parse(val, Fluent::DEFAULT_JSON_PARSE_OPTIONS) : val.strip.split(/\s*,\s*/)
-              elsif val.is_a?(Array) || val.is_a?(Hash)
+              elsif val.is_a?(Array)
                 val
-              else
+              elsif val.is_a?(Numeric) || val == true || val == false
+                # Wrap only the bare scalars that Psych/YAML actually produces
+                # here (nil is handled by the early return above). Any other
+                # type (Hash, Symbol, Time, arbitrary objects) falls through and
+                # still raises "array required" below.
                 [val]
+              else
+                val
               end
       if param.class != Array
         raise ConfigError, "array required but got #{val.inspect}"

--- a/test/config/test_types.rb
+++ b/test/config/test_types.rb
@@ -378,14 +378,19 @@ class TestConfigTypes < ::Test::Unit::TestCase
          "value_type: :integer w/o quote" => [[1,2,1], '1,2,1', {value_type: :integer}],
          "bare integer (YAML scalar)" => [[503], 503, {}],
          "bare integer w/ value_type" => [[503], 503, {value_type: :integer}],
+         "bare float (YAML scalar)" => [[1.5], 1.5, {}],
+         "bare true (YAML scalar)" => [[true], true, {}],
+         "bare false (YAML scalar)" => [[false], false, {}],
          "already an array is untouched" => [[503], [503], {}])
     test 'array' do |(expected, val, opts)|
       assert_equal(expected, Config::ARRAY_TYPE.call(val, opts))
     end
 
     data("hash" => [{"key" => "value"}, {}],
-         "hash w/ value_type" => [{"key" => "1"}, {value_type: :integer}])
-    test 'array w/ hash still raises' do |(val, opts)|
+         "hash w/ value_type" => [{"key" => "1"}, {value_type: :integer}],
+         "symbol" => [:foo, {}],
+         "time" => [Time.at(0), {}])
+    test 'array w/ unexpected type still raises' do |(val, opts)|
       assert_raise(Fluent::ConfigError.new("array required but got #{val.inspect}")) do
         Config::ARRAY_TYPE.call(val, opts)
       end

--- a/test/config/test_types.rb
+++ b/test/config/test_types.rb
@@ -383,6 +383,14 @@ class TestConfigTypes < ::Test::Unit::TestCase
       assert_equal(expected, Config::ARRAY_TYPE.call(val, opts))
     end
 
+    data("hash" => [{"key" => "value"}, {}],
+         "hash w/ value_type" => [{"key" => "1"}, {value_type: :integer}])
+    test 'array w/ hash still raises' do |(val, opts)|
+      assert_raise(Fluent::ConfigError.new("array required but got #{val.inspect}")) do
+        Config::ARRAY_TYPE.call(val, opts)
+      end
+    end
+
     data('["1","2"]' => [["1","2"], '["1","2"]'],
          '["3"]' => [["3"], '["3"]'])
     test 'array w/ default values' do |(expected, val)|

--- a/test/config/test_types.rb
+++ b/test/config/test_types.rb
@@ -375,7 +375,10 @@ class TestConfigTypes < ::Test::Unit::TestCase
          "space in a value w/o qupte" => [["a a","b","c"], 'a a,b,c', {}],
          "integers" => [[1,2,1], '[1,2,1]', {}],
          "value_type: :integer w/ quote" => [[1,2,1], '["1","2","1"]', {value_type: :integer}],
-         "value_type: :integer w/o quote" => [[1,2,1], '1,2,1', {value_type: :integer}])
+         "value_type: :integer w/o quote" => [[1,2,1], '1,2,1', {value_type: :integer}],
+         "bare integer (YAML scalar)" => [[503], 503, {}],
+         "bare integer w/ value_type" => [[503], 503, {value_type: :integer}],
+         "already an array is untouched" => [[503], [503], {}])
     test 'array' do |(expected, val, opts)|
       assert_equal(expected, Config::ARRAY_TYPE.call(val, opts))
     end

--- a/test/config/test_yaml_parser.rb
+++ b/test/config/test_yaml_parser.rb
@@ -1,5 +1,6 @@
 require 'helper'
 require 'fluent/config/yaml_parser'
+require 'fluent/configurable'
 require 'socket'
 require 'json'
 require 'date'
@@ -557,5 +558,39 @@ class YamlParserTest < Test::Unit::TestCase
     assert_equal(:foo, config.elements[0]['symbol1'])
     assert_equal(:bar, config.elements[0]['symbol2'])
     assert_equal(/^$/, config.elements[0]['regexp'])
+  end
+
+  class ArrayParamOutput
+    include Fluent::Configurable
+
+    config_param :retryable_response_codes, :array, value_type: :integer, default: nil
+  end
+
+  sub_test_case 'array parameter' do
+    def test_array_param_accepts_bare_scalar
+      write_config "#{TMP_DIR}/test_array_param_accepts_bare_scalar.yaml", <<~EOS
+        config:
+          - match:
+              $tag: "**"
+              $type: http
+              retryable_response_codes: 503
+      EOS
+      config = Fluent::Config::YamlParser.parse("#{TMP_DIR}/test_array_param_accepts_bare_scalar.yaml")
+      target = ArrayParamOutput.new.configure(config.elements[0])
+      assert_equal([503], target.retryable_response_codes)
+    end
+
+    def test_array_param_accepts_sequence
+      write_config "#{TMP_DIR}/test_array_param_accepts_sequence.yaml", <<~EOS
+        config:
+          - match:
+              $tag: "**"
+              $type: http
+              retryable_response_codes: [502, 503]
+      EOS
+      config = Fluent::Config::YamlParser.parse("#{TMP_DIR}/test_array_param_accepts_sequence.yaml")
+      target = ArrayParamOutput.new.configure(config.elements[0])
+      assert_equal([502, 503], target.retryable_response_codes)
+    end
   end
 end


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes #5149

**What this PR does / why we need it**:
In YAML config syntax, a single scalar value for an array option is rejected. For example `retryable_response_codes: 503` fails with `array required but got 503`, while the classic syntax `retryable_response_codes 503` works fine. The difference is that the classic path delivers the value as the String `"503"`, which `Config.array_value` already splits into `["503"]`, whereas YAML hands it over as a bare `Integer` that falls straight through to the "array required" check.

This wraps a non-String, non-Array, non-Hash scalar into a one-element array so both config syntaxes behave the same way. The wrapped value then flows through the existing `value_type` coercion, so `retryable_response_codes: 503` becomes `[503]` just like `retryable_response_codes: [503]` does. A Hash still raises as before, so an accidental mapping under an array option is not silently accepted.

I could not run the full suite locally (my Ruby is 2.6 and Fluentd needs 3.2), so I verified the logic by tracing the exact `array_value` path and reproducing it in isolation; CI should confirm. I added test cases in test/config/test_types.rb covering a bare integer with and without `value_type`, and that an existing array is left untouched.

**Docs Changes**:
None.

**Release Note**:
Fix a config error when a single scalar value is given to an array option in YAML config syntax (for example `retryable_response_codes: 503`).
