### PR TITLE
config: accept empty lines in quoted strings

### DIFF
--- a/lib/fluent/config/basic_parser.rb
+++ b/lib/fluent/config/basic_parser.rb
@@ -28,7 +28,6 @@ module Fluent
       SPACING = /(?:[ \t\r\n]|\z|\#.*?(?:\z|[\r\n]))+/
       ZERO_OR_MORE_SPACING = /(?:[ \t\r\n]|\z|\#.*?(?:\z|[\r\n]))*/
       SPACING_WITHOUT_COMMENT = /(?:[ \t\r\n]|\z)+/
-      LINE_END_WITHOUT_SPACING_AND_COMMENT = /(?:\z|[\r\n])/
 
       module ClassMethods
         def symbol(string)

--- a/lib/fluent/config/literal_parser.rb
+++ b/lib/fluent/config/literal_parser.rb
@@ -98,11 +98,10 @@ module Fluent
             else
               return string.join
             end
-          elsif check(/[^"]#{LINE_END_WITHOUT_SPACING_AND_COMMENT}/o)
-            if s = check(/[^\\]#{LINE_END_WITHOUT_SPACING_AND_COMMENT}/o)
-              string << s
-            end
-            skip(/[^"]#{LINE_END_WITHOUT_SPACING_AND_COMMENT}/o)
+          elsif skip(/\\(?:\r\n|[\r\n])/)
+            next
+          elsif s = scan(/\r\n|[\r\n]/)
+            string << s
           elsif s = scan(/\\./)
             string << eval_escape_char(s[1,1])
           elsif skip(/\#\{/)

--- a/lib/fluent/config/literal_parser.rb
+++ b/lib/fluent/config/literal_parser.rb
@@ -131,6 +131,8 @@ module Fluent
             string << "'"
           elsif s = scan(/\\\\/)
             string << "\\"
+          elsif s = scan(LINE_BREAK)
+            string << s
           elsif s = scan(/./)
             string << s
           else

--- a/lib/fluent/config/literal_parser.rb
+++ b/lib/fluent/config/literal_parser.rb
@@ -26,6 +26,13 @@ require 'fluent/config/basic_parser'
 module Fluent
   module Config
     class LiteralParser < BasicParser
+      # A physical line break (LF, CR, or CRLF) inside a double-quoted string.
+      # It is preserved as-is in the resulting value.
+      LINE_BREAK = /\r\n|[\r\n]/
+      # A backslash immediately followed by a physical line break.
+      # It works as a line continuation, so both are stripped from the value.
+      LINE_CONTINUATION = /\\#{LINE_BREAK}/o
+
       def self.unescape_char(c)
         case c
         when '"'
@@ -98,9 +105,9 @@ module Fluent
             else
               return string.join
             end
-          elsif skip(/\\(?:\r\n|[\r\n])/)
+          elsif skip(LINE_CONTINUATION)
             next
-          elsif s = scan(/\r\n|[\r\n]/)
+          elsif s = scan(LINE_BREAK)
             string << s
           elsif s = scan(/\\./)
             string << eval_escape_char(s[1,1])

--- a/lib/fluent/config/literal_parser.rb
+++ b/lib/fluent/config/literal_parser.rb
@@ -26,8 +26,10 @@ require 'fluent/config/basic_parser'
 module Fluent
   module Config
     class LiteralParser < BasicParser
-      # A physical line break (LF, CR, or CRLF) inside a double-quoted string.
-      # It is preserved as-is in the resulting value.
+      # A physical line break (LF, CR, or CRLF) inside a quoted string.
+      # CRLF is normalized to LF so that the same config text does not produce a
+      # different value depending on whether the file was saved with LF or CRLF.
+      # A lone CR is kept as-is, and an escaped "\r\n" still produces CRLF.
       LINE_BREAK = /\r\n|[\r\n]/
       # A backslash immediately followed by a physical line break.
       # It works as a line continuation, so both are stripped from the value.
@@ -108,7 +110,7 @@ module Fluent
           elsif skip(LINE_CONTINUATION)
             next
           elsif s = scan(LINE_BREAK)
-            string << s
+            string << (s == "\r\n" ? "\n" : s)
           elsif s = scan(/\\./)
             string << eval_escape_char(s[1,1])
           elsif skip(/\#\{/)
@@ -132,7 +134,7 @@ module Fluent
           elsif s = scan(/\\\\/)
             string << "\\"
           elsif s = scan(LINE_BREAK)
-            string << s
+            string << (s == "\r\n" ? "\n" : s)
           elsif s = scan(/./)
             string << s
           else

--- a/test/config/test_config_parser.rb
+++ b/test/config/test_config_parser.rb
@@ -149,6 +149,7 @@ module Fluent::Config
         end
 
         test "support multiline string" do
+          assert_text_parsed_as(e('ROOT', '', {"k1" => "world\n\n"}), "k1 \"world\n\n\"")
           assert_text_parsed_as(e('ROOT', '',
             {"k1" => %[line1
                        line2]

--- a/test/config/test_literal_parser.rb
+++ b/test/config/test_literal_parser.rb
@@ -111,6 +111,13 @@ module Fluent::Config
       test('"t') { assert_parse_error('"t') }  # non-terminated quoted character
       test("\"t\nt\"") { assert_text_parsed_as("t\nt", "\"t\nt\"" ) } # multiline string
       test("\"t\\\nt\"") { assert_text_parsed_as("tt", "\"t\\\nt\"" ) } # multiline string
+      test("\"t\n\nt\"") { assert_text_parsed_as("t\n\nt", "\"t\n\nt\"") }
+      test("\"\nt\"") { assert_text_parsed_as("\nt", "\"\nt\"") }
+      test("\"t\\\\\nt\"") { assert_text_parsed_as("t\\\nt", "\"t\\\\\nt\"") }
+      test("\"t\r\nt\"") { assert_text_parsed_as("t\r\nt", "\"t\r\nt\"") }
+      test("\"t\\\r\nt\"") { assert_text_parsed_as("tt", "\"t\\\r\nt\"") }
+      test("\"t\n") { assert_parse_error("\"t\n") }
+      test("\"t\\\n") { assert_parse_error("\"t\\\n") }
       test('t"') { assert_text_parsed_as('t"', 't"') }
       test('"."') { assert_text_parsed_as('.', '"."') }
       test('"*"') { assert_text_parsed_as('*', '"*"') }

--- a/test/config/test_literal_parser.rb
+++ b/test/config/test_literal_parser.rb
@@ -145,6 +145,12 @@ module Fluent::Config
       test("'\\0'") { assert_text_parsed_as('\0', "'\\0'") }
       test("'\\1'") { assert_text_parsed_as('\1', "'\\1'") }
       test("'t") { assert_parse_error("'t") }  # non-terminated quoted character
+      test("'t\nt'") { assert_text_parsed_as("t\nt", "'t\nt'") }
+      test("'t\n\nt'") { assert_text_parsed_as("t\n\nt", "'t\n\nt'") }
+      test("'\nt'") { assert_text_parsed_as("\nt", "'\nt'") }
+      test("'t\r\nt'") { assert_text_parsed_as("t\r\nt", "'t\r\nt'") }
+      test("'t\\\nt'") { assert_text_parsed_as("t\\\nt", "'t\\\nt'") }
+      test("'t\n") { assert_parse_error("'t\n") }
       test("t'") { assert_text_parsed_as("t'", "t'") }
       test("'.'") { assert_text_parsed_as('.', "'.'") }
       test("'*'") { assert_text_parsed_as('*', "'*'") }

--- a/test/config/test_literal_parser.rb
+++ b/test/config/test_literal_parser.rb
@@ -114,7 +114,8 @@ module Fluent::Config
       test("\"t\n\nt\"") { assert_text_parsed_as("t\n\nt", "\"t\n\nt\"") }
       test("\"\nt\"") { assert_text_parsed_as("\nt", "\"\nt\"") }
       test("\"t\\\\\nt\"") { assert_text_parsed_as("t\\\nt", "\"t\\\\\nt\"") }
-      test("\"t\r\nt\"") { assert_text_parsed_as("t\r\nt", "\"t\r\nt\"") }
+      test("\"t\r\nt\"") { assert_text_parsed_as("t\nt", "\"t\r\nt\"") }
+      test("\"t\rt\"") { assert_text_parsed_as("t\rt", "\"t\rt\"") }
       test("\"t\\\r\nt\"") { assert_text_parsed_as("tt", "\"t\\\r\nt\"") }
       test("\"t\n") { assert_parse_error("\"t\n") }
       test("\"t\\\n") { assert_parse_error("\"t\\\n") }
@@ -148,7 +149,8 @@ module Fluent::Config
       test("'t\nt'") { assert_text_parsed_as("t\nt", "'t\nt'") }
       test("'t\n\nt'") { assert_text_parsed_as("t\n\nt", "'t\n\nt'") }
       test("'\nt'") { assert_text_parsed_as("\nt", "'\nt'") }
-      test("'t\r\nt'") { assert_text_parsed_as("t\r\nt", "'t\r\nt'") }
+      test("'t\r\nt'") { assert_text_parsed_as("t\nt", "'t\r\nt'") }
+      test("'t\rt'") { assert_text_parsed_as("t\rt", "'t\rt'") }
       test("'t\\\nt'") { assert_text_parsed_as("t\\\nt", "'t\\\nt'") }
       test("'t\n") { assert_parse_error("'t\n") }
       test("t'") { assert_text_parsed_as("t'", "t'") }


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #4691

**What this PR does / why we need it**: 

The quoted configuration values previously handled a physical line ending together with its preceding character. When the parser was already positioned at a line ending—such as on an empty line or after an escaped literal backslash—it instead reported an unexpected end of file.

Handle backslash line continuations and preserved line endings explicitly. This accepts empty lines, preserves LF and CRLF, and retains the existing single-backslash continuation behavior.

**Docs Changes**:

None. The existing multiline-string documentation already describes the intended behavior.

**Release Note**: 

config: accept empty lines in quoted strings.

**Testing**:

Automated:

- `bundle exec rake test TEST=test/config/test_literal_parser.rb` — 220 tests, 223 assertions, 0 failures, 0 errors
- `TEST_ENV_NUMBER=focus4691 bundle exec rake test TEST=test/config/test_config_parser.rb` — 56 tests, 106 assertions, 0 failures, 0 errors
- `bundle exec rake test` (two independent runs) — 4,343 tests, 15,829 and 15,830 assertions respectively; 0 failures, 0 errors, 3 pendings, and 36 omissions in both
- `rubocop` — 459 files inspected, no offenses
- `ruby -c` for all three changed Ruby files and `git diff --check`

Manual (Ruby 4.0.6):

- Built and separately installed gems from baseline `f380d996bc828b5cd488b578018c06826ebcbf7e` and candidate `7d017869a55e179da4d195806f26d33dc485fc9d`.
- The baseline built gem rejected the reproducing configuration with a false unexpected-EOF error; the candidate built gem accepted it with `fluentd --dry-run`; a genuinely unterminated double-quoted value remained rejected.
- Ran the candidate built gem as a separate `fluentd --no-supervisor` process through `dummy` → `record_transformer` → `stdout` and externally parsed its emitted JSON as `{"message":"seed","blank":"world\n\n","literal_backslash":"left\\\nright","continued":"leftright"}`.
