### PR TITLE
test_buf_file_single: close leaked chunk

### DIFF
--- a/test/plugin/test_buf_file_single.rb
+++ b/test/plugin/test_buf_file_single.rb
@@ -142,6 +142,8 @@ class FileSingleBufferTest < Test::Unit::TestCase
       chunk = p.generate_chunk(Fluent::Plugin::Buffer::Metadata.new(nil, nil, nil))
 
       assert_equal 4 * 1024 * 1024, chunk.instance_variable_get(:@decompression_size_limit)
+
+      chunk.purge
     end
   end
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
Missing `#purge` call causes file handle leaks.
On Windows an open file cannot be deleted, so the leftover chunk file remained on disk and later sub_test_case teardowns using File.delete raised "Errno::EACCES: Permission denied" intermittently.

**Docs Changes**:
N/A

**Release Note**: 
N/A