### PR TITLE
time: fix TimeFormatter returning nil for the Unix epoch

### DIFF
--- a/lib/fluent/time.rb
+++ b/lib/fluent/time.rb
@@ -363,6 +363,8 @@ module Fluent
 
   class TimeFormatter
     def initialize(format = nil, localtime = true, timezone = nil)
+      # An empty cache slot is marked by a nil string, not by its key: 0 is a
+      # valid timestamp, so a key can never say whether the slot is filled.
       @tc1 = 0
       @tc1_str = nil
       @tc2 = 0
@@ -390,9 +392,9 @@ module Fluent
     end
 
     def format_without_subsec(time)
-      if @tc1 == time
+      if @tc1_str && @tc1 == time
         return @tc1_str
-      elsif @tc2 == time
+      elsif @tc2_str && @tc2 == time
         return @tc2_str
       else
         str = format_nocache(time)
@@ -408,9 +410,9 @@ module Fluent
     end
 
     def format_with_subsec(time)
-      if Fluent::EventTime.eq?(@tc1, time)
+      if @tc1_str && Fluent::EventTime.eq?(@tc1, time)
         return @tc1_str
-      elsif Fluent::EventTime.eq?(@tc2, time)
+      elsif @tc2_str && Fluent::EventTime.eq?(@tc2, time)
         return @tc2_str
       else
         str = format_nocache(time)

--- a/test/test_time_formatter.rb
+++ b/test/test_time_formatter.rb
@@ -196,6 +196,29 @@ class TimeFormatterTest < ::Test::Unit::TestCase
     assert_equal("20140927 0000.000000000", formatter.format(time))
   end
 
+  # The Unix epoch used to match an empty cache slot, whose string is nil.
+  def test_format_epoch
+    formatter = Fluent::TimeFormatter.new(nil, false, nil)
+    assert_equal("1970-01-01T00:00:00Z", formatter.format(Fluent::EventTime.new(0)))
+
+    formatter = Fluent::TimeFormatter.new(nil, false, nil)
+    assert_equal("1970-01-01T00:00:00Z", formatter.format(0))
+    assert_equal("1970-01-01T00:00:01Z", formatter.format(Fluent::EventTime.new(1)))
+    assert_equal("1970-01-01T00:00:00Z", formatter.format(Fluent::EventTime.new(0)))
+  end
+
+  # Here the slot is compared with EventTime.eq?, which falls back to comparing
+  # seconds alone, so the whole first second of the epoch matched an empty slot.
+  def test_format_epoch_with_subsec
+    formatter = Fluent::TimeFormatter.new("%Y%m%d %H%M%S.%N", false, nil)
+    assert_equal("19700101 000000.000000000", formatter.format(Fluent::EventTime.new(0, 0)))
+    assert_equal("19700101 000000.123456789", formatter.format(Fluent::EventTime.new(0, 123456789)))
+    assert_equal("19700101 000000.000000000", formatter.format(Fluent::EventTime.new(0, 0)))
+
+    formatter = Fluent::TimeFormatter.new("%Y%m%d %H%M%S.%N", false, nil)
+    assert_equal("19700101 000000.999999999", formatter.format(Fluent::EventTime.new(0, 999999999)))
+  end
+
   sub_test_case 'TimeMixin::Formatter' do
     class DummyForTimeFormatter
       include Fluent::Configurable

--- a/test/test_time_formatter.rb
+++ b/test/test_time_formatter.rb
@@ -201,16 +201,38 @@ class TimeFormatterTest < ::Test::Unit::TestCase
     formatter = Fluent::TimeFormatter.new(nil, false, nil)
     assert_equal("1970-01-01T00:00:00Z", formatter.format(Fluent::EventTime.new(0)))
 
+    # Only the tc2 slot is used here, so the second 0 is a miss.
     formatter = Fluent::TimeFormatter.new(nil, false, nil)
