### PR TITLE
Enable Ruby JIT by default

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -780,6 +780,7 @@ module Fluent
         MessagePackFactory.init(enable_time_support: @system_config.enable_msgpack_time_support)
         Fluent::Engine.init(@system_config, start_in_parallel: ENV.key?("FLUENT_RUNNING_IN_PARALLEL_WITH_OLD"))
         Fluent::Engine.run_configure(@conf)
+        enable_ruby_jit if @system_config.enable_jit
         Fluent::Engine.run
         self.class.cleanup_socketmanager_path if @standalone_worker
         exit 0
@@ -1214,6 +1215,19 @@ module Fluent
       exit!(unrecoverable_error ? 2 : 1)
     end
 
+    def enable_ruby_jit
+      unless defined?(RubyVM::YJIT) && RubyVM::YJIT.respond_to?(:enable)
+        $log.info "Ruby JIT is not available on this Ruby"
+        return
+      end
+
+      if RubyVM::YJIT.enable
+        $log.info "enabled Ruby JIT"
+      else
+        $log.warn "failed to enable Ruby JIT"
+      end
+    end
+
     def build_system_config(conf)
       system_config = SystemConfig.create(conf, @cl_opt[:strict_config_value])
       # Prefer the options explicitly specified in the command line
@@ -1279,11 +1293,6 @@ module Fluent
         fluentd_spawn_cmd.concat(adopted_encodes)
       else
         fluentd_spawn_cmd << '-Eascii-8bit:ascii-8bit'
-      end
-
-      if @system_config.enable_jit
-        $log.info "enable Ruby JIT for workers (--jit)"
-        fluentd_spawn_cmd << '--jit'
       end
 
       # Adding `-h` so that it can avoid ruby's command blocking

--- a/lib/fluent/system_config.rb
+++ b/lib/fluent/system_config.rb
@@ -53,7 +53,7 @@ module Fluent
     config_param :disable_shared_socket, :bool, default: nil
     config_param :enable_input_metrics, :bool, default: true
     config_param :enable_size_metrics, :bool, default: nil
-    config_param :enable_jit, :bool, default: false
+    config_param :enable_jit, :bool, default: true
     config_param :file_permission, default: nil do |v|
       v.to_i(8)
     end

--- a/test/config/test_system_config.rb
+++ b/test/config/test_system_config.rb
@@ -78,7 +78,7 @@ module Fluent::Config
       assert_true(sc.enable_input_metrics)
       assert_nil(sc.enable_size_metrics)
       assert_nil(sc.enable_msgpack_time_support)
-      assert(!sc.enable_jit)
+      assert(sc.enable_jit)
       assert_nil(sc.log.path)
       assert_equal(:text, sc.log.format)
       assert_equal('%Y-%m-%d %H:%M:%S %z', sc.log.time_format)
@@ -100,7 +100,7 @@ module Fluent::Config
       'enable_msgpack_time_support' => ['enable_msgpack_time_support', true],
       'enable_input_metrics' => ['enable_input_metrics', false],
       'enable_size_metrics' => ['enable_size_metrics', true],
-      'enable_jit' => ['enable_jit', true],
+      'enable_jit' => ['enable_jit', false],
       'umask' => ['umask', '0022'],
     )
     test "accepts parameters" do |(k, v)|

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -957,6 +957,48 @@ class SupervisorTest < ::Test::Unit::TestCase
     end
   end
 
+  sub_test_case "enable_jit" do
+    def create_worker(enable_jit)
+      sv = Fluent::Supervisor.new({})
+      conf = Fluent::Config::Element.new(
+        'ROOT', '', {}, [Fluent::Config::Element.new('system', '', { 'enable_jit' => enable_jit.to_s }, [])]
+      )
+      sv.instance_variable_set(:@system_config, sv.__send__(:build_system_config, conf))
+      sv.instance_variable_set(:@conf, conf)
+      sv
+    end
+
+    data("enabled" => [true, 1],
+         "disabled" => [false, 0])
+    def test_run_worker((enable_jit, expected_count))
+      sv = create_worker(enable_jit)
+
+      stub(sv).install_main_process_signal_handlers
+      stub(Fluent::MessagePackFactory).init
+      stub(Fluent::Engine).init
+      stub(Fluent::Engine).run_configure
+      stub(Fluent::Engine).run
+
+      enable_count = 0
+      stub(RubyVM::YJIT).enable { enable_count += 1; true }
+
+      assert_raise(SystemExit) { sv.run_worker }
+      assert_equal(expected_count, enable_count)
+    end
+
+    data("succeeded" => [true, "enabled Ruby JIT"],
+         "failed" => [false, "failed to enable Ruby JIT"])
+    def test_log_result((result, expected_message))
+      sv = create_worker(true)
+      create_info_dummy_logger
+
+      mock(RubyVM::YJIT).enable { result }
+      sv.__send__(:enable_ruby_jit)
+
+      assert { $log.out.logs.any? { |log| log.include?(expected_message) } }
+    end
+  end
+
   sub_test_case "zero_downtime_restart" do
     setup do
       omit "Not supported on Windows" if Fluent.windows?

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -958,6 +958,10 @@ class SupervisorTest < ::Test::Unit::TestCase
   end
 
   sub_test_case "enable_jit" do
+    setup do
+      omit "YJIT is not supported on Windows, and RubyVM::YJIT is not defined either" if Fluent.windows?
+    end
+
     def create_worker(enable_jit)
       sv = Fluent::Supervisor.new({})
       conf = Fluent::Config::Element.new(


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #5284

**What this PR does / why we need it**: 
Enable Ruby JIT by default.

**Docs Changes**:
https://github.com/fluent/fluentd-docs-gitbook/pull/674

**Release Note**: 
* Enable Ruby JIT by default
  * The system configuration `enable_jit` now defaults to `true`. 
  * JIT increases memory usage of each worker process. Set `enable_jit false` in the `<system>` section to restore the previous behavior.
  * This has no effect on Windows because YJIT is not supported there. Fluentd just logs `Ruby JIT is not available on this Ruby` at the info level.
