### PR TITLE
fix(buffer): decrement queue_size in ensure so failed purge does not leak

### DIFF
--- a/lib/fluent/plugin/buffer.rb
+++ b/lib/fluent/plugin/buffer.rb
@@ -601,13 +601,19 @@ module Fluent
           metadata = chunk.metadata
           log.on_trace { log.trace "purging a chunk", instance: self.object_id, chunk_id: dump_unique_id_hex(chunk_id), metadata: metadata }
 
+          bytesize = chunk.bytesize
           begin
-            bytesize = chunk.bytesize
             chunk.purge
-            @queue_size_metrics.sub(bytesize)
           rescue => e
             log.error "failed to purge buffer chunk", chunk_id: dump_unique_id_hex(chunk_id), error_class: e.class, error: e
             log.error_backtrace
+          ensure
+            # Always release the queued byte counter, even when purge raises
+            # (e.g. unlink/close failure on the buffer path). Otherwise
+            # @queue_size is never decremented for a dequeued chunk that is
+            # gone from both @queue and @dequeued, so the leak ratchets toward
+            # total_limit_size and storable? becomes permanently false (#5468).
+            @queue_size_metrics.sub(bytesize)
           end
 
           @dequeued_num[chunk.metadata] -= 1

--- a/test/plugin/test_buffer.rb
+++ b/test/plugin/test_buffer.rb
@@ -435,6 +435,32 @@ class BufferTest < Test::Unit::TestCase
       assert_equal({}, @p.dequeued)
     end
 
+    test '#purge_chunk releases queue_size even when chunk.purge raises (#5468)' do
+      # Simulate a physical purge failure (unlink/close on the buffer path)
+      # so chunk.purge raises after the chunk is dequeued.
+      failing_purge = Module.new do
+        def purge
+          raise IOError, 'simulated purge failure (unlink EIO)'
+        end
+      end
+      @p.buffer_class::Chunk.include(failing_purge)
+
+      m1 = @p.dequeue_chunk
+      assert_equal [@dm0, @dm1, @dm1], @p.queue.map(&:metadata)
+      assert_equal({m1.unique_id => m1}, @p.dequeued)
+
+      queued_before = @p.queue_size
+      assert queued_before > 0
+
+      # purge_chunk swallows the error but must still decrement queue_size
+      @p.purge_chunk(m1.unique_id)
+
+      assert m1.purged
+      # queue_size must return to its pre-dequeue value, not leak upward
+      assert_equal queued_before - m1.bytesize, @p.queue_size
+      assert @p.storable?
+    end
+
     test '#takeback_chunk returns false if specified chunk_id is already purged' do
       assert_equal [@dm0,@dm1,@dm1], @p.queue.map(&:metadata)
       assert_equal({}, @p.dequeued)

--- a/test/plugin/test_buffer.rb
+++ b/test/plugin/test_buffer.rb
@@ -436,15 +436,6 @@ class BufferTest < Test::Unit::TestCase
     end
 
     test '#purge_chunk releases queue_size even when chunk.purge raises (#5468)' do
-      # Simulate a physical purge failure (unlink/close on the buffer path)
-      # so chunk.purge raises after the chunk is dequeued.
-      failing_purge = Module.new do
-        def purge
-          raise IOError, 'simulated purge failure (unlink EIO)'
-        end
-      end
-      @p.buffer_class::Chunk.include(failing_purge)
-
       m1 = @p.dequeue_chunk
       assert_equal [@dm0, @dm1, @dm1], @p.queue.map(&:metadata)
       assert_equal({m1.unique_id => m1}, @p.dequeued)
@@ -452,10 +443,15 @@ class BufferTest < Test::Unit::TestCase
       queued_before = @p.queue_size
       assert queued_before > 0
 
+      # Simulate a physical purge failure (unlink/close on the buffer path)
+      # so chunk.purge raises after the chunk is dequeued.
+      (class << m1; self; end).module_eval do
+        define_method(:purge) { raise IOError, 'simulated purge failure (unlink EIO)' }
+      end
+
       # purge_chunk swallows the error but must still decrement queue_size
       @p.purge_chunk(m1.unique_id)
 
-      assert m1.purged
       # queue_size must return to its pre-dequeue value, not leak upward
       assert_equal queued_before - m1.bytesize, @p.queue_size
       assert @p.storable?

--- a/test/plugin/test_buffer.rb
+++ b/test/plugin/test_buffer.rb
@@ -436,8 +436,10 @@ class BufferTest < Test::Unit::TestCase
     end
 
     test '#purge_chunk releases queue_size even when chunk.purge raises (#5468)' do
+      # Initial queue: [@dm0, @dm1, @dm1]
       m1 = @p.dequeue_chunk
-      assert_equal [@dm0, @dm1, @dm1], @p.queue.map(&:metadata)
+      assert_equal @dm0, m1.metadata
+      assert_equal [@dm1, @dm1], @p.queue.map(&:metadata)
       assert_equal({m1.unique_id => m1}, @p.dequeued)
 
       queued_before = @p.queue_size
@@ -445,14 +447,17 @@ class BufferTest < Test::Unit::TestCase
 
       # Simulate a physical purge failure (unlink/close on the buffer path)
       # so chunk.purge raises after the chunk is dequeued.
+      # Inject the failure on the single chunk instance under test (the file's
+      # established idiom) rather than mutating a shared class.
       (class << m1; self; end).module_eval do
         define_method(:purge) { raise IOError, 'simulated purge failure (unlink EIO)' }
       end
 
-      # purge_chunk swallows the error but must still decrement queue_size
+      # purge_chunk swallows the error but must still decrement queue_size once
+      # (the chunk is gone from both @queue and @dequeued), so the counter does
+      # not leak upward and storable? does not permanently flip to false (#5468).
       @p.purge_chunk(m1.unique_id)
 
-      # queue_size must return to its pre-dequeue value, not leak upward
       assert_equal queued_before - m1.bytesize, @p.queue_size
       assert @p.storable?
     end


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes #5468

**What this PR does / why we need it**:
In `Fluent::Plugin::Buffer#purge_chunk`, `@queue_size_metrics` is only decremented inside `begin/rescue`. When `chunk.purge` raises (e.g. unlink/close failure on the buffer path), the error is logged and swallowed but the `sub` is skipped. The chunk is already removed from `@dequeued`, so it is never retried — the queued byte counter ratchets toward `total_limit_size`, making `storable?` permanently `false` and causing a spurious `BufferOverflowError` on a near-empty buffer.

This moves `bytesize = chunk.bytesize` above the `begin` and moves `@queue_size_metrics.sub(bytesize)` into an `ensure` block so the counter is always released exactly once per `purge_chunk` call, regardless of whether `purge` succeeds.

Why safe:
- `ensure` runs exactly once per call → no double-decrement.
- Every chunk reaching `purge_chunk` was previously enqueued (dequeue/emit path), so the `sub` is always balanced.
- If `chunk.purge` raises, the chunk is lost on filesystem error (already a logged, separate failure); this change only preserves counter integrity so `storable?` no longer spuriously goes false.

**Docs Changes**:
None (behavior fix; inline comment added).

**Release Note**:
* buffer: fix spurious `BufferOverflowError` caused by `queue_size` leaking when a chunk purge fails 