### PR TITLE
fix(in_tail): fix variable name bugs causing position file leak and NameError

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -647,7 +647,7 @@ module Fluent::Plugin
 
       tw.close if close_io
 
-      if @pf && tw.unwatched && (@follow_inode || !@tails[tw.path])
+      if @pf && tw.unwatched && (@follow_inodes || !@tails[tw.path])
         target_info = TargetInfo.new(tw.path, ino)
         @pf.unwatch(target_info)
       end
@@ -751,7 +751,7 @@ module Fluent::Plugin
           else
             if @emit_unmatched_lines
               record = {'unmatched_line' => line}
-              record[@path_key] ||= tail_watcher.path unless @path_key.nil?
+            record[@path_key] ||= tw.path unless @path_key.nil?
               es.add(Fluent::EventTime.now, record)
             end
             log.warn { "pattern not matched: #{line.inspect}" }


### PR DESCRIPTION
## Summary

Two variable name bugs in the tail input plugin (`lib/fluent/plugin/in_tail.rb`):

### 1. Wrong instance variable: `@follow_inode` vs `@follow_inodes` (line 650)

The condition references `@follow_inode` (singular), but the instance variable is defined as `@follow_inodes` (plural) on line 892. In Ruby, referencing an undefined instance variable silently returns `nil` rather than raising an error.

When `@follow_inodes` is enabled, the position file entry for unwatched tail watchers should always be cleaned up. But because `@follow_inode` evaluates to `nil`, the condition degenerates to `(!@tails[tw.path])`, so the entry is only unwatched if the path is not currently in `@tails`. During rotation, when the path IS still present, the position file entry leaks and is never cleaned up, causing unbounded growth with stale entries.

### 2. Undefined local variable `tail_watcher` (line 709)

In `flush_buffer`, the parameter is named `tw`, but line 709 references `tail_watcher` — an undefined local variable. Every other usage in this method (lines 700, 704, 711, 717) correctly uses `tw`.

This causes a `NameError: undefined local variable or method 'tail_watcher'` at runtime when `emit_unmatched_lines` is enabled with `path_key` in multiline mode, crashing the tail watcher's IOHandler and potentially losing log data.