### PR TITLE
output: treat JSON::GeneratorError as unrecoverable error

### DIFF
--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -28,6 +28,7 @@ require 'fluent/unique_id'
 require 'fluent/clock'
 require 'fluent/ext_monitor_require'
 
+require 'json'
 require 'time'
 
 module Fluent
@@ -1220,7 +1221,7 @@ module Fluent
         end
       end
 
-      UNRECOVERABLE_ERRORS = [Fluent::UnrecoverableError, TypeError, ArgumentError, NoMethodError, MessagePack::UnpackError, EncodingError]
+      UNRECOVERABLE_ERRORS = [Fluent::UnrecoverableError, TypeError, ArgumentError, NoMethodError, MessagePack::UnpackError, EncodingError, JSON::GeneratorError]
 
       def try_flush
         chunk = @buffer.dequeue_chunk

--- a/test/plugin/test_output_as_buffered_backup.rb
+++ b/test/plugin/test_output_as_buffered_backup.rb
@@ -184,7 +184,9 @@ class BufferedOutputBackupTest < Test::Unit::TestCase
          'argument error' => ArgumentError,
          'no method error' => NoMethodError,
          'msgpack unpack error' => MessagePack::UnpackError,
-         'encoding error' => EncodingError)
+         'encoding error' => EncodingError,
+         'json generate error' => JSON::GeneratorError
+    )
     test 'backup chunk without secondary' do |error_class|
       Fluent::SystemConfig.overwrite_system_config('root_dir' => TMP_DIR) do
         id = 'backup_test'


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #5414

**What this PR does / why we need it**: 
When JSON generation fails for content reasons (e.g. non-UTF-8 bytes, NaN/Infinity), `JSON.generate` raises `JSON::GeneratorError`. 
This is deterministic for a given chunk, so retrying can never succeed and the chunk should be treated as a bad chunk.

**Docs Changes**:
N/A

**Release Note**: 
* output: treat JSON::GeneratorError as unrecoverable error