### PR TITLE
plugin base: bound the number of worker lock files with hashed buckets

### DIFF
--- a/lib/fluent/plugin/base.rb
+++ b/lib/fluent/plugin/base.rb
@@ -14,6 +14,7 @@
 #    limitations under the License.
 #
 
+require 'zlib'
 require 'fluent/plugin'
 require 'fluent/configurable'
 require 'fluent/system_config'
@@ -69,9 +70,13 @@ module Fluent
         true
       end
 
+      LOCK_FILE_BUCKETS = 65536
+
       def get_lock_path(name)
-        name = name.gsub(/[^a-zA-Z0-9]/, "_")
-        File.join(@fluentd_lock_dir, "fluentd-#{name}.lock")
+        # The mapping from a name to a bucket MUST be identical across worker processes.
+        # Ruby's String#hash is randomly seeded per process and MUST NOT be used here.
+        bucket = Zlib.crc32(name.to_s) % LOCK_FILE_BUCKETS
+        File.join(@fluentd_lock_dir, "fluentd-bucket-#{bucket}.lock")
       end
 
       def acquire_worker_lock(name)

--- a/test/plugin/test_base.rb
+++ b/test/plugin/test_base.rb
@@ -121,7 +121,70 @@ class BaseTest < Test::Unit::TestCase
       path = p.get_lock_path("Aa\\|=~/_123")
 
       assert_equal lock_dir, File.dirname(path)
-      assert_equal "fluentd-Aa______123.lock", File.basename(path)
+      assert_equal "fluentd-bucket-39922.lock", File.basename(path)
+    end
+  end
+
+  data("short name" => ["test_base", "fluentd-bucket-54446.lock"],
+       "long path" => ["/var/log/app/#{'a' * 1024}.log", "fluentd-bucket-11403.lock"],
+       "multibyte" => ["ログ/日本語.log", "fluentd-bucket-29413.lock"])
+  test 'maps a name to a fixed lock file bucket' do |(name, expected)|
+    Dir.mktmpdir("test-fluentd-lock-") do |lock_dir|
+      ENV['FLUENTD_LOCK_DIR'] = lock_dir
+      p = FluentPluginBaseTest::DummyPlugin.new
+
+      assert_equal expected, File.basename(p.get_lock_path(name))
+    end
+  end
+
+  test 'maps a name to the same bucket in another process' do
+    omit "fork is not supported on Windows" if Fluent.windows?
+
+    names = [
+      "test_base",
+      "/var/log/app/083027ab-923e-4ff1-a774-a00d6a65dc76.log",
+      "ログ/日本語.log",
+      "Aa\\|=~/_123",
+    ]
+    Dir.mktmpdir("test-fluentd-lock-") do |lock_dir|
+      ENV['FLUENTD_LOCK_DIR'] = lock_dir
+      p = FluentPluginBaseTest::DummyPlugin.new
+
+      reader, writer = IO.pipe
+      pid = fork do
+        reader.close
+        writer.write(Marshal.dump(names.map { |name| p.get_lock_path(name) }))
+        writer.close
+        exit!(0)
+      end
+      writer.close
+      paths_in_child = Marshal.load(reader.read) # rubocop:disable Security/MarshalLoad
+      reader.close
+      Process.waitpid(pid)
+
+      assert_equal names.map { |name| p.get_lock_path(name) }, paths_in_child
+    end
+  end
+
+  test 'returns a bounded number of lock file names' do
+    Dir.mktmpdir("test-fluentd-lock-") do |lock_dir|
+      ENV['FLUENTD_LOCK_DIR'] = lock_dir
+      p = FluentPluginBaseTest::DummyPlugin.new
+      basenames = Array.new(2000) { |i| File.basename(p.get_lock_path("/var/log/app-#{i}/#{i}.log")) }
+
+      assert_equal [], basenames.reject { |basename| basename.match?(/\Afluentd-bucket-\d{1,5}\.lock\z/) }
+      assert_equal [], basenames.reject { |basename| basename[/\d+/].to_i < 65536 }
+    end
+  end
+
+  test 'returns the same lock path for the same name' do
+    Dir.mktmpdir("test-fluentd-lock-") do |lock_dir|
+      ENV['FLUENTD_LOCK_DIR'] = lock_dir
+      p = FluentPluginBaseTest::DummyPlugin.new
+      name = "/var/log/app/083027ab-923e-4ff1-a774-a00d6a65dc76.log"
+
+      assert_equal p.get_lock_path(name), p.get_lock_path(name)
+      assert_equal 1, Array.new(3) { p.get_lock_path(name) }.uniq.size
     end
   end
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
When `workers > 1`, `out_file` (with `append`) and `out_secondary_file` take an inter-worker lock per output path, and `get_lock_path` derives one lock file per path: `/tmp/fluentd-lock-*/fluentd-<sanitized path>.lock`. A lock file is never removed while fluentd is running; the only cleanup is `cleanup_lock_dir` at a graceful shutdown.

So the number of lock files grows with the number of unique output paths, and with a date or a tag placeholder in `path` that set is effectively unbounded over time.

This PR folds the paths into a fixed pool of buckets:

```ruby
LOCK_FILE_BUCKETS = 65536

def get_lock_path(name)
  bucket = Zlib.crc32(name.to_s) % LOCK_FILE_BUCKETS
  File.join(@fluentd_lock_dir, "fluentd-bucket-#{bucket}.lock")
end
```

The lock is a `flock`, which is bound to the open file description and released when the file is closed or the process dies. The lock file is not state; it is only an anchor that the workers rendezvous on by name. Mutual exclusion therefore does not need a 1:1 correspondence between a path and a file. It needs exactly one property:

> the same path always maps to the same file, in every worker process.

`crc32 % 65536` preserves that property, so any two workers writing the same path still contend on the same file and still serialize. `acquire_worker_lock` itself (`open` / `flock` / `touch`) is untouched.

What changes is that the number of lock files is now bounded by a constant instead of by the number of unique paths. The accumulation, the mass deletion at shutdown, and the dependence on an external tmp cleaner all disappear structurally rather than being mitigated.


#### Collision semantics

Two unrelated paths can land in the same bucket. The effect on correctness is zero: they are serialized against each other, which is exclusion that is wider than necessary, never exclusion that is lost.

The effect on throughput is a rare latency coupling, and it is worth being explicit about it because `flock` is held for the whole chunk write, not just for opening the file. With `N = 65536` buckets and `k` locks held concurrently across all workers, the probability that some pair of them collides is about `1 - exp(-k(k-1)/2N)`:

| concurrent locks `k` | some pair collides | a given flush collides with another |
| --- | --- | --- |
| 8 | 0.043% | 0.011% |
| 32 | 0.75% | 0.047% |
| 64 | 3.0% | 0.096% |
| 120 | 10.3% | 0.18% |

The right-hand column is the one a single flush actually experiences, and it stays below 0.2% even at 120 concurrent locks. A collision costs the duration of one chunk write, and only for the two paths involved.

**Docs Changes**:
N/A

**Release Note**: 
* plugin base: bound the number of worker lock files by hashing the path into a fixed set of buckets