### PR TITLE
Backport(v1.19): supervisor: reduce memory usage of cleanup_lock_dir with huge number of lock files (#5469)

### DIFF
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -100,7 +100,14 @@ module Fluent
     end
 
     def cleanup_lock_dir
-      FileUtils.rm(Dir.glob(File.join(@fluentd_lock_dir, "fluentd-*.lock")))
+      begin
+        Dir.each_child(@fluentd_lock_dir) do |name|
+          FileUtils.rm_f(File.join(@fluentd_lock_dir, name)) if File.fnmatch?("fluentd-*.lock", name)
+        end
+      rescue Errno::ENOENT
+        # Directory is already missing. Fall through and let rmdir below
+        # fail in the same way as the current implementation.
+      end
       FileUtils.rmdir(@fluentd_lock_dir)
     end
 

--- a/test/test_supervisor.rb
+++ b/test/test_supervisor.rb
@@ -942,6 +942,39 @@ class SupervisorTest < ::Test::Unit::TestCase
     end
   end
 
+  sub_test_case "cleanup_lock_dir" do
+    def create_server(lock_dir)
+      server = DummyServer.new
+      server.instance_variable_set(:@fluentd_lock_dir, lock_dir)
+      server
+    end
+
+    def test_remove_lock_dir
+      lock_dir = File.join(@tmp_dir, "fluentd-lock")
+      FileUtils.mkdir_p(lock_dir)
+      FileUtils.touch(File.join(lock_dir, "fluentd-0.lock"))
+      FileUtils.touch(File.join(lock_dir, "fluentd-1.lock"))
+
+      create_server(lock_dir).cleanup_lock_dir
+
+      assert_false(File.exist?(lock_dir))
+    end
+
+    def test_keep_unrelated_file
+      lock_dir = File.join(@tmp_dir, "fluentd-lock")
+      FileUtils.mkdir_p(lock_dir)
+      FileUtils.touch(File.join(lock_dir, "fluentd-0.lock"))
+      FileUtils.touch(File.join(lock_dir, "unrelated.txt"))
+
+      assert_raise(Errno::ENOTEMPTY) do
+        create_server(lock_dir).cleanup_lock_dir
+      end
+
+      assert_false(File.exist?(File.join(lock_dir, "fluentd-0.lock")))
+      assert_true(File.exist?(File.join(lock_dir, "unrelated.txt")))
+    end
+  end
+
   sub_test_case "zero_downtime_restart" do
     setup do
       omit "Not supported on Windows" if Fluent.windows?


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Backport #5469
Fixes #

**What this PR does / why we need it**:
`cleanup_lock_dir` collects all lock file paths with `Dir.glob` at shutdown, which materializes the whole path list in memory.

With that many files, the `Dir.glob` array causes a multi-GB memory spike during shutdown,
which increases the risk of hitting systemd's `TimeoutStopSec` and getting SIGKILLed in the middle of cleanup.

This PR switches to `Dir.each_child` to stream directory entries one by one.

Measurement (removing 1,000,000 lock files, RSS):

|                | RSS growth | elapsed |
|----------------|-----------:|--------:|
| `Dir.glob`     |  884.5 MiB |  26.0 s |
| `Dir.each_child` |  1.8 MiB |  25.4 s |

**Docs Changes**:
N/A

**Release Note**:
* supervisor: reduce memory usage of cleanup_lock_dir with huge number of lock files
