### PR TITLE
test_out_buffer: fix flaky BufferOutputTest#write

### DIFF
--- a/test/plugin/test_out_buffer.rb
+++ b/test/plugin/test_out_buffer.rb
@@ -45,7 +45,7 @@ class BufferOutputTest < Test::Unit::TestCase
 
     time = event_time
     record = {"message" => "test"}
-    d.run(default_tag: 'test') do
+    d.run(default_tag: 'test', expect_emits: 1) do
       d.feed(time, record)
     end
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
`out_buffer` flushes its buffer immediately and re-emits events asynchronously via the flush thread.
The test driver's `wait_flush_completion` only waits until the chunk leaves the buffer queue , not until `write()` actually emits. 
When the flush thread is still between `dequeue_chunk` and `write`, `run()` proceeds to shutdown, where `EventEmitter#after_shutdown` nil-s out @router before `Output#after_shutdown` joins the flush thread. 
The in-flight write then emits to a `nil` router and the event is dropped, making `d.events` empty. This surfaces as a flaky failure under CI load.

Pass `expect_emits: 1` so `run()` waits until the event is actually emitted (while the router is still valid) before shutting the plugin down.

This PR should fix following error:
```
1) Failure: test: #write(BufferOutputTest)
/Users/runner/hostedtoolcache/Ruby/3.2.11/arm64/bin/bundle:25:in `load'
/Users/runner/work/fluentd/fluentd/test/plugin/test_out_buffer.rb:52:in `block in <class:BufferOutputTest>'
/Users/runner/hostedtoolcache/Ruby/3.2.11/arm64/bin/bundle:25:in `<main>'
     49:       d.feed(time, record)
Tasks: TOP => test => base_test
     50:     end
(See full trace by running task with --trace)
     51: 
  => 52:     assert_equal [["test", time, record]], d.events
     53:   end
     54: end
<[["test", 2026-07-16 07:03:01.673742000 +0000, {"message"=>"test"}]]> expected but was
<[]>
diff:
? [["test", 2026-07-16 07:03:01.673742000 +0000, {"message"=>"test"}]]
Error: <[["test", 2026-07-16 07:03:01.673742000 +0000, {"message"=>"test"}]]> expected but was
<[]>.
```

Ref. https://github.com/fluent/fluentd/actions/runs/29478564922/job/87556893864#step:6:5358

**Docs Changes**:
N/A

**Release Note**: 
N/A