### PR TITLE
Fix infinite loop when an error event fails in @ERROR

### DIFF
--- a/lib/fluent/root_agent.rb
+++ b/lib/fluent/root_agent.rb
@@ -48,6 +48,11 @@ module Fluent
   class RootAgent < Agent
     ERROR_LABEL = "@ERROR".freeze # @ERROR is built-in error label
 
+    # Thread local key to detect an error which is raised while an error event is
+    # routed to @ERROR. @ERROR is the last resort route, so such an event must be
+    # dumped here instead of being routed back to @ERROR again and again.
+    ERROR_ROUTING_KEY = :fluentd_root_agent_routing_error_event
+
     class SourceOnlyMode
       DISABLED = 0
       NORMAL = 1
@@ -439,10 +444,13 @@ module Fluent
 
     def emit_error_event(tag, time, record, error)
       error_info = {error: error, location: (error.backtrace ? error.backtrace.first : nil), tag: tag, time: time}
-      if @error_collector
+      if @error_collector && !routing_error_event?
         # A record is not included in the logs because <@ERROR> handles it. This warn is for the notification
         log.warn "send an error event to @ERROR:", error_info
-        @error_collector.emit(tag, time, record)
+        route_error_event { @error_collector.emit(tag, time, record) }
+      elsif @error_collector
+        error_info[:record] = record
+        log.error "dump an error event because it failed in @ERROR. It is dropped to prevent an infinite loop:", error_info
       else
         error_info[:record] = record
         log.warn "dump an error event:", error_info
@@ -451,9 +459,13 @@ module Fluent
 
     def handle_emits_error(tag, es, error)
       error_info = {error: error, location: (error.backtrace ? error.backtrace.first : nil), tag: tag}
-      if @error_collector
+      if @error_collector && !routing_error_event?
         log.warn "send an error event stream to @ERROR:", error_info
-        @error_collector.emit_stream(tag, es)
+        route_error_event { @error_collector.emit_stream(tag, es) }
+      elsif @error_collector
+        # Records are not dumped here because an error event stream can be large.
+        error_info[:record_count] = es.size if es
+        log.error "dump an error event stream because it failed in @ERROR. It is dropped to prevent an infinite loop:", error_info
       else
         now = Time.now.to_i
         if @suppress_emit_error_log_interval.zero? || now > @next_emit_error_log_time
@@ -463,6 +475,19 @@ module Fluent
         end
         raise error
       end
+    end
+
+    private
+
+    def routing_error_event?
+      !!Thread.current[ERROR_ROUTING_KEY]
+    end
+
+    def route_error_event
+      Thread.current[ERROR_ROUTING_KEY] = true
+      yield
+    ensure
+      Thread.current[ERROR_ROUTING_KEY] = false
     end
   end
 end

--- a/test/test_root_agent.rb
+++ b/test/test_root_agent.rb
@@ -671,6 +671,69 @@ EOC
     end
   end
 
+  sub_test_case 'error events which fail in @ERROR' do
+    setup do
+      @ra = RootAgent.new(log: $log)
+      stub(Engine).root_agent { @ra }
+      # <match> in @ERROR raises an error at emit time, just like
+      # BufferChunkOverflowError raised for a record larger than chunk_limit_size
+      conf = <<-EOC
+<match **>
+  @type test_out
+</match>
+<label @ERROR>
+  <match **>
+    @type test_out_error
+  </match>
+</label>
+EOC
+      @ra.configure(Config.parse(conf, "(test)", "(test_dir)", true))
+      @ra.log.out.reset
+    end
+
+    test 'an error event is dumped and dropped, not routed to @ERROR again' do
+      @ra.emit_error_event("tag", event_time, {"message" => "test"}, StandardError.new("original error"))
+
+      logs = @ra.log.out.logs
+      assert_equal([1, 1],
+                   [logs.count { |line| line.include?("send an error event to @ERROR") },
+                    logs.count { |line| line.include?("dump an error event stream because it failed in @ERROR") }])
+    end
+
+    test 'an error event emitted from inside @ERROR is dumped and dropped' do
+      # A plugin in @ERROR may call router.emit_error_event by itself, e.g. a filter
+      # which fails to handle a record.
+      stub(@ra.error_collector).emit do |tag, time, record|
+        @ra.emit_error_event(tag, time, record, StandardError.new("error in @ERROR"))
+      end
+      @ra.emit_error_event("tag", event_time, {"message" => "test"}, StandardError.new("original error"))
+
+      logs = @ra.log.out.logs
+      assert_equal([1, 1],
+                   [logs.count { |line| line.include?("send an error event to @ERROR") },
+                    logs.count { |line| line.include?("dump an error event because it failed in @ERROR") }])
+    end
+
+    test 'an error event stream is dumped and dropped, not routed to @ERROR again' do
+      es = Fluent::OneEventStream.new(event_time, {"message" => "test"})
+      @ra.handle_emits_error("tag", es, StandardError.new("original error"))
+
+      logs = @ra.log.out.logs
+      assert_equal([1, 1],
+                   [logs.count { |line| line.include?("send an error event stream to @ERROR") },
+                    logs.count { |line| line.include?("dump an error event stream because it failed in @ERROR") }])
+    end
+
+    test 'the next error event is routed to @ERROR again' do
+      2.times do
+        @ra.emit_error_event("tag", event_time, {"message" => "test"}, StandardError.new("original error"))
+      end
+
+      logs = @ra.log.out.logs
+      assert_equal(2, logs.count { |line| line.include?("send an error event to @ERROR") })
+    end
+  end
+
   sub_test_case 'configured at worker2 with 4 workers environment' do
     setup do
       ENV['SERVERENGINE_WORKER_ID'] = '2'


