### PR TITLE
Add `allow_comments: true` option for json parser

### DIFF
--- a/lib/fluent/env.rb
+++ b/lib/fluent/env.rb
@@ -26,7 +26,7 @@ module Fluent
   DEFAULT_SOCKET_PATH = ENV['FLUENT_SOCKET'] || '/var/run/fluent/fluent.sock'
   DEFAULT_BACKUP_DIR = ENV['FLUENT_BACKUP_DIR'] || '/tmp/fluent'
   DEFAULT_OJ_OPTIONS = Fluent::OjOptions.load_env
-  DEFAULT_JSON_PARSE_OPTIONS = { allow_duplicate_key: true }.freeze
+  DEFAULT_JSON_PARSE_OPTIONS = { allow_duplicate_key: true, allow_comments: true }.freeze
   DEFAULT_DIR_PERMISSION = 0755
   DEFAULT_FILE_PERMISSION = 0644
   INSTANCE_ID = ENV['FLUENT_INSTANCE_ID'] || SecureRandom.uuid

--- a/test/plugin/test_parser_json.rb
+++ b/test/plugin/test_parser_json.rb
@@ -94,6 +94,18 @@ class JsonParserTest < ::Test::Unit::TestCase
     end
   end
 
+  data('oj' => 'oj', 'json' => 'json', 'yajl' => 'yajl')
+  def test_parse_with_comments(data)
+    @parser.configure('json_parser' => data)
+    assert_nothing_raised do
+      @parser.instance.parse('{
+        "key1":"a", // for a,
+        "key1":"b"  // for b
+        }') { |time, record|
+      }
+    end
+  end
+
   data('oj' => 'oj', 'yajl' => 'yajl')
   def test_parse_with_large_float(data)
     @parser.configure('json_parser' => data)


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
Related to https://github.com/fluent/fluentd/pull/5410

Since json gem 3.0, JSON.parse will raise an error when the input contains comments unless `allow_comments: true` is passed. On Ruby head this already shows up as a deprecation warning:

```
  warning: Encountered comment in JSON. This will raise an error in
  json 3.0 unless enabled via `allow_comments: true`
```

Ref. https://github.com/ruby/json/blob/master/CHANGES.md#2026-06-23-2200

Fluentd has accepted comments in JSON so far (embedded JSON in the config parsed by literal_parser, and the json parser plugin), so add `allow_comments: true` to `DEFAULT_JSON_PARSE_OPTIONS` to keep that behavior and avoid the future breakage.
Ref. https://github.com/fluent/fluentd/blob/43f46f33efb3e6dda17576568c313b3f758dfa0c/test/config/test_literal_parser.rb#L275-L277

This constant is shared by both paths, so the single change covers them together.

**Docs Changes**:

**Release Note**: 
* Add `allow_comments: true` option for json parser
