### PR TITLE
test_in_tail: relax too-tight timeouts in file-appended-after-start tests

### DIFF
--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -498,7 +498,7 @@ class TailInputTest < Test::Unit::TestCase
       d = create_driver(config)
       msg = 'x' * 65000 # in_tail reads 65536 bytes at once.
 
-      d.run(expect_emits: num_events, timeout: 2) do
+      d.run(expect_emits: num_events, timeout: 10) do
         Fluent::FileWrapper.open("#{@tmp_dir}/tail.txt", "ab") {|f|
           f.puts msg
           f.puts msg
@@ -792,7 +792,7 @@ class TailInputTest < Test::Unit::TestCase
 
       d = create_driver(config, false)
 
-      d.run(expect_emits: 1, timeout: 1) do
+      d.run(expect_emits: 1, timeout: 10) do
         Fluent::FileWrapper.open("#{@tmp_dir}/tail.txt", "ab") {|f|
           f.puts "test3"
           f.puts "test4"
@@ -834,7 +834,7 @@ class TailInputTest < Test::Unit::TestCase
     def test_always_read_from_head_on_detecting_a_new_file
       d = create_driver(SINGLE_LINE_CONFIG)
 
-      d.run(expect_emits: 1, timeout: 3) do
+      d.run(expect_emits: 1, timeout: 10) do
         Fluent::FileWrapper.open("#{@tmp_dir}/tail.txt", "wb") {|f|
           f.puts "test1\ntest2\n"
         }


### PR DESCRIPTION

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

`test_emit_with_read_lines_limit[flat 1]` fails intermittently on CI (Ruby 3.4, windows-11-arm) with:

```
3) Failure: test_emit_with_read_lines_limit[flat 1](TailInputTest::singleline)
C:/a/fluentd/fluentd/test/plugin/test_in_tail.rb:509:in 'TailInputTest::TEST_VGFpbElucHV0VGVzdDo6c2luZ2xlbGluZQ#test_emit_with_read_lines_limit'
     506:       end
     507: 
     508:       events = d.events
  => 509:       assert_equal(true, events.length > 0)
     510:       assert_equal({"message" => msg}, events[0][2])
     511:       assert_equal({"message" => msg}, events[1][2])
     512:       assert num_events <= d.emit_count
<true> expected but was
<false>

diff:
? tru e
? fals 
? ??? 
Error: <true> expected but was
<false>.
```
https://github.com/fluent/fluentd/actions/runs/29549033055/job/87787458652#step:6:5460


i.e. no event was emitted within the 2s timeout.

These tests create/append the target file *after* `d.run` starts, so the new content is only picked up by the periodic `refresh_watchers` timer. 
The first emit is therefore structurally pinned to ~1s regardless of machine speed, and `timeout: 2` leaves only ~1s of margin.

A timeout threshold sweep (30 runs each) shows both macOS and Windows 11 ARM share the ~1s floor (0.8s always fails), but Windows has large jitter around it (13/30 fail at timeout 1.0s vs 0/30 on macOS). On the slower, more-contended windows-11-arm CI runner that jitter occasionally exceeds the 2s timeout, causing the flake.

`expect_emits:` returns as soon as the expected emits arrive (~1s), so raising the timeout does not slow the passing case; a real "no emit" regression is still caught, just after 10s instead of 2s.

Relax the timeouts of the three in_tail tests that share this "file activity after run starts + short timeout" shape:

- test_emit_with_read_lines_limit: 2 -> 10
- test_always_read_from_head_on_detecting_a_new_file: 3 -> 10
- test_watch_wildcard_path_without_watch_timer: 1 -> 10 (Linux-only, but had the tightest timeout)


**Docs Changes**:
N/A

**Release Note**: 
N/A