### PR TITLE
out_http: remove the Net::HTTP extra_chain_cert monkey patch

### DIFF
--- a/lib/fluent/plugin/out_http.rb
+++ b/lib/fluent/plugin/out_http.rb
@@ -22,16 +22,6 @@ require 'fluent/tls'
 require 'fluent/plugin/output'
 require 'fluent/plugin_helper/socket'
 
-# patch Net::HTTP to support extra_chain_cert which was added in Ruby feature #9758.
-# see: https://github.com/ruby/ruby/commit/31af0dafba6d3769d2a39617c0dddedb97883712
-unless Net::HTTP::SSL_IVNAMES.include?(:@extra_chain_cert)
-  class Net::HTTP
-    SSL_IVNAMES << :@extra_chain_cert
-    SSL_ATTRIBUTES << :extra_chain_cert
-    attr_accessor :extra_chain_cert
-  end
-end
-
 module Fluent::Plugin
   class HTTPOutput < Output
     Fluent::Plugin.register_output('http', self)


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 
Net::HTTP supports extra_chain_cert since Ruby 3.0 (Feature #9758), and fluentd now requires Ruby 3.3 or later, so the patch added in PR #3146 is dead code.

**Docs Changes**:
N/A

**Release Note**: 
N/A