### PR TITLE
MAINTAINERS.md: Fix a typo in a GitHub account name

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,7 +7,7 @@
 - [Satoshi Tagomori](https://github.com/tagomoris)
 - [Toru Takahashi](https://github.com/toru-takahashi), [Treasure Data](https://www.treasuredata.com/)
 - [Eduardo Silva](https://github.com/edsiper), [Chronosphere](https://chronosphere.io/)
-- [Fujimoto Seiji](https://github.com/fujimots)
+- [Fujimoto Seiji](https://github.com/fujimotos)
 - [Takuro Ashie](https://github.com/ashie), [ClearCode](https://www.clear-code.com/)
 - [Kentaro Hayashi](https://github.com/kenhys), [ClearCode](https://www.clear-code.com/)
 - [Daijiro Fukuda](https://github.com/daipom)


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 

N/A

**What this PR does / why we need it**: 

The GitHub account of Fujimoto Seiji written in MAINTAINERS.md was typo.
As is evident from the commit history (e.g. https://github.com/fluent/fluentd/pull/3857),
his GitHub account name is `fujimotos`, not `fujimots`.

**Docs Changes**:

N/A

**Release Note**: 

N/A
