### PR TITLE
test_in_tail: fix flaky test for already throttled log reading

### DIFF
--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -623,13 +623,18 @@ class TailInputTest < Test::Unit::TestCase
 
           # We should not do shutdown here due to hard timeout.
           d.run do
-            start_time = Fluent::Clock.now
-            while Fluent::Clock.now - start_time < 0.8 do
-              Fluent::FileWrapper.open("#{@tmp_dir}/tail.txt", "ab") do |f|
-                f.puts msg
-                f.flush
+            if Fluent.linux?
+              # Other platforms receive no stat notification while appending, so it
+              # would just consume the throttling window and make this test flaky.
+              start_time = Fluent::Clock.now
+              while d.instance.statistics['input']['throttled_log_count'] < 5 &&
+                    Fluent::Clock.now - start_time < 0.8 do
+                Fluent::FileWrapper.open("#{@tmp_dir}/tail.txt", "ab") do |f|
+                  f.puts msg
+                  f.flush
+                end
+                sleep 0.05
               end
-              sleep 0.05
             end
           end
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
`test_emit_with_read_bytes_limit_per_second` in `reads_bytes_per_second w/ throttled already` was intermittently failing, especially on macOS CI runners.

```
4) Failure: test_emit_with_read_bytes_limit_per_second[flat 65536 bytes](TailInputTest::singleline::log throttling per file::reads_bytes_per_second w/ throttled already)
/Users/runner/work/fluentd/fluentd/test/plugin/test_in_tail.rb:636
     636:           assert_equal([], d.events)
<[]> expected but was
<[["t1", 2026-08-13 04:57:42.938460000 +0000, {"message"=>"xxxx..."}]]>
```
Ref. https://github.com/fluent/fluentd/actions/runs/31667602802/job/94345429056#step:6:5450

The `in_tail` throttling test must finish within a strict 1-second window before the timer (`@start_reading_time`) resets. Previously, the test appended logs for a fixed 0.8 seconds, leaving less than a 0.1-second margin. On loaded CI runners, this easily exceeded 1 second, causing the window to reset and unexpectedly emit pending logs.

**Docs Changes**:
N/A

**Release Note**: 
N/A