+    mock.proxy(formatter).format_nocache(satisfy { |t| t.to_i == 0 }).twice
+    mock.proxy(formatter).format_nocache(satisfy { |t| t.to_i == 1 }).once
     assert_equal("1970-01-01T00:00:00Z", formatter.format(0))
     assert_equal("1970-01-01T00:00:01Z", formatter.format(Fluent::EventTime.new(1)))
     assert_equal("1970-01-01T00:00:00Z", formatter.format(Fluent::EventTime.new(0)))
   end
 
+  def test_format_uses_both_cache_slots
+    formatter = Fluent::TimeFormatter.new(nil, false, nil)
+    mock.proxy(formatter).format_nocache(satisfy { |t| t.to_i == 10 }).once
+    mock.proxy(formatter).format_nocache(satisfy { |t| t.to_i == 20 }).once
+    assert_equal("1970-01-01T00:00:10Z", formatter.format(Fluent::EventTime.new(10)))
+    assert_equal("1970-01-01T00:00:20Z", formatter.format(Fluent::EventTime.new(20)))
+    assert_equal("1970-01-01T00:00:10Z", formatter.format(Fluent::EventTime.new(10)))
+    assert_equal("1970-01-01T00:00:20Z", formatter.format(Fluent::EventTime.new(20)))
+  end
+
+  def test_format_negative_timestamp
+    formatter = Fluent::TimeFormatter.new(nil, false, nil)
+    assert_equal("1969-12-31T23:59:59Z", formatter.format(Fluent::EventTime.new(-1)))
+    assert_equal("1970-01-01T00:00:00Z", formatter.format(Fluent::EventTime.new(0)))
+    assert_equal("1969-12-31T23:59:59Z", formatter.format(Fluent::EventTime.new(-1)))
+  end
+
   # Here the slot is compared with EventTime.eq?, which falls back to comparing
   # seconds alone, so the whole first second of the epoch matched an empty slot.
   def test_format_epoch_with_subsec
+    # Only the tc2 slot is used here, so every timestamp is a miss.
     formatter = Fluent::TimeFormatter.new("%Y%m%d %H%M%S.%N", false, nil)
+    mock.proxy(formatter).format_nocache(satisfy { |t| t.to_i == 0 }).times(3)
     assert_equal("19700101 000000.000000000", formatter.format(Fluent::EventTime.new(0, 0)))
     assert_equal("19700101 000000.123456789", formatter.format(Fluent::EventTime.new(0, 123456789)))
     assert_equal("19700101 000000.000000000", formatter.format(Fluent::EventTime.new(0, 0)))


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
`TimeFormatter` caches the last two formatted timestamps in two slots, and an empty slot was marked by its key being `0`. But `0` is a valid timestamp, so the epoch matched an empty slot and its `nil` string was returned as a cache hit:

```ruby
Fluent::TimeFormatter.new(nil, false, nil).format(0)  #=> nil
```

`format_with_subsec` compares slots with `EventTime.eq?`, which falls back to `EventTime#==` and compares seconds alone, so there the whole first second of the epoch is affected:

```ruby
fmt = Fluent::TimeFormatter.new("%Y%m%d %H%M%S.%N", false, nil)
fmt.format(Fluent::EventTime.new(0, 123456789))  #=> nil
```

The fix is to mark an empty slot by its cached string being `nil` rather than by its key.
`format_nocache` always returns a `String`, so a filled slot can never be mistaken for an empty one. Every other timestamp behaves exactly as before, since key `0` could never have matched it.

Impact is small, and I don't think this is urgent.
A slot keeps the key `0` only until it is written, so a formatter self-heals once it has formatted two distinct timestamps, within a second of the first record.
The exception is a stream whose timestamps are *all* the epoch: the early return never fills a slot, and `out_file` then writes every line with an empty time column.
That is reachable via `time_type unixtime`, which parses with `value.to_i` and turns an empty or non-numeric `time_key` into `EventTime.new(0)`, but such a pipeline is misconfigured anyway. The reason to fix it is simply that `nil` is never a correct result.

**Docs Changes**:

**Release Note**: 
* time: fix TimeFormatter returning nil for the Unix epoch