### PR TITLE
test: fix unused ports outside the OS dynamic port range

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -89,10 +89,16 @@ end
 # roughly 100 ports and multiple ranges may coexist, so use a sufficiently
 # wide candidate range to reduce the probability that all candidates are
 # excluded.
+# Those reservations are taken from the dynamic port range (49152-65535 on
+# Windows, observed on GitHub Actions runners), and a port can become
+# reserved even between the checks below and the actual bind, which then
+# fails with EACCES. So keep the candidate range outside the dynamic port
+# range of every platform (Linux uses 32768-60999) to avoid competing with
+# the OS for ports in the first place.
 # About dynamic excluded port ranges, see:
 # > netsh interface ipv4 show excludedportrange protocol=tcp
-# > netsh interface ipv4 show excludedportrange protocol=ucp
-PORT_RANGE_TCP_UDP = (55000..65000)
+# > netsh interface ipv4 show excludedportrange protocol=udp
+PORT_RANGE_TCP_UDP = (20000..30000)
 
 def unused_port_tcp_udp(num = 1, retries: 1000)
   raise "not support num > 1" if num > 1
@@ -106,9 +112,13 @@ def unused_port_tcp_udp(num = 1, retries: 1000)
   raise "can't find unused port"
 end
 
+# Bind the loopback address that the tests using unused_port(protocol: :all)
+# actually bind, so that a successful check means the same bind can succeed.
+BIND_ADDRESS_TCP_UDP = "127.0.0.1"
+
 def port_bindable_udp?(port)
   u = UDPSocket.new(::Socket::AF_INET)
-  u.bind("0.0.0.0", port)
+  u.bind(BIND_ADDRESS_TCP_UDP, port)
   true
 rescue SystemCallError
   false
@@ -117,7 +127,7 @@ ensure
 end
 
 def port_bindable_tcp?(port)
-  TCPServer.open("0.0.0.0", port).close
+  TCPServer.open(BIND_ADDRESS_TCP_UDP, port).close
   true
 rescue SystemCallError
   false

--- a/test/test_unused_port.rb
+++ b/test/test_unused_port.rb
@@ -5,10 +5,10 @@ class UnusedPortTest < Test::Unit::TestCase
     port = unused_port(protocol: :all)
     assert_kind_of(Integer, port)
     assert_include(PORT_RANGE_TCP_UDP, port)
-    tcp = TCPServer.open("0.0.0.0", port)
+    tcp = TCPServer.open(BIND_ADDRESS_TCP_UDP, port)
     tcp.close
     udp = UDPSocket.new(::Socket::AF_INET)
-    udp.bind("0.0.0.0", port)
+    udp.bind(BIND_ADDRESS_TCP_UDP, port)
     udp.close
   end
 
@@ -20,7 +20,7 @@ class UnusedPortTest < Test::Unit::TestCase
 
   sub_test_case "port_bindable_tcp?" do
     test "returns false while the port is held and true after release" do
-      held = TCPServer.open("0.0.0.0", 0)
+      held = TCPServer.open(BIND_ADDRESS_TCP_UDP, 0)
       port = held.addr[1]
       assert_false(port_bindable_tcp?(port))
       held.close
@@ -31,7 +31,7 @@ class UnusedPortTest < Test::Unit::TestCase
   sub_test_case "port_bindable_udp?" do
     test "returns false while the port is held and true after release" do
       held = UDPSocket.new(::Socket::AF_INET)
-      held.bind("0.0.0.0", 0)
+      held.bind(BIND_ADDRESS_TCP_UDP, 0)
       port = held.addr[1]
       assert_false(port_bindable_udp?(port))
       held.close


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
On Windows, Hyper-V/WinNAT/HNS take their reservations from the dynamic port range, which is 49152-65535 as observed on GitHub Actions runners, and a reservation can appear between the check and the actual bind. 

When searching for unused ports, this PR will avoid this range to prevent following error.

```
3) Error: test: send_with_time_as_integer(ForwardOutputTest): Errno::EACCES: Permission denied - bind(2) for 127.0.0.1:58707
C:/hostedtoolcache/windows/Ruby/4.0.5/arm64/lib/ruby/4.0.0/socket.rb:183:in 'Socket#bind'
C:/hostedtoolcache/windows/Ruby/4.0.5/arm64/lib/ruby/4.0.0/socket.rb:183:in 'Addrinfo#bind'
C:/a/fluentd/fluentd/lib/fluent/plugin_helper/server.rb:402:in 'Fluent::PluginHelper::Server#server_create_udp_socket'
C:/a/fluentd/fluentd/lib/fluent/plugin_helper/server.rb:178:in 'Fluent::PluginHelper::Server#server_create'
C:/a/fluentd/fluentd/lib/fluent/plugin/in_forward.rb:192:in 'Fluent::Plugin::ForwardInput#start'
C:/a/fluentd/fluentd/lib/fluent/test/driver/base.rb:120:in 'Fluent::Test::Driver::Base#instance_start'
C:/a/fluentd/fluentd/lib/fluent/test/driver/base.rb:78:in 'Fluent::Test::Driver::Base#run'
C:/a/fluentd/fluentd/lib/fluent/test/driver/base_owner.rb:130:in 'Fluent::Test::Driver::BaseOwner#run'
C:/a/fluentd/fluentd/test/plugin/test_out_forward.rb:516:in 'block (2 levels) in <class:ForwardOutputTest>'
C:/hostedtoolcache/windows/Ruby/4.0.5/arm64/lib/ruby/gems/4.0.0/gems/test-unit-rr-1.0.5/lib/test/unit/rr.rb:98:in 'Test::Unit::RR::Adapter#assert_rr'
C:/a/fluentd/fluentd/test/plugin/test_out_forward.rb:515:in 'block in <class:ForwardOutputTest>'
```
https://github.com/fluent/fluentd/actions/runs/29884012909/job/88810722450#step:6:5337

Related to #5434

**Docs Changes**:
N/A

**Release Note**: 
N/A