### PR TITLE
fix(child_process): fix inverted break condition in close method

### DIFF
--- a/lib/fluent/plugin_helper/child_process.rb
+++ b/lib/fluent/plugin_helper/child_process.rb
@@ -191,7 +191,7 @@ module Fluent
             child_process_kill(process_info, force: true)
           end
 
-          break if living_process_exist
+          break unless living_process_exist
 
           sleep CHILD_PROCESS_LOOP_CHECK_INTERVAL
         end


### PR DESCRIPTION
## Summary

In the `close` method's wait-for-exit loop (`lib/fluent/plugin_helper/child_process.rb:194`), the condition `break if living_process_exist` is inverted and should be `break unless living_process_exist`.

### The bug

The loop is designed to wait for all child processes to exit (or force-kill them after the kill timeout). The logic:

1. Check all tracked pids
2. If a process is still alive, set `living_process_exist = true` and force-kill it if past the timeout
3. `break if living_process_exist` — **this is backwards**

The current code breaks out of the loop as soon as it finds *any* living process, immediately proceeding to `super` and continuing shutdown without waiting for those processes to actually terminate. This allows child processes to become orphaned or zombie processes.

### Comparison with `shutdown` method

The `shutdown` method (line 142) correctly implements the same wait-for-exit pattern:
```ruby
if process_exists
  sleep CHILD_PROCESS_LOOP_CHECK_INTERVAL
else
  break
end
```

The `close` method should follow the same pattern: keep looping while processes are alive, break when they're all gone.