### PR DESCRIPTION
## What this fixes

Fixes #5462.

A record larger than `chunk_limit_size` raises `BufferChunkOverflowError` at emit time and the event is routed to `@ERROR`. If the output inside `@ERROR` raises the same error, the event was routed to `@ERROR` again, and this repeated without bound. Nothing marked the event as having already been through the error path, so there was no termination condition.

The routing is recursive rather than a flat loop:

`EventRouter#emit_stream` rescues → `RootAgent#handle_emits_error` → `@error_collector.emit_stream` → the plugin in `@ERROR` raises → that router's rescue → `handle_emits_error` → …

So each iteration adds stack frames and the worker eventually dies with `SystemStackError` (~7000 levels in my reproduction). None of the buffer's failure-handling parameters apply, because they govern flush-time failures: `retry_max_times` / `retry_timeout` need a flush that never happened, `overflow_action` governs `BufferOverflowError` (buffer full) which is a different error class, and `<secondary>` receives a chunk after flush retries are exhausted when no chunk was ever created.

## How

`@ERROR` is the last-resort route, so it should be bounded by construction. An error event that fails *while being routed to `@ERROR`* is now dumped with a distinct `error`-level log and dropped, instead of being routed back. This uses a thread-local re-entrancy guard in `RootAgent`, applied to both `handle_emits_error` (event streams) and `emit_error_event` (single records — reached when a plugin inside `@ERROR`, such as a filter, calls `router.emit_error_event` itself).

The distinct message also addresses the second half of the issue: a genuine loop is now distinguishable from repeated single failures.

```
[error]: #0 dump an error event stream because it failed in @ERROR. It is dropped to prevent an infinite loop: error_class=Fluent::Plugin::Buffer::BufferChunkOverflowError ...
```

Behaviour when no `@ERROR` label is configured is unchanged, including `raise error` and the `emit_error_log_interval` suppression. The guard resets in an `ensure`, so the next error event still gets its normal single attempt at `@ERROR`.

## Reproduction

Config from the issue (`chunk_limit_size 7` in both the primary output and `@ERROR`), 3 × 2 MB-line input file, 25 second window:

| | before | after |
|---|---|---|
| `send an error event stream to @ERROR` | 2329, still climbing | 1 |
| dropped-with-reason log | 0 | 1 |
| `SystemStackError` / worker death | yes (~7020 frames) | none, worker stays healthy |

## Known limitation

The guard catches synchronous re-entry, which covers every emit-time error path including the reported one. An error re-emitted from a *different* thread inside `@ERROR` would not be caught — bounding that would require a marker on the event itself. Happy to explore that here if a reviewer would prefer it.

## Tests

4 regression tests added to `test/test_root_agent.rb`, covering both entry points, the dropped-and-not-rerouted behaviour, and that the guard resets so a subsequent error event is still routed normally.

`bundle exec rake test` on macOS / Ruby 4.0.6: `4345 tests, 15851 assertions, 0 failures, 0 errors, 3 pendings, 36 omissions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
