### PR TITLE
Backport(v1.19): support json gem v3.x (#5492)

### DIFF
--- a/lib/fluent/command/cat.rb
+++ b/lib/fluent/command/cat.rb
@@ -326,7 +326,7 @@ case format
 when 'json'
   begin
     while line = $stdin.gets
-      record = JSON.parse(line, Fluent::DEFAULT_JSON_PARSE_OPTIONS)
+      record = JSON.parse(line, **Fluent::DEFAULT_JSON_PARSE_OPTIONS)
       w.write(record)
     end
   rescue

--- a/lib/fluent/config/literal_parser.rb
+++ b/lib/fluent/config/literal_parser.rb
@@ -252,7 +252,7 @@ EOM
             # '{"foo":"bar", #' -> '{"foo":"bar"}' (to check)
             parsed = nil
             begin
-              parsed = JSON.parse(buffer + line_buffer.rstrip.sub(/,$/, '') + (is_array ? "]" : "}"), Fluent::DEFAULT_JSON_PARSE_OPTIONS)
+              parsed = JSON.parse(buffer + line_buffer.rstrip.sub(/,$/, '') + (is_array ? "]" : "}"), **Fluent::DEFAULT_JSON_PARSE_OPTIONS)
             rescue JSON::ParserError
               # This '#' is in json string literals
             end
@@ -287,7 +287,7 @@ EOM
 
           line_buffer << char
           begin
-            result = JSON.parse(buffer + line_buffer, Fluent::DEFAULT_JSON_PARSE_OPTIONS)
+            result = JSON.parse(buffer + line_buffer, **Fluent::DEFAULT_JSON_PARSE_OPTIONS)
           rescue JSON::ParserError
             # Incomplete json string yet
           end

--- a/lib/fluent/config/types.rb
+++ b/lib/fluent/config/types.rb
@@ -201,7 +201,7 @@ module Fluent
       return nil if val.nil?
 
       param = if val.is_a?(String)
-                val.start_with?('{') ? JSON.parse(val, Fluent::DEFAULT_JSON_PARSE_OPTIONS) : Hash[val.strip.split(/\s*,\s*/).map{|v| v.split(':', 2)}]
+                val.start_with?('{') ? JSON.parse(val, **Fluent::DEFAULT_JSON_PARSE_OPTIONS) : Hash[val.strip.split(/\s*,\s*/).map{|v| v.split(':', 2)}]
               else
                 val
               end
@@ -228,7 +228,7 @@ module Fluent
       return nil if val.nil?
 
       param = if val.is_a?(String)
-                val.start_with?('[') ? JSON.parse(val, Fluent::DEFAULT_JSON_PARSE_OPTIONS) : val.strip.split(/\s*,\s*/)
+                val.start_with?('[') ? JSON.parse(val, **Fluent::DEFAULT_JSON_PARSE_OPTIONS) : val.strip.split(/\s*,\s*/)
               elsif val.is_a?(Array)
                 val
               elsif val.is_a?(Numeric) || val == true || val == false

--- a/lib/fluent/daemon.rb
+++ b/lib/fluent/daemon.rb
@@ -10,5 +10,5 @@ require 'fluent/supervisor'
 
 server_module = Fluent.const_get(ARGV[0])
 worker_module = Fluent.const_get(ARGV[1])
-params = JSON.parse(ARGV[2], Fluent::DEFAULT_JSON_PARSE_OPTIONS)
+params = JSON.parse(ARGV[2], **Fluent::DEFAULT_JSON_PARSE_OPTIONS)
 ServerEngine::Daemon.run_server(server_module, worker_module) { Fluent::Supervisor.serverengine_config(params) }

--- a/lib/fluent/plugin/filter_record_transformer.rb
+++ b/lib/fluent/plugin/filter_record_transformer.rb
@@ -117,7 +117,7 @@ module Fluent::Plugin
 
     def parse_value(value_str)
       if value_str.start_with?('{', '[')
-        JSON.parse(value_str, Fluent::DEFAULT_JSON_PARSE_OPTIONS)
+        JSON.parse(value_str, **Fluent::DEFAULT_JSON_PARSE_OPTIONS)
       else
         value_str
       end

--- a/lib/fluent/plugin/in_monitor_agent.rb
+++ b/lib/fluent/plugin/in_monitor_agent.rb
@@ -102,7 +102,7 @@ module Fluent::Plugin
       end
 
       def render_ltsv(obj, code: 200)
-        normalized = JSON.parse(obj.to_json, Fluent::DEFAULT_JSON_PARSE_OPTIONS)
+        normalized = JSON.parse(obj.to_json, **Fluent::DEFAULT_JSON_PARSE_OPTIONS)
         text = ''
         normalized.each do |hash|
           row = []

--- a/lib/fluent/plugin/in_sample.rb
+++ b/lib/fluent/plugin/in_sample.rb
@@ -45,7 +45,7 @@ module Fluent::Plugin
     desc "The sample data to be generated. An array of JSON hashes or a single JSON hash."
     config_param :sample, alias: :dummy, default: [{"message" => "sample"}] do |val|
       begin
-        parsed = JSON.parse(val, Fluent::DEFAULT_JSON_PARSE_OPTIONS)
+        parsed = JSON.parse(val, **Fluent::DEFAULT_JSON_PARSE_OPTIONS)
       rescue JSON::ParserError => ex
         # Fluent::ConfigParseError, "got incomplete JSON" will be raised
         # at literal_parser.rb with --use-v1-config, but I had to

--- a/lib/fluent/plugin/parser_json.rb
+++ b/lib/fluent/plugin/parser_json.rb
@@ -41,7 +41,7 @@ module Fluent
 
       # Use a shared proc rather than a per-call lambda so that
       # configure_json_parser returns the same object every time.
-      JSON_PARSE_PROC = ->(text) { JSON.parse(text, Fluent::DEFAULT_JSON_PARSE_OPTIONS) }
+      JSON_PARSE_PROC = ->(text) { JSON.parse(text, **Fluent::DEFAULT_JSON_PARSE_OPTIONS) }
 
       def configure(conf)
         if conf.has_key?('time_format')

--- a/lib/fluent/plugin/sd_file.rb
+++ b/lib/fluent/plugin/sd_file.rb
@@ -76,7 +76,7 @@ module Fluent
             -> (v) { YAML.safe_load(v).map }
           when :json
             require 'json'
-            -> (v) { JSON.parse(v, Fluent::DEFAULT_JSON_PARSE_OPTIONS) }
+            -> (v) { JSON.parse(v, **Fluent::DEFAULT_JSON_PARSE_OPTIONS) }
           end
       end
 

--- a/lib/fluent/plugin/storage_local.rb
+++ b/lib/fluent/plugin/storage_local.rb
@@ -90,7 +90,7 @@ module Fluent
                 log.warn "detect empty plugin storage file during startup. Ignored: #{@path}"
                 return
               end
-              data = JSON.parse(data, Fluent::DEFAULT_JSON_PARSE_OPTIONS)
+              data = JSON.parse(data, **Fluent::DEFAULT_JSON_PARSE_OPTIONS)
               raise Fluent::ConfigError, "Invalid contents (not object) in plugin storage file: '#{@path}'" unless data.is_a?(Hash)
             rescue => e
               log.error "failed to read data from plugin storage file", path: @path, error: e
@@ -114,7 +114,7 @@ module Fluent
         return unless File.exist?(@path)
         begin
           json_string = File.open(@path, 'r:utf-8:utf-8'){ |io| io.read }
-          json = JSON.parse(json_string, Fluent::DEFAULT_JSON_PARSE_OPTIONS)
+          json = JSON.parse(json_string, **Fluent::DEFAULT_JSON_PARSE_OPTIONS)
           unless json.is_a?(Hash)
             log.error "broken content for plugin storage (Hash required: ignored)", type: json.class
             log.debug "broken content", content: json_string


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Backport #5492 
Fixes #

**What this PR does / why we need it**:
json 3.0 dropped the positional options argument from `JSON.parse`, so every call passing `Fluent::DEFAULT_JSON_PARSE_OPTIONS` now fails with `ArgumentError: wrong number of arguments (given 2, expected 1)`. Ref. https://github.com/fluent/fluentd/actions/runs/34311091836

Pass the options as keyword arguments instead.

**Docs Changes**:
N/A

**Release Note**:
* Support json gem v3.x
