### PR TITLE
Drop Ruby 3.2 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
       engine: cruby
-      min_version: 3.2
+      min_version: 3.3
   test:
     needs: ruby-versions
     runs-on: ${{ matrix.os }}
@@ -38,8 +38,6 @@ jobs:
           - ruby-version: head
           - os: 'windows-11-arm'
             ruby-version: '3.3'
-          - os: 'windows-11-arm'
-            ruby-version: '3.2'
     env:
       RUBYOPT: "--disable-frozen_string_literal"
     name: Ruby ${{ matrix.ruby-version }} on ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Fluentd: Open-Source Log Collector
 
 ### Prerequisites
 
-- Ruby 3.2 or later
+- Ruby 3.3 or later
 - git
 
 `git` should be in `PATH`. On Windows, you can use `Github for Windows` and `GitShell` for easy setup.

--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.metadata["changelog_uri"] = "https://github.com/fluent/fluentd/blob/master/CHANGELOG.md"
   gem.metadata["bug_tracker_uri"] = "https://github.com/fluent/fluentd/issues"
 
-  gem.required_ruby_version = '>= 3.2'
+  gem.required_ruby_version = '>= 3.3'
 
   gem.add_runtime_dependency("bundler")
   gem.add_runtime_dependency("msgpack", [">= 1.3.1", "< 2.0.0"])


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Related to #5284

**What this PR does / why we need it**: 
This is required to enable JIT through `RubyVM::YJIT.enable`.

**Docs Changes**:
https://github.com/fluent/fluentd-docs-gitbook/pull/670

**Release Note**: 
* Drop Ruby 3.2 support